### PR TITLE
feat(ATT-119): added duplicati to balena compose

### DIFF
--- a/.env.docker-compose
+++ b/.env.docker-compose
@@ -1,0 +1,22 @@
+# Shared
+TZ=Europe/Berlin
+
+# Attraccess
+AUTH_SESSION_SECRET=super-secret
+ATTRACCESS_URL=https://meins.local.attraccess.eu
+SMTP_SERVICE=SMTP
+SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=no-reply@attraccess.org
+LOG_LEVELS=error,warn,log,debug
+LICENSE_KEY=I AM USING THIS SOFTWARE ONLY FOR NON-PROFIT AND COMPLY TO ALL TERMS OF THE LICENSE.md at https://github.com/Attraccess/Attraccess/blob/main/LICENSE.md
+
+# RabbitMQ
+RABBITMQ_ERLANG_COOKIE=please update on production
+
+# Duplicati
+SETTINGS_ENCRYPTION_KEY=super-secure
+DUPLICATI__WEBSERVICE_PASSWORD=password
+DUPLICATI__WEBSERVICE_ALLOWED_HOSTNAMES=*

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ storage-docker/
 .env.*
 !.env.example
 !.env.serve
-!.env.example.docker-compose
+!.env.docker-compose
 
 data/
 log/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,13 +108,27 @@ services:
     env_file:
       - .env.docker-compose
 
+  duplicati:
+    image: duplicati/duplicati:latest
+    expose:
+      - '8200'
+    volumes:
+      - duplicati:/data
+      # mount volumes of all services that should be backed up
+      - proxy-data:/external-storage/proxy/data
+      - proxy-letsencrypt:/external-storage/proxy/letsencrypt
+      - attraccess-storage:/external-storage/attraccess
+      - webhook-site:/external-storage/webhook-site
+      - rabbitmq_data:/external-storage/rabbitmq
+      - zigbee2mqtt:/external-storage/zigbee2mqtt
+    env_file:
+      - .env.docker-compose
+
 volumes:
-  attraccess-storage:
-  bunkerm_mosquitto_data:
-  bunkerm_mosquitto_conf:
-  bunkerm_auth_data:
-  webhook-site:
-  zigbee2mqtt:
   proxy-data:
   proxy-letsencrypt:
+  attraccess-storage:
+  webhook-site:
   rabbitmq_data:
+  zigbee2mqtt:
+  duplicati:


### PR DESCRIPTION
## Summary by Sourcery

Add Duplicati as a backup service to the Balena docker-compose setup, configure its volume mounts, and include the new environment file in version control exclusion.

New Features:
- Introduce a 'duplicati' service in docker-compose for automated backups
- Mount application service volumes into the Duplicati container under /external-storage for backup

Enhancements:
- Reorder and consolidate volume definitions in docker-compose.yml to support Duplicati mounts

Chores:
- Add .env.docker-compose file
- Update .gitignore to exclude the new .env.docker-compose