### PR TITLE
Resource metadata editor UI

### DIFF
--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.de.json
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.de.json
@@ -19,6 +19,27 @@
     "image": {
       "label": "Bild"
     },
+    "metadata": {
+      "label": "Metadaten",
+      "description": "Fügen Sie benutzerdefinierte Schlüssel/Wert-Paare für diese Ressource hinzu.",
+      "table": {
+        "ariaLabel": "Ressourcenmetadaten",
+        "columns": {
+          "key": "Schlüssel",
+          "value": "Wert",
+          "actions": "Aktionen"
+        },
+        "empty": "Noch keine Metadaten vorhanden."
+      },
+      "actions": {
+        "add": "Eintrag hinzufügen",
+        "remove": "Entfernen"
+      },
+      "placeholders": {
+        "key": "Schlüssel",
+        "value": "Wert"
+      }
+    },
     "machine": {
       "allowTakeOver": {
         "label": "Übernahme erlauben",

--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.en.json
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.en.json
@@ -19,6 +19,27 @@
     "image": {
       "label": "Image"
     },
+    "metadata": {
+      "label": "Metadata",
+      "description": "Add custom key/value pairs for this resource.",
+      "table": {
+        "ariaLabel": "Resource metadata",
+        "columns": {
+          "key": "Key",
+          "value": "Value",
+          "actions": "Actions"
+        },
+        "empty": "No metadata entries yet."
+      },
+      "actions": {
+        "add": "Add entry",
+        "remove": "Remove"
+      },
+      "placeholders": {
+        "key": "Key",
+        "value": "Value"
+      }
+    },
     "machine": {
       "allowTakeOver": {
         "label": "Allow Takeover",

--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
@@ -56,6 +56,7 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
     allowTakeOver: false,
     type: ResourceType.MACHINE,
     separateUnlockAndUnlatch: false,
+    metadata: {},
   });
 
   const setField = useCallback(
@@ -144,6 +145,7 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
       allowTakeOver: resource?.allowTakeOver || false,
       type: resource?.type || ResourceType.MACHINE,
       separateUnlockAndUnlatch: resource?.separateUnlockAndUnlatch || false,
+      metadata: resource?.metadata ?? {},
     });
     setSelectedImage(null);
   }, [resource, setFormData, setSelectedImage]);
@@ -166,6 +168,10 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
       return;
     }
 
+    const metadata = Object.fromEntries(
+      Object.entries(formData.metadata ?? {}).filter(([key]) => key.trim() !== ''),
+    ) as Record<string, unknown>;
+
     if (props.resourceId) {
       updateResource.mutate({
         id: props.resourceId,
@@ -177,6 +183,7 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
           deleteImage,
           type: formData.type,
           separateUnlockAndUnlatch: formData.separateUnlockAndUnlatch,
+          metadata,
         },
       });
       return;
@@ -190,6 +197,7 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
         image: selectedImage ?? undefined,
         type: formData.type as ResourceType,
         separateUnlockAndUnlatch: formData.separateUnlockAndUnlatch,
+        metadata,
       },
     });
   }, [formData, selectedImage, props.resourceId, updateResource, createResource, deleteImage]);

