### PR TITLE
fix(ATT-197): ensure user permissions are updated from admin ui

### DIFF
--- a/apps/api/src/users-and-auth/users/users.service.spec.ts
+++ b/apps/api/src/users-and-auth/users/users.service.spec.ts
@@ -204,6 +204,35 @@ describe('UsersService', () => {
 
       await expect(service.updateOne(1, { username: 'test' })).rejects.toThrow(UserNotFoundException);
     });
+
+    it('should persist system permission updates', async () => {
+      const user = {
+        id: 1,
+        systemPermissions: {
+          canManageResources: true,
+          canManageSystemConfiguration: false,
+          canManageUsers: false,
+          canManageBilling: false,
+        },
+      } as User;
+      const permissionsUpdate = {
+        canManageResources: true,
+        canManageSystemConfiguration: true,
+        canManageUsers: false,
+        canManageBilling: false,
+      };
+      jest.spyOn(userRepository, 'update').mockResolvedValue({ affected: 1 } as UpdateResult);
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+
+      await service.updateOne(1, { systemPermissions: permissionsUpdate });
+
+      expect(userRepository.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          systemPermissions: permissionsUpdate,
+        }),
+      );
+    });
   });
 
   describe('findMany', () => {

--- a/apps/api/src/users-and-auth/users/users.service.ts
+++ b/apps/api/src/users-and-auth/users/users.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, Logger, ForbiddenException } from '@nestjs/common';
-import { Repository, ILike, FindOneOptions as TypeormFindOneOptions, FindOptionsWhere, In } from 'typeorm';
+import { Repository, ILike, FindOneOptions as TypeormFindOneOptions, FindOptionsWhere, In, DeepPartial } from 'typeorm';
 import { SystemPermissions, User } from '@attraccess/database-entities';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PaginatedResponse } from '../../types/response';
@@ -178,7 +178,7 @@ export class UsersService {
   }
 
   async updateOne(id: number, updateData: Partial<User>): Promise<User> {
-    const updates = {
+    const updates: DeepPartial<User> = {
       username: updateData.username?.trim() ?? undefined,
       email: updateData.email?.trim() ?? undefined,
       externalIdentifier: updateData.externalIdentifier?.trim() ?? undefined,
@@ -187,6 +187,16 @@ export class UsersService {
 
     if (updates.username !== undefined) {
       this.validateUsernameOrThrow(updates.username);
+    }
+
+    if (updateData.lastUsernameChangeAt !== undefined) {
+      updates.lastUsernameChangeAt = updateData.lastUsernameChangeAt;
+    }
+
+    if (updateData.systemPermissions !== undefined) {
+      updates.systemPermissions = {
+        ...updateData.systemPermissions,
+      } as DeepPartial<SystemPermissions>;
     }
 
     // If email is being updated, check for uniqueness


### PR DESCRIPTION
## Summary by Sourcery

Ensure user updates from the admin UI correctly persist system permission changes and additional user metadata.

Bug Fixes:
- Fix updating of user systemPermissions so changes are persisted when editing users from the admin UI.

Enhancements:
- Allow updating lastUsernameChangeAt and systemPermissions fields via UsersService.updateOne with proper typing.
- Add a unit test covering persistence of system permission updates in UsersService.updateOne.

Tests:
- Add a service-level test verifying that systemPermissions changes are written to the repository on user update.