### PR TITLE
feat(ATT-76): allow introducers and managers to stop usage sessions o…

### DIFF
--- a/apps/api/src/resources/usage/resourceUsage.service.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.ts
@@ -227,13 +227,19 @@ export class ResourceUsageService {
 
     this.logger.debug(`Ending session ${activeSession.id} at ${endTime.toISOString()}`);
 
+    let endNotes = dto.notes;
+
+    if (!isSessionOwner) {
+      endNotes = `[By #${user.id} - ${user.username}] ${endNotes ?? ''}`;
+    }
+
     // Update session with end time and notes - using explicit update to avoid the generated column
     await this.resourceUsageRepository
       .createQueryBuilder()
       .update(ResourceUsage)
       .set({
         endTime,
-        endNotes: dto.notes,
+        endNotes,
       })
       .where('id = :id', { id: activeSession.id })
       .execute();

--- a/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/translations/de.json
+++ b/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/translations/de.json
@@ -2,17 +2,34 @@
   "resourceInUseBy": "Ressource wird derzeit verwendet von:",
   "unknownUser": "Unbekannter Benutzer",
   "sessionStarted": "Sitzung gestartet",
-  "takeoverAvailable": "Diese Ressource erlaubt Übernahme. Sie können die aktuelle Sitzung beenden und Ihre eigene starten.",
-  "takeoverResource": "Ressource übernehmen",
-  "takeoverOptionsMenu": {
-    "label": "Alternative Übernahme-Optionen",
-    "takeoverWithNotes": {
-      "label": "Mit Notizen übernehmen",
-      "description": "Aktuelle Sitzung beenden und eigene mit Notizen starten"
-    }
+  "takeover": {
+    "available": "Diese Ressource erlaubt Übernahme. Sie können die aktuelle Sitzung beenden und Ihre eigene starten.",
+    "button": "Ressource übernehmen",
+    "optionsMenu": {
+      "label": "Alternative Übernahme-Optionen",
+      "takeoverWithNotes": {
+        "label": "Mit Notizen übernehmen",
+        "description": "Aktuelle Sitzung beenden und eigene mit Notizen starten"
+      }
+    },
+    "successful": "Ressourcen-Übernahme erfolgreich",
+    "successfulDescription": "Sie haben die Ressource erfolgreich übernommen und eine neue Sitzung gestartet.",
+    "error": "Übernahme fehlgeschlagen",
+    "errorDescription": "Die Übernahme der Ressource ist fehlgeschlagen. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support."
   },
-  "takeoverSuccessful": "Ressourcen-Übernahme erfolgreich",
-  "takeoverSuccessfulDescription": "Sie haben die Ressource erfolgreich übernommen und eine neue Sitzung gestartet.",
-  "takeoverError": "Übernahme fehlgeschlagen",
-  "takeoverErrorDescription": "Die Übernahme der Ressource ist fehlgeschlagen. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support."
+  "stopOverUserSession": {
+    "available": "Als Einführer / Administrator können Sie die Sitzung des anderen Benutzers beenden.",
+    "button": "Andere Benutzer-Sitzung beenden",
+    "optionsMenu": {
+      "label": "Alternative Beendigung-Optionen",
+      "stopOtherUserSessionWithNotes": {
+        "label": "Mit Notizen beenden",
+        "description": "Aktuelle Sitzung mit Notizen beenden"
+      }
+    },
+    "successful": "Andere Benutzer-Sitzung beendet",
+    "successfulDescription": "Sie haben die Sitzung des anderen Benutzers erfolgreich beendet.",
+    "error": "Andere Benutzer-Sitzung beenden fehlgeschlagen",
+    "errorDescription": "Die Sitzung des anderen Benutzers ist fehlgeschlagen. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support."
+  }
 }

--- a/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/translations/en.json
+++ b/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/translations/en.json
@@ -2,17 +2,34 @@
   "resourceInUseBy": "Resource currently in use by:",
   "unknownUser": "Unknown User",
   "sessionStarted": "Session Started",
-  "takeoverAvailable": "This resource allows takeover. You can end the current session and start your own.",
-  "takeoverResource": "Takeover Resource",
-  "takeoverOptionsMenu": {
-    "label": "Alternative takeover options",
-    "takeoverWithNotes": {
-      "label": "Takeover with Notes",
-      "description": "End the current session and start your own with notes"
-    }
+  "takeover": {
+    "available": "This resource allows takeover. You can end the current session and start your own.",
+    "button": "Takeover Resource",
+    "optionsMenu": {
+      "label": "Alternative takeover options",
+      "takeoverWithNotes": {
+        "label": "Takeover with Notes",
+        "description": "End the current session and start your own with notes"
+      }
+    },
+    "successful": "Takeover Successful",
+    "successfulDescription": "You have successfully taken over the resource and started a new session.",
+    "error": "Takeover Failed",
+    "errorDescription": "Failed to takeover the resource. Please try again or contact support."
   },
-  "takeoverSuccessful": "Resource Takeover Successful",
-  "takeoverSuccessfulDescription": "You have successfully taken over the resource and started a new session.",
-  "takeoverError": "Takeover Failed",
-  "takeoverErrorDescription": "Failed to takeover the resource. Please try again or contact support."
+  "stopOtherUserSession": {
+    "available": "As an introducer / administrator, you can end the session of the other user.",
+    "button": "Stop Other User Session",
+    "optionsMenu": {
+      "label": "Alternative stop other user session options",
+      "stopOtherUserSessionWithNotes": {
+        "label": "Stop other user session with Notes",
+        "description": "Stop the current session of the other user and start your own with notes"
+      }
+    },
+    "successful": "Other User Session Stopped",
+    "successfulDescription": "You have successfully stopped the session of the other user.",
+    "error": "Other User Session Stop Failed",
+    "errorDescription": "Failed to stop the session of the other user. Please try again or contact support."
+  }
 }


### PR DESCRIPTION
…f other users

## Summary by Sourcery

Enable authorized roles to terminate and annotate other users’ resource usage sessions by adding corresponding front-end UI controls, expanding backend support for end-of-session notes, and refactoring permission checks and translations.

New Features:
- Allow introducers and users with manage permissions to stop other users' usage sessions
- Add UI buttons for immediately stopping or stopping with notes in the OtherUserSessionDisplay component
- Persist end-of-session notes on the backend with an automatic prefix when stopped by a non-owner

Enhancements:
- Replace manual introducer list fetch with a single permission check API call
- Update translation keys and rename modal state variables for clarity