### PR TITLE
chore(ATT-111): optimize the docs and explain SMTP_SECURE variable

### DIFF
--- a/docs/setup/docker-compose-guide.md
+++ b/docs/setup/docker-compose-guide.md
@@ -58,6 +58,7 @@ services:
       - SMTP_FROM=your-email@example.com
       - SMTP_HOST=smtp.example.com
       - SMTP_PORT=587
+      - SMTP_SECURE=false
       - SMTP_USER=your-email-username
       - SMTP_PASS=your-email-password
 
@@ -111,6 +112,7 @@ Update the email settings in your `docker-compose.yml` file with your actual SMT
 - SMTP_FROM=your-gmail@gmail.com
 - SMTP_HOST=smtp.gmail.com
 - SMTP_PORT=587
+- SMTP_SECURE=false
 - SMTP_USER=your-gmail@gmail.com
 - SMTP_PASS=your-app-password
 ```
@@ -234,6 +236,7 @@ SMTP_SERVICE=SMTP
 SMTP_FROM=your-email@example.com
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
+SMTP_SECURE=false
 SMTP_USER=your-email-username
 SMTP_PASS=your-email-password
 
@@ -265,13 +268,11 @@ services:
 ### Common Issues
 
 1. **Container fails to start**:
-
    - Check your `docker-compose.yml` for syntax errors
    - Verify all required environment variables are set correctly
    - Check if port 3000 is already in use by another application
 
 2. **Can't access Attraccess in browser**:
-
    - Verify the container is running with `docker-compose ps`
    - Check if your firewall is blocking port 3000
    - Make sure you're using the correct URL

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -75,11 +75,18 @@ docker run -e LICENSE_KEY="I AM USING THIS SOFTWARE ONLY FOR NON-PROFIT AND COMP
 | `SMTP_PORT` | SMTP server port | If SMTP_SERVICE=SMTP | - |
 | `SMTP_USER` | SMTP authentication username | Optional | - |
 | `SMTP_PASS` | SMTP authentication password | Optional | - |
-| `SMTP_SECURE` | Use secure connection ("true"/"false") | Optional | "false" |
+| `SMTP_SECURE` | Use SMTPS TLS from start; set `true` for port 465, `false` for STARTTLS ports like 587 (only the string "true" is treated as true) | Optional | "false" |
 | `SMTP_IGNORE_TLS` | Ignore TLS ("true"/"false") | Optional | "true" |
 | `SMTP_REQUIRE_TLS` | Require TLS ("true"/"false") | Optional | "false" |
 | `SMTP_TLS_REJECT_UNAUTHORIZED` | Reject unauthorized TLS ("true"/"false") | Optional | "true" |
 | `SMTP_TLS_CIPHERS` | TLS cipher configuration | Optional | - |
+
+> [!TIP]
+> SMTP guidance:
+>
+> - Use `SMTP_PORT=465` with `SMTP_SECURE=true` for implicit TLS (SMTPS)
+> - Use `SMTP_PORT=587` with `SMTP_SECURE=false` for STARTTLS
+> - Any value other than the string `"true"` (case-insensitive) is treated as `false`
 
 #### SSL Configuration
 
@@ -117,6 +124,7 @@ docker run -d \
   -e SMTP_FROM=no-reply@yourdomain.com \
   -e SMTP_HOST=smtp.yourdomain.com \
   -e SMTP_PORT=587 \
+  -e SMTP_SECURE=false \
   -e SMTP_USER=your_smtp_user \
   -e SMTP_PASS=your_smtp_password \
   -e LOG_LEVELS=error,warn,log \

--- a/docs/setup/portainer-guide.md
+++ b/docs/setup/portainer-guide.md
@@ -67,7 +67,6 @@ docker run -d -p 8000:8000 -p 9000:9000 --name=portainer --restart=always -v /va
 1. Click on "Advanced container settings"
 
 2. Go to the "Volumes" tab:
-
    - Click "Map additional volume"
    - **Container**: /app/storage
    - **Volume**: attraccess_storage
@@ -85,6 +84,7 @@ docker run -d -p 8000:8000 -p 9000:9000 --name=portainer --restart=always -v /va
 | SMTP_FROM           | your-email@example.com                  |
 | SMTP_HOST           | smtp.example.com                        |
 | SMTP_PORT           | 587                                     |
+| SMTP_SECURE         | false                                   |
 | SMTP_USER           | your-email-username                     |
 | SMTP_PASS           | your-email-password                     |
 | LOG_LEVELS          | error,warn,log                          |
@@ -123,6 +123,7 @@ services:
       - SMTP_FROM=your-email@example.com
       - SMTP_HOST=smtp.example.com
       - SMTP_PORT=587
+      - SMTP_SECURE=false
       - SMTP_USER=your-email-username
       - SMTP_PASS=your-email-password
 
@@ -187,10 +188,14 @@ To use Gmail as your email service:
 | SMTP_FROM    | your-gmail@gmail.com |
 | SMTP_HOST    | smtp.gmail.com       |
 | SMTP_PORT    | 587                  |
+| SMTP_SECURE  | false                |
 | SMTP_USER    | your-gmail@gmail.com |
 | SMTP_PASS    | your-app-password    |
 
 > Note: For Gmail, you need to set up an "App Password" in your Google Account security settings.
+
+> [!TIP]
+> Use `SMTP_SECURE=true` only with port `465` (SMTPS). For port `587` (STARTTLS), set `SMTP_SECURE=false`.
 
 ### Outlook/Office 365 Configuration
 
@@ -208,13 +213,11 @@ For Outlook or Office 365:
 ### Common Issues in Portainer
 
 1. **Container fails to start**:
-
    - Check the container logs for error messages
    - Verify all environment variables are set correctly
    - Ensure the ports aren't already in use by another container
 
 2. **Can't access Attraccess from web browser**:
-
    - Verify the container is running in Portainer
    - Check if your firewall is blocking port 3000
    - Make sure you're using the correct URL


### PR DESCRIPTION
## Summary by Sourcery

Clarify the SMTP_SECURE environment variable with detailed guidelines and include it in all setup examples

Documentation:
- Enhance SMTP_SECURE description to explain implicit TLS vs STARTTLS and true/false handling
- Add user tips on when to use SMTP_SECURE=true vs false
- Insert SMTP_SECURE=false in environment variable examples for installation, Portainer, and Docker Compose guides
- Remove extraneous blank lines and optimize formatting in setup documentation