### PR TITLE
Document required Boolean fields for consent/acceptance patterns

### DIFF
--- a/docs/de/forms/creating-forms.md
+++ b/docs/de/forms/creating-forms.md
@@ -36,6 +36,19 @@ Nach dem Erstellen eines Formulars fügen Sie Felder hinzu, um festzulegen, welc
 
 <!-- TODO: Screenshot der Feldkonfiguration -->
 
+### Pflicht-Boolean-Felder (Zustimmung / Akzeptanz)
+
+Wenn ein **Boolean**-Feld als **Pflichtfeld** markiert ist, muss der Benutzer es explizit auf **Ja** (aktiviert) setzen, um das Formular abzusenden. Wird es auf **Nein** belassen, wird das Absenden mit einem Validierungsfehler blockiert.
+
+Nutzen Sie dieses Muster, um Benutzer dazu zu zwingen, etwas aktiv zu bestätigen, bevor sie fortfahren können -- zum Beispiel:
+
+- Akzeptieren der AGB
+- Bestätigung, dass Sicherheitshinweise gelesen wurden
+- Bestätigung einer abgeschlossenen Sicherheits-Checkliste
+
+> [!NOTE]
+> Die Beschriftung eines Boolean-Feldes wird durch den **Namen** des Feldes bestimmt. Eine separate Checkbox-Beschriftung kann nicht gesetzt werden -- der Feldname ist das, was der Benutzer neben der Checkbox sieht.
+
 ### Auswahlfelder konfigurieren
 
 Wenn Sie **Auswahl** als Feldtyp wählen, müssen Sie die verfügbaren Optionen definieren:

--- a/docs/de/forms/overview.md
+++ b/docs/de/forms/overview.md
@@ -31,8 +31,11 @@ Formulare unterstützen die folgenden Feldtypen:
 |-----|-------------|---------|
 | **Text** | Freitexteingabe | Materialname, Anmerkungen |
 | **Zahl** | Numerische Eingabe | Dauer, Gewicht, Menge |
-| **Boolean** | Checkbox (Ja/Nein) | "Arbeitsplatz aufgeräumt?", "Sicherheitscheck durchgeführt?" |
+| **Boolean** | Checkbox (Ja/Nein) | "Arbeitsplatz aufgeräumt?", "Sicherheitscheck durchgeführt?", "Ich akzeptiere die AGB" |
 | **Auswahl** | Dropdown mit vordefinierten Optionen | Materialtyp, Projektauswahl |
+
+> [!TIP]
+> Ein **Boolean**-Feld, das als **Pflichtfeld** markiert ist, muss auf **Ja** (aktiviert) gesetzt werden, bevor das Formular abgesendet werden kann. Dies eignet sich ideal dazu, Benutzer zum Akzeptieren der AGB oder zur Bestätigung von Sicherheitshinweisen zu zwingen. Details siehe [Formulare erstellen](forms/creating-forms.md).
 
 ## Formulareinreichungen
 

--- a/docs/en/forms/creating-forms.md
+++ b/docs/en/forms/creating-forms.md
@@ -36,6 +36,19 @@ After creating a form, add fields to define what data to collect:
 
 <!-- TODO: Screenshot of field configuration -->
 
+### Required Boolean Fields (Consent / Acceptance)
+
+When a **Boolean** field is marked as **Required**, the user must explicitly set it to **Yes** (checked) to submit the form. Leaving it at **No** will block submission with a validation error.
+
+Use this pattern to force users to actively acknowledge something before proceeding -- for example:
+
+- Accepting terms and conditions (AGB)
+- Confirming safety instructions have been read
+- Confirming a safety checklist has been completed
+
+> [!NOTE]
+> The label of a Boolean field is determined by the field's **Name**. You cannot set a separate custom label for the checkbox itself -- the field name is what the user sees next to the checkbox.
+
 ### Configuring Select Fields
 
 When you choose **Select** as the field type, you need to define the available options:

--- a/docs/en/forms/overview.md
+++ b/docs/en/forms/overview.md
@@ -31,8 +31,11 @@ Forms support the following field types:
 |------|-------------|---------|
 | **Text** | Free-text input | Material name, notes |
 | **Number** | Numeric input | Duration, weight, quantity |
-| **Boolean** | Checkbox (yes/no) | "Workspace cleaned?", "Safety check done?" |
+| **Boolean** | Checkbox (yes/no) | "Workspace cleaned?", "Safety check done?", "I accept the terms" |
 | **Select** | Dropdown with predefined options | Material type, project selection |
+
+> [!TIP]
+> A **Boolean** field marked as **Required** must be set to **Yes** (checked) before the form can be submitted. This is ideal for forcing users to accept terms and conditions or confirm safety instructions. See [Creating Forms](forms/creating-forms.md) for details.
 
 ## Form Submissions
 


### PR DESCRIPTION
## Summary
Added comprehensive documentation for using required Boolean fields in forms to enforce user consent and acceptance patterns. This includes new sections in both English and German documentation explaining the behavior, use cases, and implementation details.

## Key Changes
- **Creating Forms Guide**: Added new section "Required Boolean Fields (Consent / Acceptance)" in both EN and DE versions explaining:
  - How required Boolean fields enforce explicit "Yes" selection
  - Common use cases (terms acceptance, safety confirmations, checklists)
  - Important note about field naming and label behavior

- **Forms Overview**: Updated both EN and DE overview pages with:
  - Enhanced Boolean field examples to include consent/acceptance scenarios
  - New tip callout highlighting the required Boolean field pattern and linking to detailed documentation

## Notable Details
- Documentation is provided in both English and German to maintain consistency across language versions
- Uses GitHub-flavored markdown callouts (`[!NOTE]` and `[!TIP]`) for emphasis
- Cross-references between overview and detailed documentation guide users to relevant sections
- Clarifies that Boolean field labels are determined by the field name, not a separate label property

https://claude.ai/code/session_01QJHeBFmEMYB5uVVGbVPrrm

## Summary by Sourcery

Document required Boolean field behavior for consent and acceptance patterns in form creation and overview pages in both English and German.

Documentation:
- Add a new section to the English and German form creation guides explaining how required Boolean fields enforce explicit consent/acceptance and how their labels are derived from field names.
- Extend the English and German forms overview tables and add tips highlighting required Boolean Boolean fields as a pattern for enforcing terms acceptance and safety confirmations, with links to the detailed documentation.