### PR TITLE
fix: ci build failed for attractap firmware

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PlatformIO Core
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio esptool
+          platformio --version
+
       - name: Run everything
         env:
           NODE_ENV: production


### PR DESCRIPTION
## Summary by Sourcery

Fix CI build failures in the firmware release workflow by installing Python and PlatformIO dependencies

CI:
- Add Python 3.12 setup step using actions/setup-python
- Install and verify PlatformIO Core along with pip, esptool, and dependencies