### PR TITLE
Add community/non-profit license self-select button and first-time-setup license step

### DIFF
--- a/apps/frontend/src/app/first-time-setup/de.json
+++ b/apps/frontend/src/app/first-time-setup/de.json
@@ -5,6 +5,7 @@
   "steps": {
     "app": "Anwendungseinstellungen",
     "smtp": "E-Mail (SMTP)",
+    "license": "Lizenz",
     "admin": "Admin-Benutzer anlegen",
     "verify": "Fertig"
   }

--- a/apps/frontend/src/app/first-time-setup/en.json
+++ b/apps/frontend/src/app/first-time-setup/en.json
@@ -5,6 +5,7 @@
   "steps": {
     "app": "Application settings",
     "smtp": "Email (SMTP)",
+    "license": "License",
     "admin": "Create admin user",
     "verify": "You're all set"
   }

--- a/apps/frontend/src/app/first-time-setup/index.tsx
+++ b/apps/frontend/src/app/first-time-setup/index.tsx
@@ -7,12 +7,13 @@ import { PageHeader } from '../../components/pageHeader';
 import { AppSettingsForm } from '../settings/forms/AppSettingsForm';
 import { SmtpSettingsForm } from '../settings/forms/SmtpSettingsForm';
 import { CreateAdminStep } from './steps/CreateAdminStep';
+import { LicenseStep } from './steps/LicenseStep';
 import { VerifyEmailStep } from './steps/VerifyEmailStep';
 import en from './en.json';
 import de from './de.json';
 import { useSettingsServiceGetFirstTimeSetupStatus } from '@attraccess/react-query-client';
 
