### PR TITLE
fix(ATT-173): case insensitive usernames

### DIFF
--- a/apps/api/src/database/migrations/1765143247814-cleanup-usernames.ts
+++ b/apps/api/src/database/migrations/1765143247814-cleanup-usernames.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CleanupUsernames1765143247814 implements MigrationInterface {
+  name = 'CleanupUsernames1765143247814';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`UPDATE "user" SET "username" = LOWER(TRIM("username"))`);
+  }
+
+  public async down(): Promise<void> {
+    // nothing to do here
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -80,3 +80,4 @@ export * from './1764368253546-form-submission-action';
 export * from './1764368253547-forms-select-input-field';
 export * from './1764503783778-delete-revoked-token-table';
 export * from './1765137500352-sso-email-auto-verified';
+export * from './1765143247814-cleanup-usernames';

--- a/apps/api/src/users-and-auth/auth/auth.service.spec.ts
+++ b/apps/api/src/users-and-auth/auth/auth.service.spec.ts
@@ -17,7 +17,7 @@ const AuthenticationDetailRepository = getRepositoryToken(AuthenticationDetail);
 describe('AuthService', () => {
   let authService: AuthService;
   let authenticationDetailRepository: Repository<AuthenticationDetail>;
-  let userRepository: Repository<User>;
+  let usersService: UsersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -28,7 +28,7 @@ describe('AuthService', () => {
           provide: UsersService,
           useValue: {
             findOne: jest.fn(),
-            updateUser: jest.fn(),
+            updateOne: jest.fn(),
           },
         },
         {
@@ -45,13 +45,6 @@ describe('AuthService', () => {
           },
         },
         {
-          provide: getRepositoryToken(User),
-          useValue: {
-            findOne: jest.fn(),
-            update: jest.fn(),
-          },
-        },
-        {
           provide: SSOService,
           useValue: {
             getProviderById: jest.fn(),
@@ -62,7 +55,7 @@ describe('AuthService', () => {
 
     authService = module.get<AuthService>(AuthService);
     authenticationDetailRepository = module.get<typeof authenticationDetailRepository>(AuthenticationDetailRepository);
-    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+    usersService = module.get<UsersService>(UsersService);
 
     // Reset all mocks before each test
     jest.clearAllMocks();
@@ -90,7 +83,7 @@ describe('AuthService', () => {
       authenticationDetails: [],
       resourceIntroducerPermissions: [],
     } as User;
-    jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+    jest.spyOn(usersService, 'findOne').mockResolvedValue(user);
 
     const authenticationDetail: Partial<AuthenticationDetail> = {
       userId: 1,
@@ -131,7 +124,7 @@ describe('AuthService', () => {
       authenticationDetails: [],
       resourceIntroducerPermissions: [],
     } as User;
-    jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+    jest.spyOn(usersService, 'findOne').mockResolvedValue(user);
 
     jest.spyOn(authenticationDetailRepository, 'findOne').mockResolvedValue({
       id: 1,
@@ -153,7 +146,7 @@ describe('AuthService', () => {
   });
 
   it('should not authenticate a non-existent user', async () => {
-    jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+    jest.spyOn(usersService, 'findOne').mockResolvedValue(null);
 
     const isAuthenticated = await authService.getUserByUsernameAndAuthenticationDetails('nonexistentuser', {
       type: AuthenticationType.LOCAL_PASSWORD,

--- a/apps/api/src/users-and-auth/auth/auth.service.ts
+++ b/apps/api/src/users-and-auth/auth/auth.service.ts
@@ -8,6 +8,7 @@ import { addDays } from 'date-fns';
 import * as bcrypt from 'bcrypt';
 import { SSOService } from './sso/sso.service';
 import { SSOProviderNotFoundException } from './sso/errors';
+import { UsersService } from '../users/users.service';
 
 export interface LocalPasswordAuthenticationOptions {
   password: string;
@@ -45,9 +46,8 @@ export class AuthService {
     private emailService: EmailService,
     @InjectRepository(AuthenticationDetail)
     private authenticationDetailRepository: Repository<AuthenticationDetail>,
-    @InjectRepository(User)
-    private userRepository: Repository<User>,
     private ssoService: SSOService,
+    private usersService: UsersService,
   ) {
     this.logger.debug('AuthService initialized');
   }
@@ -119,7 +119,7 @@ export class AuthService {
     username: string,
     options: AuthenticationOptions<T>,
   ): Promise<User | null> {
-    const user = await this.userRepository.findOne({ where: { username } });
+    const user = await this.usersService.findOne({ username });
 
     if (!user) {
       this.logger.debug(`No user found with username: ${username}`);
@@ -144,7 +144,7 @@ export class AuthService {
     const token = nanoid();
 
     this.logger.debug(`Setting email verification token for user ID: ${user.id} to: ${token}`);
-    await this.userRepository.update(user.id, {
+    await this.usersService.updateOne(user.id, {
       emailVerificationToken: token,
       emailVerificationTokenExpiresAt: addDays(new Date(), 3),
     });
@@ -155,7 +155,7 @@ export class AuthService {
 
   async verifyEmail(email: string, token: string): Promise<void> {
     this.logger.debug(`Verifying email: ${email} with token: ${token.substring(0, 5)}...`);
-    const user = await this.userRepository.findOne({ where: { email } });
+    const user = await this.usersService.findOne({ email });
 
     if (!user) {
       this.logger.debug(`No user found with email: ${email}`);
@@ -173,7 +173,7 @@ export class AuthService {
     }
 
     this.logger.debug(`Marking email as verified for user ID: ${user.id}`);
-    await this.userRepository.update(user.id, {
+    await this.usersService.updateOne(user.id, {
       isEmailVerified: true,
       emailVerificationToken: null,
       emailVerificationTokenExpiresAt: null,
@@ -182,14 +182,14 @@ export class AuthService {
   }
 
   async generatePasswordResetToken(email: string): Promise<string> {
-    const user = await this.userRepository.findOne({ where: { email } });
+    const user = await this.usersService.findOne({ email });
     if (!user) {
       this.logger.debug(`No user found with email: ${email}`);
       return null;
     }
 
     const token = nanoid();
-    await this.userRepository.update(user.id, {
+    await this.usersService.updateOne(user.id, {
       passwordResetToken: token,
       passwordResetTokenExpiresAt: addDays(new Date(), 1),
     });

--- a/apps/api/src/users-and-auth/users/users.service.ts
+++ b/apps/api/src/users-and-auth/users/users.service.ts
@@ -61,6 +61,10 @@ export class UsersService {
     }
   }
 
+  private cleanupUsername(username: string): string {
+    return username.trim().toLowerCase();
+  }
+
   async findOne(options: FindOneOptions, relations?: string[]): Promise<User | null> {
     const validatedOptions = FindOneOptionsSchema.parse(options);
 
@@ -72,7 +76,7 @@ export class UsersService {
     }
 
     if (validatedOptions.username !== undefined) {
-      whereCondition.username = ILike(validatedOptions.username);
+      whereCondition.username = this.cleanupUsername(validatedOptions.username);
     }
 
     if (validatedOptions.email !== undefined) {
@@ -99,7 +103,7 @@ export class UsersService {
     skipUsernameSanitization?: boolean;
   }): Promise<User> {
     const data = {
-      username: userData.username.trim(),
+      username: this.cleanupUsername(userData.username),
       email: userData.email.trim(),
       externalIdentifier: userData.externalIdentifier?.trim() ?? null,
       isEmailVerified: userData.isEmailVerified ?? false,
@@ -178,8 +182,18 @@ export class UsersService {
   }
 
   async updateOne(id: number, updateData: Partial<User>): Promise<User> {
+    let username = updateData.username;
+    if (username) {
+      username = this.cleanupUsername(username);
+
+      if (username === '') {
+        username = undefined;
+      }
+    }
+
     const updates: DeepPartial<User> = {
-      username: updateData.username?.trim() ?? undefined,
+      ...updateData,
+      username,
       email: updateData.email?.trim() ?? undefined,
       externalIdentifier: updateData.externalIdentifier?.trim() ?? undefined,
     };
@@ -187,10 +201,6 @@ export class UsersService {
 
     if (updates.username !== undefined) {
       this.validateUsernameOrThrow(updates.username);
-    }
-
-    if (updateData.lastUsernameChangeAt !== undefined) {
-      updates.lastUsernameChangeAt = updateData.lastUsernameChangeAt;
     }
 
     if (updateData.systemPermissions !== undefined) {
@@ -239,7 +249,7 @@ export class UsersService {
   }
 
   async changeUsername(targetUserId: number, newUsername: string, executingUser: User): Promise<User> {
-    newUsername = newUsername.trim();
+    newUsername = this.cleanupUsername(newUsername);
     if (newUsername.length === 0) {
       throw new BadRequestException('Username cannot be empty');
     }


### PR DESCRIPTION
## Summary by Sourcery

Normalize usernames to be lowercase and trimmed across user creation, updates, lookups, and existing data, and route auth flows through UsersService instead of accessing the User repository directly.

Bug Fixes:
- Ensure username-based lookups are case-insensitive by normalizing input usernames before querying.
- Prevent creation or update of users with usernames differing only by casing by consistently lowercasing stored usernames.

Enhancements:
- Introduce a shared username normalization helper in UsersService and apply it to create, update, and username-change operations.
- Refactor AuthService to depend on UsersService for user retrieval and updates instead of using the User repository directly.

Tests:
- Adjust AuthService unit tests to mock UsersService instead of the User repository.

Chores:
- Add a database migration to normalize all existing usernames to trimmed lowercase values.