### PR TITLE
ATT-260 flow editor allow for copy and pasting nodes

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/flowClipboard.spec.ts
+++ b/apps/frontend/src/app/resources/details/flows/flowClipboard.spec.ts
@@ -218,3 +218,82 @@ describe('buildPastedElements', () => {
     expect(result.nodes[0].type).toBe('mqtt-publish');
   });
 });
+
+describe('buildPastedElements with targetPosition', () => {
+  let idCounter: number;
+  const generateId = () => `new-${++idCounter}`;
+
+  beforeEach(() => {
+    idCounter = 0;
+  });
+
+  it('places single-node centroid at the target position', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [makeNode('a', { position: { x: 100, y: 200 } })],
+      edges: [],
+    };
+    const result = buildPastedElements(data, generateId, 50, { x: 500, y: 600 });
+    expect(result.nodes[0].position).toEqual({ x: 500, y: 600 });
+  });
+
+  it('places multi-node group centroid at the target position', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [
+        makeNode('a', { position: { x: 100, y: 200 } }),
+        makeNode('b', { position: { x: 300, y: 400 } }),
+      ],
+      edges: [],
+    };
+    const result = buildPastedElements(data, generateId, 50, { x: 500, y: 500 });
+    expect(result.nodes[0].position).toEqual({ x: 400, y: 400 });
+    expect(result.nodes[1].position).toEqual({ x: 600, y: 600 });
+  });
+
+  it('preserves relative spacing between nodes', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [
+        makeNode('a', { position: { x: 0, y: 0 } }),
+        makeNode('b', { position: { x: 200, y: 100 } }),
+        makeNode('c', { position: { x: 50, y: 300 } }),
+      ],
+      edges: [],
+    };
+    const result = buildPastedElements(data, generateId, 50, { x: 1000, y: 1000 });
+    const dx = result.nodes[1].position.x - result.nodes[0].position.x;
+    const dy = result.nodes[1].position.y - result.nodes[0].position.y;
+    expect(dx).toBe(200);
+    expect(dy).toBe(100);
+    const dx2 = result.nodes[2].position.x - result.nodes[0].position.x;
+    const dy2 = result.nodes[2].position.y - result.nodes[0].position.y;
+    expect(dx2).toBe(50);
+    expect(dy2).toBe(300);
+  });
+
+  it('still remaps edges when target position is provided', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [
+        makeNode('a', { position: { x: 100, y: 100 } }),
+        makeNode('b', { position: { x: 300, y: 300 } }),
+      ],
+      edges: [makeEdge('e1', 'a', 'b')],
+    };
+    const result = buildPastedElements(data, generateId, 50, { x: 0, y: 0 });
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe('new-1');
+    expect(result.edges[0].target).toBe('new-2');
+  });
+
+  it('falls back to legacy offset when target position is omitted', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [makeNode('a', { position: { x: 100, y: 200 } })],
+      edges: [],
+    };
+    const result = buildPastedElements(data, generateId, 50);
+    expect(result.nodes[0].position).toEqual({ x: 150, y: 250 });
+  });
+});

