### PR TITLE
fix(ATT-74): introducers of a group can introduce to single resources…

### DIFF
--- a/apps/api/src/common/request-transformers.ts
+++ b/apps/api/src/common/request-transformers.ts
@@ -27,9 +27,9 @@ export const ToBoolean = () => {
   };
 };
 
-const valueToBoolean = (value: unknown) => {
+export const valueToBoolean = (value: unknown): boolean | undefined => {
   if (value === null || value === undefined) {
-    return value;
+    return value as undefined;
   }
 
   if (typeof value === 'boolean') {

--- a/apps/api/src/resources/introducers/resourceIntroducers.controller.ts
+++ b/apps/api/src/resources/introducers/resourceIntroducers.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, Param, ParseIntPipe, Post } from '@nestjs/common';
+import { Controller, Delete, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ResourceIntroducersService } from './resourceIntroducers.service';
 import { ResourceIntroducer } from '@attraccess/database-entities';
@@ -22,10 +22,13 @@ export class ResourceIntroducersController {
   })
   async isIntroducer(
     @Param('resourceId', ParseIntPipe) resourceId: number,
-    @Param('userId', ParseIntPipe) userId: number
+    @Param('userId', ParseIntPipe) userId: number,
+    @Query('includeGroups') includeGroups: boolean
   ): Promise<IsResourceIntroducerResponseDto> {
+    const isResourceIntroducer = await this.resourceIntroducersService.isIntroducer(resourceId, userId, includeGroups);
+
     return {
-      isIntroducer: await this.resourceIntroducersService.isIntroducer(resourceId, userId),
+      isIntroducer: isResourceIntroducer,
     };
   }
 

--- a/apps/api/src/resources/introductions/resourceIntroductions.module.ts
+++ b/apps/api/src/resources/introductions/resourceIntroductions.module.ts
@@ -7,9 +7,13 @@ import {
   ResourceIntroductionHistoryItem,
 } from '@attraccess/database-entities';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ResourceIntroducersModule } from '../introducers/resourceIntroducers.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ResourceIntroduction, ResourceIntroducer, ResourceIntroductionHistoryItem])],
+  imports: [
+    TypeOrmModule.forFeature([ResourceIntroduction, ResourceIntroducer, ResourceIntroductionHistoryItem]),
+    ResourceIntroducersModule,
+  ],
   controllers: [ResourceIntroductionsController],
   providers: [ResourceIntroductionsService],
   exports: [ResourceIntroductionsService],

--- a/apps/api/src/resources/usage/resourceUsage.service.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.ts
@@ -50,7 +50,7 @@ export class ResourceUsageService {
       return true;
     }
 
