### PR TITLE
Pr precommit consistency check

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -52,6 +52,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install platformio esptool
 
+      - name: Run precommit checks
+        run: pnpm precommit
+
+      - name: Ensure precommit does not modify files
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "pnpm precommit modified files. Please run it locally and commit the changes."
+            git status --porcelain
+            git --no-pager diff
+            exit 1
+          fi
+
       - name: Run build steps (adjust target as needed)
         env:
           NODE_ENV: production


### PR DESCRIPTION
Run `pnpm precommit` in PR checks and fail if it modifies files to enforce consistent code formatting and generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0013441-3805-4ce1-9663-1fa7b1e408b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e0013441-3805-4ce1-9663-1fa7b1e408b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

## Summary by Sourcery

Enforce precommit consistency in pull request workflows by running `pnpm precommit` and failing the check if it results in uncommitted changes.

CI:
- Add a CI step to run `pnpm precommit` during pull request checks.
- Add a CI guard that fails the workflow when `pnpm precommit` produces uncommitted file changes.