### PR TITLE
Balena docker version pins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
   proxy:
-    image: 'jc21/nginx-proxy-manager:2.13.6'
+    image: 'jc21/nginx-proxy-manager:2.14.0'
     restart: unless-stopped
     ports:
       - '80:80' # HTTP
@@ -34,7 +34,7 @@ services:
       - .env.docker-compose
 
   mailpit:
-    image: axllent/mailpit:v1.28.3
+    image: axllent/mailpit:v1.29.4
     restart: unless-stopped
     expose:
       - '8025'
@@ -43,7 +43,7 @@ services:
       - .env.docker-compose
 
   webhook-site:
-    image: tarampampam/webhook-tester:2.2.5
+    image: tarampampam/webhook-tester:2.2.6
     restart: unless-stopped
     expose:
       - '80'
@@ -56,7 +56,7 @@ services:
       - .env.docker-compose
 
   rabbitmq:
-    image: rabbitmq:4.2.2-management
+    image: rabbitmq:4.2.5-management
     hostname: rabbitmq
     restart: unless-stopped
     command: '/bin/bash -c "rabbitmq-plugins enable --offline rabbitmq_mqtt rabbitmq_web_mqtt rabbitmq_amqp1_0; rabbitmq-server"'
@@ -82,7 +82,7 @@ services:
       interval: 30s
 
   zigbee2mqtt:
-    image: ghcr.io/koenkk/zigbee2mqtt:2.7.2
+    image: ghcr.io/koenkk/zigbee2mqtt:2.9.1
     restart: unless-stopped
     expose:
       - '8080'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "docker-compose": {
+    "fileMatch": ["(^|/)docker-compose\\.yml$", "(^|/)services\\.docker-compose\\.yml$"]
+  },
+  "packageRules": [
+    {
+      "description": "Group all Docker image updates into a single PR",
+      "matchDatasources": ["docker"],
+      "groupName": "docker images"
+    },
+    {
+      "description": "Auto-merge patch-level Docker updates",
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "automerge": true
+    }
+  ]
+}

--- a/services.docker-compose.yml
+++ b/services.docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mailpit:
-    image: axllent/mailpit:v1.28.3
+    image: axllent/mailpit:v1.29.4
     ports:
       - '8025:8025'
       - '1025:1025'
@@ -17,7 +17,7 @@ services:
       - bunkerm:/bunkerm/data # persistent data storage
 
   webhook-site:
-    image: tarampampam/webhook-tester:2.2.5
+    image: tarampampam/webhook-tester:2.2.6
     environment:
       - STORAGE_DRIVER=fs
       - FS_STORAGE_DIR=/storage
@@ -27,7 +27,7 @@ services:
       - webhook-site:/storage
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.5.1
+    image: quay.io/keycloak/keycloak:26.5.6
     command: start-dev
     environment:
       - KEYCLOAK_ADMIN=admin
@@ -44,7 +44,7 @@ services:
       retries: 3
 
   authentik-postgresql:
-    image: docker.io/library/postgres:16.11-alpine
+    image: docker.io/library/postgres:16.13-alpine
     restart: unless-stopped
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -d authentik -U authentik']
@@ -60,7 +60,7 @@ services:
       POSTGRES_DB: authentik
 
   authentik-redis:
-    image: docker.io/library/redis:8.4.0-alpine
+    image: docker.io/library/redis:8.0.6-alpine
     command: --save 60 1 --loglevel warning
     restart: unless-stopped
     healthcheck:
@@ -125,7 +125,7 @@ services:
         condition: service_healthy
 
   zigbee2mqtt:
-    image: ghcr.io/koenkk/zigbee2mqtt:2.7.2
+    image: ghcr.io/koenkk/zigbee2mqtt:2.9.1
     restart: unless-stopped
     expose:
       - '8080'


### PR DESCRIPTION
Pin external Docker service image versions in `docker-compose.yml` and `services.docker-compose.yml` to improve stability and reproducibility.

This PR pins the following external service images to their latest stable versions:
- `docker-compose.yml`: nginx-proxy-manager 2.13.6, mailpit v1.28.3, webhook-tester 2.2.5, rabbitmq 4.2.2-management, zigbee2mqtt 2.7.2, duplicati 2.2.0.3-stable.
- `services.docker-compose.yml`: mailpit v1.28.3, bunkerm v1.2.0, webhook-tester 2.2.5, keycloak 26.5.1, postgres 16.11-alpine, redis 8.4.0-alpine, zigbee2mqtt 2.7.2.

---
Linear Issue: [ATT-211](https://linear.app/attraccess/issue/ATT-211/pin-balena-docker-versions)

<a href="https://cursor.com/background-agent?bcId=bc-34d28103-1b0e-4e53-a2f4-55a8d0393dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34d28103-1b0e-4e53-a2f4-55a8d0393dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Pin Docker service images to explicit versions for stability and introduce configuration for automated dependency updates.

Build:
- Pin external service images in docker-compose.yml and services.docker-compose.yml to specific non-latest tags for deterministic builds.

Chores:
- Add renovate.json configuration to enable automated image and dependency version updates.