-    if (await this.resourceIntroducersService.isIntroducer(resourceId, user.id)) {
+    if (await this.resourceIntroducersService.isIntroducer(resourceId, user.id, true)) {
       this.logger.debug(`User ${user.id} is an introducer for resource ${resourceId}`);
       return true;
     }
@@ -59,11 +59,6 @@ export class ResourceUsageService {
     for (const group of groupsOfResource) {
       if (await this.resourceGroupsIntroductionsService.hasValidIntroduction({ groupId: group.id, userId: user.id })) {
         this.logger.debug(`User ${user.id} has valid group introduction for resource ${resourceId}`);
-        return true;
-      }
-
-      if (await this.resourceGroupsIntroducersService.isIntroducer({ groupId: group.id, userId: user.id })) {
-        this.logger.debug(`User ${user.id} is a group introducer for resource ${resourceId}`);
         return true;
       }
     }

--- a/apps/frontend/src/app/resources/details/resourceDetails.tsx
+++ b/apps/frontend/src/app/resources/details/resourceDetails.tsx
@@ -10,7 +10,7 @@ import { ResourceUsageHistory } from '../usage/resourceUsageHistory';
 import { PageHeader } from '../../../components/pageHeader';
 import { DeleteConfirmationModal } from '../../../components/deleteConfirmationModal';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import {
   useResourcesServiceDeleteOneResource,
   useResourcesServiceGetOneResourceById,
@@ -49,20 +49,16 @@ function ResourceDetailsComponent() {
     de,
   });
 
-  const { data: isIntroducer } = useAccessControlServiceResourceIntroducersIsIntroducer(
-    { resourceId, userId: user?.id as number },
-    undefined,
-    {
-      enabled: !!user?.id,
-      refetchInterval: 3000,
-    }
-  );
-
   const canManageResources = hasPermission('canManageResources');
 
-  const canManageIntroductions = useMemo(
-    () => canManageResources || isIntroducer?.isIntroducer,
-    [canManageResources, isIntroducer]
+  const { data: isIntroducer } = useAccessControlServiceResourceIntroducersIsIntroducer(
+    {
+      resourceId,
+      userId: user?.id as number,
+      includeGroups: true,
+    },
+    undefined,
+    { enabled: !!user?.id }
   );
 
   const {
@@ -206,7 +202,7 @@ function ResourceDetailsComponent() {
       {/* Add the ManageResourceGroups component */}
 
       <div className="flex flex-row flex-wrap w-full gap-6 items-stretch">
-        {canManageIntroductions && (
+        {isIntroducer?.isIntroducer && (
           <ResourceIntroductionsManagement
             resourceId={resourceId}
             className="flex-1 min-w-80"

--- a/libs/api-client/src/generated/Api.ts
+++ b/libs/api-client/src/generated/Api.ts
@@ -1981,6 +1981,12 @@ export type ResourceUsageGetActiveSessionData = GetActiveUsageSessionDto;
 
 export type ResourceUsageCanControlData = CanControlResponseDto;
 
+export interface ResourceIntroducersIsIntroducerParams {
+  includeGroups: boolean;
+  resourceId: number;
+  userId: number;
+}
+
 export type ResourceIntroducersIsIntroducerData =
   IsResourceIntroducerResponseDto;
 
@@ -3457,7 +3463,9 @@ export namespace AccessControl {
       resourceId: number;
       userId: number;
     };
-    export type RequestQuery = {};
+    export type RequestQuery = {
+      includeGroups: boolean;
+    };
     export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = ResourceIntroducersIsIntroducerData;
@@ -5843,13 +5851,13 @@ export class Api<
      * @request GET:/api/resources/{resourceId}/introducers/{userId}/is-introducer
      */
     resourceIntroducersIsIntroducer: (
-      resourceId: number,
-      userId: number,
+      { resourceId, userId, ...query }: ResourceIntroducersIsIntroducerParams,
       params: RequestParams = {},
     ) =>
       this.request<ResourceIntroducersIsIntroducerData, any>({
         path: `/api/resources/${resourceId}/introducers/${userId}/is-introducer`,
         method: "GET",
+        query: query,
         format: "json",
         ...params,
       }),

--- a/libs/react-query-client/src/lib/queries/common.ts
+++ b/libs/react-query-client/src/lib/queries/common.ts
@@ -209,10 +209,11 @@ export const UseAccessControlServiceResourceGroupIntroducersIsIntroducerKeyFn = 
 export type AccessControlServiceResourceIntroducersIsIntroducerDefaultResponse = Awaited<ReturnType<typeof AccessControlService.resourceIntroducersIsIntroducer>>;
 export type AccessControlServiceResourceIntroducersIsIntroducerQueryResult<TData = AccessControlServiceResourceIntroducersIsIntroducerDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useAccessControlServiceResourceIntroducersIsIntroducerKey = "AccessControlServiceResourceIntroducersIsIntroducer";
-export const UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn = ({ resourceId, userId }: {
+export const UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn = ({ includeGroups, resourceId, userId }: {
+  includeGroups: boolean;
   resourceId: number;
   userId: number;
-}, queryKey?: Array<unknown>) => [useAccessControlServiceResourceIntroducersIsIntroducerKey, ...(queryKey ?? [{ resourceId, userId }])];
+}, queryKey?: Array<unknown>) => [useAccessControlServiceResourceIntroducersIsIntroducerKey, ...(queryKey ?? [{ includeGroups, resourceId, userId }])];
 export type AccessControlServiceResourceIntroducersGetManyDefaultResponse = Awaited<ReturnType<typeof AccessControlService.resourceIntroducersGetMany>>;
 export type AccessControlServiceResourceIntroducersGetManyQueryResult<TData = AccessControlServiceResourceIntroducersGetManyDefaultResponse, TError = unknown> = UseQueryResult<TData, TError>;
 export const useAccessControlServiceResourceIntroducersGetManyKey = "AccessControlServiceResourceIntroducersGetMany";

--- a/libs/react-query-client/src/lib/queries/ensureQueryData.ts
+++ b/libs/react-query-client/src/lib/queries/ensureQueryData.ts
@@ -108,10 +108,11 @@ export const ensureUseAccessControlServiceResourceGroupIntroducersIsIntroducerDa
   groupId: number;
   userId: number;
 }) => queryClient.ensureQueryData({ queryKey: Common.UseAccessControlServiceResourceGroupIntroducersIsIntroducerKeyFn({ groupId, userId }), queryFn: () => AccessControlService.resourceGroupIntroducersIsIntroducer({ groupId, userId }) });
-export const ensureUseAccessControlServiceResourceIntroducersIsIntroducerData = (queryClient: QueryClient, { resourceId, userId }: {
+export const ensureUseAccessControlServiceResourceIntroducersIsIntroducerData = (queryClient: QueryClient, { includeGroups, resourceId, userId }: {
+  includeGroups: boolean;
   resourceId: number;
   userId: number;
-}) => queryClient.ensureQueryData({ queryKey: Common.UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn({ resourceId, userId }), queryFn: () => AccessControlService.resourceIntroducersIsIntroducer({ resourceId, userId }) });
+}) => queryClient.ensureQueryData({ queryKey: Common.UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn({ includeGroups, resourceId, userId }), queryFn: () => AccessControlService.resourceIntroducersIsIntroducer({ includeGroups, resourceId, userId }) });
 export const ensureUseAccessControlServiceResourceIntroducersGetManyData = (queryClient: QueryClient, { resourceId }: {
   resourceId: number;
 }) => queryClient.ensureQueryData({ queryKey: Common.UseAccessControlServiceResourceIntroducersGetManyKeyFn({ resourceId }), queryFn: () => AccessControlService.resourceIntroducersGetMany({ resourceId }) });

--- a/libs/react-query-client/src/lib/queries/prefetch.ts
+++ b/libs/react-query-client/src/lib/queries/prefetch.ts
@@ -108,10 +108,11 @@ export const prefetchUseAccessControlServiceResourceGroupIntroducersIsIntroducer
   groupId: number;
   userId: number;
 }) => queryClient.prefetchQuery({ queryKey: Common.UseAccessControlServiceResourceGroupIntroducersIsIntroducerKeyFn({ groupId, userId }), queryFn: () => AccessControlService.resourceGroupIntroducersIsIntroducer({ groupId, userId }) });
-export const prefetchUseAccessControlServiceResourceIntroducersIsIntroducer = (queryClient: QueryClient, { resourceId, userId }: {
+export const prefetchUseAccessControlServiceResourceIntroducersIsIntroducer = (queryClient: QueryClient, { includeGroups, resourceId, userId }: {
+  includeGroups: boolean;
   resourceId: number;
   userId: number;
-}) => queryClient.prefetchQuery({ queryKey: Common.UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn({ resourceId, userId }), queryFn: () => AccessControlService.resourceIntroducersIsIntroducer({ resourceId, userId }) });
+}) => queryClient.prefetchQuery({ queryKey: Common.UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn({ includeGroups, resourceId, userId }), queryFn: () => AccessControlService.resourceIntroducersIsIntroducer({ includeGroups, resourceId, userId }) });
 export const prefetchUseAccessControlServiceResourceIntroducersGetMany = (queryClient: QueryClient, { resourceId }: {
   resourceId: number;
 }) => queryClient.prefetchQuery({ queryKey: Common.UseAccessControlServiceResourceIntroducersGetManyKeyFn({ resourceId }), queryFn: () => AccessControlService.resourceIntroducersGetMany({ resourceId }) });

--- a/libs/react-query-client/src/lib/queries/queries.ts
+++ b/libs/react-query-client/src/lib/queries/queries.ts
@@ -109,10 +109,11 @@ export const useAccessControlServiceResourceGroupIntroducersIsIntroducer = <TDat
   groupId: number;
   userId: number;
 }, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseAccessControlServiceResourceGroupIntroducersIsIntroducerKeyFn({ groupId, userId }, queryKey), queryFn: () => AccessControlService.resourceGroupIntroducersIsIntroducer({ groupId, userId }) as TData, ...options });
-export const useAccessControlServiceResourceIntroducersIsIntroducer = <TData = Common.AccessControlServiceResourceIntroducersIsIntroducerDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ resourceId, userId }: {
+export const useAccessControlServiceResourceIntroducersIsIntroducer = <TData = Common.AccessControlServiceResourceIntroducersIsIntroducerDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ includeGroups, resourceId, userId }: {
+  includeGroups: boolean;
   resourceId: number;
   userId: number;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn({ resourceId, userId }, queryKey), queryFn: () => AccessControlService.resourceIntroducersIsIntroducer({ resourceId, userId }) as TData, ...options });
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn({ includeGroups, resourceId, userId }, queryKey), queryFn: () => AccessControlService.resourceIntroducersIsIntroducer({ includeGroups, resourceId, userId }) as TData, ...options });
 export const useAccessControlServiceResourceIntroducersGetMany = <TData = Common.AccessControlServiceResourceIntroducersGetManyDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ resourceId }: {
   resourceId: number;
 }, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useQuery<TData, TError>({ queryKey: Common.UseAccessControlServiceResourceIntroducersGetManyKeyFn({ resourceId }, queryKey), queryFn: () => AccessControlService.resourceIntroducersGetMany({ resourceId }) as TData, ...options });

