### PR TITLE
fix(metrics): avoid double-wrapping cached QueryRunner (ATT-282)

### DIFF
--- a/apps/api/src/metrics/instrumentation/db/db.instrumentation.spec.ts
+++ b/apps/api/src/metrics/instrumentation/db/db.instrumentation.spec.ts
@@ -46,6 +46,37 @@ describe('DbMetricsInstrumentation', () => {
     expect(driver.createQueryRunner).toBe(patched);
   });
 
+  it('does not double-wrap a cached runner across createQueryRunner calls', async () => {
+    let queryCalls = 0;
+    const cachedRunner: FakeRunner = {
+      query: async () => {
+        queryCalls += 1;
+        return [];
+      },
+    };
+    const registry = new Registry();
+    const metrics = createDbMetrics(registry);
+    const toggle = {
+      isEnabledCached: jest.fn().mockReturnValue(true),
+      getSlowQueryThresholdSecondsCached: jest.fn().mockReturnValue(0.5),
+    } as unknown as MetricsToggleService;
+    const driver: FakeDriver = {
+      createQueryRunner: () => cachedRunner,
+    };
+    const dataSource = { driver } as unknown as DataSource;
+    const instrumentation = new DbMetricsInstrumentation(metrics, toggle, dataSource);
+    instrumentation.install(dataSource);
+
+    for (let i = 0; i < 200; i += 1) {
+      (driver.createQueryRunner('master') as unknown as QueryRunner);
+    }
+    await (cachedRunner.query as (sql: string) => Promise<unknown>)('SELECT * FROM "user"');
+
+    expect(queryCalls).toBe(1);
+    const text = await registry.metrics();
+    expect(text).toContain('attraccess_db_query_duration_seconds_count{entity="user",method="select"} 1');
+  });
+
   it('records select duration with parsed entity from FROM clause', async () => {
     const { instrumentation, dataSource, driver, registry } = setup();
     instrumentation.install(dataSource);

--- a/apps/api/src/metrics/instrumentation/db/db.instrumentation.ts
+++ b/apps/api/src/metrics/instrumentation/db/db.instrumentation.ts
@@ -18,14 +18,13 @@ interface ParsedSql {
 const SKIP_VERBS = new Set(['begin', 'commit', 'rollback', 'savepoint', 'release', 'pragma']);
 
 const PATCH_FLAG = '__attraccessDbMetricsPatched';
-const RUNNER_PATCH_FLAG = '__attraccessDbMetricsRunnerPatched';
 
 interface PatchableDriver {
   createQueryRunner: (mode: 'master' | 'slave') => QueryRunner;
   [PATCH_FLAG]?: boolean;
 }
 
-type PatchableRunner = QueryRunner & { [RUNNER_PATCH_FLAG]?: boolean };
+const patchedRunners = new WeakSet<QueryRunner>();
 
 @Injectable()
 export class DbMetricsInstrumentation implements OnModuleInit {
@@ -45,10 +44,11 @@ export class DbMetricsInstrumentation implements OnModuleInit {
     const original = driver.createQueryRunner.bind(driver);
     const observe = this.observe.bind(this);
     driver.createQueryRunner = (mode: 'master' | 'slave') => {
-      const runner = original(mode) as PatchableRunner;
-      if (runner[RUNNER_PATCH_FLAG]) {
+      const runner = original(mode);
+      if (patchedRunners.has(runner)) {
         return runner;
       }
+      patchedRunners.add(runner);
       const originalQuery = runner.query.bind(runner) as (
         sql: string,
         parameters?: unknown[],
@@ -61,7 +61,6 @@ export class DbMetricsInstrumentation implements OnModuleInit {
         }
         return observe(parsed, () => originalQuery(sql, parameters, useStructuredResult));
       }) as unknown as QueryRunner['query'];
-      runner[RUNNER_PATCH_FLAG] = true;
       return runner;
     };
     driver[PATCH_FLAG] = true;

--- a/apps/api/src/metrics/instrumentation/db/db.instrumentation.ts
+++ b/apps/api/src/metrics/instrumentation/db/db.instrumentation.ts
@@ -18,11 +18,14 @@ interface ParsedSql {
 const SKIP_VERBS = new Set(['begin', 'commit', 'rollback', 'savepoint', 'release', 'pragma']);
 
 const PATCH_FLAG = '__attraccessDbMetricsPatched';
+const RUNNER_PATCH_FLAG = '__attraccessDbMetricsRunnerPatched';
 
 interface PatchableDriver {
   createQueryRunner: (mode: 'master' | 'slave') => QueryRunner;
   [PATCH_FLAG]?: boolean;
 }
+
+type PatchableRunner = QueryRunner & { [RUNNER_PATCH_FLAG]?: boolean };
 
 @Injectable()
 export class DbMetricsInstrumentation implements OnModuleInit {
@@ -42,7 +45,10 @@ export class DbMetricsInstrumentation implements OnModuleInit {
     const original = driver.createQueryRunner.bind(driver);
     const observe = this.observe.bind(this);
     driver.createQueryRunner = (mode: 'master' | 'slave') => {
-      const runner = original(mode);
+      const runner = original(mode) as PatchableRunner;
+      if (runner[RUNNER_PATCH_FLAG]) {
+        return runner;
+      }
       const originalQuery = runner.query.bind(runner) as (
         sql: string,
         parameters?: unknown[],
@@ -55,6 +61,7 @@ export class DbMetricsInstrumentation implements OnModuleInit {
         }
         return observe(parsed, () => originalQuery(sql, parameters, useStructuredResult));
       }) as unknown as QueryRunner['query'];
+      runner[RUNNER_PATCH_FLAG] = true;
       return runner;
     };
     driver[PATCH_FLAG] = true;


### PR DESCRIPTION
## Summary

Fixes ATT-282: production server crashed with `RangeError: Maximum call stack size exceeded` after deploying the ATT-276 metrics nightly. Stack trace pointed at `DbMetricsInstrumentation.observe` recursing through itself.

Root cause: TypeORM's SQLite driver caches a single `QueryRunner` instance and returns it on every `driver.createQueryRunner(mode)` call. The previous patch wrapped `runner.query` once per call, so each invocation stacked another wrap layer on the same runner. After N TypeORM calls, every query traversed N nested `observe()` frames — explaining both the linear `attraccess_db_query_duration_seconds_count` ramp visible in Grafana and the eventual stack overflow.

Fix:
- Track per-runner patch state with `__attraccessDbMetricsRunnerPatched` and skip already-wrapped runners.

## Test plan
- [x] New unit test: 200 `createQueryRunner` calls against a cached runner result in one query execution and one histogram observation
- [x] Existing `DbMetricsInstrumentation` spec still green (19/19)
- [x] Full metrics suite green (133/133)
- [x] api lint + build + test + e2e green via pre-commit hook
- [ ] Post-deploy: confirm DB throughput plateaus instead of ramping linearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent database metrics instrumentation from double-wrapping cached TypeORM query runners to avoid recursive query observation and stack overflows.

Bug Fixes:
- Ensure cached QueryRunner instances are only wrapped once by DbMetricsInstrumentation when createQueryRunner is called repeatedly.

Tests:
- Add regression test verifying that repeatedly obtaining a cached QueryRunner only results in a single underlying query execution and a single metrics observation.