### PR TITLE
feat(ATT-164): prevent sso users from changing/setting their password

### DIFF
--- a/apps/api/src/users-and-auth/users/users.controller.ts
+++ b/apps/api/src/users-and-auth/users/users.controller.ts
@@ -608,7 +608,7 @@ export class UsersController {
       return { message: 'OK' };
     }
 
-    const isSSOUser = this.usersService.isSSOUser(user.id);
+    const isSSOUser = await this.usersService.isSSOUser(user.id);
     if (isSSOUser) {
       throw new ForbiddenException('You cannot reset the password of an SSO user');
     }
@@ -638,7 +638,7 @@ export class UsersController {
       throw new UserNotFoundException(userId);
     }
 
-    const isSSOUser = this.usersService.isSSOUser(userId);
+    const isSSOUser = await this.usersService.isSSOUser(userId);
     if (isSSOUser) {
       throw new ForbiddenException('You cannot reset the password of an SSO user');
     }

--- a/libs/api-client/src/generated/Api.ts
+++ b/libs/api-client/src/generated/Api.ts
@@ -6642,7 +6642,7 @@ export class HttpClient<SecurityDataType = unknown> {
 
 /**
  * @title Attraccess API
- * @version 1.0.0
+ * @version 0.0.16
  * @contact
  *
  * The Attraccess API used to manage machine and tool access in a Makerspace or FabLab


### PR DESCRIPTION
## Summary by Sourcery

Disallow password changes and resets for users authenticated via SSO across the authentication and user management flows.

New Features:
- Block SSO users from changing or setting a local password via the authentication service.
- Prevent SSO users from initiating or completing password reset flows via the user controller.