### PR TITLE
fix(ATT-71): mqtt edit page works again, removed no longer existing r…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pnpm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/apps/api/src/mqtt/servers/mqtt-server.service.ts
+++ b/apps/api/src/mqtt/servers/mqtt-server.service.ts
@@ -2,10 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { MqttServer } from '@attraccess/database-entities';
-import {
-  CreateMqttServerDto,
-  UpdateMqttServerDto,
-} from './dtos/mqtt-server.dto';
+import { CreateMqttServerDto, UpdateMqttServerDto } from './dtos/mqtt-server.dto';
 
 @Injectable()
 export class MqttServerService {
@@ -27,7 +24,6 @@ export class MqttServerService {
   async findOne(id: number): Promise<MqttServer> {
     const server = await this.mqttServerRepository.findOne({
       where: { id },
-      relations: ['resourceConfigs'],
     });
 
     if (!server) {
@@ -48,10 +44,7 @@ export class MqttServerService {
   /**
    * Update an existing MQTT server
    */
-  async update(
-    id: number,
-    updateMqttServerDto: UpdateMqttServerDto
-  ): Promise<MqttServer> {
+  async update(id: number, updateMqttServerDto: UpdateMqttServerDto): Promise<MqttServer> {
     const server = await this.findOne(id);
 
     // Update the server with the new values


### PR DESCRIPTION
…elation from db query

## Summary by Sourcery

Remove outdated relation from MQTT server queries and apply minor formatting cleanups to restore edit functionality

Bug Fixes:
- Remove non-existent 'resourceConfigs' relation from findOne query to fix the MQTT edit page

Enhancements:
- Consolidate import statement formatting
- Normalize method signature formatting in update function