### PR TITLE
fix(api): correct OIDC scope and force userinfo fetch

### DIFF
--- a/apps/api/src/users-and-auth/auth/sso/oidc/oidc.strategy.spec.ts
+++ b/apps/api/src/users-and-auth/auth/sso/oidc/oidc.strategy.spec.ts
@@ -284,6 +284,58 @@ describe('SSOOIDCStrategy - claim path resolution', () => {
     expect(user.systemPermissions.canManageUsers).toBe(false);
   });
 
+  describe('strategy options passed to passport-openidconnect', () => {
+    function readOptions(strategy: SSOOIDCStrategy): { scope: unknown; skipUserProfile: unknown } {
+      const internal = strategy as unknown as { _scope: unknown; _skipUserProfile: unknown };
+      return { scope: internal._scope, skipUserProfile: internal._skipUserProfile };
+    }
+
+    it('filters configured `openid` from scopes so it is not passed twice', () => {
+      const strategy = createStrategy(
+        { scopes: ['openid', 'email', 'profile'] },
+        { findOne: jest.fn(), updateOne: jest.fn(), buildUsernameFromSSOClaim: jest.fn(), createOne: jest.fn() },
+        { findUserIdBySSO: jest.fn(), addAuthenticationDetails: jest.fn() },
+      );
+      expect(readOptions(strategy).scope).toEqual(['email', 'profile']);
+    });
+
+    it('filters `openid` case-insensitively and trimmed from configured scopes', () => {
+      const strategy = createStrategy(
+        { scopes: [' OpenID ', 'Email', 'profile'] },
+        { findOne: jest.fn(), updateOne: jest.fn(), buildUsernameFromSSOClaim: jest.fn(), createOne: jest.fn() },
+        { findUserIdBySSO: jest.fn(), addAuthenticationDetails: jest.fn() },
+      );
+      expect(readOptions(strategy).scope).toEqual(['Email', 'profile']);
+    });
+
+    it('uses default scopes (without openid) when scopes is unset', () => {
+      const strategy = createStrategy(
+        {},
+        { findOne: jest.fn(), updateOne: jest.fn(), buildUsernameFromSSOClaim: jest.fn(), createOne: jest.fn() },
+        { findUserIdBySSO: jest.fn(), addAuthenticationDetails: jest.fn() },
+      );
+      expect(readOptions(strategy).scope).toEqual(['email', 'profile']);
+    });
+
+    it('uses default scopes (without openid) when scopes is an empty array', () => {
+      const strategy = createStrategy(
+        { scopes: [] },
+        { findOne: jest.fn(), updateOne: jest.fn(), buildUsernameFromSSOClaim: jest.fn(), createOne: jest.fn() },
+        { findUserIdBySSO: jest.fn(), addAuthenticationDetails: jest.fn() },
+      );
+      expect(readOptions(strategy).scope).toEqual(['email', 'profile']);
+    });
+
+    it('passes `skipUserProfile: false` explicitly so the userinfo endpoint is always fetched', () => {
+      const strategy = createStrategy(
+        {},
+        { findOne: jest.fn(), updateOne: jest.fn(), buildUsernameFromSSOClaim: jest.fn(), createOne: jest.fn() },
+        { findUserIdBySSO: jest.fn(), addAuthenticationDetails: jest.fn() },
+      );
+      expect(readOptions(strategy).skipUserProfile).toBe(false);
+    });
+  });
+
   describe('authenticate (per-request callback URL)', () => {
     it('passes callback URL from request to base strategy when set (no restart needed for URL changes)', () => {
       const baseAuthenticateSpy = jest.spyOn(Strategy.prototype, 'authenticate').mockImplementation(() => {

--- a/apps/api/src/users-and-auth/auth/sso/oidc/oidc.strategy.ts
+++ b/apps/api/src/users-and-auth/auth/sso/oidc/oidc.strategy.ts
@@ -37,6 +37,12 @@ export class SSOOIDCStrategy extends PassportStrategy(Strategy, 'sso-oidc', true
     callbackURL: string,
     stateStore: OidcCookieStateStore,
   ) {
+    const configuredScopes =
+      config.scopes && config.scopes.length > 0 ? config.scopes : ['openid', 'email', 'profile'];
+    // passport-openidconnect always prepends `openid` to the scope param, so strip it from the
+    // configured list to avoid sending `scope=openid openid email profile`.
+    const scopeWithoutOpenid = configuredScopes.filter((s) => s.trim().toLowerCase() !== 'openid');
+
     super({
       issuer: config.issuer,
       authorizationURL: config.authorizationURL,
@@ -45,8 +51,11 @@ export class SSOOIDCStrategy extends PassportStrategy(Strategy, 'sso-oidc', true
       clientID: config.clientId,
       clientSecret: config.clientSecret,
       callbackURL,
-      scope: config.scopes && config.scopes.length > 0 ? config.scopes : ['openid', 'email', 'profile'],
+      scope: scopeWithoutOpenid,
       store: stateStore,
+      // Force userinfo endpoint fetch — the library otherwise skips it unless the verify
+      // callback has arity ≥ 9. Some IdPs only return `email` from userinfo, not the id_token.
+      skipUserProfile: false,
     });
 
     this.logger.log(`Initialized OIDC strategy with issuer: ${config.issuer} and callbackURL: ${callbackURL}`);

--- a/libs/database-entities/src/lib/entities/ssoProvider.oidc.ts
+++ b/libs/database-entities/src/lib/entities/ssoProvider.oidc.ts
@@ -74,8 +74,9 @@ export class SSOProviderOIDCConfiguration {
 
   @Column({ type: 'simple-array', nullable: true })
   @ApiProperty({
-    description: 'Optional list of OIDC scopes to request',
-    example: ['openid', 'email', 'profile'],
+    description:
+      'Optional list of OIDC scopes to request. The `openid` scope is added automatically and does not need to be listed here.',
+    example: ['email', 'profile'],
     required: false,
   })
   scopes!: string[] | null;


### PR DESCRIPTION
## Summary
Customer feedback in [ATT-245](https://linear.app/attraccess/issue/ATT-245/oidc-client-optimizations) flagged two issues in our OIDC client:

1. **Duplicate `openid` scope** in the authorization request (`scope=openid openid email profile`). `passport-openidconnect@0.1.2` always prepends `openid` to the scope param (`lib/strategy.js:295`), so listing `openid` in the configured scopes produces a duplicate.
2. **Userinfo endpoint never called** → `BadRequestException: No email found in SSO profile` for IdPs that only release `email` via userinfo (Shibboleth IdP). The library's `_skipUserProfile` heuristic skips the userinfo fetch unless the verify callback arity >= 9; ours is 4.

### Changes
- `apps/api/src/users-and-auth/auth/sso/oidc/oidc.strategy.ts`
  - Filter out `openid` from the configured scopes before passing them to the base strategy.
  - Pass `skipUserProfile: false` explicitly so the userinfo endpoint is always called and merged into the claim sources used to resolve email/username/permissions.
- `libs/database-entities/src/lib/entities/ssoProvider.oidc.ts`
  - Update the `scopes` ApiProperty description and example to make clear that `openid` is added automatically.

Notes on customer's other points:
- `token_endpoint_auth_method=client_secret_post` is already what we send.
- Redirect URI no longer carries `redirectTo` as a query param; that was already migrated to the `state` parameter via `OidcCookieStateStore`.

## Test plan
- [ ] `nx run api:test --testPathPatterns=oidc.strategy`
- [ ] Manual: end-to-end login against a Shibboleth IdP that only returns `email` via userinfo
- [ ] Manual: confirm the authorize URL contains `scope=openid email profile` (single `openid`)

## Summary by Sourcery

Adjust OIDC strategy configuration to avoid duplicate openid scopes and always fetch the userinfo profile, and clarify OIDC scope documentation.

Bug Fixes:
- Prevent sending duplicate openid values in the OIDC scope parameter.
- Ensure the OIDC client always calls the userinfo endpoint so email and related claims are retrieved for all IdPs.

Enhancements:
- Clarify OIDC provider configuration docs to note that openid is added automatically and update the scopes example accordingly.

<!-- generated-by-cyrus -->