### PR TITLE
fix(ATT-20): add missing translating for signingIn (login button in p…

### DIFF
--- a/apps/frontend/src/app/unauthorized/loginForm.de.json
+++ b/apps/frontend/src/app/unauthorized/loginForm.de.json
@@ -11,5 +11,6 @@
   "error": {
     "title": "Hoppla! Kleines Anmeldeproblem",
     "generic": "Bitte überprüfe deine Anmeldedaten und versuche es erneut"
-  }
+  },
+  "signingIn": "Anmelden..."
 }

--- a/apps/frontend/src/app/unauthorized/loginForm.en.json
+++ b/apps/frontend/src/app/unauthorized/loginForm.en.json
@@ -11,5 +11,6 @@
   "error": {
     "title": "Oops! Sign-in hiccup",
     "generic": "Please check your credentials and try again"
-  }
+  },
+  "signingIn": "Signing in..."
 }


### PR DESCRIPTION
…rogress label)

## Summary by Sourcery

Add missing translation entries for the signingIn progress label on the login button in both English and German locales

Bug Fixes:
- Add 'signingIn' translation key to loginForm.en.json
- Add 'signingIn' translation key to loginForm.de.json