### PR TITLE
feat(ATT-198): set email verified to true for sso users

### DIFF
--- a/apps/api/src/database/migrations/1765137500352-sso-email-auto-verified.ts
+++ b/apps/api/src/database/migrations/1765137500352-sso-email-auto-verified.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SsoEmailAutoVerified1765137500352 implements MigrationInterface {
+  name = 'SsoEmailAutoVerified1765137500352';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // auto verify email for all sso users
+    await queryRunner.query(`
+      UPDATE "user" 
+      SET "isEmailVerified" = 1 
+      WHERE "externalIdentifier" IS NOT NULL 
+      AND "id" NOT IN (
+        SELECT DISTINCT "userId" 
+        FROM "authentication_detail"
+      )
+    `);
+
+    // update external identifier for all sso users
+    await queryRunner.query(`
+      UPDATE "user" 
+      SET "externalIdentifier" = 'SSO:OIDC:' || "externalIdentifier"
+      WHERE "externalIdentifier" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // remove the SSO:OIDC prefix we added to external identifiers
+    await queryRunner.query(`
+      UPDATE "user"
+      SET "externalIdentifier" = SUBSTRING("externalIdentifier" FROM 10)
+      WHERE "externalIdentifier" LIKE 'SSO:OIDC:%'
+    `);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -79,3 +79,4 @@ export * from './1764105833243-forms-resource-usage';
 export * from './1764368253546-form-submission-action';
 export * from './1764368253547-forms-select-input-field';
 export * from './1764503783778-delete-revoked-token-table';
+export * from './1765137500352-sso-email-auto-verified';

--- a/apps/api/src/users-and-auth/auth/auth.service.spec.ts
+++ b/apps/api/src/users-and-auth/auth/auth.service.spec.ts
@@ -5,6 +5,7 @@ import { AuthenticationDetail, AuthenticationType, User } from '@attraccess/data
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { EmailService } from '../../email/email.service';
+import { SSOService } from './sso/sso.service';
 import * as bcrypt from 'bcrypt';
 
 jest.mock('bcrypt', () => ({
@@ -48,6 +49,12 @@ describe('AuthService', () => {
           useValue: {
             findOne: jest.fn(),
             update: jest.fn(),
+          },
+        },
+        {
+          provide: SSOService,
+          useValue: {
+            getProviderById: jest.fn(),
           },
         },
       ],

--- a/apps/api/src/users-and-auth/auth/auth.service.ts
+++ b/apps/api/src/users-and-auth/auth/auth.service.ts
@@ -6,6 +6,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { EmailService } from '../../email/email.service';
 import { addDays } from 'date-fns';
 import * as bcrypt from 'bcrypt';
+import { SSOService } from './sso/sso.service';
+import { SSOProviderNotFoundException } from './sso/errors';
 
 export interface LocalPasswordAuthenticationOptions {
   password: string;
@@ -45,6 +47,7 @@ export class AuthService {
     private authenticationDetailRepository: Repository<AuthenticationDetail>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    private ssoService: SSOService,
   ) {
     this.logger.debug('AuthService initialized');
   }
@@ -195,10 +198,42 @@ export class AuthService {
   }
 
   async changePassword(user: User, password: string): Promise<void> {
-    const authenticationDetail = await this.getAuthenticationDetail(AuthenticationType.LOCAL_PASSWORD, user.id);
+    const authenticationDetail = await this.getAuthenticationDetail(AuthenticationType.LOCAL_PASSWORD, user.id).catch(
+      (error) => {
+        if (error instanceof NotFoundException) {
+          return null;
+        }
+        throw error;
+      },
+    );
 
-    authenticationDetail.password = await this.hashPassword(password);
-    await this.authenticationDetailRepository.save(authenticationDetail);
+    if (authenticationDetail) {
+      authenticationDetail.password = await this.hashPassword(password);
+      await this.authenticationDetailRepository.save(authenticationDetail);
+    } else {
+      if (!user.externalIdentifier.startsWith('SSO:')) {
+        const [, providerType, providerId] = user.externalIdentifier.split(':');
+        const provider = await this.ssoService.getProviderById(Number(providerId)).catch((error) => {
+          if (error instanceof SSOProviderNotFoundException) {
+            return null;
+          }
+          throw error;
+        });
+
+        if (provider?.type !== providerType) {
+          throw new ForbiddenException('You cannot change the password of an SSO user');
+        }
+
+        throw new ForbiddenException('You cannot change the password of an SSO user');
+      }
+
+      await this.addAuthenticationDetails(user.id, {
+        type: AuthenticationType.LOCAL_PASSWORD,
+        details: {
+          password,
+        },
+      });
+    }
 
     // Notify user about password change
     await this.emailService.sendPasswordChangedEmail(user);

--- a/apps/api/src/users-and-auth/auth/sso/oidc/oidc.strategy.ts
+++ b/apps/api/src/users-and-auth/auth/sso/oidc/oidc.strategy.ts
@@ -49,6 +49,8 @@ export class SSOOIDCStrategy extends PassportStrategy(Strategy, 'sso-oidc') {
 
     const oidcUserId = profile.id;
 
+    const externalIdentifier = `SSO:OIDC:${this.config.ssoProviderId}:${oidcUserId}`;
+
     if (!oidcUserId) {
       this.logger.error('No user ID found in SSO profile');
       throw new BadRequestException('No user ID found in SSO profile');
@@ -78,7 +80,7 @@ export class SSOOIDCStrategy extends PassportStrategy(Strategy, 'sso-oidc') {
 
     // Step 1: Check if user exists by external ID
     this.logger.debug(`Checking if user exists with external ID: ${oidcUserId}`);
-    let user = await usersService.findOne({ externalIdentifier: oidcUserId }).catch(() => null);
+    let user = await usersService.findOne({ externalIdentifier }).catch(() => null);
 
     if (user) {
       this.logger.log(`Found existing user with external ID: ${oidcUserId}`);
@@ -125,8 +127,9 @@ export class SSOOIDCStrategy extends PassportStrategy(Strategy, 'sso-oidc') {
     user = await usersService.createOne({
       username,
       email,
-      externalIdentifier: oidcUserId,
+      externalIdentifier,
       isEmailVerified: true,
+      skipUsernameSanitization: true,
     });
 
     if (!user) {

--- a/apps/api/src/users-and-auth/users/users.service.ts
+++ b/apps/api/src/users-and-auth/users/users.service.ts
@@ -96,6 +96,7 @@ export class UsersService {
     email: string;
     externalIdentifier: string | null;
     isEmailVerified?: boolean;
+    skipUsernameSanitization?: boolean;
   }): Promise<User> {
     const data = {
       username: userData.username.trim(),
@@ -105,7 +106,9 @@ export class UsersService {
     };
     this.logger.debug(`Creating new user - username: ${data.username}, email: ${data.email}`);
 
-    this.validateUsernameOrThrow(data.username);
+    if (!userData.skipUsernameSanitization) {
+      this.validateUsernameOrThrow(data.username);
+    }
 
     // verifying usage limits
     const currentAmountOfUsers = await this.userRepository.count();


### PR DESCRIPTION
## Summary by Sourcery

Update user creation to support an email verification flag and mark SSO-created users as verified by default.

New Features:
- Allow user creation to accept an optional email verification flag when creating users.

Enhancements:
- Default newly created users to an unverified email state unless explicitly marked verified, and automatically mark SSO OIDC users as email-verified on creation.