### PR TITLE
feat: upgrade notes in docs

### DIFF
--- a/docs/HOME.md
+++ b/docs/HOME.md
@@ -16,6 +16,7 @@ Attraccess is a powerful platform designed to simplify and secure access managem
 ## Getting Started
 
 - For new installations, visit the [Setup Guide](setup/installation.md)
+- Upgrading an existing instance? See [Upgrade Notes](setup/upgrade-notes.md)
 - Existing users should check the [User Guides](user/getting-started.md)
 - Developers interested in extending Attraccess can explore the [Developer Documentation](developer/get-started.md)
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
 
   - [Installation](setup/installation.md)
   - [SSL Configuration](setup/ssl-configuration.md)
+  - [Upgrade Notes](setup/upgrade-notes.md)
   - **Beginner Guides**
     - [Complete Beginner Guide](setup/beginner-guide.md)
     - [Docker Compose Guide](setup/docker-compose-guide.md)

--- a/docs/setup/upgrade-notes.md
+++ b/docs/setup/upgrade-notes.md
@@ -1,0 +1,43 @@
+# Upgrade Notes
+
+This page lists version-specific steps required when upgrading.
+
+## v1.4.0 - appuser introduced
+
+**What changed**
+The runtime container now runs as an unprivileged user `appuser`.
+
+**Symptoms**
+- API logs show `SQLITE_READONLY` errors.
+- Storage is not writable.
+
+**Fix: update storage ownership**
+
+If your storage is a **bind mount on the host**, `appuser` does not exist on the host.
+Use numeric ownership based on the container's `appuser` IDs:
+
+```
+docker exec <container> id -u appuser
+docker exec <container> id -g appuser
+chown -R <uid>:<gid> /path/to/storage
+```
+
+If you want to run it **inside the container**, you must exec as root (no sudo in the image):
+
+```
+docker exec --user 0 -it <container> sh
+chown -R appuser:appuser /app/storage
+```
+
+For Docker Compose:
+
+```
+docker compose exec --user 0 api sh
+chown -R appuser:appuser /app/storage
+```
+
+**Notes**
+- On the host, `chown appuser:appuser` fails unless you create that user.
+- The `appuser` UID/GID can vary between images unless explicitly pinned.
+- Some storage backends (NFS/SMB) may block ownership changes. Update ownership
+  on the storage server or adjust mount options.


### PR DESCRIPTION
## Summary by Sourcery

Document upgrade-specific guidance for running the application as an unprivileged container user and surface it in the main docs navigation.

Documentation:
- Add an Upgrade Notes page detailing version-specific upgrade steps for v1.4.0 related to the new unprivileged appuser and storage ownership.
- Link the new Upgrade Notes page from the home Getting Started section and the setup sidebar navigation.