--- a/libs/react-query-client/src/lib/queries/suspense.ts
+++ b/libs/react-query-client/src/lib/queries/suspense.ts
@@ -108,10 +108,11 @@ export const useAccessControlServiceResourceGroupIntroducersIsIntroducerSuspense
   groupId: number;
   userId: number;
 }, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseAccessControlServiceResourceGroupIntroducersIsIntroducerKeyFn({ groupId, userId }, queryKey), queryFn: () => AccessControlService.resourceGroupIntroducersIsIntroducer({ groupId, userId }) as TData, ...options });
-export const useAccessControlServiceResourceIntroducersIsIntroducerSuspense = <TData = Common.AccessControlServiceResourceIntroducersIsIntroducerDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ resourceId, userId }: {
+export const useAccessControlServiceResourceIntroducersIsIntroducerSuspense = <TData = Common.AccessControlServiceResourceIntroducersIsIntroducerDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ includeGroups, resourceId, userId }: {
+  includeGroups: boolean;
   resourceId: number;
   userId: number;
-}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn({ resourceId, userId }, queryKey), queryFn: () => AccessControlService.resourceIntroducersIsIntroducer({ resourceId, userId }) as TData, ...options });
+}, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseAccessControlServiceResourceIntroducersIsIntroducerKeyFn({ includeGroups, resourceId, userId }, queryKey), queryFn: () => AccessControlService.resourceIntroducersIsIntroducer({ includeGroups, resourceId, userId }) as TData, ...options });
 export const useAccessControlServiceResourceIntroducersGetManySuspense = <TData = Common.AccessControlServiceResourceIntroducersGetManyDefaultResponse, TError = unknown, TQueryKey extends Array<unknown> = unknown[]>({ resourceId }: {
   resourceId: number;
 }, queryKey?: TQueryKey, options?: Omit<UseQueryOptions<TData, TError>, "queryKey" | "queryFn">) => useSuspenseQuery<TData, TError>({ queryKey: Common.UseAccessControlServiceResourceIntroducersGetManyKeyFn({ resourceId }, queryKey), queryFn: () => AccessControlService.resourceIntroducersGetMany({ resourceId }) as TData, ...options });