--- a/apps/frontend/src/app/resources/editModal/resourceMetadataEditor.tsx
+++ b/apps/frontend/src/app/resources/editModal/resourceMetadataEditor.tsx
@@ -1,0 +1,143 @@
+import {
+  Button,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from '@heroui/react';
+import { PlusIcon, Trash2Icon } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+import { TFunction } from '@attraccess/plugins-frontend-ui';
+import { EmptyState } from '../../../components/emptyState';
+
+interface Props {
+  t: TFunction;
+  metadata?: Record<string, unknown>;
+  onChange: (metadata: Record<string, unknown>) => void;
+}
+
+const stringifyMetadataValue = (value: unknown) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export function ResourceMetadataEditor(props: Props) {
+  const { t, metadata, onChange } = props;
+
+  const rows = useMemo(
+    () =>
+      Object.entries(metadata ?? {}).map(([key, value], index) => ({
+        id: `${key || 'empty'}-${index}`,
+        key,
+        value,
+      })),
+    [metadata],
+  );
+
+  const handleKeyChange = useCallback(
+    (currentKey: string, nextKey: string) => {
+      const currentMetadata = metadata ?? {};
+      const normalizedKey = nextKey.trim();
+      const newKey = normalizedKey === '' ? '' : normalizedKey;
+      const nextMetadata = { ...currentMetadata };
+      const currentValue = nextMetadata[currentKey];
+      delete nextMetadata[currentKey];
+      nextMetadata[newKey] = currentValue ?? '';
+      onChange(nextMetadata);
+    },
+    [metadata, onChange],
+  );
+
+  const handleValueChange = useCallback(
+    (key: string, nextValue: string) => {
+      onChange({ ...(metadata ?? {}), [key]: nextValue });
+    },
+    [metadata, onChange],
+  );
+
+  const handleRemove = useCallback(
+    (key: string) => {
+      const nextMetadata = { ...(metadata ?? {}) };
+      delete nextMetadata[key];
+      onChange(nextMetadata);
+    },
+    [metadata, onChange],
+  );
+
+  const handleAdd = useCallback(() => {
+    const currentMetadata = metadata ?? {};
+    if (Object.prototype.hasOwnProperty.call(currentMetadata, '')) {
+      return;
+    }
+    onChange({ ...currentMetadata, '': '' });
+  }, [metadata, onChange]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1">
+        <span className="text-small font-medium">{t('inputs.metadata.label')}</span>
+        <span className="text-tiny text-default-400">{t('inputs.metadata.description')}</span>
+      </div>
+
+      <Table removeWrapper aria-label={t('inputs.metadata.table.ariaLabel')}>
+        <TableHeader>
+          <TableColumn>{t('inputs.metadata.table.columns.key')}</TableColumn>
+          <TableColumn>{t('inputs.metadata.table.columns.value')}</TableColumn>
+          <TableColumn className="w-[1%]">{t('inputs.metadata.table.columns.actions')}</TableColumn>
+        </TableHeader>
+        <TableBody items={rows} emptyContent={<EmptyState message={t('inputs.metadata.table.empty')} />}>
+          {(row) => (
+            <TableRow key={row.id}>
+              <TableCell>
+                <Input
+                  size="sm"
+                  value={row.key}
+                  placeholder={t('inputs.metadata.placeholders.key')}
+                  aria-label={t('inputs.metadata.table.columns.key')}
+                  onValueChange={(nextKey) => handleKeyChange(row.key, nextKey)}
+                />
+              </TableCell>
+              <TableCell>
+                <Input
+                  size="sm"
+                  value={stringifyMetadataValue(row.value)}
+                  placeholder={t('inputs.metadata.placeholders.value')}
+                  aria-label={t('inputs.metadata.table.columns.value')}
+                  onValueChange={(nextValue) => handleValueChange(row.key, nextValue)}
+                />
+              </TableCell>
+              <TableCell>
+                <Button
+                  size="sm"
+                  variant="light"
+                  color="danger"
+                  isIconOnly
+                  onPress={() => handleRemove(row.key)}
+                  aria-label={t('inputs.metadata.actions.remove')}
+                >
+                  <Trash2Icon className="h-4 w-4" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+
+      <Button size="sm" variant="flat" startContent={<PlusIcon className="h-4 w-4" />} onPress={handleAdd}>
+        {t('inputs.metadata.actions.add')}
+      </Button>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/resources/editModal/tabs/shared.tsx
+++ b/apps/frontend/src/app/resources/editModal/tabs/shared.tsx
@@ -2,6 +2,7 @@ import { Input } from '@heroui/react';
 import { EditorTabProps } from './props';
 import { ImageUpload } from '../../../../components/imageUpload';
 import { filenameToUrl } from '../../../../api';
+import { ResourceMetadataEditor } from '../resourceMetadataEditor';
 
 interface Props {
   onImageSelected: (file: File | null) => void;
@@ -34,6 +35,12 @@ export function SharedDataTab(props: EditorTabProps & Props) {
         className="w-full"
         autoScale={{ maxWidth: 800, maxHeight: 800, output: 'auto' }}
         currentImageUrl={resource?.imageFilename ? filenameToUrl(resource?.imageFilename) : undefined}
+      />
+
+      <ResourceMetadataEditor
+        t={t}
+        metadata={formData.metadata}
+        onChange={(metadata) => setField('metadata', metadata)}
       />
 
       <button hidden type="submit" />

--- a/libs/react-query-client/src/lib/requests/schemas.gen.ts
+++ b/libs/react-query-client/src/lib/requests/schemas.gen.ts
@@ -1065,6 +1065,11 @@ export const $CreateResourceDto = {
             description: 'A detailed description of the resource',
             example: 'Prusa i3 MK3S+ 3D printer with 0.4mm nozzle'
         },
+        metadata: {
+            type: 'object',
+            description: 'Custom metadata for the resource',
+            additionalProperties: true
+        },
         image: {
             type: 'string',
             description: 'Resource image file',
@@ -1224,6 +1229,11 @@ export const $Resource = {
             type: 'string',
             description: 'A detailed description of the resource',
             example: 'Prusa i3 MK3S+ 3D printer with 0.4mm nozzle'
+        },
+        metadata: {
+            type: 'object',
+            description: 'Custom metadata for the resource',
+            additionalProperties: true
         },
         imageFilename: {
             type: 'string',
@@ -1758,6 +1768,11 @@ export const $UpdateResourceDto = {
             type: 'string',
             description: 'A detailed description of the resource',
             example: 'Prusa i3 MK3S+ 3D printer with 0.4mm nozzle'
+        },
+        metadata: {
+            type: 'object',
+            description: 'Custom metadata for the resource',
+            additionalProperties: true
         },
         image: {
             type: 'string',

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -683,6 +683,12 @@ export type CreateResourceDto = {
      */
     description?: string;
     /**
+     * Custom metadata for the resource
+     */
+    metadata?: {
+        [key: string]: unknown;
+    };
+    /**
      * Resource image file
      */
     image?: (Blob | File);
@@ -805,6 +811,12 @@ export type Resource = {
      * A detailed description of the resource
      */
     description?: string;
+    /**
+     * Custom metadata for the resource
+     */
+    metadata?: {
+        [key: string]: unknown;
+    };
     /**
      * The filename of the resource image
      */
@@ -1177,6 +1189,12 @@ export type UpdateResourceDto = {
      * A detailed description of the resource
      */
     description?: string;
+    /**
+     * Custom metadata for the resource
+     */
+    metadata?: {
+        [key: string]: unknown;
+    };
     /**
      * New resource image file
      */


### PR DESCRIPTION
Add a UI for editing/viewing resource metadata in the general resource editor modal.

This allows users to configure custom key-value pairs for resources directly in the frontend, completing the metadata per resource feature.

---
Linear Issue: [ATT-226](https://linear.app/attraccess/issue/ATT-226/metadata-per-resource)

<a href="https://cursor.com/background-agent?bcId=bc-33301023-ccae-4609-b0e5-5b978ea0f113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33301023-ccae-4609-b0e5-5b978ea0f113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Add support for custom per-resource metadata across the API client types and the resource edit modal, including a UI for managing metadata key-value pairs.

New Features:
- Allow create, read, and update operations on resources to include arbitrary metadata objects via the generated API client types and schemas.
- Introduce a metadata editor section in the resource edit modal for adding, editing, and removing custom key-value metadata pairs on resources.

Enhancements:
- Normalize and filter metadata entries before submitting resource create and update mutations to avoid empty keys.