### PR TITLE
fix: mqtt flow node editor broke because of undefined default server key

### DIFF
--- a/apps/frontend/src/components/mqttServerSelect/index.tsx
+++ b/apps/frontend/src/components/mqttServerSelect/index.tsx
@@ -2,7 +2,7 @@ import { useMqttServiceMqttServersGetAll } from '@attraccess/react-query-client'
 import { Select, Props as SelectProps } from '../select';
 
 interface Props {
-  selectedId: number;
+  selectedId?: number;
   onSelectionChange: (id: number) => void;
   label?: string;
   placeholder?: string;
@@ -23,7 +23,7 @@ export function MqttServerSelect(
       items={(servers ?? []).map((server) => ({ key: server.id.toString(), label: server.name }))}
       label={label}
       placeholder={servers?.find((r) => r.id === selectedId)?.name ?? placeholder}
-      selectedKey={selectedId.toString()}
+      selectedKey={selectedId?.toString() ?? ''}
       onSelectionChange={(key) => onSelectionChange(Number(key))}
       data-cy="mqtt-server-select"
       isLoading={isLoading}


### PR DESCRIPTION
## Summary by Sourcery

Handle undefined selectedId in MqttServerSelect by making its prop optional and defaulting selectedKey to an empty string to prevent errors in the flow node editor.

Bug Fixes:
- Make selectedId optional to avoid undefined values.
- Default selectedKey to an empty string when selectedId is undefined.