--- a/libs/react-query-client/src/lib/requests/services.gen.ts
+++ b/libs/react-query-client/src/lib/requests/services.gen.ts
@@ -1452,6 +1452,7 @@ export class AccessControlService {
      * @param data The data for the request.
      * @param data.resourceId
      * @param data.userId
+     * @param data.includeGroups
      * @returns IsResourceIntroducerResponseDto User is an introducer for the resource
      * @throws ApiError
      */
@@ -1462,6 +1463,9 @@ export class AccessControlService {
             path: {
                 resourceId: data.resourceId,
                 userId: data.userId
+            },
+            query: {
+                includeGroups: data.includeGroups
             }
         });
     }

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -2181,6 +2181,7 @@ export type ResourceGroupIntroducersRevokeData = {
 export type ResourceGroupIntroducersRevokeResponse = unknown;
 
 export type ResourceIntroducersIsIntroducerData = {
+    includeGroups: boolean;
     resourceId: number;
     userId: number;
 };


### PR DESCRIPTION
… of that group

## Summary by Sourcery

Enable group introducers to introduce to single resources by adding an includeGroups flag across the isIntroducer endpoint, service logic, frontend hooks, and API client, and refactor guards and UI checks for consistency.

New Features:
- Extend the isIntroducer endpoint with an includeGroups query parameter to allow group introducers to act as introducers for individual resources
- Update frontend and react-query hooks to pass includeGroups flag when checking introducer status

Enhancements:
- Refactor IsResourceIntroducerGuard to use ResourceIntroducersService instead of direct repository access
- Simplify UI logic by removing polling and system permissions check for introducer management

Chores:
- Update generated API client types and service calls to include the includeGroups parameter
- Export the valueToBoolean helper with an explicit boolean | undefined return type