--- a/apps/frontend/src/app/resources/details/flows/flowClipboard.spec.ts
+++ b/apps/frontend/src/app/resources/details/flows/flowClipboard.spec.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import { Node, Edge } from '@xyflow/react';
+import {
+  buildClipboardData,
+  parseClipboardData,
+  buildPastedElements,
+  CLIPBOARD_TYPE,
+  FlowClipboardData,
+} from './flowClipboard';
+
+const makeNode = (id: string, overrides: Partial<Node> = {}): Node => ({
+  id,
+  type: 'test-node',
+  position: { x: 100, y: 200 },
+  data: { label: `Node ${id}` },
+  ...overrides,
+});
+
+const makeEdge = (id: string, source: string, target: string, overrides: Partial<Edge> = {}): Edge => ({
+  id,
+  source,
+  target,
+  ...overrides,
+});
+
+describe('buildClipboardData', () => {
+  it('returns null when no nodes are selected', () => {
+    const nodes = [makeNode('a'), makeNode('b')];
+    expect(buildClipboardData(nodes, [])).toBeNull();
+  });
+
+  it('returns only selected nodes', () => {
+    const nodes = [
+      makeNode('a', { selected: true }),
+      makeNode('b'),
+      makeNode('c', { selected: true }),
+    ];
+    const result = buildClipboardData(nodes, []);
+    expect(result?.nodes).toHaveLength(2);
+    expect(result?.nodes.map((n) => n.id)).toEqual(['a', 'c']);
+  });
+
+  it('includes edges where both source and target are selected', () => {
+    const nodes = [
+      makeNode('a', { selected: true }),
+      makeNode('b', { selected: true }),
+      makeNode('c'),
+    ];
+    const edges = [
+      makeEdge('e1', 'a', 'b'),
+      makeEdge('e2', 'a', 'c'),
+      makeEdge('e3', 'c', 'b'),
+    ];
+    const result = buildClipboardData(nodes, edges);
+    expect(result?.edges).toHaveLength(1);
+    expect(result?.edges[0].id).toBe('e1');
+  });
+
+  it('strips measured, selected, and dragging from nodes', () => {
+    const nodes = [
+      makeNode('a', {
+        selected: true,
+        measured: { width: 200, height: 100 },
+        dragging: true,
+      }),
+    ];
+    const result = buildClipboardData(nodes, []);
+    const node = result?.nodes[0];
+    expect(node).not.toHaveProperty('measured');
+    expect(node).not.toHaveProperty('selected');
+    expect(node).not.toHaveProperty('dragging');
+    expect(node?.id).toBe('a');
+    expect(node?.data).toEqual({ label: 'Node a' });
+  });
+
+  it('strips selected from edges', () => {
+    const nodes = [
+      makeNode('a', { selected: true }),
+      makeNode('b', { selected: true }),
+    ];
+    const edges = [makeEdge('e1', 'a', 'b', { selected: true })];
+    const result = buildClipboardData(nodes, edges);
+    expect(result?.edges[0]).not.toHaveProperty('selected');
+  });
+
+  it('preserves node data and position', () => {
+    const nodes = [
+      makeNode('a', {
+        selected: true,
+        position: { x: 42, y: 99 },
+        data: { config: { threshold: 5 } },
+      }),
+    ];
+    const result = buildClipboardData(nodes, []);
+    expect(result?.nodes[0].position).toEqual({ x: 42, y: 99 });
+    expect(result?.nodes[0].data).toEqual({ config: { threshold: 5 } });
+  });
+});
+
+describe('parseClipboardData', () => {
+  it('parses valid clipboard JSON', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [makeNode('a')],
+      edges: [],
+    };
+    const result = parseClipboardData(JSON.stringify(data));
+    expect(result?.type).toBe(CLIPBOARD_TYPE);
+    expect(result?.nodes).toHaveLength(1);
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseClipboardData('not json')).toBeNull();
+  });
+
+  it('returns null for wrong type marker', () => {
+    expect(parseClipboardData(JSON.stringify({ type: 'something-else', nodes: [], edges: [] }))).toBeNull();
+  });
+
+  it('returns null for missing nodes array', () => {
+    expect(parseClipboardData(JSON.stringify({ type: CLIPBOARD_TYPE, edges: [] }))).toBeNull();
+  });
+
+  it('returns null for missing edges array', () => {
+    expect(parseClipboardData(JSON.stringify({ type: CLIPBOARD_TYPE, nodes: [] }))).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseClipboardData('')).toBeNull();
+  });
+});
+
+describe('buildPastedElements', () => {
+  let idCounter: number;
+  const generateId = () => `new-${++idCounter}`;
+
+  const clipboardData: FlowClipboardData = {
+    type: CLIPBOARD_TYPE,
+    nodes: [makeNode('a', { position: { x: 100, y: 200 } }), makeNode('b', { position: { x: 300, y: 400 } })],
+    edges: [makeEdge('e1', 'a', 'b')],
+  };
+
+  beforeEach(() => {
+    idCounter = 0;
+  });
+
+  it('generates new IDs for all nodes', () => {
+    const result = buildPastedElements(clipboardData, generateId);
+    expect(result.nodes.map((n) => n.id)).toEqual(['new-1', 'new-2']);
+  });
+
+  it('offsets positions by the given offset', () => {
+    const result = buildPastedElements(clipboardData, generateId, 75);
+    expect(result.nodes[0].position).toEqual({ x: 175, y: 275 });
+    expect(result.nodes[1].position).toEqual({ x: 375, y: 475 });
+  });
+
+  it('uses default offset of 50', () => {
+    const result = buildPastedElements(clipboardData, generateId);
+    expect(result.nodes[0].position).toEqual({ x: 150, y: 250 });
+  });
+
+  it('marks all pasted nodes as selected', () => {
+    const result = buildPastedElements(clipboardData, generateId);
+    expect(result.nodes.every((n) => n.selected)).toBe(true);
+  });
+
+  it('remaps edge source and target to new node IDs', () => {
+    const result = buildPastedElements(clipboardData, generateId);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe('new-1');
+    expect(result.edges[0].target).toBe('new-2');
+  });
+
+  it('generates new IDs for edges', () => {
+    const result = buildPastedElements(clipboardData, generateId);
+    expect(result.edges[0].id).toBe('new-3');
+  });
+
+  it('drops edges referencing nodes not in clipboard', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [makeNode('a')],
+      edges: [makeEdge('e1', 'a', 'missing')],
+    };
+    const result = buildPastedElements(data, generateId);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('strips measured and dragging from pasted nodes', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [makeNode('a', { measured: { width: 200, height: 100 }, dragging: true })],
+      edges: [],
+    };
+    const result = buildPastedElements(data, generateId);
+    expect(result.nodes[0]).not.toHaveProperty('measured');
+    expect(result.nodes[0]).not.toHaveProperty('dragging');
+  });
+
+  it('preserves node data through paste', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [makeNode('a', { data: { config: { mqtt_topic: 'sensors/temp' } } })],
+      edges: [],
+    };
+    const result = buildPastedElements(data, generateId);
+    expect(result.nodes[0].data).toEqual({ config: { mqtt_topic: 'sensors/temp' } });
+  });
+
+  it('preserves node type through paste', () => {
+    const data: FlowClipboardData = {
+      type: CLIPBOARD_TYPE,
+      nodes: [makeNode('a', { type: 'mqtt-publish' })],
+      edges: [],
+    };
+    const result = buildPastedElements(data, generateId);
+    expect(result.nodes[0].type).toBe('mqtt-publish');
+  });
+});

