### PR TITLE
feat(ATT-161): mqtt qos and retain settings per resource flow node

### DIFF
--- a/apps/api/src/database/migrations/1761910926026-mqtt-qos-retain-setting-per-flow-node.ts
+++ b/apps/api/src/database/migrations/1761910926026-mqtt-qos-retain-setting-per-flow-node.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MqttQosRetainSettingPerFlowNode1761910926026 implements MigrationInterface {
+  name = 'MqttQosRetainSettingPerFlowNode1761910926026';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "temporary_mqtt_server" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" text NOT NULL, "host" text NOT NULL, "port" integer NOT NULL, "username" text, "password" text, "clientId" text, "useTls" boolean NOT NULL DEFAULT (0), "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "defaultPublishQos" integer NOT NULL DEFAULT (0), "defaultPublishRetain" boolean NOT NULL DEFAULT (0), "defaultSubscribeQos" integer NOT NULL DEFAULT (0))`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_mqtt_server"("id", "name", "host", "port", "username", "password", "clientId", "useTls", "createdAt", "updatedAt") SELECT "id", "name", "host", "port", "username", "password", "clientId", "useTls", "createdAt", "updatedAt" FROM "mqtt_server"`,
+    );
+    await queryRunner.query(`DROP TABLE "mqtt_server"`);
+    await queryRunner.query(`ALTER TABLE "temporary_mqtt_server" RENAME TO "mqtt_server"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_sso_provider_oidc_configuration" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "ssoProviderId" integer NOT NULL, "issuer" text NOT NULL, "authorizationURL" text NOT NULL, "tokenURL" text NOT NULL, "userInfoURL" text NOT NULL, "clientId" text NOT NULL, "clientSecret" text NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "scopes" text, "usernameClaimPaths" text, "emailClaimPaths" text, CONSTRAINT "REL_e0afa5fbb3a37c919d37d5438a" UNIQUE ("ssoProviderId"), CONSTRAINT "FK_e0afa5fbb3a37c919d37d5438ab" FOREIGN KEY ("ssoProviderId") REFERENCES "sso_provider" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_sso_provider_oidc_configuration"("id", "ssoProviderId", "issuer", "authorizationURL", "tokenURL", "userInfoURL", "clientId", "clientSecret", "createdAt", "updatedAt", "scopes", "usernameClaimPaths", "emailClaimPaths") SELECT "id", "ssoProviderId", "issuer", "authorizationURL", "tokenURL", "userInfoURL", "clientId", "clientSecret", "createdAt", "updatedAt", "scopes", "usernameClaimPaths", "emailClaimPaths" FROM "sso_provider_oidc_configuration"`,
+    );
+    await queryRunner.query(`DROP TABLE "sso_provider_oidc_configuration"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_sso_provider_oidc_configuration" RENAME TO "sso_provider_oidc_configuration"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sso_provider_oidc_configuration" RENAME TO "temporary_sso_provider_oidc_configuration"`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "sso_provider_oidc_configuration" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "ssoProviderId" integer NOT NULL, "issuer" text NOT NULL, "authorizationURL" text NOT NULL, "tokenURL" text NOT NULL, "userInfoURL" text NOT NULL, "clientId" text NOT NULL, "clientSecret" text NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "scopes" varchar, "usernameClaimPaths" varchar, "emailClaimPaths" varchar, CONSTRAINT "REL_e0afa5fbb3a37c919d37d5438a" UNIQUE ("ssoProviderId"), CONSTRAINT "FK_e0afa5fbb3a37c919d37d5438ab" FOREIGN KEY ("ssoProviderId") REFERENCES "sso_provider" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "sso_provider_oidc_configuration"("id", "ssoProviderId", "issuer", "authorizationURL", "tokenURL", "userInfoURL", "clientId", "clientSecret", "createdAt", "updatedAt", "scopes", "usernameClaimPaths", "emailClaimPaths") SELECT "id", "ssoProviderId", "issuer", "authorizationURL", "tokenURL", "userInfoURL", "clientId", "clientSecret", "createdAt", "updatedAt", "scopes", "usernameClaimPaths", "emailClaimPaths" FROM "temporary_sso_provider_oidc_configuration"`,
+    );
+    await queryRunner.query(`DROP TABLE "temporary_sso_provider_oidc_configuration"`);
+    await queryRunner.query(`ALTER TABLE "mqtt_server" RENAME TO "temporary_mqtt_server"`);
+    await queryRunner.query(
+      `CREATE TABLE "mqtt_server" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" text NOT NULL, "host" text NOT NULL, "port" integer NOT NULL, "username" text, "password" text, "clientId" text, "useTls" boolean NOT NULL DEFAULT (0), "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')))`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "mqtt_server"("id", "name", "host", "port", "username", "password", "clientId", "useTls", "createdAt", "updatedAt") SELECT "id", "name", "host", "port", "username", "password", "clientId", "useTls", "createdAt", "updatedAt" FROM "temporary_mqtt_server"`,
+    );
+    await queryRunner.query(`DROP TABLE "temporary_mqtt_server"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -64,3 +64,4 @@ export * from './1760468005000-email-templates-variables-fix';
 export * from './1761776665535-wait-for-mqtt-message-flow-node';
 export * from './1761832730725-end-usage-session-flow-node';
 export * from './1761903220000-sso-oidc-add-scopes-and-claim-paths';
+export * from './1761910926026-mqtt-qos-retain-setting-per-flow-node';

--- a/apps/api/src/mqtt/mqtt-client.service.spec.ts
+++ b/apps/api/src/mqtt/mqtt-client.service.spec.ts
@@ -60,6 +60,9 @@ describe('MqttClientService', () => {
     username: 'testuser',
     password: 'testpass',
     useTls: false,
+    defaultPublishQos: 0,
+    defaultPublishRetain: false,
+    defaultSubscribeQos: 0,
   };
 
   let mockEventEmitter: Partial<EventEmitter2>;
@@ -143,6 +146,55 @@ describe('MqttClientService', () => {
 
       // Act & Assert
       await expect(service.publish(1, 'test/topic', 'test message')).rejects.toThrow('Publish error');
+    });
+
+    it('should use server defaults when no options are provided', async () => {
+      // Arrange
+      (mockRepository.findOneBy as jest.Mock).mockResolvedValue({
+        ...mockServer,
+        defaultPublishQos: 1,
+        defaultPublishRetain: true,
+      });
+      const getOrCreateClientSpy = jest.spyOn(service as unknown as MqttClientServicePrivate, 'getOrCreateClient');
+      const mockClient = mqtt.connect({});
+      getOrCreateClientSpy.mockResolvedValue(mockClient);
+
+      // Spy on publish call args
+      const publishSpy = jest.spyOn(mockClient, 'publish');
+
+      // Act
+      await service.publish(1, 'test/topic', 'test message');
+
+      // Assert
+      expect(publishSpy).toHaveBeenCalled();
+      const args = (publishSpy.mock.calls[0] ?? []) as unknown[];
+      const options = (args[2] ?? {}) as { qos?: number; retain?: boolean };
+      expect(options.qos).toBe(1);
+      expect(options.retain).toBe(true);
+    });
+
+    it('should prefer per-call options over server defaults', async () => {
+      // Arrange
+      (mockRepository.findOneBy as jest.Mock).mockResolvedValue({
+        ...mockServer,
+        defaultPublishQos: 0,
+        defaultPublishRetain: true,
+      });
+      const getOrCreateClientSpy = jest.spyOn(service as unknown as MqttClientServicePrivate, 'getOrCreateClient');
+      const mockClient = mqtt.connect({});
+      getOrCreateClientSpy.mockResolvedValue(mockClient);
+
+      const publishSpy = jest.spyOn(mockClient, 'publish');
+
+      // Act
+      await service.publish(1, 'test/topic', 'test message', { qos: 2, retain: false });
+
+      // Assert
+      expect(publishSpy).toHaveBeenCalled();
+      const args = (publishSpy.mock.calls[0] ?? []) as unknown[];
+      const options = (args[2] ?? {}) as { qos?: number; retain?: boolean };
+      expect(options.qos).toBe(2);
+      expect(options.retain).toBe(false);
     });
   });
 

--- a/apps/api/src/mqtt/mqtt-client.service.ts
+++ b/apps/api/src/mqtt/mqtt-client.service.ts
@@ -11,7 +11,7 @@ import { MqttMessageEvent } from './mqtt-message.event';
 export class MqttClientService implements OnModuleDestroy {
   private clients: Map<number, MqttClient> = new Map();
   private connectionPromises: Map<number, Promise<MqttClient>> = new Map();
-  private subscriptions: Map<number, Set<string>> = new Map();
+  private subscriptions: Map<number, Map<string, 0 | 1 | 2>> = new Map();
   private readonly logger = new Logger(MqttClientService.name);
 
   constructor(
@@ -103,9 +103,13 @@ export class MqttClientService implements OnModuleDestroy {
         // Re-subscribe to all known topics for this server on each successful connect
         const topics = this.subscriptions.get(serverId);
         if (topics && topics.size > 0) {
-          for (const t of topics.values()) {
-            client.subscribe(t);
-            this.logger.debug(`(re)subscribed to ${t} on server ${server.name}`);
+          for (const [t, qos] of topics.entries()) {
+            client.subscribe(t, { qos: qos ?? (server.defaultSubscribeQos as 0 | 1 | 2) ?? 0 }, (err) => {
+              if (err) {
+                this.logger.warn(`Failed to (re)subscribe to ${t} on server ${server.name}: ${err.message}`);
+              }
+            });
+            this.logger.debug(`(re)subscribed to ${t} on server ${server.name} with qos=${qos ?? 0}`);
           }
         }
         resolve(client);
@@ -145,11 +149,26 @@ export class MqttClientService implements OnModuleDestroy {
     });
   }
 
-  async publish(serverId: number, topic: string, message: string): Promise<void> {
+  async publish(
+    serverId: number,
+    topic: string,
+    message: string,
+    options?: { qos?: 0 | 1 | 2; retain?: boolean },
+  ): Promise<void> {
     try {
-      const client = await this.getOrCreateClient(serverId);
+      const [client, server] = await Promise.all([
+        this.getOrCreateClient(serverId),
+        this.mqttServerRepository.findOneBy({ id: serverId }),
+      ]);
+
+      if (!server) {
+        throw new Error(`MQTT server with ID ${serverId} not found`);
+      }
+
+      const qos: 0 | 1 | 2 = (options?.qos ?? (server.defaultPublishQos as 0 | 1 | 2) ?? 0) as 0 | 1 | 2;
+      const retain: boolean = options?.retain ?? Boolean(server.defaultPublishRetain ?? false);
       return new Promise((resolve, reject) => {
-        client.publish(topic, message, { qos: 2, retain: true }, (error) => {
+        client.publish(topic, message, { qos, retain }, (error) => {
           if (error) {
             this.logger.error(`Failed to publish to topic ${topic}: ${error.message}`);
             reject(error);
@@ -165,16 +184,26 @@ export class MqttClientService implements OnModuleDestroy {
     }
   }
 
-  async subscribe(serverId: number, topic: string): Promise<void> {
+  async subscribe(serverId: number, topic: string, qos?: 0 | 1 | 2): Promise<void> {
     // Track desired subscriptions so they can be (re)applied on connect/reconnect
     if (!this.subscriptions.has(serverId)) {
-      this.subscriptions.set(serverId, new Set());
+      this.subscriptions.set(serverId, new Map());
     }
-    this.subscriptions.get(serverId).add(topic);
+    const serverTopics = this.subscriptions.get(serverId);
+    if (qos !== undefined) {
+      serverTopics.set(topic, qos);
+    } else if (!serverTopics.has(topic)) {
+      // Leave qos undefined to allow resolution from server defaults on (re)subscribe
+      serverTopics.set(topic, undefined as unknown as 0 | 1 | 2);
+    }
 
     try {
-      const client = await this.getOrCreateClient(serverId, true);
-      client.subscribe(topic);
+      const [client, server] = await Promise.all([
+        this.getOrCreateClient(serverId, true),
+        this.mqttServerRepository.findOneBy({ id: serverId }),
+      ]);
+      const effectiveQos: 0 | 1 | 2 = (qos ?? (server?.defaultSubscribeQos as 0 | 1 | 2) ?? 0) as 0 | 1 | 2;
+      client.subscribe(topic, { qos: effectiveQos });
     } catch (error) {
       // Do not throw: the client will keep trying to connect and will subscribe on next connect
       this.logger.warn(

--- a/apps/api/src/mqtt/servers/dtos/mqtt-server.dto.ts
+++ b/apps/api/src/mqtt/servers/dtos/mqtt-server.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsNumber, IsOptional, IsBoolean } from 'class-validator';
+import { IsString, IsNotEmpty, IsNumber, IsOptional, IsBoolean, IsIn } from 'class-validator';
 import { PartialType } from '@nestjs/swagger';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
@@ -56,6 +56,38 @@ export class CreateMqttServerDto {
     default: false,
   })
   useTls?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @IsIn([0, 1, 2])
+  @ApiProperty({
+    description: 'Default publish QoS (0, 1, or 2)',
+    required: false,
+    example: 0,
+  })
+  defaultPublishQos?: number;
+
+  @IsOptional()
+  @ToBoolean()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Default publish retain flag',
+    required: false,
+    example: false,
+  })
+  defaultPublishRetain?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @IsIn([0, 1, 2])
+  @ApiProperty({
+    description: 'Default subscribe QoS (0, 1, or 2)',
+    required: false,
+    example: 0,
+  })
+  defaultSubscribeQos?: number;
 }
 
 /**

--- a/apps/api/src/resources/flows/resource-flows-executor.service.spec.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.spec.ts
@@ -470,7 +470,7 @@ describe('ResourceFlowsExecutorService MQTT', () => {
 
     const results = await service.runFlow(1, ResourceFlowNodeType.INPUT_BUTTON, {});
     expect(results).toEqual([{ topic: 'devices/abc/state', payload: { on: true } }]);
-    expect(mqttClientService.subscribe).toHaveBeenCalledWith(7, 'devices/+/state');
+    expect(mqttClientService.subscribe).toHaveBeenCalledWith(7, 'devices/+/state', undefined);
   });
 
   it('processing.mqtt.waitForMessage times out and throws error', async () => {

--- a/apps/api/src/resources/flows/resource-flows-executor.service.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.ts
@@ -144,7 +144,7 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
       }),
     ]);
 
-    const subscribePairs: Array<{ serverId: number; topic: string }> = [];
+    const subscribePairs: Array<{ serverId: number; topic: string; qos?: 0 | 1 | 2 }> = [];
 
     for (const node of mqttMessageReceivedNodes) {
       const { topic, serverId } = node.data as z.infer<typeof MqttMessageReceivedNodeDataSchema>;
@@ -156,16 +156,16 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
     }
 
     for (const node of mqttWaitForMessageNodes) {
-      const { topic, serverId } = node.data as z.infer<typeof MqttWaitForMessageNodeDataSchema>;
+      const { topic, serverId, subscribeQos } = node.data as z.infer<typeof MqttWaitForMessageNodeDataSchema>;
       if (!serverId || !topic) {
         this.logger.warn(`Skipping subscription to topic ${topic} for server ID ${serverId} because it is missing`);
         continue;
       }
-      subscribePairs.push({ serverId, topic });
+      subscribePairs.push({ serverId, topic, qos: subscribeQos as unknown as 0 | 1 | 2 });
     }
 
-    for (const { serverId, topic } of subscribePairs) {
-      await this.mqttClientService.subscribe(serverId, topic).catch((error) => {
+    for (const { serverId, topic, qos } of subscribePairs) {
+      await this.mqttClientService.subscribe(serverId, topic, qos).catch((error) => {
         this.logger.error(`Failed to subscribe to topic ${topic} for server ID ${serverId}`, error.stack);
       });
     }
@@ -729,10 +729,12 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _transactionManager?: EntityManager,
   ): Promise<NodeProcessingResult> {
-    const { serverId, topic, timeoutSeconds } = node.data as z.infer<typeof MqttWaitForMessageNodeDataSchema>;
+    const { serverId, topic, timeoutSeconds, subscribeQos } = node.data as z.infer<
+      typeof MqttWaitForMessageNodeDataSchema
+    >;
 
     // Ensure subscription exists (wildcards allowed)
-    await this.mqttClientService.subscribe(serverId, topic).catch((error) => {
+    await this.mqttClientService.subscribe(serverId, topic, subscribeQos as unknown as 0 | 1 | 2).catch((error) => {
       this.logger.error(`Failed to subscribe for wait node to topic ${topic} on server ${serverId}`, error.stack);
       throw error;
     });
@@ -785,7 +787,10 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
       `Publishing MQTT message to server ID: ${serverId} with topic: ${topic} and payload: "${payload}"`,
     );
 
-    await this.mqttClientService.publish(serverId, topic, payload);
+    await this.mqttClientService.publish(serverId, topic, payload, {
+      qos: data.qos as 0 | 1 | 2,
+      retain: data.retain as boolean,
+    });
 
     return {
       payload: input,

--- a/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
@@ -35,6 +35,9 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
     username: '',
     password: '',
     useTls: false,
+    defaultPublishQos: 0,
+    defaultPublishRetain: false,
+    defaultSubscribeQos: 0,
   });
 
   const createMqttServer = useMqttServiceMqttServersCreateOne({
@@ -166,6 +169,46 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
       >
         {t('useTls')}
       </Checkbox>
+
+      <Input
+        label={t('defaultPublishQosLabel')}
+        id="defaultPublishQos"
+        name="defaultPublishQos"
+        type="number"
+        min={0}
+        max={2}
+        step={1}
+        placeholder={t('qosPlaceholder')}
+        value={String(formValues.defaultPublishQos ?? 0)}
+        onChange={handleInputChange}
+        fullWidth
+        data-cy="create-mqtt-server-form-default-publish-qos-input"
+      />
+
+      <Checkbox
+        id="defaultPublishRetain"
+        name="defaultPublishRetain"
+        isSelected={!!formValues.defaultPublishRetain}
+        onValueChange={(checked) => setFormValues((prev) => ({ ...prev, defaultPublishRetain: checked }))}
+        data-cy="create-mqtt-server-form-default-publish-retain-checkbox"
+      >
+        {t('defaultPublishRetainLabel')}
+      </Checkbox>
+
+      <Input
+        label={t('defaultSubscribeQosLabel')}
+        id="defaultSubscribeQos"
+        name="defaultSubscribeQos"
+        type="number"
+        min={0}
+        max={2}
+        step={1}
+        placeholder={t('qosPlaceholder')}
+        value={String(formValues.defaultSubscribeQos ?? 0)}
+        onChange={handleInputChange}
+        fullWidth
+        data-cy="create-mqtt-server-form-default-subscribe-qos-input"
+      />
 
       <div className="flex justify-end space-x-3 mt-4">
         <Button color="default" variant="flat" onPress={handleCancel} data-cy="create-mqtt-server-form-cancel-button">

--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, CardHeader, Input, Checkbox, Spinner } from '@heroui/react';
+import { Button, Card, CardHeader, Input, Checkbox, Spinner, Switch } from '@heroui/react';
 import { ArrowLeft } from 'lucide-react';
 import { PasswordInput } from '../../../components/PasswordInput';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -30,6 +30,9 @@ export function EditMqttServerPage() {
     username: '',
     password: '',
     useTls: false,
+    defaultPublishQos: 0,
+    defaultPublishRetain: false,
+    defaultSubscribeQos: 0,
   });
 
   // Fetch server details
@@ -50,6 +53,9 @@ export function EditMqttServerPage() {
         username: server.username ?? '',
         password: server.password ?? '',
         useTls: server.useTls,
+        defaultPublishQos: server.defaultPublishQos ?? 0,
+        defaultPublishRetain: server.defaultPublishRetain ?? false,
+        defaultSubscribeQos: server.defaultSubscribeQos ?? 0,
       });
     }
   }, [server]);
@@ -237,6 +243,52 @@ export function EditMqttServerPage() {
                 <label htmlFor="useTls" className="text-sm">
                   {t('useTls')}
                 </label>
+              </div>
+
+              <div>
+                <Input
+                  label={t('defaultPublishQosLabel')}
+                  id="defaultPublishQos"
+                  name="defaultPublishQos"
+                  type="number"
+                  min={0}
+                  max={2}
+                  step={1}
+                  placeholder={t('qosPlaceholder')}
+                  value={String(formValues.defaultPublishQos ?? 0)}
+                  onChange={handleInputChange}
+                  fullWidth
+                  data-cy="edit-mqtt-server-form-default-publish-qos-input"
+                />
+              </div>
+
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="defaultPublishRetain"
+                  name="defaultPublishRetain"
+                  isSelected={!!formValues.defaultPublishRetain}
+                  onValueChange={(checked) => setFormValues((prev) => ({ ...prev, defaultPublishRetain: checked }))}
+                  data-cy="edit-mqtt-server-form-default-publish-retain-checkbox"
+                >
+                  {t('defaultPublishRetainLabel')}
+                </Switch>
+              </div>
+
+              <div>
+                <Input
+                  label={t('defaultSubscribeQosLabel')}
+                  id="defaultSubscribeQos"
+                  name="defaultSubscribeQos"
+                  type="number"
+                  min={0}
+                  max={2}
+                  step={1}
+                  placeholder={t('qosPlaceholder')}
+                  value={String(formValues.defaultSubscribeQos ?? 0)}
+                  onChange={handleInputChange}
+                  fullWidth
+                  data-cy="edit-mqtt-server-form-default-subscribe-qos-input"
+                />
               </div>
             </div>
 

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -214,15 +214,21 @@ function FlowsPageInner() {
 
   const addStartNode = useCallback(
     (nodeType: string) => {
+      let maxX = 0;
+      nodes.forEach((node) => {
+        maxX = Math.max(maxX, node.position.x);
+      });
       const newNode: Node = {
         id: nanoid(),
-        position: { x: 0, y: 0 },
+        position: { x: maxX + 300, y: 0 },
         type: nodeType,
         data: {},
       };
       addNode(newNode);
+
+      fitView({ nodes: [newNode], duration: 1000, maxZoom: 0.9 });
     },
-    [addNode],
+    [addNode, nodes, fitView],
   );
 
   const [flowIsRunning, setFlowIsRunning] = useState(false);

--- a/apps/frontend/src/app/resources/details/flows/node/de.json
+++ b/apps/frontend/src/app/resources/details/flows/node/de.json
@@ -147,7 +147,8 @@
           "config": {
             "serverId": { "label": "Server" },
             "topic": { "label": "Thema (unterstützt + und #)" },
-            "timeoutSeconds": { "label": "Timeout (Sekunden)" }
+            "timeoutSeconds": { "label": "Timeout (Sekunden)" },
+            "subscribeQos": { "label": "QoS (effektiv ist min(publish, subscribe))" }
           }
         }
       },
@@ -276,7 +277,9 @@
             },
             "payload": {
               "label": "Nutzlast"
-            }
+            },
+            "qos": { "label": "QoS" },
+            "retain": { "label": "Nachricht behalten (retain)" }
           }
         }
       },

--- a/apps/frontend/src/app/resources/details/flows/node/en.json
+++ b/apps/frontend/src/app/resources/details/flows/node/en.json
@@ -147,7 +147,8 @@
           "config": {
             "serverId": { "label": "Server" },
             "topic": { "label": "Topic (supports + and #)" },
-            "timeoutSeconds": { "label": "Timeout (seconds)" }
+            "timeoutSeconds": { "label": "Timeout (seconds)" },
+            "subscribeQos": { "label": "QoS (effective is min(publish, subscribe))" }
           }
         }
       },
@@ -276,7 +277,9 @@
             },
             "payload": {
               "label": "Payload"
-            }
+            },
+            "qos": { "label": "QoS" },
+            "retain": { "label": "Retain message" }
           }
         }
       },

--- a/apps/frontend/src/app/resources/details/flows/node/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/index.tsx
@@ -32,7 +32,6 @@ enum ProcessingState {
 export function AttraccessNode(props: Props) {
   const { schema, previewMode, tNodeTranslations: t, data } = props;
 
-  const { removeNode } = useFlowContext();
   const nodeId = useNodeId();
 
   const [processingState, setProcessingState] = useState<ProcessingState>(ProcessingState.IDLE);
@@ -65,7 +64,7 @@ export function AttraccessNode(props: Props) {
     [nodeId],
   );
 
-  const { addLiveLogReceiver, removeLiveLogReceiver } = useFlowContext();
+  const { addLiveLogReceiver, removeLiveLogReceiver, removeNode } = useFlowContext();
 
   useEffect(() => {
     if (!nodeId || previewMode) {

--- a/apps/frontend/src/test-utils/helpers.ts
+++ b/apps/frontend/src/test-utils/helpers.ts
@@ -1,4 +1,5 @@
-import { act, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { act } from 'react';
 import { vi } from 'vitest';
 
 /**
@@ -71,7 +72,7 @@ export function createMockResponse<T>(data: T, ok = true, status = 200): Respons
 export function createMockEvent(
   type: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  values: Record<string, any> = {}
+  values: Record<string, any> = {},
 ): Partial<Event> {
   return {
     type,
@@ -87,7 +88,7 @@ export function createMockEvent(
 export function createMockKeyboardEvent(
   key: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  values: Record<string, any> = {}
+  values: Record<string, any> = {},
 ): Partial<KeyboardEvent> {
   return {
     key,

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
     setupFiles: ['./src/test-utils/setup.ts'],
   },
   esbuild: {
-    target: 'node14',
+    target: 'node20',
   },
 });

--- a/docs/user/resources/iots/mqtt/mqtt-integration.md
+++ b/docs/user/resources/iots/mqtt/mqtt-integration.md
@@ -14,15 +14,18 @@ When a resource is used or released, Attraccess can automatically publish messag
 
 MQTT servers can be configured with the following parameters:
 
-| Parameter   | Description                               | Required | Default            |
-| ----------- | ----------------------------------------- | -------- | ------------------ |
-| Name        | Friendly name for the server              | Yes      | -                  |
-| Host        | Hostname or IP address of the MQTT server | Yes      | -                  |
-| Port        | Port number of the MQTT server            | Yes      | 1883               |
-| Client ID   | Client identifier for the MQTT connection | No       | Randomly generated |
-| Username    | Authentication username                   | No       | -                  |
-| Password    | Authentication password                   | No       | -                  |
-| Use TLS/SSL | Whether to use TLS/SSL for the connection | No       | false              |
+| Parameter             | Description                                                   | Required | Default            |
+| --------------------- | ------------------------------------------------------------- | -------- | ------------------ |
+| Name                  | Friendly name for the server                                  | Yes      | -                  |
+| Host                  | Hostname or IP address of the MQTT server                     | Yes      | -                  |
+| Port                  | Port number of the MQTT server                                | Yes      | 1883               |
+| Client ID             | Client identifier for the MQTT connection                     | No       | Randomly generated |
+| Username              | Authentication username                                       | No       | -                  |
+| Password              | Authentication password                                       | No       | -                  |
+| Use TLS/SSL           | Whether to use TLS/SSL for the connection                     | No       | false              |
+| Default publish QoS   | Default QoS used when publishing if not set per node (0/1/2)  | No       | 0                  |
+| Default retain        | Default retain flag used when publishing if not set per node  | No       | false              |
+| Default subscribe QoS | Default QoS used when subscribing if not set per node (0/1/2) | No       | 0                  |
 
 ### Resource MQTT Configuration
 
@@ -37,6 +40,15 @@ Each resource can have its own MQTT configuration with the following parameters:
 | Not-In-Use Message | Message template for when the resource is not in use | Yes      |
 
 ## Template Variables
+
+## QoS and retain behavior
+
+- Publish options can be set per node (flow editor) or defaulted per MQTT server.
+- Subscribe QoS can be set on the "Wait for MQTT message" node, or defaulted per MQTT server.
+- Precedence: per-node settings → server defaults → global defaults.
+- Global defaults: publish QoS 0, retain false; subscribe QoS 0.
+- Effective delivery QoS equals the lower of the publisher QoS and the subscriber QoS.
+- Retain stores the last published message on the broker so new subscribers receive it immediately.
 
 Both topic and message templates use Handlebars syntax and support the following variables:
 
@@ -198,13 +210,11 @@ mosquitto_pub -h localhost -p 1883 -t "test/topic" -m "Hello MQTT"
 ### Common Issues
 
 1. **Connection Refused**
-
    - Check if the MQTT server is running
    - Verify the hostname and port are correct
    - Ensure there are no firewall rules blocking the connection
 
 2. **Authentication Failed**
-
    - Verify the username and password are correct
    - Check if the MQTT server requires authentication
 
@@ -228,19 +238,16 @@ To view detailed logs of MQTT connections and message publishing:
 ## Production Considerations
 
 1. **Security**
-
    - Use TLS/SSL for all MQTT connections in production
    - Set strong, unique passwords
    - Consider using a dedicated MQTT broker with access controls
 
 2. **Reliability**
-
    - Configure appropriate QoS levels based on your requirements
    - Implement monitoring for MQTT connections
    - Consider using a managed MQTT service for production
 
 3. **Scaling**
-
    - For high-volume environments, consider using a clustered MQTT broker
    - Monitor message throughput and adjust accordingly
 

--- a/libs/database-entities/src/lib/entities/mqttServer.entity.ts
+++ b/libs/database-entities/src/lib/entities/mqttServer.entity.ts
@@ -62,6 +62,27 @@ export class MqttServer {
   })
   useTls!: boolean;
 
+  @Column({ type: 'integer', default: 0 })
+  @ApiProperty({
+    description: 'Default QoS level for publish operations (0, 1, or 2)',
+    example: 0,
+  })
+  defaultPublishQos!: number;
+
+  @Column({ type: 'boolean', default: false })
+  @ApiProperty({
+    description: 'Default retain flag for publish operations',
+    example: false,
+  })
+  defaultPublishRetain!: boolean;
+
+  @Column({ type: 'integer', default: 0 })
+  @ApiProperty({
+    description: 'Default QoS level for subscribe operations (0, 1, or 2)',
+    example: 0,
+  })
+  defaultSubscribeQos!: number;
+
   @CreateDateColumn()
   @ApiProperty({
     description: 'When the MQTT server was created',

--- a/libs/database-entities/src/lib/entities/resourceFlowNode.ts
+++ b/libs/database-entities/src/lib/entities/resourceFlowNode.ts
@@ -50,6 +50,12 @@ export const MqttSendMessageNodeDataSchema = z.object({
   payload: z.string().optional().default('').meta({
     stringVariant: 'multiline',
   }),
+  qos: z.number().min(0).max(2).optional().meta({
+    helpText: 'Publish QoS: 0 (at most once), 1 (at least once), 2 (exactly once)',
+  }),
+  retain: z.boolean().optional().meta({
+    helpText: 'Retain publishes: broker stores last message for new subscribers',
+  }),
 });
 
 export const WaitNodeDataSchema = z.object({
@@ -102,6 +108,10 @@ export const MqttWaitForMessageNodeDataSchema = z.object({
   serverId: MqttServerIdSchema,
   topic: z.string().min(1, 'Topic is required'),
   timeoutSeconds: z.number().int().positive('Timeout must be a positive integer (seconds)'),
+  subscribeQos: z.number().min(0).max(2).optional().meta({
+    helpText:
+      'Subscribe QoS sets the maximum delivery level for received messages; effective QoS is the lower of publisher and subscriber QoS.',
+  }),
 });
 
 export const ResourceUsageEndSessionNodeDataSchema = z

--- a/libs/react-query-client/src/lib/requests/schemas.gen.ts
+++ b/libs/react-query-client/src/lib/requests/schemas.gen.ts
@@ -1052,6 +1052,21 @@ export const $MqttServer = {
             description: 'Whether to use TLS/SSL',
             example: false
         },
+        defaultPublishQos: {
+            type: 'number',
+            description: 'Default QoS level for publish operations (0, 1, or 2)',
+            example: 0
+        },
+        defaultPublishRetain: {
+            type: 'boolean',
+            description: 'Default retain flag for publish operations',
+            example: false
+        },
+        defaultSubscribeQos: {
+            type: 'number',
+            description: 'Default QoS level for subscribe operations (0, 1, or 2)',
+            example: 0
+        },
         createdAt: {
             format: 'date-time',
             type: 'string',
@@ -1063,7 +1078,7 @@ export const $MqttServer = {
             description: 'When the MQTT server was last updated'
         }
     },
-    required: ['id', 'name', 'host', 'port', 'useTls', 'createdAt', 'updatedAt']
+    required: ['id', 'name', 'host', 'port', 'useTls', 'defaultPublishQos', 'defaultPublishRetain', 'defaultSubscribeQos', 'createdAt', 'updatedAt']
 } as const;
 
 export const $CreateMqttServerDto = {
@@ -1098,6 +1113,21 @@ export const $CreateMqttServerDto = {
             type: 'boolean',
             description: 'Whether to use TLS/SSL for the connection',
             default: false
+        },
+        defaultPublishQos: {
+            type: 'number',
+            description: 'Default publish QoS (0, 1, or 2)',
+            example: 0
+        },
+        defaultPublishRetain: {
+            type: 'boolean',
+            description: 'Default publish retain flag',
+            example: false
+        },
+        defaultSubscribeQos: {
+            type: 'number',
+            description: 'Default subscribe QoS (0, 1, or 2)',
+            example: 0
         }
     },
     required: ['name', 'host', 'port']
@@ -1135,6 +1165,21 @@ export const $UpdateMqttServerDto = {
             type: 'boolean',
             description: 'Whether to use TLS/SSL for the connection',
             default: false
+        },
+        defaultPublishQos: {
+            type: 'number',
+            description: 'Default publish QoS (0, 1, or 2)',
+            example: 0
+        },
+        defaultPublishRetain: {
+            type: 'boolean',
+            description: 'Default publish retain flag',
+            example: false
+        },
+        defaultSubscribeQos: {
+            type: 'number',
+            description: 'Default subscribe QoS (0, 1, or 2)',
+            example: 0
         }
     }
 } as const;

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -719,6 +719,18 @@ export type MqttServer = {
      */
     useTls: boolean;
     /**
+     * Default QoS level for publish operations (0, 1, or 2)
+     */
+    defaultPublishQos: number;
+    /**
+     * Default retain flag for publish operations
+     */
+    defaultPublishRetain: boolean;
+    /**
+     * Default QoS level for subscribe operations (0, 1, or 2)
+     */
+    defaultSubscribeQos: number;
+    /**
      * When the MQTT server was created
      */
     createdAt: string;
@@ -757,6 +769,18 @@ export type CreateMqttServerDto = {
      * Whether to use TLS/SSL for the connection
      */
     useTls?: boolean;
+    /**
+     * Default publish QoS (0, 1, or 2)
+     */
+    defaultPublishQos?: number;
+    /**
+     * Default publish retain flag
+     */
+    defaultPublishRetain?: boolean;
+    /**
+     * Default subscribe QoS (0, 1, or 2)
+     */
+    defaultSubscribeQos?: number;
 };
 
 export type UpdateMqttServerDto = {
@@ -788,6 +812,18 @@ export type UpdateMqttServerDto = {
      * Whether to use TLS/SSL for the connection
      */
     useTls?: boolean;
+    /**
+     * Default publish QoS (0, 1, or 2)
+     */
+    defaultPublishQos?: number;
+    /**
+     * Default publish retain flag
+     */
+    defaultPublishRetain?: boolean;
+    /**
+     * Default subscribe QoS (0, 1, or 2)
+     */
+    defaultSubscribeQos?: number;
 };
 
 export type CreateResourceGroupDto = {


### PR DESCRIPTION
## Summary by Sourcery

Implement per-resource-flow MQ TT QoS and retain settings, propagate defaults from server config, update UI, database schema, documentation, and tests accordingly

New Features:
- Support per-node publish QoS and retain flags in flow executor service
- Expose defaultPublishQos, defaultPublishRetain, and defaultSubscribeQos in MqttServer entity, DTOs, API schemas, and frontend forms

Enhancements:
- Track and apply subscription QoS in MqttClientService with error logging on failures
- Publish method now respects per-call options or server defaults for QoS and retain

Build:
- Add database migration to include default QoS and retain columns in mqtt_server table

CI:
- Bump Vitest target from node14 to node20

Documentation:
- Update MQTT integration documentation to describe default QoS and retain behavior

Tests:
- Add unit tests for publish defaults and per-call overrides
- Update flow executor service tests to assert subscription QoS parameter

Chores:
- Improve frontend flow editor to auto-position new nodes and auto-fit view