### PR TITLE
fix: allow ssl connection without synced time

### DIFF
--- a/apps/attractap-firmware/platformio.ini
+++ b/apps/attractap-firmware/platformio.ini
@@ -34,7 +34,7 @@ lib_deps =
 build_flags =
 	-D FIRMWARE_NAME='"attractap_touch"'
 	-D FIRMWARE_FRIENDLY_NAME='"Attractap Touch"'
-	-D FIRMWARE_VERSION='"1.0.2"'
+	-D FIRMWARE_VERSION='"1.0.3 "'
 	-D FIRMWARE_VARIANT='"wifi"'
 	-D FIRMWARE_VARIANT_FRIENDLY_NAME='"WiFi"'
 

--- a/apps/attractap-firmware/src/network/network.cpp
+++ b/apps/attractap-firmware/src/network/network.cpp
@@ -1,6 +1,7 @@
 #include "network.hpp"
 #include "esp_err.h"
 #include "esp_log.h"
+#include <time.h>
 
 // Static member definitions
 bool Network::_sharedComponentsInitialized = false;
@@ -24,6 +25,9 @@ void Network::setup()
 
     logger.info("Starting Ethernet interface");
     Ethernet::setup();
+
+    logger.info("Configuring SNTP time server...");
+    configTime(0, 0, "pool.ntp.org", "time.nist.gov");
 
     logger.info("initialization complete");
 }

--- a/apps/attractap-firmware/src/websocket/websocket.cpp
+++ b/apps/attractap-firmware/src/websocket/websocket.cpp
@@ -1,26 +1,5 @@
 #include "websocket.hpp"
 
-#include <time.h>
-
-static bool timeSettingsSet = false;
-static bool ensureTimeSynced(Logger &logger)
-{
-    time_t now = time(nullptr);
-    if (now > 1700000000)
-    {                // ~2023-11-14
-        return true; // time already valid
-    }
-
-    if (!timeSettingsSet)
-    {
-        logger.info("Configuring SNTP...");
-        configTime(0, 0, "pool.ntp.org", "time.nist.gov");
-        timeSettingsSet = true;
-    }
-
-    return false;
-}
-
 void Websocket::setup()
 {
     logger.info("Websocket setup");
@@ -71,12 +50,6 @@ void Websocket::connectWebSocket()
 {
     if (!connectionAttemptsEnabled)
     {
-        return;
-    }
-
-    if (!ensureTimeSynced(logger))
-    {
-        setState(INIT);
         return;
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Allow SSL connections to proceed without awaiting synchronized time by removing the time sync gate in the websocket code, pre-configuring SNTP during network setup, and bumping the firmware version.

Bug Fixes:
- Remove the time synchronization check from the websocket connection flow to allow SSL connections without a synced clock

Enhancements:
- Move SNTP time server configuration to the network setup phase

Chores:
- Update firmware version to 1.0.3