--- a/apps/frontend/src/app/resources/details/flows/flowClipboard.ts
+++ b/apps/frontend/src/app/resources/details/flows/flowClipboard.ts
@@ -44,14 +44,26 @@ export function buildPastedElements(
   clipboardData: FlowClipboardData,
   generateId: () => string,
   offset = 50,
+  targetPosition?: { x: number; y: number },
 ): PasteResult {
   const idMap = new Map<string, string>();
   clipboardData.nodes.forEach((n) => idMap.set(n.id, generateId()));
 
+  let dx = offset;
+  let dy = offset;
+  if (targetPosition && clipboardData.nodes.length > 0) {
+    const xs = clipboardData.nodes.map((n) => n.position.x);
+    const ys = clipboardData.nodes.map((n) => n.position.y);
+    const centerX = (Math.min(...xs) + Math.max(...xs)) / 2;
+    const centerY = (Math.min(...ys) + Math.max(...ys)) / 2;
+    dx = targetPosition.x - centerX;
+    dy = targetPosition.y - centerY;
+  }
+
   const nodes: Node[] = clipboardData.nodes.map(({ measured, dragging, ...n }) => ({
     ...n,
     id: idMap.get(n.id) ?? generateId(),
-    position: { x: n.position.x + offset, y: n.position.y + offset },
+    position: { x: n.position.x + dx, y: n.position.y + dy },
     selected: true,
   }));
 

--- a/apps/frontend/src/app/resources/details/flows/flowClipboard.ts
+++ b/apps/frontend/src/app/resources/details/flows/flowClipboard.ts
@@ -1,0 +1,68 @@
+import { Node, Edge } from '@xyflow/react';
+
+export const CLIPBOARD_TYPE = 'attraccess-flow-nodes' as const;
+
+export interface FlowClipboardData {
+  type: typeof CLIPBOARD_TYPE;
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export function buildClipboardData(nodes: Node[], edges: Edge[]): FlowClipboardData | null {
+  const selectedNodes = nodes.filter((n) => n.selected);
+  if (selectedNodes.length === 0) return null;
+
+  const selectedIds = new Set(selectedNodes.map((n) => n.id));
+  const selectedEdges = edges.filter(
+    (e) => selectedIds.has(e.source) && selectedIds.has(e.target)
+  );
+
+  return {
+    type: CLIPBOARD_TYPE,
+    nodes: selectedNodes.map(({ measured, selected, dragging, ...rest }) => rest as Node),
+    edges: selectedEdges.map(({ selected, ...rest }) => rest as Edge),
+  };
+}
+
+export function parseClipboardData(text: string): FlowClipboardData | null {
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed?.type !== CLIPBOARD_TYPE) return null;
+    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export interface PasteResult {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export function buildPastedElements(
+  clipboardData: FlowClipboardData,
+  generateId: () => string,
+  offset = 50,
+): PasteResult {
+  const idMap = new Map<string, string>();
+  clipboardData.nodes.forEach((n) => idMap.set(n.id, generateId()));
+
+  const nodes: Node[] = clipboardData.nodes.map(({ measured, dragging, ...n }) => ({
+    ...n,
+    id: idMap.get(n.id) ?? generateId(),
+    position: { x: n.position.x + offset, y: n.position.y + offset },
+    selected: true,
+  }));
+
+  const edges: Edge[] = clipboardData.edges
+    .filter((e) => idMap.has(e.source) && idMap.has(e.target))
+    .map((e) => ({
+      ...e,
+      id: generateId(),
+      source: idMap.get(e.source) ?? e.source,
+      target: idMap.get(e.target) ?? e.target,
+    }));
+
+  return { nodes, edges };
+}

--- a/apps/frontend/src/app/resources/details/flows/flowContext.tsx
+++ b/apps/frontend/src/app/resources/details/flows/flowContext.tsx
@@ -45,6 +45,7 @@ interface FlowContextType {
   removeLiveLogReceiver: (receiver: LiveLogReceiver) => void;
   flowNodeTypes: NodeTypes;
   copySelectedNodes: () => Promise<void>;
+  cutSelectedNodes: () => Promise<void>;
   pasteNodes: (targetFlowPosition?: { x: number; y: number }) => Promise<void>;
 }
 
@@ -147,6 +148,19 @@ export function FlowProvider({ children, resourceId }: FlowProviderProps) {
     await navigator.clipboard.writeText(JSON.stringify(clipboardData));
   }, [nodes, edges]);
 
+  const cutSelectedNodes = useCallback(async () => {
+    const clipboardData = buildClipboardData(nodes, edges);
+    if (!clipboardData) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(clipboardData));
+    } catch {
+      return;
+    }
+    const removedIds = new Set(clipboardData.nodes.map((n) => n.id));
+    setNodes((prev) => prev.filter((n) => !removedIds.has(n.id)));
+    setEdges((prev) => prev.filter((e) => !removedIds.has(e.source) && !removedIds.has(e.target)));
+  }, [nodes, edges, setNodes, setEdges]);
+
   const pasteNodes = useCallback(
     async (targetFlowPosition?: { x: number; y: number }) => {
       const text = await navigator.clipboard.readText().catch(() => '');
@@ -181,6 +195,7 @@ export function FlowProvider({ children, resourceId }: FlowProviderProps) {
       removeLiveLogReceiver,
       flowNodeTypes,
       copySelectedNodes,
+      cutSelectedNodes,
       pasteNodes,
     }),
     [
@@ -203,6 +218,7 @@ export function FlowProvider({ children, resourceId }: FlowProviderProps) {
       removeLiveLogReceiver,
       flowNodeTypes,
       copySelectedNodes,
+      cutSelectedNodes,
       pasteNodes,
     ],
   );

--- a/apps/frontend/src/app/resources/details/flows/flowContext.tsx
+++ b/apps/frontend/src/app/resources/details/flows/flowContext.tsx
@@ -45,7 +45,7 @@ interface FlowContextType {
   removeLiveLogReceiver: (receiver: LiveLogReceiver) => void;
   flowNodeTypes: NodeTypes;
   copySelectedNodes: () => Promise<void>;
-  pasteNodes: () => Promise<void>;
+  pasteNodes: (targetFlowPosition?: { x: number; y: number }) => Promise<void>;
 }
 
 const FlowContext = createContext<FlowContextType | undefined>(undefined);
@@ -147,15 +147,18 @@ export function FlowProvider({ children, resourceId }: FlowProviderProps) {
     await navigator.clipboard.writeText(JSON.stringify(clipboardData));
   }, [nodes, edges]);
 
