### PR TITLE
fix(ATT-72): use select component correctly and use correct translati…

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/nodes/http/sendRequest/de.json
+++ b/apps/frontend/src/app/resources/details/flows/nodes/http/sendRequest/de.json
@@ -2,12 +2,7 @@
   "editor": {
     "inputs": {
       "url": {
-        "origin": {
-          "label": "Origin"
-        },
-        "pathname": {
-          "label": "Pfad"
-        }
+        "label": "URL"
       },
       "method": {
         "label": "Methode"

--- a/apps/frontend/src/app/resources/details/flows/nodes/http/sendRequest/en.json
+++ b/apps/frontend/src/app/resources/details/flows/nodes/http/sendRequest/en.json
@@ -2,12 +2,7 @@
   "editor": {
     "inputs": {
       "url": {
-        "origin": {
-          "label": "Origin"
-        },
-        "pathname": {
-          "label": "Pathname"
-        }
+        "label": "URL"
       },
       "method": {
         "label": "Method"

--- a/apps/frontend/src/app/resources/details/flows/nodes/http/sendRequest/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/nodes/http/sendRequest/index.tsx
@@ -117,6 +117,10 @@ export function HTTPRequestNode(
     return new URL(urlString);
   }, [node?.data.url]);
 
+  const selectionToSet = useCallback((selection: string) => {
+    return new Set(selection ? [selection] : []);
+  }, []);
+
   return (
     <BaseNodeCard
       title={t('nodes.output.http.sendRequest.title')}
@@ -129,7 +133,7 @@ export function HTTPRequestNode(
       <div className="flex flex-col gap-2">
         <Input label={t('editor.inputs.method.label')} isReadOnly value={node?.data.method as string} />
         <Input
-          label={t('editor.inputs.url.origin.label')}
+          label={t('editor.inputs.url.label')}
           isReadOnly
           value={urlObject?.origin}
           title={urlObject?.toString()}
@@ -149,16 +153,11 @@ export function HTTPRequestNode(
             <Input label={t('editor.inputs.url.label')} value={url} onChange={(e) => setUrl(e.target.value)} />
             <Select
               label={t('editor.inputs.method.label')}
-              selectedKeys={method}
-              onChange={(e) => setMethod(e.target.value)}
+              items={['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'].map((i) => ({ method: i }))}
+              selectedKeys={selectionToSet(method)}
+              onSelectionChange={(keys) => setMethod((keys as Set<string>).values().next().value as string)}
             >
-              <SelectItem key="GET">GET</SelectItem>
-              <SelectItem key="POST">POST</SelectItem>
-              <SelectItem key="PUT">PUT</SelectItem>
-              <SelectItem key="PATCH">PATCH</SelectItem>
-              <SelectItem key="DELETE">DELETE</SelectItem>
-              <SelectItem key="HEAD">HEAD</SelectItem>
-              <SelectItem key="OPTIONS">OPTIONS</SelectItem>
+              {(item) => <SelectItem key={item.method}>{item.method}</SelectItem>}
             </Select>
 
             <div className="flex flex-col gap-2">


### PR DESCRIPTION
…on keys

## Summary by Sourcery

Fix Select component usage and translation keys in the HTTP request node by introducing a helper to map selections, switching to dynamic method items, and updating the URL label translation key.

Bug Fixes:
- Fix HTTPRequestNode to correctly configure the Select component's selectedKeys and onSelectionChange
- Correct the translation key for the URL input label

Enhancements:
- Add a selectionToSet helper for converting the selected method string into a Set
- Replace hardcoded SelectItem components with dynamic item mapping for HTTP methods