### PR TITLE
Resource edit modal mobile

### DIFF
--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
@@ -216,14 +216,15 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
                     e.preventDefault();
                     onSubmit();
                   }}
-                  className="flex flex-row gap-2 w-full"
+                  className="flex flex-col gap-4 w-full lg:flex-row"
                 >
-                  <div className="flex flex-1 flex-col gap-2">
+                  <div className="flex w-full flex-1 flex-col gap-2 min-w-0">
                     <SharedDataTab t={t} formData={formData} setField={setField} onImageSelected={onImageSelected} />
                   </div>
 
-                  <div className="flex flex-1 flex-col gap-2">
+                  <div className="flex w-full flex-1 flex-col gap-2 min-w-0">
                     <Tabs
+                      className="w-full"
                       onSelectionChange={(key) => setField('type', key as UpdateResourceDto['type'])}
                       selectedKey={formData.type}
                       destroyInactiveTabPanel={false}


### PR DESCRIPTION
Make the resource edit modal responsive for mobile devices to improve layout and usability.

---
Linear Issue: [ATT-226](https://linear.app/attraccess/issue/ATT-226/metadata-per-resource)

<a href="https://cursor.com/background-agent?bcId=bc-5958a1d7-3794-4ce0-a775-c3f1551d5fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5958a1d7-3794-4ce0-a775-c3f1551d5fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Make the resource edit modal layout responsive by stacking sections vertically on small screens and constraining widths to avoid overflow.

Enhancements:
- Adjust the resource edit modal form layout to stack vertically on small viewports and switch back to a horizontal layout on large screens.
- Ensure both the shared data tab and the tabs section use full width with constrained minimum widths to prevent content overflow on mobile.