### PR TITLE
fix(Attractap): increase version number

### DIFF
--- a/apps/attractap-firmware/platformio.ini
+++ b/apps/attractap-firmware/platformio.ini
@@ -34,7 +34,7 @@ lib_deps =
 build_flags =
 	-D FIRMWARE_NAME='"attractap_touch"'
 	-D FIRMWARE_FRIENDLY_NAME='"Attractap Touch"'
-	-D FIRMWARE_VERSION='"1.1.0"'
+	-D FIRMWARE_VERSION='"1.1.1"'
 	-D FIRMWARE_VARIANT='"wifi"'
 	-D FIRMWARE_VARIANT_FRIENDLY_NAME='"WiFi"'
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update the firmware configuration to report version 1.1.1 instead of 1.1.0.