### PR TITLE
Att-14 cannot change own password in backend

### DIFF
--- a/apps/frontend/src/app/account/de.json
+++ b/apps/frontend/src/app/account/de.json
@@ -1,0 +1,7 @@
+{
+  "title": "Konto",
+  "sections": {
+    "profile": "Profil",
+    "security": "Sicherheit"
+  }
+}

--- a/apps/frontend/src/app/account/en.json
+++ b/apps/frontend/src/app/account/en.json
@@ -1,0 +1,7 @@
+{
+  "title": "Account",
+  "sections": {
+    "profile": "Profile",
+    "security": "Security"
+  }
+}

--- a/apps/frontend/src/app/account/username/de.json
+++ b/apps/frontend/src/app/account/username/de.json
@@ -5,5 +5,11 @@
   "errors": {
     "updateFailed": "Aktualisierung des Benutzernamens fehlgeschlagen",
     "oncePerDay": "Der Benutzername kann nur einmal pro Tag geändert werden"
+  },
+  "username": {
+    "label": "Benutzername"
+  },
+  "actions": {
+    "save": "Speichern"
   }
 }

--- a/apps/frontend/src/app/account/username/en.json
+++ b/apps/frontend/src/app/account/username/en.json
@@ -5,5 +5,11 @@
   "errors": {
     "updateFailed": "Failed to update username",
     "oncePerDay": "Username can only be changed once per day"
+  },
+  "username": {
+    "label": "Username"
+  },
+  "actions": {
+    "save": "Save"
   }
 }

--- a/apps/frontend/src/app/account/username/index.tsx
+++ b/apps/frontend/src/app/account/username/index.tsx
@@ -1,0 +1,68 @@
+import {
+  ApiError,
+  useUsersServiceChangeMyUsername,
+  useUsersServiceGetCurrent,
+  useUsersServiceGetCurrentKey,
+} from '@attraccess/react-query-client';
+import { Button, Input } from '@heroui/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+import { useToastMessage } from '../../../components/toastProvider';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import * as en from './en.json';
+import * as de from './de.json';
+
+export function UsernameForm() {
+  const { t } = useTranslations('account.username', { en, de });
+
+  const { data: me, isLoading: isLoadingMe } = useUsersServiceGetCurrent();
+  const [username, setUsername] = useState('');
+  const queryClient = useQueryClient();
+  const { success: showSuccess, error: showError } = useToastMessage();
+
+  useEffect(() => {
+    if (me?.username) setUsername(me.username);
+  }, [me?.username]);
+
+  const { mutate, isPending } = useUsersServiceChangeMyUsername({
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [useUsersServiceGetCurrentKey],
+      });
+      showSuccess({ title: t('messages.updated') });
+    },
+    onError: (rawError) => {
+      let messageToDisplay = t('errors.updateFailed');
+      if (rawError instanceof ApiError) {
+        const body = rawError.body as { message?: string | string[] } | undefined;
+        const msg = Array.isArray(body?.message) ? body?.message[0] : body?.message;
+        if (typeof msg === 'string' && msg.trim().length > 0) {
+          const lower = msg.toLowerCase();
+          if (lower.includes('once per day')) {
+            messageToDisplay = t('errors.oncePerDay');
+          } else {
+            messageToDisplay = msg;
+          }
+        }
+      } else if (rawError instanceof Error && rawError.message) {
+        messageToDisplay = rawError.message;
+      }
+      showError({ title: messageToDisplay });
+    },
+  });
+
+  const onSubmit = useCallback(() => {
+    mutate({
+      requestBody: { username },
+    });
+  }, [mutate, username]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Input label={t('username.label')} value={username} onValueChange={setUsername} isDisabled={isLoadingMe} />
+      <Button isLoading={isPending} onPress={onSubmit} color="primary">
+        {t('actions.save')}
+      </Button>
+    </div>
+  );
+}

--- a/libs/react-query-client/src/lib/requests/services.gen.ts
+++ b/libs/react-query-client/src/lib/requests/services.gen.ts
@@ -116,7 +116,7 @@ export class UsersService {
     public static changePasswordViaResetToken(data: ChangePasswordViaResetTokenData): CancelablePromise<ChangePasswordViaResetTokenResponse> {
         return __request(OpenAPI, {
             method: 'POST',
-            url: '/api/users/{userId}/change-password',
+            url: '/api/users/{userId}/change-password-by-token',
             path: {
                 userId: data.userId
             },
@@ -289,7 +289,7 @@ export class UsersService {
     public static setUserPassword(data: SetUserPasswordData): CancelablePromise<SetUserPasswordResponse> {
         return __request(OpenAPI, {
             method: 'POST',
-            url: '/api/users/{id}/set-password',
+            url: '/api/users/{id}/password',
             path: {
                 id: data.id
             },
@@ -298,7 +298,6 @@ export class UsersService {
             errors: {
                 400: 'Invalid input data.',
                 401: 'Unauthorized',
-                403: 'Forbidden - User does not have permission to manage users.',
                 404: 'User not found.'
             }
         });

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -2466,7 +2466,7 @@ export type $OpenApiTs = {
             };
         };
     };
-    '/api/users/{userId}/change-password': {
+    '/api/users/{userId}/change-password-by-token': {
         post: {
             req: ChangePasswordViaResetTokenData;
             res: {
@@ -2627,7 +2627,7 @@ export type $OpenApiTs = {
             };
         };
     };
-    '/api/users/{id}/set-password': {
+    '/api/users/{id}/password': {
         post: {
             req: SetUserPasswordData;
             res: {
@@ -2645,10 +2645,6 @@ export type $OpenApiTs = {
                  * Unauthorized
                  */
                 401: unknown;
-                /**
-                 * Forbidden - User does not have permission to manage users.
-                 */
-                403: unknown;
                 /**
                  * User not found.
                  */

--- a/nx.json
+++ b/nx.json
@@ -20,7 +20,6 @@
     "swagger": ["default", "{projectRoot}/webpack.config.swagger.js"],
     "typeorm": ["default", "{projectRoot}/src/database/**/*"]
   },
-  "neverConnectToCloud": false,
   "tui": { "enabled": false },
   "plugins": [
     {
@@ -146,9 +145,8 @@
       "git": {
         "commitMessage": "chore(release): {version} [skip ci]"
       }
-    },
-    "#projects": ["apps/*", "libs/*", "!apps/attractap-firmware", "!apps/attractap-touch-firmware"],
-    "#projectsRelationship": "independent"
+    }
   },
-  "nxCloudId": "688bc2bf431a85dc91337685"
+  "not_nxCloudId": "688bc2bf431a85dc91337685",
+  "neverConnectToCloud": true
 }


### PR DESCRIPTION
## Summary by Sourcery

Restructure the account management flow to separate username updates and introduce a self-service password change form, update corresponding backend endpoints and permission checks, and synchronize client SDK and workspace configuration.

New Features:
- Add SetPasswordForm component to the account page enabling users to change their own password.

Enhancements:
- Refactor AccountPage to use useAuth hook and move username update logic into a dedicated UsernameForm component.
- Rename backend routes: change-password → change-password-by-token and set-password → password, and adjust permission logic to prevent unauthorized password changes.
- Update generated react-query client types and service methods to match the renamed API endpoints.

Build:
- Update nx.json to disable cloud connection by setting neverConnectToCloud to true.

Documentation:
- Reorganize frontend translation files under account/username directory.