-  const pasteNodes = useCallback(async () => {
-    const text = await navigator.clipboard.readText().catch(() => '');
-    const clipboardData = parseClipboardData(text);
-    if (!clipboardData) return;
+  const pasteNodes = useCallback(
+    async (targetFlowPosition?: { x: number; y: number }) => {
+      const text = await navigator.clipboard.readText().catch(() => '');
+      const clipboardData = parseClipboardData(text);
+      if (!clipboardData) return;
 
-    const { nodes: newNodes, edges: newEdges } = buildPastedElements(clipboardData, nanoid);
-    setNodes((prev) => [...prev.map((n) => ({ ...n, selected: false })), ...newNodes]);
-    setEdges((prev) => [...prev, ...newEdges]);
-  }, [setNodes, setEdges]);
+      const { nodes: newNodes, edges: newEdges } = buildPastedElements(clipboardData, nanoid, 50, targetFlowPosition);
+      setNodes((prev) => [...prev.map((n) => ({ ...n, selected: false })), ...newNodes]);
+      setEdges((prev) => [...prev, ...newEdges]);
+    },
+    [setNodes, setEdges],
+  );
 
   const value: FlowContextType = useMemo(
     () => ({

--- a/apps/frontend/src/app/resources/details/flows/flowContext.tsx
+++ b/apps/frontend/src/app/resources/details/flows/flowContext.tsx
@@ -13,6 +13,7 @@ import {
   NodeTypes,
   NodeProps,
 } from '@xyflow/react';
+import { nanoid } from 'nanoid';
 import { ResourceFlowLog, useResourceFlowsServiceGetNodeSchemas } from '@attraccess/react-query-client';
 import { useResourcesServiceGetOneResourceById } from '@attraccess/react-query-client';
 import { useLiveLogs } from './liveLogs';
@@ -22,6 +23,12 @@ import nodesDeTranslations from './node/de.json';
 import nodesEnTranslations from './node/en.json';
 
 export type LiveLogReceiver = (log: ResourceFlowLog) => void;
+
+interface AttraccessClipboardData {
+  type: 'attraccess-flow-nodes';
+  nodes: Node[];
+  edges: Edge[];
+}
 
 interface FlowContextType {
   nodes: Node[];
@@ -42,6 +49,8 @@ interface FlowContextType {
   addLiveLogReceiver: (receiver: LiveLogReceiver) => void;
   removeLiveLogReceiver: (receiver: LiveLogReceiver) => void;
   flowNodeTypes: NodeTypes;
+  copySelectedNodes: () => Promise<void>;
+  pasteNodes: () => Promise<void>;
 }
 
 const FlowContext = createContext<FlowContextType | undefined>(undefined);
@@ -137,6 +146,59 @@ export function FlowProvider({ children, resourceId }: FlowProviderProps) {
     return types;
   }, [nodeSchemas, tNodeTranslations]);
 
+  const copySelectedNodes = useCallback(async () => {
+    const selectedNodes = nodes.filter((n) => n.selected);
+    if (selectedNodes.length === 0) return;
+
+    const selectedIds = new Set(selectedNodes.map((n) => n.id));
+    const selectedEdges = edges.filter(
+      (e) => selectedIds.has(e.source) && selectedIds.has(e.target)
+    );
+
+    const clipboardData: AttraccessClipboardData = {
+      type: 'attraccess-flow-nodes',
+      nodes: selectedNodes,
+      edges: selectedEdges,
+    };
+
+    await navigator.clipboard.writeText(JSON.stringify(clipboardData));
+  }, [nodes, edges]);
+
+  const pasteNodes = useCallback(async () => {
+    let clipboardData: AttraccessClipboardData;
+    try {
+      const text = await navigator.clipboard.readText();
+      const parsed = JSON.parse(text);
+      if (parsed?.type !== 'attraccess-flow-nodes') return;
+      clipboardData = parsed;
+    } catch {
+      return;
+    }
+
+    const idMap = new Map<string, string>();
+    clipboardData.nodes.forEach((n) => idMap.set(n.id, nanoid()));
+
+    const PASTE_OFFSET = 50;
+    const newNodes: Node[] = clipboardData.nodes.map((n) => ({
+      ...n,
+      id: idMap.get(n.id)!,
+      position: { x: n.position.x + PASTE_OFFSET, y: n.position.y + PASTE_OFFSET },
+      selected: true,
+    }));
+
+    const newEdges: Edge[] = clipboardData.edges
+      .filter((e) => idMap.has(e.source) && idMap.has(e.target))
+      .map((e) => ({
+        ...e,
+        id: nanoid(),
+        source: idMap.get(e.source)!,
+        target: idMap.get(e.target)!,
+      }));
+
+    setNodes((prev) => [...prev.map((n) => ({ ...n, selected: false })), ...newNodes]);
+    setEdges((prev) => [...prev, ...newEdges]);
+  }, [setNodes, setEdges]);
+
   const value: FlowContextType = useMemo(
     () => ({
       nodes,
@@ -157,6 +219,8 @@ export function FlowProvider({ children, resourceId }: FlowProviderProps) {
       addLiveLogReceiver,
       removeLiveLogReceiver,
       flowNodeTypes,
+      copySelectedNodes,
+      pasteNodes,
     }),
     [
       nodes,
@@ -177,6 +241,8 @@ export function FlowProvider({ children, resourceId }: FlowProviderProps) {
       addLiveLogReceiver,
       removeLiveLogReceiver,
       flowNodeTypes,
+      copySelectedNodes,
+      pasteNodes,
     ],
   );
 

--- a/apps/frontend/src/app/resources/details/flows/flowContext.tsx
+++ b/apps/frontend/src/app/resources/details/flows/flowContext.tsx
@@ -21,14 +21,9 @@ import { AttraccessNode } from './node';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import nodesDeTranslations from './node/de.json';
 import nodesEnTranslations from './node/en.json';
+import { buildClipboardData, parseClipboardData, buildPastedElements } from './flowClipboard';
 
 export type LiveLogReceiver = (log: ResourceFlowLog) => void;
-
-interface AttraccessClipboardData {
-  type: 'attraccess-flow-nodes';
-  nodes: Node[];
-  edges: Edge[];
-}
 
 interface FlowContextType {
   nodes: Node[];
@@ -147,54 +142,17 @@ export function FlowProvider({ children, resourceId }: FlowProviderProps) {
   }, [nodeSchemas, tNodeTranslations]);
 
   const copySelectedNodes = useCallback(async () => {
-    const selectedNodes = nodes.filter((n) => n.selected);
-    if (selectedNodes.length === 0) return;
-
-    const selectedIds = new Set(selectedNodes.map((n) => n.id));
-    const selectedEdges = edges.filter(
-      (e) => selectedIds.has(e.source) && selectedIds.has(e.target)
-    );
-
-    const clipboardData: AttraccessClipboardData = {
-      type: 'attraccess-flow-nodes',
-      nodes: selectedNodes,
-      edges: selectedEdges,
-    };
-
+    const clipboardData = buildClipboardData(nodes, edges);
+    if (!clipboardData) return;
     await navigator.clipboard.writeText(JSON.stringify(clipboardData));
   }, [nodes, edges]);
 
   const pasteNodes = useCallback(async () => {
-    let clipboardData: AttraccessClipboardData;
-    try {
-      const text = await navigator.clipboard.readText();
-      const parsed = JSON.parse(text);
-      if (parsed?.type !== 'attraccess-flow-nodes') return;
-      clipboardData = parsed;
-    } catch {
-      return;
-    }
+    const text = await navigator.clipboard.readText().catch(() => '');
+    const clipboardData = parseClipboardData(text);
+    if (!clipboardData) return;
 
-    const idMap = new Map<string, string>();
-    clipboardData.nodes.forEach((n) => idMap.set(n.id, nanoid()));
-
-    const PASTE_OFFSET = 50;
-    const newNodes: Node[] = clipboardData.nodes.map((n) => ({
-      ...n,
-      id: idMap.get(n.id)!,
-      position: { x: n.position.x + PASTE_OFFSET, y: n.position.y + PASTE_OFFSET },
-      selected: true,
-    }));
-
-    const newEdges: Edge[] = clipboardData.edges
-      .filter((e) => idMap.has(e.source) && idMap.has(e.target))
-      .map((e) => ({
-        ...e,
-        id: nanoid(),
-        source: idMap.get(e.source)!,
-        target: idMap.get(e.target)!,
-      }));
-
+    const { nodes: newNodes, edges: newEdges } = buildPastedElements(clipboardData, nanoid);
     setNodes((prev) => [...prev.map((n) => ({ ...n, selected: false })), ...newNodes]);
     setEdges((prev) => [...prev, ...newEdges]);
   }, [setNodes, setEdges]);

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -155,6 +155,7 @@ function FlowsPageInner() {
     removeLiveLogReceiver,
     flowNodeTypes,
     copySelectedNodes,
+    cutSelectedNodes,
     pasteNodes,
   } = useFlowContext();
 
@@ -308,6 +309,8 @@ function FlowsPageInner() {
       const isMod = e.metaKey || e.ctrlKey;
       if (isMod && e.key === 'c') {
         copySelectedNodes();
+      } else if (isMod && e.key === 'x') {
+        cutSelectedNodes();
       } else if (isMod && e.key === 'v') {
         const targetFlowPosition = mousePosRef.current ? screenToFlowPosition(mousePosRef.current) : undefined;
         pasteNodes(targetFlowPosition);
@@ -318,7 +321,7 @@ function FlowsPageInner() {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [copySelectedNodes, pasteNodes, setNodes, screenToFlowPosition]);
+  }, [copySelectedNodes, cutSelectedNodes, pasteNodes, setNodes, screenToFlowPosition]);
 
   const edgesWithCorrectType = useMemo(() => {
     return edges.map((edge) => ({

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -13,7 +13,7 @@ import {
   useResourceFlowsServiceSaveResourceFlow,
   useResourcesServiceGetOneResourceById,
 } from '@attraccess/react-query-client';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from '@heroui/use-theme';
 import { usePtrStore } from '../../../../stores/ptr.store';
 import Dagre from '@dagrejs/dagre';
@@ -140,7 +140,8 @@ function FlowsPageInner() {
     },
   });
 
-  const { fitView } = useReactFlow();
+  const { fitView, screenToFlowPosition } = useReactFlow();
+  const mousePosRef = useRef<{ x: number; y: number } | null>(null);
   const {
     nodes,
     edges,
@@ -308,7 +309,8 @@ function FlowsPageInner() {
       if (isMod && e.key === 'c') {
         copySelectedNodes();
       } else if (isMod && e.key === 'v') {
-        pasteNodes();
+        const targetFlowPosition = mousePosRef.current ? screenToFlowPosition(mousePosRef.current) : undefined;
+        pasteNodes(targetFlowPosition);
       } else if (isMod && e.key === 'a') {
         e.preventDefault();
         setNodes((prev) => prev.map((n) => ({ ...n, selected: true })));
@@ -316,7 +318,7 @@ function FlowsPageInner() {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [copySelectedNodes, pasteNodes, setNodes]);
+  }, [copySelectedNodes, pasteNodes, setNodes, screenToFlowPosition]);
 
   const edgesWithCorrectType = useMemo(() => {
     return edges.map((edge) => ({
@@ -341,7 +343,12 @@ function FlowsPageInner() {
         backTo={`/resources/${resourceId}`}
       />
 
-      <div className="w-full h-full rounded-lg overflow-hidden border border-gray-200 dark:border-gray-800">
+      <div
+        className="w-full h-full rounded-lg overflow-hidden border border-gray-200 dark:border-gray-800"
+        onMouseMove={(e) => {
+          mousePosRef.current = { x: e.clientX, y: e.clientY };
+        }}
+      >
         <ReactFlow
           nodes={nodes}
           edges={edgesWithCorrectType}

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -345,6 +345,7 @@ function FlowsPageInner() {
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           selectionOnDrag
+          panOnDrag={[1, 2]}
           selectionMode={SelectionMode.Partial}
           deleteKeyCode={['Backspace', 'Delete']}
           multiSelectionKeyCode="Shift"

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -1,7 +1,7 @@
 import { PageHeader } from '../../../../components/pageHeader';
 import { useParams } from 'react-router-dom';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Background, BackgroundVariant, Controls, ReactFlow, Node, Panel, Edge, useReactFlow } from '@xyflow/react';
+import { Background, BackgroundVariant, Controls, ReactFlow, Node, Panel, Edge, useReactFlow, SelectionMode } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import {
   ApiError,
@@ -153,6 +153,8 @@ function FlowsPageInner() {
     addLiveLogReceiver,
     removeLiveLogReceiver,
     flowNodeTypes,
+    copySelectedNodes,
+    pasteNodes,
   } = useFlowContext();
 
   const { handleExport, handleImportClick } = useFlowImportExport({
@@ -296,6 +298,22 @@ function FlowsPageInner() {
     };
   }, [addLiveLogReceiver, removeLiveLogReceiver, onLiveLog]);
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const isMod = e.metaKey || e.ctrlKey;
+      if (isMod && e.key === 'c') {
+        copySelectedNodes();
+      } else if (isMod && e.key === 'v') {
+        pasteNodes();
+      } else if (isMod && e.key === 'a') {
+        e.preventDefault();
+        setNodes((prev) => prev.map((n) => ({ ...n, selected: true })));
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [copySelectedNodes, pasteNodes, setNodes]);
+
   const edgesWithCorrectType = useMemo(() => {
     return edges.map((edge) => ({
       ...edge,
@@ -326,6 +344,10 @@ function FlowsPageInner() {
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
+          selectionOnDrag
+          selectionMode={SelectionMode.Partial}
+          deleteKeyCode={['Backspace', 'Delete']}
+          multiSelectionKeyCode="Shift"
           colorMode={theme === 'dark' ? 'dark' : 'light'}
           fitView
           defaultEdgeOptions={{ style: { strokeWidth: 4 } }}

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -300,6 +300,10 @@ function FlowsPageInner() {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.isContentEditable || target?.closest('input, textarea, select, [contenteditable="true"]')) {
+        return;
+      }
       const isMod = e.metaKey || e.ctrlKey;
       if (isMod && e.key === 'c') {
         copySelectedNodes();

--- a/apps/frontend/src/app/resources/details/flows/node/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/index.tsx
@@ -89,17 +89,20 @@ export function AttraccessNode(props: Props) {
     onClose: userDoesNotWantToDelete,
   } = useDisclosure();
 
+  const isSelected = props.node?.selected ?? false;
+
   const cardClasses = useMemo(() => {
     const baseClasses = 'bg-gray-100 dark:bg-gray-800 w-64 overflow-visible';
 
     return cn(baseClasses, {
-      'border-2 border-gray-500': processingState === ProcessingState.IDLE,
+      'border-2 border-gray-500': processingState === ProcessingState.IDLE && !isSelected,
+      'border-2 border-primary-500 ring-2 ring-primary-300 dark:ring-primary-700': isSelected && processingState === ProcessingState.IDLE,
       'animate-pulse border-2 border-blue-500': processingState === ProcessingState.PROCESSING,
       'border-2 border-red-500': processingState === ProcessingState.FAILED,
       'border-2 border-green-500': processingState === ProcessingState.COMPLETED,
       'opacity-60 grayscale border-dashed': !schema.supportedByResource,
     });
-  }, [processingState, schema]);
+  }, [processingState, schema, isSelected]);
 
   const targetHandlesWithStyles = useMemo((): { id: string; label?: string; style: React.CSSProperties }[] => {
     return schema.inputs.map((inputName, index) => {


### PR DESCRIPTION
## Summary by Sourcery

Add copy-paste support and improved keyboard/selection handling to the flow editor while ensuring pasted elements are safely reconstructed from clipboard data.

New Features:
- Allow users to copy selected flow nodes and their connecting edges to the clipboard and paste them back into the editor with new IDs and offsets.
- Enable keyboard shortcuts for copy, paste, and select-all within the flow editor canvas.

Enhancements:
- Highlight selected nodes with distinct styling and improve flow canvas interaction settings such as drag selection, panning, deletion keys, and multi-selection behavior.

Tests:
- Add unit tests for building clipboard payloads, parsing clipboard contents, and generating pasted nodes and edges from stored flow data.