### PR TITLE
feat(ATT-151): resource flow node to end usage session

### DIFF
--- a/apps/api/src/database/migrations/1761832730725-end-usage-session-flow-node.ts
+++ b/apps/api/src/database/migrations/1761832730725-end-usage-session-flow-node.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EndUsageSessionFlowNode1761832730725 implements MigrationInterface {
+  name = 'EndUsageSessionFlowNode1761832730725';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "temporary_resource_flow_node" ("id" text PRIMARY KEY NOT NULL, "type" varchar CHECK( "type" IN ('input.button','input.resource.usage.started','input.resource.usage.stopped','input.resource.usage.takeover','input.resource.door.unlocked','input.resource.door.locked','input.resource.door.unlatched','input.mqtt.message.received','output.http.sendRequest','output.mqtt.sendMessage','output.resource.billing.calculation.set-additional-items','output.resource.usage.end-session','processing.wait','processing.if','processing.set-payload','processing.mqtt.waitForMessage') ) NOT NULL, "data" json, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "resourceId" integer NOT NULL, "positionX" integer NOT NULL, "positionY" integer NOT NULL, CONSTRAINT "FK_ca3080b2dbc9c7c88a4a64c469d" FOREIGN KEY ("resourceId") REFERENCES "resource" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_resource_flow_node"("id", "type", "data", "createdAt", "updatedAt", "resourceId", "positionX", "positionY") SELECT "id", "type", "data", "createdAt", "updatedAt", "resourceId", "positionX", "positionY" FROM "resource_flow_node"`,
+    );
+    await queryRunner.query(`DROP TABLE "resource_flow_node"`);
+    await queryRunner.query(`ALTER TABLE "temporary_resource_flow_node" RENAME TO "resource_flow_node"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "resource_flow_node" RENAME TO "temporary_resource_flow_node"`);
+    await queryRunner.query(
+      `CREATE TABLE "resource_flow_node" ("id" text PRIMARY KEY NOT NULL, "type" varchar CHECK( "type" IN ('input.button','input.resource.usage.started','input.resource.usage.stopped','input.resource.usage.takeover','input.resource.door.unlocked','input.resource.door.locked','input.resource.door.unlatched','input.mqtt.message.received','output.http.sendRequest','output.mqtt.sendMessage','output.resource.billing.calculation.set-additional-items','processing.wait','processing.if','processing.set-payload','processing.mqtt.waitForMessage') ) NOT NULL, "data" json, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "resourceId" integer NOT NULL, "positionX" integer NOT NULL, "positionY" integer NOT NULL, CONSTRAINT "FK_ca3080b2dbc9c7c88a4a64c469d" FOREIGN KEY ("resourceId") REFERENCES "resource" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "resource_flow_node"("id", "type", "data", "createdAt", "updatedAt", "resourceId", "positionX", "positionY") SELECT "id", "type", "data", "createdAt", "updatedAt", "resourceId", "positionX", "positionY" FROM "temporary_resource_flow_node"`,
+    );
+    await queryRunner.query(`DROP TABLE "temporary_resource_flow_node"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -62,3 +62,4 @@ export * from './1760018355011-seed-resource-usage-billing-transaction-summary-t
 export * from './1760467441063-nfc-card-single-key';
 export * from './1760468005000-email-templates-variables-fix';
 export * from './1761776665535-wait-for-mqtt-message-flow-node';
+export * from './1761832730725-end-usage-session-flow-node';

--- a/apps/api/src/resources/flows/resource-flows-executor.service.spec.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.spec.ts
@@ -14,6 +14,7 @@ import { ResourceUsageService } from '../usage/resourceUsage.service';
 import { FlowConfigType } from './flow.config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MqttMessageEvent as MqttMessageReceivedEvent } from '../../mqtt/mqtt-message.event';
+import { NoUsageSessionError } from './errors/no-usage-session.error';
 
 // Minimal edge shape for our mocks
 type Edge = { source: string; target: string; sourceHandle?: string | null };
@@ -251,6 +252,64 @@ describe('ResourceFlowsExecutorService.runFlow', () => {
       unitPrice: 1,
       quantity: 1,
     });
+  });
+
+  it('ends the active usage session with templated notes and passes payload through', async () => {
+    // Arrange nodes: INPUT -> END_SESSION (terminal)
+    const inputNode = createNode({ id: 'in-1', type: ResourceFlowNodeType.INPUT_RESOURCE_USAGE_STARTED });
+    const endNode = createNode({
+      id: 'end-1',
+      type: ResourceFlowNodeType.OUTPUT_RESOURCE_USAGE_END_SESSION,
+      data: { notes: 'Ended by {{user.username}}' },
+    });
+    nodesById[inputNode.id] = inputNode;
+    nodesById[endNode.id] = endNode;
+    initialNodes = [inputNode];
+    edgesBySourceAndHandle[`${inputNode.id}|`] = [{ source: inputNode.id, target: endNode.id }];
+    edgesBySourceAndHandle[`${endNode.id}|`] = [];
+
+    // Mock active session and endSession
+    (resourceUsageService.getActiveSession as jest.Mock).mockResolvedValue({
+      id: 'ru-1',
+      user: { id: 42, username: 'alice' },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (resourceUsageService as any).endSession = jest.fn().mockResolvedValue(undefined);
+
+    const initialData = { user: { username: 'bob' } };
+
+    // Act
+    const result = await service.runFlow(1, ResourceFlowNodeType.INPUT_RESOURCE_USAGE_STARTED, initialData);
+
+    // Assert leaf payload passthrough
+    expect(result).toEqual([initialData]);
+
+    // Assert endSession called with compiled notes
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((resourceUsageService as any).endSession).toHaveBeenCalledWith(
+      1,
+      { id: 42, username: 'alice' },
+      {
+        notes: 'Ended by bob',
+      },
+    );
+  });
+
+  it('throws NoUsageSessionError when no active session exists', async () => {
+    const inputNode = createNode({ id: 'in-1', type: ResourceFlowNodeType.INPUT_RESOURCE_USAGE_STARTED });
+    const endNode = createNode({ id: 'end-1', type: ResourceFlowNodeType.OUTPUT_RESOURCE_USAGE_END_SESSION, data: {} });
+    nodesById[inputNode.id] = inputNode;
+    nodesById[endNode.id] = endNode;
+    initialNodes = [inputNode];
+    edgesBySourceAndHandle[`${inputNode.id}|`] = [{ source: inputNode.id, target: endNode.id }];
+    edgesBySourceAndHandle[`${endNode.id}|`] = [];
+
+    (resourceUsageService.getActiveSession as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.runFlow(1, ResourceFlowNodeType.INPUT_RESOURCE_USAGE_STARTED, {})).rejects.toBeInstanceOf(
+      NoUsageSessionError,
+    );
   });
 });
 

--- a/apps/api/src/resources/flows/resource-flows-executor.service.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.ts
@@ -29,6 +29,7 @@ import {
   SetPayloadNodeDataSchema,
   MqttMessageReceivedNodeDataSchema,
   MqttWaitForMessageNodeDataSchema,
+  ResourceUsageEndSessionNodeDataSchema,
 } from '@attraccess/database-entities';
 import { OnEvent } from '@nestjs/event-emitter';
 import { ResourceUsageEvent } from '../usage/events/resource-usage.events';
@@ -489,6 +490,14 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
           );
           break;
 
+        case ResourceFlowNodeType.OUTPUT_RESOURCE_USAGE_END_SESSION:
+          responseOfNode = await this.processEndUsageSessionNode(
+            node,
+            resultOfPreviousNode.payload,
+            transactionManager,
+          );
+          break;
+
         case ResourceFlowNodeType.PROCESSING_IF:
           responseOfNode = await this.processIfNode(node, resultOfPreviousNode.payload, transactionManager);
           break;
@@ -781,6 +790,34 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
     return {
       payload: input,
     };
+  }
+
+  private async processEndUsageSessionNode(
+    node: ResourceFlowNode,
+    input: object,
+    transactionManager?: EntityManager,
+  ): Promise<NodeProcessingResult> {
+    const activeUsage = await this.resourceUsageService.getActiveSession(node.resourceId, transactionManager);
+
+    if (!activeUsage) {
+      throw new NoUsageSessionError();
+    }
+
+    if (!activeUsage.user) {
+      throw new ForbiddenException('Active session has no owner user; cannot end');
+    }
+
+    const { notes } = ResourceUsageEndSessionNodeDataSchema.parse(node.data ?? {});
+
+    let finalNotes = '';
+    if (typeof notes === 'string' && notes.length > 0) {
+      const compiled = this.compileTemplate(notes, input);
+      finalNotes = compiled && compiled.trim().length > 0 ? compiled : notes;
+    }
+
+    await this.resourceUsageService.endSession(node.resourceId, activeUsage.user, { notes: finalNotes });
+
+    return { payload: input };
   }
 
   private compileTemplate(template: string, data: object): string {

--- a/apps/api/src/resources/flows/resource-flows.service.ts
+++ b/apps/api/src/resources/flows/resource-flows.service.ts
@@ -19,6 +19,7 @@ import {
   SetPayloadNodeDataSchema,
   MqttMessageReceivedNodeDataSchema,
   MqttWaitForMessageNodeDataSchema,
+  ResourceUsageEndSessionNodeDataSchema,
 } from '@attraccess/database-entities';
 import { ResourceNotFoundException } from '../../exceptions/resource.notFound.exception';
 import { ResourceFlowSaveDto, ResourceFlowResponseDto } from './dto';
@@ -359,6 +360,14 @@ export class ResourceFlowsService {
           schema.inputs = ['input'];
           schema.outputs = ['output'];
           schema.supportedByResource = true;
+          schema.isOutput = true;
+          break;
+
+        case ResourceFlowNodeType.OUTPUT_RESOURCE_USAGE_END_SESSION:
+          schema.configSchema = z.toJSONSchema(ResourceUsageEndSessionNodeDataSchema);
+          schema.inputs = ['input'];
+          schema.outputs = ['output'];
+          schema.supportedByResource = resource.type === ResourceType.Machine;
           schema.isOutput = true;
           break;
 

--- a/apps/frontend/src/app/resources/details/flows/node/de.json
+++ b/apps/frontend/src/app/resources/details/flows/node/de.json
@@ -281,6 +281,20 @@
         }
       },
       "resource": {
+        "usage": {
+          "end-session": {
+            "title": "Nutzung beenden",
+            "description": "Beendet die aktive Nutzungssitzung. Optional mit Notizen (Template oder statisch).",
+            "inputs": { "input": "Eingabe" },
+            "outputs": { "output": "Ausgabe" },
+            "config": {
+              "notes": { "label": "Notizen (Templates erlaubt)" }
+            },
+            "preview": {
+              "notes": "Notizen"
+            }
+          }
+        },
         "billing": {
           "calculation": {
             "set-additional-items": {

--- a/apps/frontend/src/app/resources/details/flows/node/en.json
+++ b/apps/frontend/src/app/resources/details/flows/node/en.json
@@ -281,6 +281,20 @@
         }
       },
       "resource": {
+        "usage": {
+          "end-session": {
+            "title": "End usage session",
+            "description": "Ends the active usage session. Optionally sends notes (template or static).",
+            "inputs": { "input": "Input" },
+            "outputs": { "output": "Output" },
+            "config": {
+              "notes": { "label": "Notes (templates allowed)" }
+            },
+            "preview": {
+              "notes": "Notes"
+            }
+          }
+        },
         "billing": {
           "calculation": {
             "set-additional-items": {

--- a/apps/frontend/src/app/resources/details/flows/node/preview/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/preview/index.tsx
@@ -44,34 +44,6 @@ export function useNodePreviewRows(props: Props): NodePreviewData {
           },
         ];
 
-      case 'output.resource.billing.calculation.set-additional-items':
-        return [
-          {
-            label: t('nodes.output.resource.billing.calculation.set-additional-items.preview.position'),
-            value: nodeData?.data.name as string,
-          },
-        ];
-
-      case 'output.http.sendRequest':
-        return [
-          {
-            label: t('nodes.output.http.sendRequest.preview.method'),
-            value: nodeData?.data.method as string,
-          },
-          {
-            label: t('nodes.output.http.sendRequest.preview.url'),
-            value: nodeData?.data.url as string,
-          },
-        ];
-
-      case 'output.mqtt.sendMessage':
-        return [
-          {
-            label: t('nodes.output.mqtt.sendMessage.preview.topic'),
-            value: nodeData?.data.topic as string,
-          },
-        ];
-
       case 'processing.wait':
         return [
           {
@@ -113,6 +85,42 @@ export function useNodePreviewRows(props: Props): NodePreviewData {
           },
         ];
       }
+
+      case 'output.resource.billing.calculation.set-additional-items':
+        return [
+          {
+            label: t('nodes.output.resource.billing.calculation.set-additional-items.preview.position'),
+            value: nodeData?.data.name as string,
+          },
+        ];
+
+      case 'output.http.sendRequest':
+        return [
+          {
+            label: t('nodes.output.http.sendRequest.preview.method'),
+            value: nodeData?.data.method as string,
+          },
+          {
+            label: t('nodes.output.http.sendRequest.preview.url'),
+            value: nodeData?.data.url as string,
+          },
+        ];
+
+      case 'output.mqtt.sendMessage':
+        return [
+          {
+            label: t('nodes.output.mqtt.sendMessage.preview.topic'),
+            value: nodeData?.data.topic as string,
+          },
+        ];
+
+      case 'output.resource.usage.end-session':
+        return [
+          {
+            label: t('nodes.output.resource.usage.end-session.preview.notes'),
+            value: nodeData?.data.notes as string,
+          },
+        ];
 
       default: {
         const exhaustiveCheck: never = schema.type;

--- a/libs/database-entities/src/lib/entities-index.ts
+++ b/libs/database-entities/src/lib/entities-index.ts
@@ -33,6 +33,7 @@ import {
   SetPayloadNodeDataSchema,
   MqttMessageReceivedNodeDataSchema,
   MqttWaitForMessageNodeDataSchema,
+  ResourceUsageEndSessionNodeDataSchema,
 } from './entities/resourceFlowNode';
 import { ResourceFlowEdge } from './entities/resourceFlowEdge';
 import { ResourceFlowLog, ResourceFlowLogType } from './entities/resourceFlowLog';
@@ -90,6 +91,7 @@ export {
   BillingTransactionItemCreateSchema,
   MqttMessageReceivedNodeDataSchema,
   MqttWaitForMessageNodeDataSchema,
+  ResourceUsageEndSessionNodeDataSchema,
 };
 
 // Export the entities object

--- a/libs/database-entities/src/lib/entities/resourceFlowNode.ts
+++ b/libs/database-entities/src/lib/entities/resourceFlowNode.ts
@@ -16,6 +16,7 @@ export enum ResourceFlowNodeType {
   OUTPUT_HTTP_SEND_REQUEST = 'output.http.sendRequest',
   OUTPUT_MQTT_SEND_MESSAGE = 'output.mqtt.sendMessage',
   OUTPUT_RESOURCE_BILLING_SET_ADDITIONAL_ITEMS = 'output.resource.billing.calculation.set-additional-items',
+  OUTPUT_RESOURCE_USAGE_END_SESSION = 'output.resource.usage.end-session',
   PROCESSING_WAIT = 'processing.wait',
   PROCESSING_IF = 'processing.if',
   PROCESSING_SET_PAYLOAD = 'processing.set-payload',
@@ -103,6 +104,14 @@ export const MqttWaitForMessageNodeDataSchema = z.object({
   timeoutSeconds: z.number().int().positive('Timeout must be a positive integer (seconds)'),
 });
 
+export const ResourceUsageEndSessionNodeDataSchema = z
+  .object({
+    notes: z.string().optional().meta({
+      stringVariant: 'multiline',
+    }),
+  })
+  .optional();
+
 // Helper function to get the appropriate schema for a node type
 export function getNodeDataSchema(nodeType: ResourceFlowNodeType) {
   switch (nodeType) {
@@ -140,6 +149,9 @@ export function getNodeDataSchema(nodeType: ResourceFlowNodeType) {
 
     case ResourceFlowNodeType.PROCESSING_MQTT_WAIT_FOR_MESSAGE:
       return MqttWaitForMessageNodeDataSchema;
+
+    case ResourceFlowNodeType.OUTPUT_RESOURCE_USAGE_END_SESSION:
+      return ResourceUsageEndSessionNodeDataSchema;
 
     default: {
       const exhaustiveCheck: never = nodeType;

--- a/libs/react-query-client/src/lib/requests/schemas.gen.ts
+++ b/libs/react-query-client/src/lib/requests/schemas.gen.ts
@@ -2094,7 +2094,7 @@ export const $ResourceFlowNodeSchemaDto = {
         type: {
             type: 'string',
             description: 'The name of the node type',
-            enum: ['input.button', 'input.resource.usage.started', 'input.resource.usage.stopped', 'input.resource.usage.takeover', 'input.resource.door.unlocked', 'input.resource.door.locked', 'input.resource.door.unlatched', 'input.mqtt.message.received', 'output.http.sendRequest', 'output.mqtt.sendMessage', 'output.resource.billing.calculation.set-additional-items', 'processing.wait', 'processing.if', 'processing.set-payload', 'processing.mqtt.waitForMessage']
+            enum: ['input.button', 'input.resource.usage.started', 'input.resource.usage.stopped', 'input.resource.usage.takeover', 'input.resource.door.unlocked', 'input.resource.door.locked', 'input.resource.door.unlatched', 'input.mqtt.message.received', 'output.http.sendRequest', 'output.mqtt.sendMessage', 'output.resource.billing.calculation.set-additional-items', 'output.resource.usage.end-session', 'processing.wait', 'processing.if', 'processing.set-payload', 'processing.mqtt.waitForMessage']
         },
         configSchema: {
             type: 'object',
@@ -2156,7 +2156,7 @@ export const $ResourceFlowNodeDto = {
             type: 'string',
             description: 'The type of the node',
             example: 'input.resource.usage.started',
-            enum: ['input.button', 'input.resource.usage.started', 'input.resource.usage.stopped', 'input.resource.usage.takeover', 'input.resource.door.unlocked', 'input.resource.door.locked', 'input.resource.door.unlatched', 'input.mqtt.message.received', 'output.http.sendRequest', 'output.mqtt.sendMessage', 'output.resource.billing.calculation.set-additional-items', 'processing.wait', 'processing.if', 'processing.set-payload', 'processing.mqtt.waitForMessage']
+            enum: ['input.button', 'input.resource.usage.started', 'input.resource.usage.stopped', 'input.resource.usage.takeover', 'input.resource.door.unlocked', 'input.resource.door.locked', 'input.resource.door.unlatched', 'input.mqtt.message.received', 'output.http.sendRequest', 'output.mqtt.sendMessage', 'output.resource.billing.calculation.set-additional-items', 'output.resource.usage.end-session', 'processing.wait', 'processing.if', 'processing.set-payload', 'processing.mqtt.waitForMessage']
         },
         position: {
             description: 'The position of the node',

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -1436,7 +1436,7 @@ export type ResourceFlowNodeSchemaDto = {
     /**
      * The name of the node type
      */
-    type: 'input.button' | 'input.resource.usage.started' | 'input.resource.usage.stopped' | 'input.resource.usage.takeover' | 'input.resource.door.unlocked' | 'input.resource.door.locked' | 'input.resource.door.unlatched' | 'input.mqtt.message.received' | 'output.http.sendRequest' | 'output.mqtt.sendMessage' | 'output.resource.billing.calculation.set-additional-items' | 'processing.wait' | 'processing.if' | 'processing.set-payload' | 'processing.mqtt.waitForMessage';
+    type: 'input.button' | 'input.resource.usage.started' | 'input.resource.usage.stopped' | 'input.resource.usage.takeover' | 'input.resource.door.unlocked' | 'input.resource.door.locked' | 'input.resource.door.unlatched' | 'input.mqtt.message.received' | 'output.http.sendRequest' | 'output.mqtt.sendMessage' | 'output.resource.billing.calculation.set-additional-items' | 'output.resource.usage.end-session' | 'processing.wait' | 'processing.if' | 'processing.set-payload' | 'processing.mqtt.waitForMessage';
     /**
      * The schema for a node type
      */
@@ -1476,6 +1476,7 @@ export enum type3 {
     OUTPUT_HTTP_SEND_REQUEST = 'output.http.sendRequest',
     OUTPUT_MQTT_SEND_MESSAGE = 'output.mqtt.sendMessage',
     OUTPUT_RESOURCE_BILLING_CALCULATION_SET_ADDITIONAL_ITEMS = 'output.resource.billing.calculation.set-additional-items',
+    OUTPUT_RESOURCE_USAGE_END_SESSION = 'output.resource.usage.end-session',
     PROCESSING_WAIT = 'processing.wait',
     PROCESSING_IF = 'processing.if',
     PROCESSING_SET_PAYLOAD = 'processing.set-payload',
@@ -1501,7 +1502,7 @@ export type ResourceFlowNodeDto = {
     /**
      * The type of the node
      */
-    type: 'input.button' | 'input.resource.usage.started' | 'input.resource.usage.stopped' | 'input.resource.usage.takeover' | 'input.resource.door.unlocked' | 'input.resource.door.locked' | 'input.resource.door.unlatched' | 'input.mqtt.message.received' | 'output.http.sendRequest' | 'output.mqtt.sendMessage' | 'output.resource.billing.calculation.set-additional-items' | 'processing.wait' | 'processing.if' | 'processing.set-payload' | 'processing.mqtt.waitForMessage';
+    type: 'input.button' | 'input.resource.usage.started' | 'input.resource.usage.stopped' | 'input.resource.usage.takeover' | 'input.resource.door.unlocked' | 'input.resource.door.locked' | 'input.resource.door.unlatched' | 'input.mqtt.message.received' | 'output.http.sendRequest' | 'output.mqtt.sendMessage' | 'output.resource.billing.calculation.set-additional-items' | 'output.resource.usage.end-session' | 'processing.wait' | 'processing.if' | 'processing.set-payload' | 'processing.mqtt.waitForMessage';
     /**
      * The position of the node
      */


### PR DESCRIPTION
## Summary by Sourcery

Add support for a new resource flow node type to end usage sessions with optional templated notes

New Features:
- Allow flows to end resource usage sessions via a new end-session node, including database schema, API, and frontend preview support

Enhancements:
- Implement processEndUsageSessionNode to fetch the active session, compile optional Handlebars notes, and invoke ResourceUsageService.endSession
- Introduce NoUsageSessionError and error handling when no active usage session exists

Build:
- Add a TypeORM migration to include the new node type in the resource_flow_node table enum
- Update generated API schemas and React Query client types to include OUTPUT_RESOURCE_USAGE_END_SESSION

Tests:
- Add executor unit tests for successful end-session with templated notes and for the no-active-session error case