### PR TITLE
fix(deps): update typeorm to v0.3.29 with patch rename

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -40,7 +40,7 @@
     "reflect-metadata": "^0.2.2",
     "swagger-typescript-api": "^13.1.3",
     "tslib": "^2.8.1",
-    "typeorm": "0.3.28",
+    "typeorm": "0.3.29",
     "uuid": "^14.0.0",
     "ws": "^8.19.0",
     "zod": "^4.1.5"

--- a/libs/database-entities/package.json
+++ b/libs/database-entities/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "tslib": "^2.8.1",
-    "typeorm": "0.3.28",
+    "typeorm": "0.3.29",
     "@nestjs/swagger": "^11.2.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.3.0",
     "tslib": "^2.8.1",
-    "typeorm": "0.3.28",
+    "typeorm": "0.3.29",
     "uuid": "^14.0.0",
     "workbox-core": "^7.4.1",
     "workbox-expiration": "^7.4.1",
@@ -232,7 +232,7 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "typeorm@0.3.28": "patches/typeorm@0.3.28.patch"
+      "typeorm@0.3.29": "patches/typeorm@0.3.29.patch"
     },
     "overrides": {
       "@internationalized/date": "3.12.1"

--- a/patches/typeorm@0.3.29.patch
+++ b/patches/typeorm@0.3.29.patch
@@ -1,0 +1,75 @@
+diff --git a/driver/sqlite-abstract/AbstractSqliteDriver.js b/driver/sqlite-abstract/AbstractSqliteDriver.js
+index 5d74dc90a91e04df7d8ddd8364caf304e5c58707..3fccd2d80693312dc1c19886002a32eb1584ed8d 100644
+--- a/driver/sqlite-abstract/AbstractSqliteDriver.js
++++ b/driver/sqlite-abstract/AbstractSqliteDriver.js
+@@ -563,8 +563,13 @@ class AbstractSqliteDriver {
+             const tableColumn = tableColumns.find((c) => c.name === columnMetadata.databaseName);
+             if (!tableColumn)
+                 return false; // we don't need new columns, we only need exist and changed
++            const normType = this.normalizeType(columnMetadata);
++            const typeMismatch = tableColumn.type !== normType &&
++                !(tableColumn.enum && columnMetadata.enum &&
++                    ((tableColumn.type === "varchar" && normType === "text") ||
++                        (tableColumn.type === "text" && normType === "varchar")));
+             const isColumnChanged = tableColumn.name !== columnMetadata.databaseName ||
+-                tableColumn.type !== this.normalizeType(columnMetadata) ||
++                typeMismatch ||
+                 tableColumn.length !== columnMetadata.length ||
+                 tableColumn.precision !== columnMetadata.precision ||
+                 tableColumn.scale !== columnMetadata.scale ||
+diff --git a/driver/sqlite-abstract/AbstractSqliteQueryRunner.js b/driver/sqlite-abstract/AbstractSqliteQueryRunner.js
+index 4f4e657f787f7c598cbf3ebb92a897b65d0ebb49..7dbf803b0722a70ee3c58f530cd6984a021eeab5 100644
+--- a/driver/sqlite-abstract/AbstractSqliteQueryRunner.js
++++ b/driver/sqlite-abstract/AbstractSqliteQueryRunner.js
+@@ -944,7 +944,14 @@ class AbstractSqliteQueryRunner extends BaseQueryRunner_1.BaseQueryRunner {
+             table.columns = await Promise.all(dbColumns.map(async (dbColumn) => {
+                 const tableColumn = new TableColumn_1.TableColumn();
+                 tableColumn.name = dbColumn["name"];
+-                tableColumn.type = dbColumn["type"].toLowerCase();
++                // SQLite PRAGMA table_xinfo returns the full declared type including CHECK(...) for enum columns.
++                // Strip CHECK so type is just "varchar"/"text"; otherwise schema comparison thinks the column changed
++                // and keeps generating the same migration. See: enum columns with simple-enum in SQLite.
++                let rawType = dbColumn["type"].toLowerCase();
++                if (rawType.includes(" check(")) {
++                    rawType = rawType.substring(0, rawType.indexOf(" check("));
++                }
++                tableColumn.type = rawType;
+                 tableColumn.default =
+                     dbColumn["dflt_value"] !== null &&
+                         dbColumn["dflt_value"] !== undefined
+@@ -976,7 +983,7 @@ class AbstractSqliteQueryRunner extends BaseQueryRunner_1.BaseQueryRunner {
+                         tableColumn.asExpression = "";
+                     }
+                 }
+-                if (tableColumn.type === "varchar") {
++                if (tableColumn.type === "varchar" || tableColumn.type === "text") {
+                     tableColumn.enum = OrmUtils_1.OrmUtils.parseSqlCheckExpression(sql, tableColumn.name);
+                 }
+                 // parse datatype and attempt to retrieve length, precision and scale
+@@ -1014,9 +1021,10 @@ class AbstractSqliteQueryRunner extends BaseQueryRunner_1.BaseQueryRunner {
+             while ((fkResult = fkRegex.exec(sql)) !== null) {
+                 fkMappings.push({
+                     name: fkResult[1],
+-                    columns: fkResult[2]
+-                        .substr(1, fkResult[2].length - 2)
+-                        .split(`", "`),
++                    columns: (() => {
++                    const colPart = fkResult[2].replace(/\\s+/g, " ").trim();
++                    return colPart.length >= 2 ? colPart.substr(1, colPart.length - 2).split(`", "`).map((c) => c.trim()) : [];
++                })(),
+                     referencedTableName: fkResult[3],
+                 });
+             }
+@@ -1031,8 +1039,11 @@ class AbstractSqliteQueryRunner extends BaseQueryRunner_1.BaseQueryRunner {
+                 const fkMapping = fkMappings.find((it) => it.referencedTableName ===
+                     foreignKey["table"] &&
+                     it.columns.every((column) => columnNames.indexOf(column) !== -1));
++                const fkName = fkMapping?.name !== undefined && fkMapping?.name !== ""
++                    ? fkMapping.name
++                    : this.connection.namingStrategy.foreignKeyName(table, columnNames, foreignKey["table"], referencedColumnNames);
+                 return new TableForeignKey_1.TableForeignKey({
+-                    name: fkMapping?.name,
++                    name: fkName,
+                     columnNames: columnNames,
+                     referencedTableName: foreignKey["table"],
+                     referencedColumnNames: referencedColumnNames,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ overrides:
   '@internationalized/date': 3.12.1
 
 patchedDependencies:
-  typeorm@0.3.28:
+  typeorm@0.3.29:
     hash: awxlykwbpei6nnl5vfaztyyefy
-    path: patches/typeorm@0.3.28.patch
+    path: patches/typeorm@0.3.29.patch
 
 importers:
 
@@ -99,7 +99,7 @@ importers:
         version: 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@11.1.19)
       '@nestjs/typeorm':
         specifier: ^11.0.1
-        version: 11.0.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3)))
+        version: 11.0.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.29(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3)))
       '@nestjs/websockets':
         specifier: ^11.1.19
         version: 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-socket.io@11.0.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -335,8 +335,8 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       typeorm:
-        specifier: 0.3.28
-        version: 0.3.28(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3))
+        specifier: 0.3.29
+        version: 0.3.29(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3))
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
@@ -8349,9 +8349,6 @@ packages:
   dayjs@1.11.18:
     resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
-  dayjs@1.11.19:
-    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
-
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
@@ -8466,6 +8463,14 @@ packages:
 
   dedent@1.7.0:
     resolution: {integrity: sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
       babel-plugin-macros: ^3.1.0
     peerDependenciesMeta:
@@ -12837,10 +12842,6 @@ packages:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
     engines: {node: '>= 0.12.0'}
 
-  possible-typed-array-names@1.0.0:
-    resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
-    engines: {node: '>= 0.4'}
-
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -15040,8 +15041,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typeorm@0.3.28:
-    resolution: {integrity: sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==}
+  typeorm@0.3.29:
+    resolution: {integrity: sha512-wwPEX/df4l72gCmOsrs0otJZYLGA9lLQkUZCkukbsymEycV4zXv2KM7wU7v2r8L01TaCgY9ApSSqHQWBOUhEoQ==}
     engines: {node: '>=16.13.0'}
     hasBin: true
     peerDependencies:
@@ -15351,8 +15352,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@13.0.2:
@@ -20381,13 +20382,13 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
 
-  '@nestjs/typeorm@11.0.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3)))':
+  '@nestjs/typeorm@11.0.1(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.29(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3)))':
     dependencies:
       '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(@nestjs/websockets@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
-      typeorm: 0.3.28(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3))
+      typeorm: 0.3.29(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3))
 
   '@nestjs/websockets@11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-socket.io@11.0.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
@@ -24913,7 +24914,7 @@ snapshots:
 
   available-typed-arrays@1.0.7:
     dependencies:
-      possible-typed-array-names: 1.0.0
+      possible-typed-array-names: 1.1.0
 
   aws-sign2@0.7.0: {}
 
@@ -26361,8 +26362,6 @@ snapshots:
 
   dayjs@1.11.18: {}
 
-  dayjs@1.11.19: {}
-
   dayjs@1.11.20: {}
 
   de-indent@1.0.2:
@@ -26457,6 +26456,10 @@ snapshots:
       strip-dirs: 2.1.0
 
   dedent@1.7.0(babel-plugin-macros@3.1.0):
+    optionalDependencies:
+      babel-plugin-macros: 3.1.0
+
+  dedent@1.7.2(babel-plugin-macros@3.1.0):
     optionalDependencies:
       babel-plugin-macros: 3.1.0
 
@@ -26888,7 +26891,7 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.18
+      which-typed-array: 1.1.20
 
   es-abstract@1.24.1:
     dependencies:
@@ -28630,7 +28633,7 @@ snapshots:
 
   is-arguments@1.2.0:
     dependencies:
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
   is-array-buffer@3.0.5:
@@ -28715,7 +28718,7 @@ snapshots:
 
   is-generator-function@1.1.0:
     dependencies:
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       get-proto: 1.0.1
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
@@ -28845,7 +28848,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.18
+      which-typed-array: 1.1.20
 
   is-typedarray@1.0.0: {}
 
@@ -32696,8 +32699,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  possible-typed-array-names@1.0.0: {}
-
   possible-typed-array-names@1.1.0: {}
 
   postcss-calc@10.1.1(postcss@8.5.10):
@@ -35241,22 +35242,22 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typeorm@0.3.28(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3)):
+  typeorm@0.3.29(patch_hash=awxlykwbpei6nnl5vfaztyyefy)(babel-plugin-macros@3.1.0)(pg@8.15.6)(sql.js@1.13.0)(sqlite3@5.1.7)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@20.19.40)(typescript@6.0.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0
       app-root-path: 3.1.0
       buffer: 6.0.3
-      dayjs: 1.11.19
+      dayjs: 1.11.20
       debug: 4.4.3
-      dedent: 1.7.0(babel-plugin-macros@3.1.0)
+      dedent: 1.7.2(babel-plugin-macros@3.1.0)
       dotenv: 16.6.1
       glob: 10.5.0
       reflect-metadata: 0.2.2
       sha.js: 2.4.12
       sql-highlight: 6.1.0
       tslib: 2.8.1
-      uuid: 11.1.0
+      uuid: 11.1.1
       yargs: 17.7.2
     optionalDependencies:
       pg: 8.15.6
@@ -35548,7 +35549,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.0: {}
+  uuid@11.1.1: {}
 
   uuid@13.0.2: {}
 
@@ -36028,7 +36029,7 @@ snapshots:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       for-each: 0.3.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2


### PR DESCRIPTION
## Summary

- Bumps `typeorm` 0.3.28 → 0.3.29 across root `package.json`, `apps/api/package.json`, and `libs/database-entities/package.json`
- Renames the pnpm patch from `typeorm@0.3.28` → `typeorm@0.3.29` (patch content unchanged — SQLite enum-column type mismatch and FK mapping fixes are still needed in 0.3.29)
- Regenerates `pnpm-lock.yaml`

Supersedes / closes #765 and #762

## Test plan
- [x] All lint, typecheck, build, and test targets pass locally
- [x] `typeorm@0.3.29` confirmed in `pnpm-lock.yaml` with patch hash

https://claude.ai/code/session_01MAz9xSvaFUGWbyzzH9Y98D

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAz9xSvaFUGWbyzzH9Y98D)_

## Summary by Sourcery

Update the project to use TypeORM 0.3.29 and keep the existing local patch aligned with the new version.

Build:
- Bump TypeORM dependency from 0.3.28 to 0.3.29 in root, API app, and database entities packages.
- Rename and re-point the pnpm patched dependency from typeorm@0.3.28 to typeorm@0.3.29 while retaining the same patch contents.
- Regenerate pnpm-lock.yaml to reflect the updated TypeORM version and patch reference.