### PR TITLE
fix: use correct permissions on nfc reader for resource introductions

### DIFF
--- a/apps/api/src/attractap/websockets/websocket.gateway.ts
+++ b/apps/api/src/attractap/websockets/websocket.gateway.ts
@@ -819,7 +819,7 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     socket.state.lastAuthenticatedUserId = nfcCard.user.id;
 
-    const hasIntroduction = await this.resourceIntroductionService.hasValidIntroduction(resourceId, nfcCard.user.id);
+    const hasIntroduction = await this.resourceUsageService.canControllResource(resourceId, nfcCard.user);
     const isIntroducer = await this.resourceIntroducersService.isIntroducer(resourceId, nfcCard.user.id, true);
 
     await socket.sendMessage(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Use the resourceUsageService.canControllResource method instead of hasValidIntroduction to correctly check NFC reader permissions on resource introductions