### PR TITLE
fix(ATT-157): ensure topic scubscriptions on mqtt server re-connect

### DIFF
--- a/apps/api/src/mqtt/mqtt-client.service.ts
+++ b/apps/api/src/mqtt/mqtt-client.service.ts
@@ -4,7 +4,6 @@ import { Repository } from 'typeorm';
 import { MqttServer } from '@attraccess/database-entities';
 import * as mqtt from 'mqtt';
 import { MqttClient } from 'mqtt';
-import { MqttConnectionError } from './errors/mqtt-connection.error';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MqttMessageEvent } from './mqtt-message.event';
 
@@ -12,6 +11,7 @@ import { MqttMessageEvent } from './mqtt-message.event';
 export class MqttClientService implements OnModuleDestroy {
   private clients: Map<number, MqttClient> = new Map();
   private connectionPromises: Map<number, Promise<MqttClient>> = new Map();
+  private subscriptions: Map<number, Set<string>> = new Map();
   private readonly logger = new Logger(MqttClientService.name);
 
   constructor(
@@ -100,6 +100,14 @@ export class MqttClientService implements OnModuleDestroy {
 
       client.on('connect', () => {
         this.logger.log(`Connected to MQTT server ${server.name} (${url})`);
+        // Re-subscribe to all known topics for this server on each successful connect
+        const topics = this.subscriptions.get(serverId);
+        if (topics && topics.size > 0) {
+          for (const t of topics.values()) {
+            client.subscribe(t);
+            this.logger.debug(`(re)subscribed to ${t} on server ${server.name}`);
+          }
+        }
         resolve(client);
       });
 
@@ -158,12 +166,20 @@ export class MqttClientService implements OnModuleDestroy {
   }
 
   async subscribe(serverId: number, topic: string): Promise<void> {
+    // Track desired subscriptions so they can be (re)applied on connect/reconnect
+    if (!this.subscriptions.has(serverId)) {
+      this.subscriptions.set(serverId, new Set());
+    }
+    this.subscriptions.get(serverId).add(topic);
+
     try {
       const client = await this.getOrCreateClient(serverId, true);
       client.subscribe(topic);
     } catch (error) {
-      this.logger.error(`Failed to subscribe to topic ${topic} for server ${serverId}`, error);
-      throw new MqttConnectionError(error.message);
+      // Do not throw: the client will keep trying to connect and will subscribe on next connect
+      this.logger.warn(
+        `Will subscribe to topic ${topic} for server ${serverId} once connection is available: ${error?.message ?? error}`,
+      );
     }
   }
 }

--- a/apps/api/src/resources/flows/resource-flows-executor.service.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.ts
@@ -134,9 +134,16 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
   }
 
   private async subscribeToMqttTopics() {
-    const mqttMessageReceivedNodes = await this.flowNodeRepository.find({
-      where: { type: ResourceFlowNodeType.INPUT_MQTT_MESSAGE_RECEIVED },
-    });
+    const [mqttMessageReceivedNodes, mqttWaitForMessageNodes] = await Promise.all([
+      this.flowNodeRepository.find({
+        where: { type: ResourceFlowNodeType.INPUT_MQTT_MESSAGE_RECEIVED },
+      }),
+      this.flowNodeRepository.find({
+        where: { type: ResourceFlowNodeType.PROCESSING_MQTT_WAIT_FOR_MESSAGE },
+      }),
+    ]);
+
+    const subscribePairs: Array<{ serverId: number; topic: string }> = [];
 
     for (const node of mqttMessageReceivedNodes) {
       const { topic, serverId } = node.data as z.infer<typeof MqttMessageReceivedNodeDataSchema>;
@@ -144,6 +151,19 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
         this.logger.warn(`Skipping subscription to topic ${topic} for server ID ${serverId} because it is missing`);
         continue;
       }
+      subscribePairs.push({ serverId, topic });
+    }
+
+    for (const node of mqttWaitForMessageNodes) {
+      const { topic, serverId } = node.data as z.infer<typeof MqttWaitForMessageNodeDataSchema>;
+      if (!serverId || !topic) {
+        this.logger.warn(`Skipping subscription to topic ${topic} for server ID ${serverId} because it is missing`);
+        continue;
+      }
+      subscribePairs.push({ serverId, topic });
+    }
+
+    for (const { serverId, topic } of subscribePairs) {
       await this.mqttClientService.subscribe(serverId, topic).catch((error) => {
         this.logger.error(`Failed to subscribe to topic ${topic} for server ID ${serverId}`, error.stack);
       });

--- a/apps/api/src/resources/flows/resource-flows.service.ts
+++ b/apps/api/src/resources/flows/resource-flows.service.ts
@@ -133,21 +133,41 @@ export class ResourceFlowsService {
 
     // Start transaction to ensure data consistency
     const result = await this.flowNodeRepository.manager.transaction(async (transactionalEntityManager) => {
-      const oldMqttMessageReceivedNodes = await transactionalEntityManager.find(ResourceFlowNode, {
-        where: { resource: { id: resourceId }, type: ResourceFlowNodeType.INPUT_MQTT_MESSAGE_RECEIVED },
-      });
+      const [oldMqttMessageReceivedNodes, oldMqttWaitForMessageNodes] = await Promise.all([
+        transactionalEntityManager.find(ResourceFlowNode, {
+          where: { resource: { id: resourceId }, type: ResourceFlowNodeType.INPUT_MQTT_MESSAGE_RECEIVED },
+        }),
+        transactionalEntityManager.find(ResourceFlowNode, {
+          where: { resource: { id: resourceId }, type: ResourceFlowNodeType.PROCESSING_MQTT_WAIT_FOR_MESSAGE },
+        }),
+      ]);
 
-      const newOrChangedMqttMessageReceivedNodes = [];
+      const newOrChangedMqttMessageReceivedNodes = [] as typeof flowData.nodes;
+      const newOrChangedMqttWaitForMessageNodes = [] as typeof flowData.nodes;
+
       for (const nodeData of flowData.nodes) {
-        const existingNode = oldMqttMessageReceivedNodes.find((oldNode) => oldNode.id === nodeData.id);
-        if (!existingNode) {
-          newOrChangedMqttMessageReceivedNodes.push(nodeData);
-          continue;
+        if (nodeData.type === ResourceFlowNodeType.INPUT_MQTT_MESSAGE_RECEIVED) {
+          const existingNode = oldMqttMessageReceivedNodes.find((oldNode) => oldNode.id === nodeData.id);
+          if (!existingNode) {
+            newOrChangedMqttMessageReceivedNodes.push(nodeData);
+          } else if (
+            existingNode.data.topic !== nodeData.data.topic ||
+            existingNode.data.serverId !== nodeData.data.serverId
+          ) {
+            newOrChangedMqttMessageReceivedNodes.push(nodeData);
+          }
         }
 
-        if (existingNode.data.topic !== nodeData.data.topic || existingNode.data.serverId !== nodeData.data.serverId) {
-          newOrChangedMqttMessageReceivedNodes.push(nodeData);
-          continue;
+        if (nodeData.type === ResourceFlowNodeType.PROCESSING_MQTT_WAIT_FOR_MESSAGE) {
+          const existingNode = oldMqttWaitForMessageNodes.find((oldNode) => oldNode.id === nodeData.id);
+          if (!existingNode) {
+            newOrChangedMqttWaitForMessageNodes.push(nodeData);
+          } else if (
+            existingNode.data.topic !== nodeData.data.topic ||
+            existingNode.data.serverId !== nodeData.data.serverId
+          ) {
+            newOrChangedMqttWaitForMessageNodes.push(nodeData);
+          }
         }
       }
 
@@ -194,12 +214,31 @@ export class ResourceFlowsService {
           );
           continue;
         }
-        this.mqttClientService.subscribe(nodeData.data.serverId, nodeData.data.topic).catch((error) => {
-          this.logger.error(
-            `Failed to subscribe to topic ${nodeData.data.topic} for server ID ${nodeData.data.serverId}`,
-            error.stack,
+        this.mqttClientService
+          .subscribe(nodeData.data.serverId as number, nodeData.data.topic as string)
+          .catch((error) => {
+            this.logger.error(
+              `Failed to subscribe to topic ${nodeData.data.topic} for server ID ${nodeData.data.serverId}`,
+              error.stack,
+            );
+          });
+      }
+
+      for (const nodeData of newOrChangedMqttWaitForMessageNodes) {
+        if (!nodeData.data.serverId || !nodeData.data.topic) {
+          this.logger.warn(
+            `Skipping subscription to topic ${nodeData.data.topic} for server ID ${nodeData.data.serverId} because it is missing`,
           );
-        });
+          continue;
+        }
+        this.mqttClientService
+          .subscribe(nodeData.data.serverId as number, nodeData.data.topic as string)
+          .catch((error) => {
+            this.logger.error(
+              `Failed to subscribe to topic ${nodeData.data.topic} for server ID ${nodeData.data.serverId}`,
+              error.stack,
+            );
+          });
       }
 
       return { nodes: savedNodes, edges: savedEdges };


### PR DESCRIPTION
## Summary by Sourcery

Ensure MQTT topic subscriptions persist across reconnects and enhance flow services to handle subscriptions for both message received and wait-for-message nodes

New Features:
- Persist MQTT subscriptions and automatically re-subscribe to topics on client reconnect

Bug Fixes:
- Maintain MQTT topic subscriptions across server reconnects

Enhancements:
- Extend flow service and executor to subscribe both INPUT_MQTT_MESSAGE_RECEIVED and PROCESSING_MQTT_WAIT_FOR_MESSAGE node types
- Validate presence of serverId and topic before subscribing and log warnings for missing values
- Refactor executor to consolidate subscription logic into a single list of server-topic pairs
- Track desired subscriptions in the MQTT client service and defer subscription until connection is available