### PR TITLE
feat(ATT-152): open node editor on double click

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/node/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/index.tsx
@@ -177,7 +177,7 @@ export function AttraccessNode(props: Props) {
               )}
             </div>
           </NodeToolbar>
-          <Card className={cardClasses} onDoubleClick={openEditor}>
+          <Card className={cardClasses} onDoubleClick={isEditable ? openEditor : undefined}>
             <CardHeader className="flex flex-col gap-1">
               <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center min-w-0">


### PR DESCRIPTION
## Summary by Sourcery

Allow users to open the node editor via double-click and streamline the edit action logic by centralizing edit controls in NodeEditor and using an isEditable state.

New Features:
- Enable opening the node editor by double-clicking the node card

Enhancements:
- Wrap the entire node UI in NodeEditor and provide an openEditor callback
- Extract an isEditable flag to conditionally render the edit button when not in preview mode and schema has properties
- Render the edit button within the toolbar only if the node is editable