### PR TITLE
fix(ATT-146): do not send resource usage receipt email when usage cos…

### DIFF
--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -339,12 +339,15 @@ export class BillingService {
             relations: ['items'],
           });
           const billingConfiguration = await this.getConfiguration();
-          await this.emailService.sendResourceUsageBillingSummaryEmail(
-            freshUser,
-            transaction,
-            usage,
-            billingConfiguration.minorUnit,
-          );
+
+          if (transaction.amount !== 0) {
+            await this.emailService.sendResourceUsageBillingSummaryEmail(
+              freshUser,
+              transaction,
+              usage,
+              billingConfiguration.minorUnit,
+            );
+          }
         } catch {
           // ignore email failures to not break billing
         }

--- a/apps/api/src/database/migrations/1760018355011-seed-resource-usage-billing-transaction-summary-template.ts
+++ b/apps/api/src/database/migrations/1760018355011-seed-resource-usage-billing-transaction-summary-template.ts
@@ -43,10 +43,6 @@ const BILLING_SUMMARY_MJML = `
           </tr>
           {{/each}}
           <tr>
-            <td colspan="3" align="right"><strong>Discount</strong></td>
-            <td align="right">{{discount}}</td>
-          </tr>
-          <tr>
             <td colspan="3" align="right"><strong>Total Credits</strong></td>
             <td align="right"><strong>{{totalCredits}}</strong></td>
           </tr>
@@ -71,7 +67,7 @@ export class SeedBillingTransactionSummaryTemplate1759800000100 implements Migra
         'resource-usage-billing-transaction-summary',
         'Your usage receipt for {{resource.name}}',
         BILLING_SUMMARY_MJML,
-        JSON.stringify([
+        [
           'user.username',
           'user.email',
           'host.frontend',
@@ -83,10 +79,9 @@ export class SeedBillingTransactionSummaryTemplate1759800000100 implements Migra
           'items[].quantity',
           'items[].unitPrice',
           'items[].total',
-          'discount',
           'totalCredits',
           'newBalance',
-        ]),
+        ].join(','),
       ],
     );
   }

--- a/apps/api/src/database/migrations/1760468005000-email-templates-variables-fix.ts
+++ b/apps/api/src/database/migrations/1760468005000-email-templates-variables-fix.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FixEmailTemplateVariables1760468005000 implements MigrationInterface {
+  name = 'FixEmailTemplateVariables1760468005000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const rows: Array<{ type: string; variables: string | null }> = await queryRunner.query(
+      `SELECT "type", "variables" FROM "email_templates"`,
+    );
+
+    for (const row of rows) {
+      const { type, variables } = row;
+      if (variables == null) continue;
+      const trimmed = variables.trim();
+
+      if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (Array.isArray(parsed)) {
+            const csv = parsed.join(',');
+            await queryRunner.query(`UPDATE "email_templates" SET "variables" = $1 WHERE "type" = $2`, [csv, type]);
+          }
+        } catch {
+          // ignore invalid JSON; leave as-is
+        }
+      }
+    }
+  }
+
+  public async down(): Promise<void> {
+    // no-op
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -60,3 +60,4 @@ export * from './1759918355010-billing-factor';
 export * from './1760018355010-email-templates-add-resource-usage-billing-summary';
 export * from './1760018355011-seed-resource-usage-billing-transaction-summary-template';
 export * from './1760467441063-nfc-card-single-key';
+export * from './1760468005000-email-templates-variables-fix';

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -153,9 +153,7 @@ export class EmailService {
       total: dbCurrencyToUserCurrency(item.unitPrice * item.quantity, currencyMinorUnit),
     }));
 
-    const totalFromItems = items.reduce((sum, it) => sum + it.total, 0);
     const totalCredits = dbCurrencyToUserCurrency(-transaction.amount, currencyMinorUnit); // transaction.amount is negative when charging user
-    const discount = totalFromItems - totalCredits;
 
     const context = {
       ...this.getBaseContext(user),
@@ -169,7 +167,6 @@ export class EmailService {
         roundedMinutes,
       },
       items,
-      discount,
       totalCredits,
       newBalance: dbCurrencyToUserCurrency(user.creditBalance, currencyMinorUnit), // already updated by DB triggers for completed tx
     };


### PR DESCRIPTION
…ts nothing

## Summary by Sourcery

Skip sending resource usage billing summary emails when the transaction amount is zero, remove obsolete discount references from the billing email template and related code, and add a migration to convert stored email template variables from JSON arrays to comma-separated lists.

Enhancements:
- Only send resource usage billing summary emails for transactions with non-zero amounts
- Remove discount field from resource usage billing summary email template and associated code

Chores:
- Add database migration to normalize email_templates.variables from JSON array format to comma-separated strings