### PR TITLE
Fix docker build containerize step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,16 @@ RUN apk add --no-cache \
     python3 \
     py3-pip \
     build-base \
-    libstdc++
+    libstdc++ \
+    git
 
 # Optional: ESP tooling often used by firmware-related scripts
-# (safe to have in builder; not copied to runtime image)
-RUN python3 -m pip install --upgrade pip && \
-    pip3 install platformio esptool
+# Create a virtual environment to avoid PEP 668 restrictions on Alpine
+RUN python3 -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip install --upgrade pip && \
+    pip install platformio esptool
 
 WORKDIR /app
 


### PR DESCRIPTION
Add Python, PlatformIO, esptool, and `libstdc++` to the Dockerfile to fix the failing container build step in the PR workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-9656ef82-0bd2-467c-ab37-aa8ced713b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9656ef82-0bd2-467c-ab37-aa8ced713b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

