### PR TITLE
fix(ATT-98): use soft-delete for resources

### DIFF
--- a/apps/api/src/database/migrations/1759780631804-resource-soft-delete.ts
+++ b/apps/api/src/database/migrations/1759780631804-resource-soft-delete.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ResourceSoftDelete1759780631804 implements MigrationInterface {
+  name = 'ResourceSoftDelete1759780631804';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "temporary_resource" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" text NOT NULL, "description" text, "imageFilename" text, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "documentationType" text, "documentationMarkdown" text, "documentationUrl" text, "allowTakeOver" boolean NOT NULL DEFAULT (0), "type" varchar CHECK( "type" IN ('machine','door') ) NOT NULL, "separateUnlockAndUnlatch" boolean NOT NULL DEFAULT (0), "deletedAt" datetime)`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_resource"("id", "name", "description", "imageFilename", "createdAt", "updatedAt", "documentationType", "documentationMarkdown", "documentationUrl", "allowTakeOver", "type", "separateUnlockAndUnlatch") SELECT "id", "name", "description", "imageFilename", "createdAt", "updatedAt", "documentationType", "documentationMarkdown", "documentationUrl", "allowTakeOver", "type", "separateUnlockAndUnlatch" FROM "resource"`,
+    );
+    await queryRunner.query(`DROP TABLE "resource"`);
+    await queryRunner.query(`ALTER TABLE "temporary_resource" RENAME TO "resource"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "resource" RENAME TO "temporary_resource"`);
+    await queryRunner.query(
+      `CREATE TABLE "resource" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" text NOT NULL, "description" text, "imageFilename" text, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "documentationType" text, "documentationMarkdown" text, "documentationUrl" text, "allowTakeOver" boolean NOT NULL DEFAULT (0), "type" varchar CHECK( "type" IN ('machine','door') ) NOT NULL, "separateUnlockAndUnlatch" boolean NOT NULL DEFAULT (0))`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "resource"("id", "name", "description", "imageFilename", "createdAt", "updatedAt", "documentationType", "documentationMarkdown", "documentationUrl", "allowTakeOver", "type", "separateUnlockAndUnlatch") SELECT "id", "name", "description", "imageFilename", "createdAt", "updatedAt", "documentationType", "documentationMarkdown", "documentationUrl", "allowTakeOver", "type", "separateUnlockAndUnlatch" FROM "temporary_resource"`,
+    );
+    await queryRunner.query(`DROP TABLE "temporary_resource"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -55,3 +55,4 @@ export * from './1758571800304-one-transaction-per-resource-usage';
 export * from './1759691989179-mqtt-receive-input-flow-node';
 export * from './1759695000000-recreate-billing-balance-triggers';
 export * from './1759700688169-set-payload-flow-node';
+export * from './1759780631804-resource-soft-delete';

--- a/apps/api/src/resources/resources.controller.spec.ts
+++ b/apps/api/src/resources/resources.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ResourcesController } from './resources.controller';
 import { ResourcesService } from './resources.service';
 import { Resource, DocumentationType, ResourceType } from '@attraccess/database-entities';
+import { createMockResource } from '../test-utils/resource.fixtures';
 import { CreateResourceDto } from './dtos/createResource.dto';
 import { UpdateResourceDto } from './dtos/updateResource.dto';
 import { NotFoundException } from '@nestjs/common';
@@ -12,7 +13,6 @@ import { AuthenticatedRequest } from '@attraccess/plugins-backend-sdk';
 describe('ResourcesController', () => {
   let controller: ResourcesController;
   let service: ResourcesService;
-  // ResourceImageService is injected but not directly used in tests
 
   beforeEach(async () => {
     const mockResourcesService = {
@@ -54,30 +54,12 @@ describe('ResourcesController', () => {
   describe('getAll', () => {
     it('should return paginated resources', async () => {
       const resources: Resource[] = [
-        {
+        createMockResource({
           id: 1,
           name: 'Test Resource',
           description: 'Test Description',
-          type: ResourceType.Machine,
-          separateUnlockAndUnlatch: false,
           imageFilename: 'test.jpg',
-          documentationType: DocumentationType.MARKDOWN,
-          documentationMarkdown: '# Test Documentation\n\nThis is a test documentation.',
-          documentationUrl: null,
-          allowTakeOver: false,
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          introductions: [],
-          usages: [],
-          introducers: [],
-          groups: [],
-          flowNodes: [],
-          flowEdges: [],
-          flowLogs: [],
-          attractapReaders: [],
-          maintenances: [],
-          billingConfigurations: [],
-        },
+        }),
       ];
 
       const paginatedResponse: PaginatedResponse<Resource> = {
@@ -108,30 +90,12 @@ describe('ResourcesController', () => {
 
   describe('getOneById', () => {
     it('should return a resource by id', async () => {
-      const resource: Resource = {
+      const resource: Resource = createMockResource({
         id: 1,
         name: 'Test Resource',
         description: 'Test Description',
-        type: ResourceType.Machine,
-        separateUnlockAndUnlatch: false,
         imageFilename: 'test.jpg',
-        documentationType: DocumentationType.MARKDOWN,
-        documentationMarkdown: '# Test Documentation\n\nThis is a test documentation.',
-        documentationUrl: null,
-        allowTakeOver: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        introductions: [],
-        usages: [],
-        introducers: [],
-        groups: [],
-        flowNodes: [],
-        flowEdges: [],
-        flowLogs: [],
-        attractapReaders: [],
-        maintenances: [],
-        billingConfigurations: [],
-      };
+      });
 
       jest.spyOn(service, 'getResourceById').mockResolvedValue(resource);
 
@@ -162,30 +126,15 @@ describe('ResourcesController', () => {
         documentationMarkdown: null,
       };
 
-      const newResource: Resource = {
+      const newResource: Resource = createMockResource({
         id: 1,
         name: createDto.name,
         description: createDto.description,
-        type: ResourceType.Machine,
-        separateUnlockAndUnlatch: false,
-        imageFilename: null,
         documentationType: createDto.documentationType,
         documentationMarkdown: createDto.documentationMarkdown,
         documentationUrl: createDto.documentationUrl,
-        allowTakeOver: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        introductions: [],
-        usages: [],
-        introducers: [],
-        groups: [],
-        flowNodes: [],
-        flowEdges: [],
-        flowLogs: [],
-        attractapReaders: [],
-        maintenances: [],
-        billingConfigurations: [],
-      };
+        imageFilename: null,
+      });
 
       jest.spyOn(service, 'createResource').mockResolvedValue(newResource);
 
@@ -207,30 +156,16 @@ describe('ResourcesController', () => {
         documentationUrl: null,
       };
 
-      const updatedResource: Resource = {
+      const updatedResource: Resource = createMockResource({
         id: 1,
         name: updateDto.name as string,
         description: updateDto.description as string,
-        type: ResourceType.Machine,
-        separateUnlockAndUnlatch: false,
-        imageFilename: null,
         documentationType: updateDto.documentationType as DocumentationType,
         documentationMarkdown: updateDto.documentationMarkdown,
         documentationUrl: updateDto.documentationUrl,
-        allowTakeOver: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        introductions: [],
-        usages: [],
-        introducers: [],
-        groups: [],
-        flowNodes: [],
-        flowEdges: [],
-        flowLogs: [],
-        attractapReaders: [],
-        maintenances: [],
-        billingConfigurations: [],
-      };
+        imageFilename: null,
+        deletedAt: null as unknown as Date,
+      });
 
       jest.spyOn(service, 'updateResource').mockResolvedValue(updatedResource);
 

--- a/apps/api/src/resources/resources.service.spec.ts
+++ b/apps/api/src/resources/resources.service.spec.ts
@@ -8,6 +8,7 @@ import { UpdateResourceDto } from './dtos/updateResource.dto';
 import { ResourceNotFoundException } from '../exceptions/resource.notFound.exception';
 import { ResourceImageService } from './resourceImage.service';
 import { LicenseService } from '../license/license.service';
+import { createMockResource } from '../test-utils/resource.fixtures';
 
 describe('ResourcesService', () => {
   let service: ResourcesService;
@@ -22,6 +23,7 @@ describe('ResourcesService', () => {
     create: jest.fn(),
     save: jest.fn(),
     delete: jest.fn(),
+    softDelete: jest.fn(),
     createQueryBuilder: jest.fn(() => ({
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       leftJoin: jest.fn().mockReturnThis(),
@@ -75,33 +77,6 @@ describe('ResourcesService', () => {
   describe('listResources', () => {
     let mockQueryBuilder: jest.Mocked<SelectQueryBuilder<Resource>>;
 
-    const createMockResource = (id: number, name: string, description: string) => ({
-      id,
-      name,
-      description,
-      type: ResourceType.Machine,
-      separateUnlockAndUnlatch: false,
-      imageFilename: null,
-      documentationType: DocumentationType.MARKDOWN,
-      documentationMarkdown: `# Documentation ${id}`,
-      documentationUrl: null,
-      allowTakeOver: false,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      introductions: [],
-      usages: [],
-      introducers: [],
-      mqttConfigs: [],
-      webhookConfigs: [],
-      groups: [],
-      flowNodes: [],
-      flowEdges: [],
-      flowLogs: [],
-      attractapReaders: [],
-      maintenances: [],
-      billingConfigurations: [],
-    });
-
     beforeEach(() => {
       mockQueryBuilder = {
         leftJoinAndSelect: jest.fn().mockReturnThis(),
@@ -122,8 +97,18 @@ describe('ResourcesService', () => {
     describe('Basic functionality', () => {
       it('should return paginated resources with default options', async () => {
         const mockResources = [
-          createMockResource(1, 'Resource 1', 'Description 1'),
-          createMockResource(2, 'Resource 2', 'Description 2'),
+          createMockResource({
+            id: 1,
+            name: 'Resource 1',
+            description: 'Description 1',
+            documentationMarkdown: '# Documentation 1',
+          }),
+          createMockResource({
+            id: 2,
+            name: 'Resource 2',
+            description: 'Description 2',
+            documentationMarkdown: '# Documentation 2',
+          }),
         ];
 
         mockQueryBuilder.getManyAndCount.mockResolvedValue([mockResources, 2]);
@@ -142,7 +127,14 @@ describe('ResourcesService', () => {
       });
 
       it('should handle custom pagination', async () => {
-        const mockResources = [createMockResource(1, 'Resource 1', 'Description 1')];
+        const mockResources = [
+          createMockResource({
+            id: 1,
+            name: 'Resource 1',
+            description: 'Description 1',
+            documentationMarkdown: '# Documentation 1',
+          }),
+        ];
         mockQueryBuilder.getManyAndCount.mockResolvedValue([mockResources, 1]);
 
         const result = await service.listResources({ page: 2, limit: 5 });
@@ -165,7 +157,14 @@ describe('ResourcesService', () => {
 
     describe('Search filtering', () => {
       it('should filter by search term in name and description', async () => {
-        const mockResources = [createMockResource(1, 'Test Resource', 'Test Description')];
+        const mockResources = [
+          createMockResource({
+            id: 1,
+            name: 'Test Resource',
+            description: 'Test Description',
+            documentationMarkdown: '# Documentation 1',
+          }),
+        ];
         mockQueryBuilder.getManyAndCount.mockResolvedValue([mockResources, 1]);
 
         await service.listResources({ search: 'test' });
@@ -297,7 +296,14 @@ describe('ResourcesService', () => {
 
     describe('Combined filtering', () => {
       it('should handle multiple filters simultaneously', async () => {
-        const mockResources = [createMockResource(1, 'Test Resource', 'Test Description')];
+        const mockResources = [
+          createMockResource({
+            id: 1,
+            name: 'Test Resource',
+            description: 'Test Description',
+            documentationMarkdown: '# Documentation 1',
+          }),
+        ];
         mockQueryBuilder.getManyAndCount.mockResolvedValue([mockResources, 1]);
 
         const result = await service.listResources({
@@ -440,32 +446,12 @@ describe('ResourcesService', () => {
 
   describe('getResourceById', () => {
     it('should return a resource by id', async () => {
-      const mockResource = {
+      const mockResource = createMockResource({
         id: 1,
         name: 'Resource 1',
         description: 'Description 1',
-        type: ResourceType.Machine,
-        separateUnlockAndUnlatch: false,
-        imageFilename: null,
-        documentationType: DocumentationType.MARKDOWN,
         documentationMarkdown: '# Documentation 1',
-        documentationUrl: null,
-        allowTakeOver: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        introductions: [],
-        usages: [],
-        introducers: [],
-        mqttConfigs: [],
-        webhookConfigs: [],
-        groups: [],
-        flowNodes: [],
-        flowEdges: [],
-        flowLogs: [],
-        attractapReaders: [],
-        maintenances: [],
-        billingConfigurations: [],
-      };
+      });
 
       resourceRepository.find.mockResolvedValue([mockResource]);
 
@@ -497,32 +483,15 @@ describe('ResourcesService', () => {
         allowTakeOver: false,
       };
 
-      const newResource = {
+      const newResource = createMockResource({
         id: 1,
         name: createDto.name,
         description: createDto.description,
-        type: ResourceType.Machine,
-        separateUnlockAndUnlatch: false,
-        imageFilename: null,
         documentationType: createDto.documentationType,
-        documentationMarkdown: createDto.documentationMarkdown,
+        documentationMarkdown: createDto.documentationMarkdown as string,
         documentationUrl: createDto.documentationUrl,
-        allowTakeOver: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        introductions: [],
-        usages: [],
-        introducers: [],
-        mqttConfigs: [],
-        webhookConfigs: [],
-        groups: [],
-        flowNodes: [],
-        flowEdges: [],
-        flowLogs: [],
-        attractapReaders: [],
-        maintenances: [],
-        billingConfigurations: [],
-      };
+        imageFilename: null,
+      });
 
       resourceRepository.create.mockReturnValue(newResource);
       resourceRepository.save.mockResolvedValue(newResource);
@@ -555,42 +524,26 @@ describe('ResourcesService', () => {
         documentationUrl: 'https://example.com/updated',
       };
 
-      const existingResource = {
+      const existingResource = createMockResource({
         id: resourceId,
         name: 'Old Resource',
         description: 'Old Description',
-        type: ResourceType.Machine,
-        separateUnlockAndUnlatch: false,
-        imageFilename: null,
         documentationType: DocumentationType.MARKDOWN,
         documentationMarkdown: '# Old Documentation',
         documentationUrl: null,
-        allowTakeOver: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        introductions: [],
-        usages: [],
-        introducers: [],
-        mqttConfigs: [],
-        webhookConfigs: [],
-        groups: [],
-        flowNodes: [],
-        flowEdges: [],
-        flowLogs: [],
-        attractapReaders: [],
-        maintenances: [],
-        billingConfigurations: [],
-      };
+        imageFilename: null,
+      });
 
-      const updatedResource = {
-        ...existingResource,
+      const updatedResource = createMockResource({
+        id: resourceId,
         name: updateDto.name,
         description: updateDto.description,
         documentationType: updateDto.documentationType,
         documentationMarkdown: null,
         documentationUrl: updateDto.documentationUrl,
+        imageFilename: null,
         maintenances: [],
-      };
+      });
 
       jest.spyOn(service, 'getResourceById').mockResolvedValue(existingResource);
       resourceRepository.save.mockResolvedValue(updatedResource);
@@ -617,43 +570,15 @@ describe('ResourcesService', () => {
 
   describe('deleteResource', () => {
     it('should delete a resource', async () => {
-      const mockResource = {
-        id: 1,
-        name: 'Resource 1',
-        description: 'Description 1',
-        type: ResourceType.Machine,
-        separateUnlockAndUnlatch: false,
-        imageFilename: null,
-        documentationType: DocumentationType.MARKDOWN,
-        documentationMarkdown: '# Documentation 1',
-        documentationUrl: null,
-        allowTakeOver: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        introductions: [],
-        usages: [],
-        introducers: [],
-        mqttConfigs: [],
-        webhookConfigs: [],
-        groups: [],
-        flowNodes: [],
-        flowEdges: [],
-        flowLogs: [],
-        attractapReaders: [],
-        maintenances: [],
-        billingConfigurations: [],
-      };
-
-      resourceRepository.find.mockResolvedValue([mockResource]);
-      resourceRepository.delete.mockResolvedValue({ affected: 1, raw: {} });
+      (resourceRepository.softDelete as jest.Mock).mockResolvedValue({ affected: 1, raw: {}, generatedMaps: [] });
 
       await service.deleteResource(1);
 
-      expect(resourceRepository.delete).toHaveBeenCalledWith(1);
+      expect(resourceRepository.softDelete).toHaveBeenCalledWith(1);
     });
 
     it('should throw ResourceNotFoundException if resource not found', async () => {
-      resourceRepository.find.mockResolvedValue([]);
+      (resourceRepository.softDelete as jest.Mock).mockResolvedValue({ affected: 0, raw: {}, generatedMaps: [] });
 
       await expect(service.deleteResource(999)).rejects.toThrow(ResourceNotFoundException);
     });

--- a/apps/api/src/resources/resources.service.ts
+++ b/apps/api/src/resources/resources.service.ts
@@ -18,7 +18,7 @@ export class ResourcesService {
     @InjectRepository(Resource)
     private readonly resourceRepository: Repository<Resource>,
     private readonly resourceImageService: ResourceImageService,
-    private readonly licenseService: LicenseService
+    private readonly licenseService: LicenseService,
   ) {}
 
   async createResource(dto: CreateResourceDto, image?: FileUpload): Promise<Resource> {
@@ -65,7 +65,7 @@ export class ResourcesService {
   }
 
   async getResourceById<Tid extends number | number[]>(
-    idOrArrayOfIds: Tid
+    idOrArrayOfIds: Tid,
   ): Promise<Tid extends number ? Resource | null : Resource[]> {
     const arrayOfIds: number[] = Array.isArray(idOrArrayOfIds) ? idOrArrayOfIds : [idOrArrayOfIds];
 
@@ -127,14 +127,7 @@ export class ResourcesService {
   }
 
   async deleteResource(id: number): Promise<void> {
-    const resource = await this.getResourceById(id);
-
-    // Delete associated image if it exists
-    if (resource.imageFilename) {
-      await this.resourceImageService.deleteImage(id, resource.imageFilename);
-    }
-
-    const result = await this.resourceRepository.delete(id);
+    const result = await this.resourceRepository.softDelete(id);
     if (result.affected === 0) {
       throw new ResourceNotFoundException(id);
     }
@@ -198,7 +191,7 @@ export class ResourcesService {
         new Brackets((qb) => {
           qb.where('usage.userId = :userId', { userId: onlyInUseByUserId });
           qb.andWhere('usage.endTime IS NULL');
-        })
+        }),
       );
     }
 
@@ -211,7 +204,7 @@ export class ResourcesService {
         'introduction.history',
         'laterResourceIntroductionHistory',
         'laterResourceIntroductionHistory.introductionId = resourceIntroductionHistory.introductionId \
-         AND laterResourceIntroductionHistory.createdAt > resourceIntroductionHistory.createdAt'
+         AND laterResourceIntroductionHistory.createdAt > resourceIntroductionHistory.createdAt',
       );
 
       queryBuilder.leftJoin('resource.groups', 'resourceGroup');
@@ -222,7 +215,7 @@ export class ResourcesService {
         'groupIntroduction.history',
         'laterGroupIntroductionHistory',
         'laterGroupIntroductionHistory.introductionId = groupIntroductionHistory.introductionId \
-         AND laterGroupIntroductionHistory.createdAt > groupIntroductionHistory.createdAt'
+         AND laterGroupIntroductionHistory.createdAt > groupIntroductionHistory.createdAt',
       );
 
       queryBuilder.andWhere(
@@ -240,7 +233,7 @@ export class ResourcesService {
                 .where('introduction.receiverUserId = :userId', { userId: onlyWithPermissionForUserId })
                 .andWhere('resourceIntroductionHistory.action = :action', { action: 'grant' })
                 .andWhere('laterResourceIntroductionHistory.id IS NULL');
-            })
+            }),
           );
 
           // Group introductions (users who received introduction to resource group)
@@ -250,9 +243,9 @@ export class ResourcesService {
                 .where('groupIntroduction.receiverUserId = :userId', { userId: onlyWithPermissionForUserId })
                 .andWhere('groupIntroductionHistory.action = :action', { action: 'grant' })
                 .andWhere('laterGroupIntroductionHistory.id IS NULL');
-            })
+            }),
           );
-        })
+        }),
       );
     }
 
@@ -278,7 +271,7 @@ export class ResourcesService {
         '(LOWER(resource.name) LIKE LOWER(:search) OR LOWER(resource.description) LIKE LOWER(:search))',
         {
           search: `%${search}%`,
-        }
+        },
       );
     }
 

--- a/apps/api/src/test-utils/resource.fixtures.ts
+++ b/apps/api/src/test-utils/resource.fixtures.ts
@@ -1,0 +1,32 @@
+import { DocumentationType, Resource, ResourceType } from '@attraccess/database-entities';
+
+export function createMockResource(overrides: Partial<Resource> = {}): Resource {
+  const now = new Date();
+  const base: Resource = {
+    id: 1,
+    name: 'Test Resource',
+    type: ResourceType.Machine,
+    separateUnlockAndUnlatch: false,
+    description: 'Test Description',
+    imageFilename: null,
+    documentationType: DocumentationType.MARKDOWN,
+    documentationMarkdown: '# Test Documentation\n\nThis is a test documentation.',
+    documentationUrl: null,
+    allowTakeOver: false,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+    introductions: [],
+    usages: [],
+    introducers: [],
+    groups: [],
+    flowNodes: [],
+    flowEdges: [],
+    flowLogs: [],
+    attractapReaders: [],
+    maintenances: [],
+    billingConfigurations: [],
+  };
+
+  return { ...base, ...overrides } as Resource;
+}

--- a/libs/database-entities/src/lib/entities/resource.entity.ts
+++ b/libs/database-entities/src/lib/entities/resource.entity.ts
@@ -7,6 +7,7 @@ import {
   OneToMany,
   ManyToMany,
   JoinTable,
+  DeleteDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { ResourceIntroduction } from './resourceIntroduction.entity';
@@ -114,6 +115,12 @@ export class Resource {
     description: 'When the resource was last updated',
   })
   updatedAt!: Date;
+
+  @DeleteDateColumn()
+  @ApiProperty({
+    description: 'When the resource was deleted',
+  })
+  deletedAt!: Date | null;
 
   @OneToMany(() => ResourceIntroduction, (introduction) => introduction.resource)
   introductions!: ResourceIntroduction[];


### PR DESCRIPTION
## Summary by Sourcery

Implement soft-delete for resources by adding a deletedAt column, updating the deleteResource method to use softDelete, and introducing a migration; refactor tests to use a shared createMockResource fixture.

Enhancements:
- Replace hard deletes with repository.softDelete in ResourcesService.deleteResource
- Add deletedAt column to Resource entity and create a migration to backfill and rename the table
- Introduce a createMockResource test fixture to centralize mock resource creation

Tests:
- Update service and controller specs to use createMockResource and mock softDelete instead of delete