### PR TITLE
feat(ATT-24): when creating a group open it immedaitely, also give visual clu…

### DIFF
--- a/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.tsx
+++ b/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.tsx
@@ -26,13 +26,6 @@ import { AxiosError } from 'axios';
 import { useToastMessage } from '../../../components/toastProvider';
 import { useNavigate } from 'react-router-dom';
 
-interface ResourceGroupUpsertModalProps {
-  children: (onOpen: () => void) => React.ReactNode;
-  /** If provided, the modal will be in edit mode */
-  resourceGroup?: ResourceGroup;
-  onUpserted?: (resourceGroup: ResourceGroup) => void;
-}
-
 type FormData = CreateResourceGroupDto | UpdateResourceGroupDto;
 
 // Define a more specific type for the expected error structure from the API
@@ -43,7 +36,14 @@ interface ApiValidationError {
   message?: string; // General error message field
 }
 
-export function ResourceGroupUpsertModal(props: Readonly<ResourceGroupUpsertModalProps>) {
+interface Props {
+  children: (onOpen: () => void) => React.ReactNode;
+  /** If provided, the modal will be in edit mode */
+  resourceGroup?: ResourceGroup;
+  onUpserted?: (resourceGroup: ResourceGroup) => void;
+}
+
+export function ResourceGroupUpsertModal(props: Readonly<Props>) {
   const { isOpen, onOpen, onOpenChange, onClose: closeDisclosure } = useDisclosure();
   const { t } = useTranslations('resourceGroupUpsertModal', {
     en,

--- a/apps/frontend/src/app/resourceOverview/filterProps.ts
+++ b/apps/frontend/src/app/resourceOverview/filterProps.ts
@@ -5,4 +5,6 @@ export interface FilterProps {
   onOnlyInUseByMeChanged: (value: boolean) => void;
   onlyWithPermissions: boolean;
   onOnlyWithPermissionsChanged: (value: boolean) => void;
+  hideEmptyResourceGroups?: boolean;
+  onHideEmptyResourceGroupsChanged?: (value: boolean) => void;
 }

--- a/apps/frontend/src/app/resourceOverview/filterProps.ts
+++ b/apps/frontend/src/app/resourceOverview/filterProps.ts
@@ -5,6 +5,6 @@ export interface FilterProps {
   onOnlyInUseByMeChanged: (value: boolean) => void;
   onlyWithPermissions: boolean;
   onOnlyWithPermissionsChanged: (value: boolean) => void;
-  hideEmptyResourceGroups?: boolean;
-  onHideEmptyResourceGroupsChanged?: (value: boolean) => void;
+  hideEmptyResourceGroups: boolean;
+  onHideEmptyResourceGroupsChanged: (value: boolean) => void;
 }

--- a/apps/frontend/src/app/resourceOverview/noResourcesFound/de.json
+++ b/apps/frontend/src/app/resourceOverview/noResourcesFound/de.json
@@ -1,0 +1,6 @@
+{
+  "alert": {
+    "title": "Keine Ressourcen gefunden",
+    "description": "Passe deine Suche oder die Filter-Optionen an, um Ressourcen zu finden"
+  }
+}

--- a/apps/frontend/src/app/resourceOverview/noResourcesFound/en.json
+++ b/apps/frontend/src/app/resourceOverview/noResourcesFound/en.json
@@ -1,0 +1,6 @@
+{
+  "alert": {
+    "title": "No resources found",
+    "description": "Adjust your search or the filter-options to find resources"
+  }
+}

--- a/apps/frontend/src/app/resourceOverview/noResourcesFound/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/noResourcesFound/index.tsx
@@ -1,0 +1,19 @@
+import { Alert } from '@heroui/react';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+
+import de from './de.json';
+import en from './en.json';
+
+export function NoResourcesFound() {
+  const { t } = useTranslations('resourceOverview.noResourcesFound', {
+    de,
+    en,
+  });
+  return (
+    <div>
+      <Alert color="warning" title={t('alert.title')}>
+        {t('alert.description')}
+      </Alert>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/de.json
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/de.json
@@ -5,9 +5,5 @@
     "image": "Bild",
     "name": "Name",
     "status": "Status"
-  },
-  "empty": {
-    "title": "Keine Ressourcen gefunden",
-    "description": "Passe deine Suche an, um Ressourcen zu finden"
   }
 }

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/en.json
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/en.json
@@ -5,9 +5,5 @@
     "image": "Image",
     "name": "Name",
     "status": "Status"
-  },
-  "empty": {
-    "title": "No resources found",
-    "description": "Adjust your search to find resources"
   }
 }

--- a/apps/frontend/src/app/resourceOverview/toolbar/filter/de.json
+++ b/apps/frontend/src/app/resourceOverview/toolbar/filter/de.json
@@ -3,7 +3,8 @@
     "title": "Filtere Ressourcen",
     "options": {
       "onlyInUseByMe": "ist in Verwendung durch mich",
-      "onlyWithPermissions": "ich bin bereits Eingewiesen / Berechtigt"
+      "onlyWithPermissions": "ich bin bereits Eingewiesen / Berechtigt",
+      "hideEmptyResourceGroups": "leere Ressourcengruppen ausblenden"
     }
   }
 }

