### PR TITLE
fix(ATT-261): consistent thumbnail size in resource group cards

### DIFF
--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
@@ -174,16 +174,17 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
             {(resource) => (
               <TableRow key={resource.id} className="cursor-pointer hover:bg-primary-50 transition-bg duration-300">
                 <TableCell>
-                  <Image
-                    height={48}
-                    width={48}
-                    isBlurred
-                    src={filenameToUrl(resource.imageFilename)}
-                    alt={resource.name}
-                    classNames={{
-                      img: 'object-contain',
-                    }}
-                  />
+                  <div className="w-12 h-12 shrink-0">
+                    <Image
+                      isBlurred
+                      src={filenameToUrl(resource.imageFilename)}
+                      alt={resource.name}
+                      classNames={{
+                        wrapper: '!max-w-none w-12 h-12',
+                        img: 'object-contain w-12 h-12',
+                      }}
+                    />
+                  </div>
                 </TableCell>
                 <TableCell>{resource.name}</TableCell>
                 <TableCell className="text-right">


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Resource group cards rendered thumbnails at inconsistent sizes (most visibly on Firefox) — short resource names made the table's image column collapse and the HeroUI `Image` wrapper followed it down, while wider tables rendered the thumbnail at the intended 48×48.

The image column declares `width="0"` so the HTML `<col>` shrinks to min-content. The HeroUI `Image` wrapper has `max-w-fit` and applies the explicit `width`/`height` to the inner `<img>`, so the cell's effective minimum width depended on browser interpretation and load timing.

## Fix

- Wrap the `Image` in a fixed `w-12 h-12 shrink-0` container so the cell can never collapse below 48px.
- Move the `w-12 h-12` sizing onto both the HeroUI wrapper and inner `img` slots and override `max-w-fit` via `!max-w-none` so the wrapper always fills the container.
- Drop the redundant `width`/`height` props on `Image` (sizing now comes from Tailwind classes).

Closes [ATT-261](https://linear.app/attraccess/issue/ATT-261/inconsisten-thumbnail-size-in-resource-group-cards).

## Test plan

- [x] Frontend typecheck passes (`nx run frontend:typecheck`).
- [x] Frontend lint passes (`nx run frontend:lint`).
- [x] Frontend tests pass (`nx run frontend:test`).
- [ ] Manual: open resource overview in Firefox, confirm all resource group cards render thumbnails at the same size regardless of group/name length.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Prevent resource group card thumbnail images from shrinking when table columns collapse, particularly in Firefox.