### PR TITLE
Fix/ci build attractap firmware

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,17 +176,16 @@ jobs:
     needs: build-test
     runs-on: ubuntu-latest
     steps:
-      - uses: pnpm/action-setup@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      # Cache node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: v22.18.0
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
 
       # Download build artifacts - Updated path to ensure dist directory structure is preserved
       - name: Download build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PlatformIO Core
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio esptool
+          platformio --version
+
       - name: Run everything
         env:
           NODE_ENV: production


### PR DESCRIPTION
## Summary by Sourcery

Enhance the GitHub Actions release workflow to support building Attractap firmware by adding Python and PlatformIO setup and reorganizing steps

CI:
- Set up Python 3.12 and install PlatformIO core (with esptool) in the release job
- Reorder build-test job to checkout the repository before setting up pnpm