--- a/apps/frontend/src/app/resourceOverview/toolbar/filter/en.json
+++ b/apps/frontend/src/app/resourceOverview/toolbar/filter/en.json
@@ -3,7 +3,8 @@
     "title": "Filter",
     "options": {
       "onlyInUseByMe": "is in use by me",
-      "onlyWithPermissions": "I am already introduced / authorized"
+      "onlyWithPermissions": "I am already introduced / authorized",
+      "hideEmptyResourceGroups": "Hide empty resource groups"
     }
   }
 }

--- a/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
@@ -34,6 +34,12 @@ export function ResourceFilter(props: Props & Omit<FilterProps, 'onSearchChanged
             >
               {t('drawer.options.onlyWithPermissions')}
             </Switch>
+            <Switch
+              isSelected={filterProps.hideEmptyResourceGroups}
+              onValueChange={filterProps.onHideEmptyResourceGroupsChanged}
+            >
+              {t('drawer.options.hideEmptyResourceGroups')}
+            </Switch>
           </DrawerBody>
         </DrawerContent>
       </Drawer>

--- a/apps/frontend/src/app/resourceOverview/toolbar/toolbar.tsx
+++ b/apps/frontend/src/app/resourceOverview/toolbar/toolbar.tsx
@@ -6,18 +6,25 @@ import { useAuth } from '../../../hooks/useAuth';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { ResourceEditModal } from '../../resources/editModal/resourceEditModal';
 import { useNavigate } from 'react-router-dom';
-
 import * as en from './toolbar.en.json';
 import * as de from './toolbar.de.json';
 import { ResourceScanner } from './scanner';
 import { ResourceFilter } from './filter';
 import { FilterProps } from '../filterProps';
+import { cn } from '@heroui/react';
 
 interface ToolbarProps {
   searchIsLoading?: boolean;
+  highlightSearch?: boolean;
+  highlightFilter?: boolean;
 }
 
-export function Toolbar({ searchIsLoading, ...filterProps }: Readonly<ToolbarProps & FilterProps>) {
+export function Toolbar({
+  searchIsLoading,
+  highlightSearch,
+  highlightFilter,
+  ...filterProps
+}: Readonly<ToolbarProps & FilterProps>) {
   const { hasPermission } = useAuth();
   const canManageResources = hasPermission('canManageResources');
   const navigate = useNavigate();
@@ -36,7 +43,8 @@ export function Toolbar({ searchIsLoading, ...filterProps }: Readonly<ToolbarPro
             value={filterProps.search}
             onChange={(e) => filterProps.onSearchChanged(e.target.value)}
             placeholder={t('searchPlaceholder')}
-            className={` ${searchIsLoading ? 'animate-pulse' : ''}`}
+            className={cn((searchIsLoading || highlightSearch) && 'animate-pulse')}
+            color={highlightSearch ? 'danger' : undefined}
             startContent={
               <>
                 <ResourceFilter
@@ -44,13 +52,16 @@ export function Toolbar({ searchIsLoading, ...filterProps }: Readonly<ToolbarPro
                   onOnlyInUseByMeChanged={filterProps.onOnlyInUseByMeChanged}
                   onlyWithPermissions={filterProps.onlyWithPermissions}
                   onOnlyWithPermissionsChanged={filterProps.onOnlyWithPermissionsChanged}
+                  hideEmptyResourceGroups={filterProps.hideEmptyResourceGroups}
+                  onHideEmptyResourceGroupsChanged={filterProps.onHideEmptyResourceGroupsChanged}
                 >
                   {({ onOpen }) => (
                     <Button
                       size="sm"
                       variant="light"
-                      startContent={<ListFilterIcon size={18} />}
+                      startContent={<ListFilterIcon size={18} className={cn(highlightFilter && 'animate-pulse')} />}
                       isIconOnly
+                      color={highlightFilter ? 'danger' : undefined}
                       onPress={onOpen}
                     />
                   )}
@@ -76,7 +87,7 @@ export function Toolbar({ searchIsLoading, ...filterProps }: Readonly<ToolbarPro
       <div className="flex flex-row gap-2 justify-end mb-6">
         {canManageResources && (
           <div className="flex items-center gap-2 mr-1 hidden md:flex">
-            <ResourceGroupUpsertModal>
+            <ResourceGroupUpsertModal onUpserted={(resourceGroup) => navigate(`/resource-groups/${resourceGroup.id}`)}>
               {(onOpen: () => void) => (
                 <Button
                   radius="full"


### PR DESCRIPTION
…es that your search is not resulting any resources

## Summary by Sourcery

Enable immediate navigation to a newly created group, allow users to hide empty groups, and provide clear visual feedback when searches return no resources while simplifying related components

New Features:
- Automatically open and navigate to a newly created resource group upon creation
- Add a "Hide empty resource groups" toggle in the toolbar, persisted in local storage
- Introduce a warning alert component when no resources are found

Enhancements:
- Simplify ResourceGroupCard by removing special empty-group handling and adding a hideIfEmpty prop
- Highlight the search input and filter button with a pulsing animation and danger color when a search yields no results
- Centralise persisted filter keys using an enum and update filterProps interfaces