-const WIZARD_STEPS = ['step-1', 'step-2', 'step-3', 'step-4'] as const;
+const WIZARD_STEPS = ['step-1', 'step-2', 'step-3', 'step-4', 'step-5'] as const;
 type WizardStepKey = (typeof WIZARD_STEPS)[number];
 
 function isWizardStepKey(key: string): key is WizardStepKey {
@@ -25,6 +26,7 @@ export function FirstTimeSetupPage() {
   const [currentStep, setCurrentStep] = useState<WizardStepKey>(WIZARD_STEPS[0]);
   const hasInitializedStep = useRef(false);
   const hasSeenSetupAvailable = useRef(false);
+  const [localCompleted, setLocalCompleted] = useState({ url: false, license: false });
 
   const { data: setupStatus, isLoading: isCheckingSetup } = useSettingsServiceGetFirstTimeSetupStatus();
 
@@ -34,24 +36,29 @@ export function FirstTimeSetupPage() {
 
   const stepCompleted = useMemo(() => {
     const s = setupStatus?.stepsCompleted;
-    if (!s) return [false, false, false, false] as const;
-    return [s.app, s.smtp, s.admin, s.admin] as const;
-  }, [setupStatus?.stepsCompleted]);
+    const serverApp = s?.app ?? false;
+    const smtpDone = s?.smtp ?? false;
+    const adminDone = s?.admin ?? false;
+    return [
+      localCompleted.url || serverApp,
+      smtpDone,
+      localCompleted.license || serverApp,
+      adminDone,
+      adminDone,
+    ] as const;
+  }, [setupStatus?.stepsCompleted, localCompleted]);
 
   const firstIncompleteIndex = useMemo(() => {
     const i = stepCompleted.findIndex((done) => !done);
     return i >= 0 ? i : WIZARD_STEPS.length - 1;
   }, [stepCompleted]);
 
-  // Only redirect when user landed on this page with setup already complete (e.g. bookmarked).
-  // Do not redirect when they just completed the admin step – let them see the final step.
   useEffect(() => {
     if (!isCheckingSetup && setupStatus && !setupStatus.available && !hasSeenSetupAvailable.current) {
       navigate('/', { replace: true });
     }
   }, [isCheckingSetup, navigate, setupStatus]);
 
-  // Set current step to first incomplete step once when status has loaded (only once).
   useEffect(() => {
     if (isCheckingSetup || setupStatus === undefined || hasInitializedStep.current) {
       return;
@@ -60,9 +67,16 @@ export function FirstTimeSetupPage() {
     setCurrentStep(WIZARD_STEPS[firstIncompleteIndex]);
   }, [isCheckingSetup, firstIncompleteIndex, setupStatus]);
 
-  const goToStep2 = useCallback(() => setCurrentStep('step-2'), []);
+  const goToStep2 = useCallback(() => {
+    setLocalCompleted((prev) => ({ ...prev, url: true }));
+    setCurrentStep('step-2');
+  }, []);
   const goToStep3 = useCallback(() => setCurrentStep('step-3'), []);
-  const goToStep4 = useCallback(() => setCurrentStep('step-4'), []);
+  const goToStep4 = useCallback(() => {
+    setLocalCompleted((prev) => ({ ...prev, license: true }));
+    setCurrentStep('step-4');
+  }, []);
+  const goToStep5 = useCallback(() => setCurrentStep('step-5'), []);
 
   const currentStepIndex = WIZARD_STEPS.indexOf(currentStep);
 
@@ -137,24 +151,38 @@ export function FirstTimeSetupPage() {
         </AccordionItem>
         <AccordionItem
           key="step-3"
-          aria-label={t('steps.admin')}
+          aria-label={t('steps.license')}
           title={
             <span className="flex items-center gap-2">
               {stepCompleted[2] && (
+                <CheckCircle2Icon className="size-5 shrink-0 text-success" aria-hidden />
+              )}
+              {t('steps.license')}
+            </span>
+          }
+        >
+          <LicenseStep onSuccess={goToStep4} />
+        </AccordionItem>
+        <AccordionItem
+          key="step-4"
+          aria-label={t('steps.admin')}
+          title={
+            <span className="flex items-center gap-2">
+              {stepCompleted[3] && (
                 <CheckCircle2Icon className="size-5 shrink-0 text-success" aria-hidden />
               )}
               {t('steps.admin')}
             </span>
           }
         >
-          <CreateAdminStep onSuccess={goToStep4} />
+          <CreateAdminStep onSuccess={goToStep5} />
         </AccordionItem>
         <AccordionItem
-          key="step-4"
+          key="step-5"
           aria-label={t('steps.verify')}
           title={
             <span className="flex items-center gap-2">
-              {stepCompleted[3] && (
+              {stepCompleted[4] && (
                 <CheckCircle2Icon className="size-5 shrink-0 text-success" aria-hidden />
               )}
               {t('steps.verify')}

--- a/apps/frontend/src/app/first-time-setup/steps/LicenseStep/de.json
+++ b/apps/frontend/src/app/first-time-setup/steps/LicenseStep/de.json
@@ -1,0 +1,18 @@
+{
+  "title": "Lizenz",
+  "subtitle": "Aktiviere Attraccess mit einem Lizenzschlüssel.",
+  "intro": "Wenn du ein privater Nutzer oder eine gemeinnützige Organisation bist, klicke auf die Schaltfläche unten, um die kostenlose Community-Lizenz zu nutzen. Kommerzielle Nutzer fügen ihren bezahlten Lizenzschlüssel ein.",
+  "inputs": {
+    "licenseKey": {
+      "label": "Lizenzschlüssel",
+      "description": "Füge deinen kommerziellen Lizenzschlüssel ein oder nutze die Community-Schaltfläche oben."
+    }
+  },
+  "actions": {
+    "save": "Lizenz speichern"
+  },
+  "success": {
+    "title": "Lizenz gespeichert",
+    "description": "Dein Lizenzschlüssel wurde übernommen."
+  }
+}

--- a/apps/frontend/src/app/first-time-setup/steps/LicenseStep/en.json
+++ b/apps/frontend/src/app/first-time-setup/steps/LicenseStep/en.json
@@ -1,0 +1,18 @@
+{
+  "title": "License",
+  "subtitle": "Activate Attraccess with a license key.",
+  "intro": "If you are a private user or non-profit organization, click the button below to use the free community license. Commercial users should paste their paid license key.",
+  "inputs": {
+    "licenseKey": {
+      "label": "License Key",
+      "description": "Paste your commercial license key, or use the community button above."
+    }
+  },
+  "actions": {
+    "save": "Save license"
+  },
+  "success": {
+    "title": "License saved",
+    "description": "Your license key has been applied."
+  }
+}

--- a/apps/frontend/src/app/first-time-setup/steps/LicenseStep/index.tsx
+++ b/apps/frontend/src/app/first-time-setup/steps/LicenseStep/index.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Alert, Button, Form } from '@heroui/react';
+import { KeyRoundIcon } from 'lucide-react';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  ApiError,
+  useSettingsServiceApplyFirstTimeSetupSettings,
+  UseSettingsServiceGetFirstTimeSetupStatusKeyFn,
+  UseSettingsServiceGetSystemSettingsKeyFn,
+} from '@attraccess/react-query-client';
+import { PageHeader } from '../../../../components/pageHeader';
+import { PasswordInput } from '../../../../components/PasswordInput';
+import { CommunityLicenseButton } from '../../../../components/CommunityLicenseButton';
+import { useToastMessage } from '../../../../components/toastProvider';
+import API_ERROR_TRANSLATIONS_DE from '../../../../global-translations/api-errors.de.json';
+import API_ERROR_TRANSLATIONS_EN from '../../../../global-translations/api-errors.en.json';
+import en from './en.json';
+import de from './de.json';
+
+export type LicenseStepProps = {
+  onSuccess?: () => void;
+};
+
+export function LicenseStep({ onSuccess }: LicenseStepProps) {
+  const { t, tExists } = useTranslations({
+    en: { ...en, api: API_ERROR_TRANSLATIONS_EN },
+    de: { ...de, api: API_ERROR_TRANSLATIONS_DE },
+  });
+  const toast = useToastMessage();
+  const queryClient = useQueryClient();
+  const formRef = useRef<HTMLFormElement>(null);
+  const [licenseKey, setLicenseKey] = useState('');
+
+  const mutateConfig = useMemo(
+    () => ({
+      onSuccess() {
+        toast.success({
+          title: t('success.title'),
+          description: t('success.description'),
+        });
+        queryClient.invalidateQueries({ queryKey: UseSettingsServiceGetSystemSettingsKeyFn() });
+        queryClient.invalidateQueries({ queryKey: UseSettingsServiceGetFirstTimeSetupStatusKeyFn() });
+        setLicenseKey('');
+        onSuccess?.();
+      },
+      onError(error: Error) {
+        toast.apiError({
+          error: error as ApiError,
+          t,
+          tExists,
+          baseTranslationKey: 'api',
+        });
+      },
+    }),
+    [t, tExists, toast, queryClient, onSuccess],
+  );
+
+  const { mutate: saveSettings, isPending } = useSettingsServiceApplyFirstTimeSetupSettings(mutateConfig);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = licenseKey.trim();
+    if (!trimmed) return;
+    if (!formRef.current?.checkValidity()) return;
+    saveSettings({ requestBody: { app: { licenseKey: trimmed } } });
+  }, [licenseKey, saveSettings]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title={t('title')}
+        subtitle={t('subtitle')}
+        icon={<KeyRoundIcon size={18} />}
+        noMargin
+      />
+      <Alert color="primary" variant="flat" description={t('intro')} />
+      <CommunityLicenseButton onAccept={setLicenseKey} isDisabled={isPending} />
+      <Form
+        ref={formRef}
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+        className="flex flex-col gap-4"
+      >
+        <PasswordInput
+          label={t('inputs.licenseKey.label')}
+          description={t('inputs.licenseKey.description')}
+          value={licenseKey}
+          onValueChange={setLicenseKey}
+          autoComplete="off"
+          isRequired
+        />
+        <input type="submit" hidden />
+      </Form>
+      <Button
+        color="primary"
+        onPress={handleSubmit}
+        isLoading={isPending}
+        isDisabled={!licenseKey.trim()}
+      >
+        {t('actions.save')}
+      </Button>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/settings/forms/AppSettingsForm/index.tsx
+++ b/apps/frontend/src/app/settings/forms/AppSettingsForm/index.tsx
@@ -11,6 +11,7 @@ import {
 import { Button, Form, Input, Spinner } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PasswordInput } from '../../../../components/PasswordInput';
+import { CommunityLicenseButton } from '../../../../components/CommunityLicenseButton';
 import { useToastMessage } from '../../../../components/toastProvider';
 import API_ERROR_TRANSLATIONS_DE from '../../../../global-translations/api-errors.de.json';
 import API_ERROR_TRANSLATIONS_EN from '../../../../global-translations/api-errors.en.json';
@@ -132,14 +133,18 @@ export function AppSettingsForm({ variant, endpoint, onNext }: AppSettingsFormPr
         value={publicInternetUrl}
         onValueChange={setPublicInternetUrl}
       />
-      <PasswordInput
-        label={t('inputs.licenseKey.label')}
-        description={t('inputs.licenseKey.description')}
-        value={licenseKey}
-        onValueChange={setLicenseKey}
-        autoComplete="off"
-        isRequired={endpoint === 'first-time-setup'}
-      />
+      {variant === 'standalone' && (
+        <>
+          <PasswordInput
+            label={t('inputs.licenseKey.label')}
+            description={t('inputs.licenseKey.description')}
+            value={licenseKey}
+            onValueChange={setLicenseKey}
+            autoComplete="off"
+          />
+          <CommunityLicenseButton onAccept={setLicenseKey} isDisabled={isSaving} />
+        </>
+      )}
       <Button
         color="primary"
         onPress={handleSubmit}

--- a/apps/frontend/src/components/CommunityLicenseButton/de.json
+++ b/apps/frontend/src/components/CommunityLicenseButton/de.json
@@ -1,0 +1,10 @@
+{
+  "button": "Community-/Non-Profit-Lizenz verwenden",
+  "modal": {
+    "title": "Community-/Non-Profit-Nutzung bestätigen",
+    "question": "Bist du ein privater Nutzer oder eine gemeinnützige Organisation und stimmst du den Bedingungen der <link>Prosperity Public License</link> zu?",
+    "commercialNotice": "Kommerzielle Nutzung über die 30-tägige Testphase hinaus erfordert einen kostenpflichtigen Lizenzschlüssel.",
+    "cancel": "Abbrechen",
+    "confirm": "Ja, ich erfülle die Bedingungen"
+  }
+}

--- a/apps/frontend/src/components/CommunityLicenseButton/en.json
+++ b/apps/frontend/src/components/CommunityLicenseButton/en.json
@@ -1,0 +1,10 @@
+{
+  "button": "Use community / non-profit license",
+  "modal": {
+    "title": "Confirm community / non-profit use",
+    "question": "Are you a private user or non-profit organization and do you agree to the <link>Prosperity Public License</link> terms?",
+    "commercialNotice": "Commercial use beyond the 30-day trial requires a paid license key.",
+    "cancel": "Cancel",
+    "confirm": "Yes, I qualify"
+  }
+}

--- a/apps/frontend/src/components/CommunityLicenseButton/index.test.tsx
+++ b/apps/frontend/src/components/CommunityLicenseButton/index.test.tsx
@@ -1,0 +1,95 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CommunityLicenseButton, COMMUNITY_LICENSE_KEY, LICENSE_URL } from './index';
+import { TestWrapper } from '../../test-utils/wrappers';
+
+vi.mock('@attraccess/plugins-frontend-ui', async () => {
+  const React = await import('react');
+  const translations: Record<string, string> = {
+    button: 'Use community / non-profit license',
+    'modal.title': 'Confirm community / non-profit use',
+    'modal.question':
+      'Are you a private user or non-profit organization and do you agree to the <link>Prosperity Public License</link> terms?',
+    'modal.commercialNotice': 'Commercial use beyond the 30-day trial requires a paid license key.',
+    'modal.cancel': 'Cancel',
+    'modal.confirm': 'Yes, I qualify',
+  };
+
+  const useTranslations = () => {
+    const t = (key: string) => translations[key] ?? key;
+    const tExists = (key: string) => Boolean(translations[key]);
+    return { t, tExists };
+  };
+
+  const I18nTransComponent = ({
+    t,
+    i18nKey,
+    components,
+  }: {
+    t: (key: string) => string;
+    i18nKey: string;
+    components?: Record<string, React.ReactElement>;
+  }) => {
+    const raw = t(i18nKey);
+    const match = raw.match(/^([\s\S]*?)<(\w+)>([\s\S]*?)<\/\2>([\s\S]*)$/);
+    if (!match || !components?.[match[2]]) {
+      return React.createElement(React.Fragment, null, raw);
+    }
+    const [, before, tag, inner, after] = match;
+    return React.createElement(
+      React.Fragment,
+      null,
+      before,
+      React.cloneElement(components[tag], { key: tag }, inner),
+      after,
+    );
+  };
+
+  return { useTranslations, I18nTransComponent };
+});
+
+describe('CommunityLicenseButton', () => {
+  it('renders the button label', () => {
+    render(<CommunityLicenseButton onAccept={vi.fn()} />, { wrapper: TestWrapper });
+    expect(screen.getByRole('button', { name: /Use community \/ non-profit license/i })).toBeInTheDocument();
+  });
+
+  it('opens the modal with PPL link and commercial notice when clicked', async () => {
+    const user = userEvent.setup();
+    render(<CommunityLicenseButton onAccept={vi.fn()} />, { wrapper: TestWrapper });
+
+    await user.click(screen.getByRole('button', { name: /Use community \/ non-profit license/i }));
+
+    expect(await screen.findByText(/Confirm community \/ non-profit use/i)).toBeInTheDocument();
+    expect(screen.getByText(/Commercial use beyond the 30-day trial requires a paid license key\./i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /Prosperity Public License/i });
+    expect(link).toHaveAttribute('href', LICENSE_URL);
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('calls onAccept with the community license string on confirm', async () => {
+    const user = userEvent.setup();
+    const onAccept = vi.fn();
+    render(<CommunityLicenseButton onAccept={onAccept} />, { wrapper: TestWrapper });
+
+    await user.click(screen.getByRole('button', { name: /Use community \/ non-profit license/i }));
+    await user.click(await screen.findByRole('button', { name: /Yes, I qualify/i }));
+
+    expect(onAccept).toHaveBeenCalledTimes(1);
+    expect(onAccept).toHaveBeenCalledWith(COMMUNITY_LICENSE_KEY);
+  });
+
+  it('does not call onAccept when cancelled', async () => {
+    const user = userEvent.setup();
+    const onAccept = vi.fn();
+    render(<CommunityLicenseButton onAccept={onAccept} />, { wrapper: TestWrapper });
+
+    await user.click(screen.getByRole('button', { name: /Use community \/ non-profit license/i }));
+    await user.click(await screen.findByRole('button', { name: /^Cancel$/i }));
+
+    expect(onAccept).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/CommunityLicenseButton/index.tsx
+++ b/apps/frontend/src/components/CommunityLicenseButton/index.tsx
@@ -1,0 +1,84 @@
+import {
+  Alert,
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  useDisclosure,
+} from '@heroui/react';
+import { HeartHandshakeIcon } from 'lucide-react';
+import { I18nTransComponent, useTranslations } from '@attraccess/plugins-frontend-ui';
+import en from './en.json';
+import de from './de.json';
+
+export const COMMUNITY_LICENSE_KEY =
+  'I AM USING THIS SOFTWARE ONLY FOR NON-PROFIT AND COMPLY TO ALL TERMS OF THE LICENSE.md at https://github.com/Attraccess/Attraccess/blob/main/LICENSE.md';
+
+export const LICENSE_URL = 'https://github.com/Attraccess/Attraccess/blob/main/LICENSE.md';
+
+export interface CommunityLicenseButtonProps {
+  onAccept: (licenseKey: string) => void;
+  isDisabled?: boolean;
+  'data-cy'?: string;
+}
+
+export function CommunityLicenseButton({ onAccept, isDisabled, ...rest }: CommunityLicenseButtonProps) {
+  const { t } = useTranslations({ en, de });
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const handleConfirm = () => {
+    onAccept(COMMUNITY_LICENSE_KEY);
+    onClose();
+  };
+
+  return (
+    <>
+      <Button
+        variant="flat"
+        color="secondary"
+        onPress={onOpen}
+        isDisabled={isDisabled}
+        startContent={<HeartHandshakeIcon size={16} />}
+        data-cy={rest['data-cy'] ?? 'community-license-button'}
+      >
+        {t('button')}
+      </Button>
+      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside">
+        <ModalContent>
+          <ModalHeader>{t('modal.title')}</ModalHeader>
+          <ModalBody>
+            <p className="text-sm">
+              <I18nTransComponent
+                t={t}
+                i18nKey="modal.question"
+                components={{
+                  link: (
+                    <a
+                      href={LICENSE_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary underline"
+                    >
+                      LICENSE.md
+                    </a>
+                  ),
+                }}
+              />
+            </p>
+            <Alert color="warning" variant="flat" description={t('modal.commercialNotice')} />
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="light" onPress={onClose} data-cy="community-license-cancel">
+              {t('modal.cancel')}
+            </Button>
+            <Button color="primary" onPress={handleConfirm} data-cy="community-license-confirm">
+              {t('modal.confirm')}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
https://claude.ai/code/session_01C3PkySpNGid4hpswysyHy1

## Summary by Sourcery

Introduce a dedicated license selection step to the first-time setup wizard and add a reusable community/non-profit license self-selection control.

New Features:
- Add a new license step to the first-time setup flow, separating license entry from general app configuration and admin creation.
- Introduce a reusable community/non-profit license button that lets eligible users self-select a community license key with confirmation.
- Allow standalone app settings to include license key configuration through the community license selector.

Enhancements:
- Update first-time setup step tracking logic to account for the new license step and ensure correct completion state handling across steps.

Documentation:
- Add localized copy for the new license step and community license button in English and German.

Tests:
- Add component tests for the community license button, including modal interactions and confirmation behavior.