### PR TITLE
feat(ATT-158): custom error flow node

### DIFF
--- a/apps/api/src/database/migrations/1762115538090-resource-flow-error-node.ts
+++ b/apps/api/src/database/migrations/1762115538090-resource-flow-error-node.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ResourceFlowErrorNode1762115538090 implements MigrationInterface {
+  name = 'ResourceFlowErrorNode1762115538090';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "temporary_resource_flow_node" ("id" text PRIMARY KEY NOT NULL, "type" varchar CHECK( "type" IN ('input.button','input.resource.usage.started','input.resource.usage.stopped','input.resource.usage.takeover','input.resource.door.unlocked','input.resource.door.locked','input.resource.door.unlatched','input.mqtt.message.received','output.http.sendRequest','output.mqtt.sendMessage','output.resource.billing.calculation.set-additional-items','output.resource.usage.end-session','processing.wait','processing.if','processing.set-payload','processing.mqtt.waitForMessage','processing.error') ) NOT NULL, "data" json, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "resourceId" integer NOT NULL, "positionX" integer NOT NULL, "positionY" integer NOT NULL, CONSTRAINT "FK_ca3080b2dbc9c7c88a4a64c469d" FOREIGN KEY ("resourceId") REFERENCES "resource" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_resource_flow_node"("id", "type", "data", "createdAt", "updatedAt", "resourceId", "positionX", "positionY") SELECT "id", "type", "data", "createdAt", "updatedAt", "resourceId", "positionX", "positionY" FROM "resource_flow_node"`,
+    );
+    await queryRunner.query(`DROP TABLE "resource_flow_node"`);
+    await queryRunner.query(`ALTER TABLE "temporary_resource_flow_node" RENAME TO "resource_flow_node"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "resource_flow_node" RENAME TO "temporary_resource_flow_node"`);
+    await queryRunner.query(
+      `CREATE TABLE "resource_flow_node" ("id" text PRIMARY KEY NOT NULL, "type" varchar CHECK( "type" IN ('input.button','input.resource.usage.started','input.resource.usage.stopped','input.resource.usage.takeover','input.resource.door.unlocked','input.resource.door.locked','input.resource.door.unlatched','input.mqtt.message.received','output.http.sendRequest','output.mqtt.sendMessage','output.resource.billing.calculation.set-additional-items','output.resource.usage.end-session','processing.wait','processing.if','processing.set-payload','processing.mqtt.waitForMessage') ) NOT NULL, "data" json, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "resourceId" integer NOT NULL, "positionX" integer NOT NULL, "positionY" integer NOT NULL, CONSTRAINT "FK_ca3080b2dbc9c7c88a4a64c469d" FOREIGN KEY ("resourceId") REFERENCES "resource" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "resource_flow_node"("id", "type", "data", "createdAt", "updatedAt", "resourceId", "positionX", "positionY") SELECT "id", "type", "data", "createdAt", "updatedAt", "resourceId", "positionX", "positionY" FROM "temporary_resource_flow_node"`,
+    );
+    await queryRunner.query(`DROP TABLE "temporary_resource_flow_node"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -65,3 +65,4 @@ export * from './1761776665535-wait-for-mqtt-message-flow-node';
 export * from './1761832730725-end-usage-session-flow-node';
 export * from './1761903220000-sso-oidc-add-scopes-and-claim-paths';
 export * from './1761910926026-mqtt-qos-retain-setting-per-flow-node';
+export * from './1762115538090-resource-flow-error-node';

--- a/apps/api/src/resources/flows/errors/flow-execution.error.ts
+++ b/apps/api/src/resources/flows/errors/flow-execution.error.ts
@@ -1,0 +1,8 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+
+export class FlowExecutionError extends UnprocessableEntityException {
+  constructor(message: string) {
+    super('FLOW_EXECUTION_ERROR: ' + message);
+    this.name = 'FlowExecutionError';
+  }
+}

--- a/apps/api/src/resources/flows/resource-flows-executor.service.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.ts
@@ -30,6 +30,7 @@ import {
   MqttMessageReceivedNodeDataSchema,
   MqttWaitForMessageNodeDataSchema,
   ResourceUsageEndSessionNodeDataSchema,
+  ErrorNodeDataSchema,
 } from '@attraccess/database-entities';
 import { OnEvent } from '@nestjs/event-emitter';
 import { ResourceUsageEvent } from '../usage/events/resource-usage.events';
@@ -47,6 +48,7 @@ import z from 'zod';
 import { NoUsageSessionError } from './errors/no-usage-session.error';
 import { MqttMessageEvent as MqttMessageReceivedEvent } from '../../mqtt/mqtt-message.event';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { FlowExecutionError } from './errors/flow-execution.error';
 
 // Handlebars helpers
 Handlebars.registerHelper('json', (value: unknown) => {
@@ -514,6 +516,10 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
           );
           break;
 
+        case ResourceFlowNodeType.PROCESSING_ERROR:
+          responseOfNode = await this.processErrorNode(node, resultOfPreviousNode.payload, transactionManager);
+          break;
+
         default: {
           const exhaustiveCheck: never = node.type;
           throw new Error(`Unknown node type: ${exhaustiveCheck}`);
@@ -667,7 +673,7 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
         break;
       default: {
         const exhaustiveCheck: never = comparisonOperator;
-        throw new Error(`Unknown comparison operator: ${exhaustiveCheck}`);
+        throw new FlowExecutionError(`Unknown comparison operator: ${exhaustiveCheck}`);
       }
     }
 
@@ -772,6 +778,19 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
     return { payload: { topic: result.topic, payload: result.payload } };
   }
 
+  private async processErrorNode(
+    node: ResourceFlowNode,
+    input: object,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _transactionManager?: EntityManager,
+  ): Promise<NodeProcessingResult> {
+    const { message: messageTemplate } = node.data as z.infer<typeof ErrorNodeDataSchema>;
+
+    const message = this.compileTemplate(messageTemplate, input);
+
+    throw new FlowExecutionError(message);
+  }
+
   private async processMqttSendMessageNode(
     node: ResourceFlowNode,
     input: object,
@@ -809,7 +828,7 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
     }
 
     if (!activeUsage.user) {
-      throw new ForbiddenException('Active session has no owner user; cannot end');
+      throw new FlowExecutionError('Active session has no owner user; cannot end');
     }
 
     const { notes } = ResourceUsageEndSessionNodeDataSchema.parse(node.data ?? {});

--- a/apps/api/src/resources/flows/resource-flows.service.ts
+++ b/apps/api/src/resources/flows/resource-flows.service.ts
@@ -20,6 +20,7 @@ import {
   MqttMessageReceivedNodeDataSchema,
   MqttWaitForMessageNodeDataSchema,
   ResourceUsageEndSessionNodeDataSchema,
+  ErrorNodeDataSchema,
 } from '@attraccess/database-entities';
 import { ResourceNotFoundException } from '../../exceptions/resource.notFound.exception';
 import { ResourceFlowSaveDto, ResourceFlowResponseDto } from './dto';
@@ -396,6 +397,13 @@ export class ResourceFlowsService {
           schema.configSchema = z.toJSONSchema(MqttWaitForMessageNodeDataSchema);
           schema.inputs = ['input'];
           schema.outputs = ['output'];
+          schema.supportedByResource = true;
+          break;
+
+        case ResourceFlowNodeType.PROCESSING_ERROR:
+          schema.configSchema = z.toJSONSchema(ErrorNodeDataSchema);
+          schema.inputs = ['input'];
+          schema.outputs = [];
           schema.supportedByResource = true;
           break;
 

--- a/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/index.tsx
@@ -8,6 +8,7 @@ import {
   useResourcesServiceResourceUsageEndSession,
   useResourcesServiceGetAllResourcesKey,
   UseResourcesServiceResourceUsageGetActiveSessionKeyFn,
+  ApiError,
 } from '@attraccess/react-query-client';
 import { useToastMessage } from '../../../components/toastProvider';
 import en from './translations/en.json';
@@ -19,9 +20,9 @@ type ActiveUsageSessionsBannerProps = {
 };
 
 export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessionsBannerProps) {
-  const { t } = useTranslations({ en, de });
+  const { t, tExists } = useTranslations({ en, de });
   const queryClient = useQueryClient();
-  const { success, error: showError } = useToastMessage();
+  const toast = useToastMessage();
 
   // Fetch just the total count (1 item per page is sufficient)
   const { data, isLoading, isFetching } = useResourcesServiceGetAllResources({
@@ -74,11 +75,16 @@ export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessi
       setEndStatuses(collected.reduce((acc, r) => ({ ...acc, [r.id]: 'pending' }), {}));
     } catch (e) {
       console.error(e);
-      showError({ title: t('endedAllError') });
+      toast.apiError({
+        baseTranslationKey: 'endedAll.error',
+        error: e as ApiError,
+        t,
+        tExists,
+      });
     } finally {
       setIsLoadingResources(false);
     }
-  }, [activeCount, showError, t]);
+  }, [activeCount, tExists, t, toast]);
 
   const confirmEndAll = useCallback(async () => {
     if (isEndingAll || resourcesInUse.length === 0) return;
@@ -90,17 +96,15 @@ export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessi
       return updated;
     });
     try {
-      const localStatuses: Record<number, 'done' | 'error'> = {};
-      await Promise.all(
+      const results = await Promise.allSettled(
         resourcesInUse.map(async (r) => {
           try {
             await endSession({ resourceId: r.id, requestBody: {} });
-            localStatuses[r.id] = 'done';
             setEndStatuses((prev) => ({ ...prev, [r.id]: 'done' }));
           } catch (err) {
             console.error('Failed to end session for resource', r.id, err);
-            localStatuses[r.id] = 'error';
             setEndStatuses((prev) => ({ ...prev, [r.id]: 'error' }));
+            throw err;
           }
         }),
       );
@@ -109,18 +113,23 @@ export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessi
       await queryClient.invalidateQueries({ queryKey: [useResourcesServiceGetAllResourcesKey] });
 
       // If all succeeded -> show completion state and auto-close
-      const allSucceeded = resourcesInUse.every((r) => localStatuses[r.id] === 'done');
-      if (allSucceeded) {
+      const rejectedResult = results.find((r) => r.status === 'rejected');
+      if (!rejectedResult) {
         setAllCompleted(true);
-        success({ title: t('endedAllSuccess') });
+        toast.success({ title: t('endedAll.success') });
         setTimeout(() => setIsModalOpen(false), 1000);
       } else {
-        showError({ title: t('endedAllError') });
+        toast.apiError({
+          error: rejectedResult.reason as ApiError,
+          t,
+          tExists,
+          baseTranslationKey: 'endedAll.error',
+        });
       }
     } finally {
       setIsEndingAll(false);
     }
-  }, [endSession, isEndingAll, queryClient, resourcesInUse, success, showError, t]);
+  }, [endSession, isEndingAll, queryClient, resourcesInUse, toast, t, tExists]);
 
   if (isLoading || isFetching) {
     return (

--- a/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/translations/de.json
+++ b/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/translations/de.json
@@ -5,8 +5,19 @@
   "description": "Du hast aktuell {{count}} laufende Sitzungen. Du kannst schnell auf deine Sitzungen filtern oder alle beenden.",
   "showMine": "Meine anzeigen",
   "endAll": "Alle beenden",
-  "endedAllSuccess": "Alle aktiven Nutzungssitzungen wurden beendet.",
-  "endedAllError": "Fehler beim Beenden. Einige Sitzungen sind möglicherweise noch aktiv.",
+  "endedAll": {
+    "success": "Alle aktiven Nutzungssitzungen wurden beendet.",
+    "error": {
+      "generic": {
+        "title": "Fehler beim Beenden. Einige Sitzungen sind möglicherweise noch aktiv.",
+        "description": "Beim Beenden der Sitzungen ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+      },
+      "FLOW_EXECUTION_ERROR": {
+        "title": "Fehler beim Beenden der Sitzung",
+        "description": "{{error}}"
+      }
+    }
+  },
   "modal.title": "Alle aktiven Sitzungen beenden",
   "modal.description": "Wir beenden die Sitzung für jede Ressource unten.",
   "modal.loadingList": "Aktive Sitzungen werden geladen...",

--- a/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/translations/en.json
+++ b/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/translations/en.json
@@ -5,8 +5,19 @@
   "description": "You currently have {{count}} ongoing sessions. You can quickly filter to your sessions or end them all.",
   "showMine": "Show mine",
   "endAll": "End all",
-  "endedAllSuccess": "All your active usage sessions were ended.",
-  "endedAllError": "Failed to end all sessions. Some sessions may still be active.",
+  "endedAll": {
+    "success": "All your active usage sessions were ended.",
+    "error": {
+      "generic": {
+        "title": "Failed to end all sessions. Some sessions may still be active.",
+        "description": "An error occurred while ending the sessions. Please try again."
+      },
+      "FLOW_EXECUTION_ERROR": {
+        "title": "Failed to end all sessions. Some sessions may still be active.",
+        "description": "{{error}}"
+      }
+    }
+  },
   "modal.title": "End all your active sessions",
   "modal.description": "We will end the session for each resource below.",
   "modal.loadingList": "Loading active sessions...",

--- a/apps/frontend/src/app/resources/details/flows/node/de.json
+++ b/apps/frontend/src/app/resources/details/flows/node/de.json
@@ -211,6 +211,21 @@
             }
           }
         }
+      },
+      "error": {
+        "title": "Fehler",
+        "description": "Erzeugt einen Fehler und beendet den aktuellen Flow.",
+        "inputs": {
+          "input": "Eingabe"
+        },
+        "preview": {
+          "message": "Fehlermeldung"
+        },
+        "config": {
+          "message": {
+            "label": "Fehlermeldungs-Vorlage"
+          }
+        }
       }
     },
     "output": {

--- a/apps/frontend/src/app/resources/details/flows/node/en.json
+++ b/apps/frontend/src/app/resources/details/flows/node/en.json
@@ -211,6 +211,21 @@
             }
           }
         }
+      },
+      "error": {
+        "title": "Error",
+        "description": "This node throws an error and stops the current flow.",
+        "inputs": {
+          "input": "Input"
+        },
+        "preview": {
+          "message": "Error message"
+        },
+        "config": {
+          "message": {
+            "label": "Error message template"
+          }
+        }
       }
     },
     "output": {

--- a/apps/frontend/src/app/resources/details/flows/node/preview/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/preview/index.tsx
@@ -64,6 +64,14 @@ export function useNodePreviewRows(props: Props): NodePreviewData {
           },
         ];
 
+      case 'processing.error':
+        return [
+          {
+            label: t('nodes.processing.error.preview.message'),
+            value: nodeData?.data.message as string,
+          },
+        ];
+
       case 'processing.if':
         return [
           {

--- a/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/index.tsx
@@ -6,6 +6,7 @@ import { useToastMessage } from '../../../../../components/toastProvider';
 import { SessionTimer } from '../SessionTimer';
 import { SessionNotesModal, SessionModalMode } from '../SessionNotesModal';
 import {
+  ApiError,
   useResourcesServiceResourceUsageEndSession,
   UseResourcesServiceResourceUsageGetActiveSessionKeyFn,
   UseResourcesServiceResourceUsageGetHistoryKeyFn,
@@ -21,8 +22,8 @@ interface ActiveSessionDisplayProps {
 }
 
 export function ActiveSessionDisplay({ resourceId, startTime }: ActiveSessionDisplayProps) {
-  const { t } = useTranslations({ en, de });
-  const { success, error: showError } = useToastMessage();
+  const { t, tExists } = useTranslations({ en, de });
+  const toast = useToastMessage();
   const queryClient = useQueryClient();
   const [isNotesModalOpen, setIsNotesModalOpen] = useState(false);
 
@@ -45,16 +46,18 @@ export function ActiveSessionDisplay({ resourceId, startTime }: ActiveSessionDis
       queryClient.resetQueries({
         queryKey: UseResourcesServiceResourceUsageGetActiveSessionKeyFn({ resourceId }),
       });
-      success({
-        title: t('sessionEnded'),
-        description: t('sessionEndedDescription'),
+      toast.success({
+        title: t('sessionEnded.success.title'),
+        description: t('sessionEnded.success.description'),
       });
     },
     onError: (err) => {
       console.error('Error ending session:', err);
-      showError({
-        title: t('sessionEndError'),
-        description: t('sessionEndErrorDescription'),
+      toast.apiError({
+        baseTranslationKey: 'sessionEnded.error',
+        t,
+        tExists,
+        error: err as ApiError,
       });
     },
   });

--- a/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/translations/de.json
+++ b/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/translations/de.json
@@ -1,9 +1,21 @@
 {
   "endSession": "Sitzung beenden",
-  "sessionEnded": "Sitzung beendet",
-  "sessionEndedDescription": "Ihre Nutzungssitzung wurde erfolgreich beendet.",
-  "sessionEndError": "Fehler beim Beenden der Sitzung",
-  "sessionEndErrorDescription": "Beim Beenden der Sitzung ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+  "sessionEnded": {
+    "success": {
+      "title": "Sitzung beendet",
+      "description": "Ihre Nutzungssitzung wurde erfolgreich beendet."
+    },
+    "error": {
+      "generic": {
+        "title": "Fehler beim Beenden der Sitzung",
+        "description": "Beim Beenden der Sitzung ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+      },
+      "FLOW_EXECUTION_ERROR": {
+        "title": "Fehler beim Beenden der Sitzung",
+        "description": "{{error}}"
+      }
+    }
+  },
   "alternativeEndSessionOptionsMenu": {
     "label": "Alternative Sitzungsbeendigung",
     "endWithNotes": {

--- a/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/translations/en.json
+++ b/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/translations/en.json
@@ -1,9 +1,21 @@
 {
   "endSession": "End Session",
-  "sessionEnded": "Session Ended",
-  "sessionEndedDescription": "Your usage session has been successfully ended.",
-  "sessionEndError": "Failed to End Session",
-  "sessionEndErrorDescription": "An error occurred while ending the session. Please try again.",
+  "sessionEnded": {
+    "success": {
+      "title": "Session Ended",
+      "description": "Your usage session has been successfully ended."
+    },
+    "error": {
+      "generic": {
+        "title": "Failed to End Session",
+        "description": "An error occurred while ending the session. Please try again."
+      },
+      "FLOW_EXECUTION_ERROR": {
+        "title": "Failed to End Session",
+        "description": "{{error}}"
+      }
+    }
+  },
   "alternativeEndSessionOptionsMenu": {
     "label": "Alternative Session End",
     "endWithNotes": {

--- a/apps/frontend/src/utils/apiError.ts
+++ b/apps/frontend/src/utils/apiError.ts
@@ -10,13 +10,20 @@ export interface Props {
 }
 
 export function getTranslationKeyForApiError(props: Props) {
-  const errorMessage =
-    ((props.error as ApiError).body as { message?: string | string[] } | undefined)?.message ?? props.error.message;
+  let errorMessage = String(
+    ((props.error as ApiError).body as { message?: string | string[] } | undefined)?.message ?? props.error.message,
+  );
 
-  const translationExists = props.tExists(props.baseTranslationKey + '.' + errorMessage);
+  let errorMessageTranslationKey = errorMessage;
 
+  if (errorMessage.startsWith('FLOW_EXECUTION_ERROR: ')) {
+    errorMessageTranslationKey = 'FLOW_EXECUTION_ERROR';
+    errorMessage = errorMessage.replace('FLOW_EXECUTION_ERROR: ', '');
+  }
+
+  const translationExists = props.tExists(props.baseTranslationKey + '.' + errorMessageTranslationKey);
   const fullBaseKey = translationExists
-    ? props.baseTranslationKey + '.' + errorMessage
+    ? props.baseTranslationKey + '.' + errorMessageTranslationKey
     : props.baseTranslationKey + '.' + (props.fallbackKey ?? 'generic');
 
   return { key: fullBaseKey, errorMessage };

--- a/libs/database-entities/src/lib/entities-index.ts
+++ b/libs/database-entities/src/lib/entities-index.ts
@@ -34,6 +34,7 @@ import {
   MqttMessageReceivedNodeDataSchema,
   MqttWaitForMessageNodeDataSchema,
   ResourceUsageEndSessionNodeDataSchema,
+  ErrorNodeDataSchema,
 } from './entities/resourceFlowNode';
 import { ResourceFlowEdge } from './entities/resourceFlowEdge';
 import { ResourceFlowLog, ResourceFlowLogType } from './entities/resourceFlowLog';
@@ -92,6 +93,7 @@ export {
   MqttMessageReceivedNodeDataSchema,
   MqttWaitForMessageNodeDataSchema,
   ResourceUsageEndSessionNodeDataSchema,
+  ErrorNodeDataSchema,
 };
 
 // Export the entities object

--- a/libs/database-entities/src/lib/entities/resourceFlowNode.ts
+++ b/libs/database-entities/src/lib/entities/resourceFlowNode.ts
@@ -21,6 +21,7 @@ export enum ResourceFlowNodeType {
   PROCESSING_IF = 'processing.if',
   PROCESSING_SET_PAYLOAD = 'processing.set-payload',
   PROCESSING_MQTT_WAIT_FOR_MESSAGE = 'processing.mqtt.waitForMessage',
+  PROCESSING_ERROR = 'processing.error',
 }
 
 // Zod schemas for node data validation
@@ -114,6 +115,10 @@ export const MqttWaitForMessageNodeDataSchema = z.object({
   }),
 });
 
+export const ErrorNodeDataSchema = z.object({
+  message: z.string().min(1),
+});
+
 export const ResourceUsageEndSessionNodeDataSchema = z
   .object({
     notes: z.string().optional().meta({
@@ -159,6 +164,9 @@ export function getNodeDataSchema(nodeType: ResourceFlowNodeType) {
 
     case ResourceFlowNodeType.PROCESSING_MQTT_WAIT_FOR_MESSAGE:
       return MqttWaitForMessageNodeDataSchema;
+
+    case ResourceFlowNodeType.PROCESSING_ERROR:
+      return ErrorNodeDataSchema;
 
     case ResourceFlowNodeType.OUTPUT_RESOURCE_USAGE_END_SESSION:
       return ResourceUsageEndSessionNodeDataSchema;

--- a/libs/react-query-client/src/lib/requests/schemas.gen.ts
+++ b/libs/react-query-client/src/lib/requests/schemas.gen.ts
@@ -2211,7 +2211,7 @@ export const $ResourceFlowNodeSchemaDto = {
         type: {
             type: 'string',
             description: 'The name of the node type',
-            enum: ['input.button', 'input.resource.usage.started', 'input.resource.usage.stopped', 'input.resource.usage.takeover', 'input.resource.door.unlocked', 'input.resource.door.locked', 'input.resource.door.unlatched', 'input.mqtt.message.received', 'output.http.sendRequest', 'output.mqtt.sendMessage', 'output.resource.billing.calculation.set-additional-items', 'output.resource.usage.end-session', 'processing.wait', 'processing.if', 'processing.set-payload', 'processing.mqtt.waitForMessage']
+            enum: ['input.button', 'input.resource.usage.started', 'input.resource.usage.stopped', 'input.resource.usage.takeover', 'input.resource.door.unlocked', 'input.resource.door.locked', 'input.resource.door.unlatched', 'input.mqtt.message.received', 'output.http.sendRequest', 'output.mqtt.sendMessage', 'output.resource.billing.calculation.set-additional-items', 'output.resource.usage.end-session', 'processing.wait', 'processing.if', 'processing.set-payload', 'processing.mqtt.waitForMessage', 'processing.error']
         },
         configSchema: {
             type: 'object',
@@ -2273,7 +2273,7 @@ export const $ResourceFlowNodeDto = {
             type: 'string',
             description: 'The type of the node',
             example: 'input.resource.usage.started',
-            enum: ['input.button', 'input.resource.usage.started', 'input.resource.usage.stopped', 'input.resource.usage.takeover', 'input.resource.door.unlocked', 'input.resource.door.locked', 'input.resource.door.unlatched', 'input.mqtt.message.received', 'output.http.sendRequest', 'output.mqtt.sendMessage', 'output.resource.billing.calculation.set-additional-items', 'output.resource.usage.end-session', 'processing.wait', 'processing.if', 'processing.set-payload', 'processing.mqtt.waitForMessage']
+            enum: ['input.button', 'input.resource.usage.started', 'input.resource.usage.stopped', 'input.resource.usage.takeover', 'input.resource.door.unlocked', 'input.resource.door.locked', 'input.resource.door.unlatched', 'input.mqtt.message.received', 'output.http.sendRequest', 'output.mqtt.sendMessage', 'output.resource.billing.calculation.set-additional-items', 'output.resource.usage.end-session', 'processing.wait', 'processing.if', 'processing.set-payload', 'processing.mqtt.waitForMessage', 'processing.error']
         },
         position: {
             description: 'The position of the node',

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -1508,7 +1508,7 @@ export type ResourceFlowNodeSchemaDto = {
     /**
      * The name of the node type
      */
-    type: 'input.button' | 'input.resource.usage.started' | 'input.resource.usage.stopped' | 'input.resource.usage.takeover' | 'input.resource.door.unlocked' | 'input.resource.door.locked' | 'input.resource.door.unlatched' | 'input.mqtt.message.received' | 'output.http.sendRequest' | 'output.mqtt.sendMessage' | 'output.resource.billing.calculation.set-additional-items' | 'output.resource.usage.end-session' | 'processing.wait' | 'processing.if' | 'processing.set-payload' | 'processing.mqtt.waitForMessage';
+    type: 'input.button' | 'input.resource.usage.started' | 'input.resource.usage.stopped' | 'input.resource.usage.takeover' | 'input.resource.door.unlocked' | 'input.resource.door.locked' | 'input.resource.door.unlatched' | 'input.mqtt.message.received' | 'output.http.sendRequest' | 'output.mqtt.sendMessage' | 'output.resource.billing.calculation.set-additional-items' | 'output.resource.usage.end-session' | 'processing.wait' | 'processing.if' | 'processing.set-payload' | 'processing.mqtt.waitForMessage' | 'processing.error';
     /**
      * The schema for a node type
      */
@@ -1552,7 +1552,8 @@ export enum type3 {
     PROCESSING_WAIT = 'processing.wait',
     PROCESSING_IF = 'processing.if',
     PROCESSING_SET_PAYLOAD = 'processing.set-payload',
-    PROCESSING_MQTT_WAIT_FOR_MESSAGE = 'processing.mqtt.waitForMessage'
+    PROCESSING_MQTT_WAIT_FOR_MESSAGE = 'processing.mqtt.waitForMessage',
+    PROCESSING_ERROR = 'processing.error'
 }
 
 export type ResourceFlowNodePositionDto = {
@@ -1574,7 +1575,7 @@ export type ResourceFlowNodeDto = {
     /**
      * The type of the node
      */
-    type: 'input.button' | 'input.resource.usage.started' | 'input.resource.usage.stopped' | 'input.resource.usage.takeover' | 'input.resource.door.unlocked' | 'input.resource.door.locked' | 'input.resource.door.unlatched' | 'input.mqtt.message.received' | 'output.http.sendRequest' | 'output.mqtt.sendMessage' | 'output.resource.billing.calculation.set-additional-items' | 'output.resource.usage.end-session' | 'processing.wait' | 'processing.if' | 'processing.set-payload' | 'processing.mqtt.waitForMessage';
+    type: 'input.button' | 'input.resource.usage.started' | 'input.resource.usage.stopped' | 'input.resource.usage.takeover' | 'input.resource.door.unlocked' | 'input.resource.door.locked' | 'input.resource.door.unlatched' | 'input.mqtt.message.received' | 'output.http.sendRequest' | 'output.mqtt.sendMessage' | 'output.resource.billing.calculation.set-additional-items' | 'output.resource.usage.end-session' | 'processing.wait' | 'processing.if' | 'processing.set-payload' | 'processing.mqtt.waitForMessage' | 'processing.error';
     /**
      * The position of the node
      */


### PR DESCRIPTION
## Summary by Sourcery

Add a custom error flow node to resource flows and update both backend and frontend to process and display flow errors uniformly using a new FlowExecutionError type and a unified toast.apiError mechanism.

New Features:
- Add support for a new “processing.error” flow node type with template-based error message handling
- Introduce FlowExecutionError exception class for uniform error flows
- Expose unified toast.apiError and updated toast.success methods for consistent API error and success notifications

Enhancements:
- Migrate ActiveUsageSessionsBanner and ActiveSessionDisplay components to use the unified toast API error handling
- Enhance getTranslationKeyForApiError to recognize FlowExecutionError messages and dynamic translation keys

Build:
- Add a database migration to include the processing.error node type in the resource_flow_node table enum
- Update react-query client types and JSON schemas to support the new processing.error node