### PR TITLE
fix(frontend): add isRowHeader to one TableColumn per table for v3 (ATT-285)

### DIFF
--- a/apps/frontend/src/app/attractap/AttractapList/index.tsx
+++ b/apps/frontend/src/app/attractap/AttractapList/index.tsx
@@ -173,7 +173,7 @@ export function AttractapList() {
               >
                 <TableContent aria-label={`${tableIndex === 0 ? 'active' : 'stale'} attractaps`}>
                 <TableHeader>
-                  <TableColumn>{t('table.columns.name')}</TableColumn>
+                  <TableColumn isRowHeader>{t('table.columns.name')}</TableColumn>
                   <TableColumn>{t('table.columns.type')}</TableColumn>
                   <TableColumn>{t('table.columns.lastConnection')}</TableColumn>
                   <TableColumn>{t('table.columns.actions')}</TableColumn>

--- a/apps/frontend/src/app/attractap/NfcCardList/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/index.tsx
@@ -330,8 +330,8 @@ export function NfcCardList() {
       <Table data-cy="nfc-card-list-table">
         <TableContent aria-label={t('nfcCards')}>
         <TableHeader>
-          {headers.map((header) => (
-            <TableColumn key={header} id={header}>
+          {headers.map((header, idx) => (
+            <TableColumn key={header} id={header} isRowHeader={idx === 0}>
               {t('nfcCardsTable.headers.' + header)}
             </TableColumn>
           ))}

--- a/apps/frontend/src/app/billing/administration/sumup/readers/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/readers/index.tsx
@@ -62,7 +62,7 @@ export function SumUpReadersCard(props: Omit<CardProps, 'children'>) {
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
-            <TableColumn>{t('table.columns.name')}</TableColumn>
+            <TableColumn isRowHeader>{t('table.columns.name')}</TableColumn>
             <TableColumn>{t('table.columns.device')}</TableColumn>
             <TableColumn>{t('table.columns.status')}</TableColumn>
             <TableColumn>{t('table.columns.actions')}</TableColumn>

--- a/apps/frontend/src/app/billing/dashboard/summary/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/index.tsx
@@ -178,7 +178,7 @@ export function SummaryCard(props: Omit<CardProps, 'children'> & Props) {
         <Table>
           <TableContent aria-label={t('transactions.table.ariaLabel')}>
           <TableHeader>
-            <TableColumn>{t('transactions.table.columns.id')}</TableColumn>
+            <TableColumn isRowHeader>{t('transactions.table.columns.id')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.dateTime')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.status')}</TableColumn>
             <TableColumn className="w-full">

--- a/apps/frontend/src/app/billing/dashboard/summary/transactionDetailsModal/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/transactionDetailsModal/index.tsx
@@ -194,7 +194,7 @@ export function TransactionDetailsModal(props: Props) {
                           <Table>
                             <TableContent aria-label="Transaction items">
                             <TableHeader>
-                              <TableColumn>{t('items.columns.name')}</TableColumn>
+                              <TableColumn isRowHeader>{t('items.columns.name')}</TableColumn>
                               <TableColumn>{t('items.columns.description')}</TableColumn>
                               <TableColumn>{t('items.columns.quantity')}</TableColumn>
                               <TableColumn>{t('items.columns.unitPrice')}</TableColumn>

--- a/apps/frontend/src/app/csv-export/base-modal/index.tsx
+++ b/apps/frontend/src/app/csv-export/base-modal/index.tsx
@@ -163,7 +163,7 @@ export function BaseCsvExportModal<TData extends Row>(props: Props<TData>) {
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader columns={selectedColumns}>
             {(column) => (
-              <TableColumn key={column.key} id={column.key}>
+              <TableColumn key={column.key} id={column.key} isRowHeader={column.key === selectedColumns[0]?.key}>
                 {column.label}
               </TableColumn>
             )}

--- a/apps/frontend/src/app/email-templates/EmailTemplatesPage.tsx
+++ b/apps/frontend/src/app/email-templates/EmailTemplatesPage.tsx
@@ -36,7 +36,7 @@ export function EmailTemplatesPage() {
       <Table>
         <TableContent aria-label="Email templates table">
           <TableHeader>
-          <TableColumn>{t('columns.type')}</TableColumn>
+          <TableColumn isRowHeader>{t('columns.type')}</TableColumn>
           <TableColumn>{t('columns.subject')}</TableColumn>
           <TableColumn>{t('columns.actions')}</TableColumn>
         </TableHeader>

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -107,7 +107,7 @@ export function PluginsList() {
           <Table data-cy="plugins-list-table">
             <TableContent aria-label="Plugins table">
             <TableHeader>
-              <TableColumn>{t('columns.name')}</TableColumn>
+              <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
               <TableColumn>{t('columns.version')}</TableColumn>
               <TableColumn>{t('columns.directory')}</TableColumn>
               <TableColumn>{t('columns.actions')}</TableColumn>

--- a/apps/frontend/src/app/projects/details/components/projectUsageCharts/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectUsageCharts/index.tsx
@@ -269,7 +269,7 @@ export function ProjectUsageCharts({ projectId }: ProjectUsageChartsProps) {
               <Table>
                 <TableContent aria-label={t('charts.topResources.table.ariaLabel')}>
                 <TableHeader>
-                  <TableColumn>{t('charts.topResources.columns.resource')}</TableColumn>
+                  <TableColumn isRowHeader>{t('charts.topResources.columns.resource')}</TableColumn>
                   <TableColumn>{t('charts.topResources.columns.sessions')}</TableColumn>
                   <TableColumn>{t('charts.topResources.columns.minutes')}</TableColumn>
                   <TableColumn>{t('charts.topResources.columns.spend')}</TableColumn>

--- a/apps/frontend/src/app/projects/details/components/projectUsageHistory/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectUsageHistory/index.tsx
@@ -66,7 +66,7 @@ export function ProjectUsageHistory({ projectId }: ProjectUsageHistoryProps) {
           <Table data-cy="project-usage-history-table">
             <TableContent aria-label={t('history.title')}>
             <TableHeader>
-              <TableColumn>{t('history.columns.resource')}</TableColumn>
+              <TableColumn isRowHeader>{t('history.columns.resource')}</TableColumn>
               <TableColumn>{t('history.columns.user')}</TableColumn>
               <TableColumn>{t('history.columns.start')}</TableColumn>
               <TableColumn>{t('history.columns.end')}</TableColumn>

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
@@ -150,7 +150,7 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
           <TableContent aria-label={tableAriaLabel}>
           <TableHeader>
             <TableColumn width="0">{t('columns.image')}</TableColumn>
-            <TableColumn>{t('columns.name')}</TableColumn>
+            <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
             <TableColumn width="0" className="text-left">
               {t('columns.status')}
             </TableColumn>

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -102,7 +102,7 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children'>
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
-            <TableColumn>{t('table.columns.start')}</TableColumn>
+            <TableColumn isRowHeader>{t('table.columns.start')}</TableColumn>
             <TableColumn>{t('table.columns.end')}</TableColumn>
             <TableColumn>{t('table.columns.reason')}</TableColumn>
             <TableColumn>{t('table.columns.createdBy')}</TableColumn>

--- a/apps/frontend/src/app/resources/details/maintenance-schedules/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-schedules/index.tsx
@@ -123,7 +123,7 @@ export function MaintenanceSchedules(props: Props & Omit<CardProps, 'children'>)
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
-            <TableColumn>{t('table.columns.name')}</TableColumn>
+            <TableColumn isRowHeader>{t('table.columns.name')}</TableColumn>
             <TableColumn>{t('table.columns.triggerType')}</TableColumn>
             <TableColumn>{t('table.columns.configSummary')}</TableColumn>
             <TableColumn>{t('table.columns.enabled')}</TableColumn>

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -139,7 +139,7 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children'>) 
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
-            <TableColumn> </TableColumn>
+            <TableColumn isRowHeader> </TableColumn>
             <TableColumn> </TableColumn>
           </TableHeader>
           <TableBody>

--- a/apps/frontend/src/app/resources/groups/index.tsx
+++ b/apps/frontend/src/app/resources/groups/index.tsx
@@ -150,7 +150,7 @@ export function ManageResourceGroups({
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
-            <TableColumn>{t('columns.group')}</TableColumn>
+            <TableColumn isRowHeader>{t('columns.group')}</TableColumn>
             <TableColumn>{t('columns.actions')}</TableColumn>
           </TableHeader>
           <TableBody

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableHeaders.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableHeaders.tsx
@@ -11,14 +11,15 @@ export function generateHeaderColumns(
 ): ReactElement<TableColumnProps>[] {
   const headers: ReactElement<TableColumnProps>[] = [];
 
-  // Only show user column if we're showing all users (requires canManageResources)
-  if (canManageResources && showAllUsers) {
-    headers.push(<TableColumn key="user" id="user">{t('headers.user')}</TableColumn>);
+  const showUserColumn = canManageResources && showAllUsers;
+
+  if (showUserColumn) {
+    headers.push(<TableColumn key="user" id="user" isRowHeader>{t('headers.user')}</TableColumn>);
   }
 
   if (resource.type === 'machine') {
     headers.push(
-      <TableColumn key="startTime" id="startTime">{t('headers.machine.startTime')}</TableColumn>,
+      <TableColumn key="startTime" id="startTime" isRowHeader={!showUserColumn}>{t('headers.machine.startTime')}</TableColumn>,
       <TableColumn key="endTime" id="endTime" className="hidden md:table-cell">
         {t('headers.machine.endTime')}
       </TableColumn>,
@@ -30,7 +31,7 @@ export function generateHeaderColumns(
     );
   } else if (resource.type === 'door') {
     headers.push(
-      <TableColumn key="time" id="time">{t('headers.door.time')}</TableColumn>,
+      <TableColumn key="time" id="time" isRowHeader={!showUserColumn}>{t('headers.door.time')}</TableColumn>,
       <TableColumn key="action" id="action" className="hidden md:table-cell">
         {t('headers.door.action')}
       </TableColumn>,

--- a/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
+++ b/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
@@ -649,7 +649,7 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
         <Table data-cy="sso-providers-table">
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
-            <TableColumn>{t('id')}</TableColumn>
+            <TableColumn isRowHeader>{t('id')}</TableColumn>
             <TableColumn>{t('name')}</TableColumn>
             <TableColumn>{t('type')}</TableColumn>
             <TableColumn>{t('actions')}</TableColumn>

--- a/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
@@ -157,7 +157,7 @@ export function AllowedSignupDomainsEditorModal(props: Props) {
                     <Table>
                       <TableContent aria-label={t('table.ariaLabel')}>
                       <TableHeader>
-                        <TableColumn>{t('table.columns.domain')}</TableColumn>
+                        <TableColumn isRowHeader>{t('table.columns.domain')}</TableColumn>
                         <TableColumn>{t('table.columns.actions')}</TableColumn>
                       </TableHeader>
                       <TableBody

--- a/apps/frontend/src/app/user-management/index.tsx
+++ b/apps/frontend/src/app/user-management/index.tsx
@@ -142,7 +142,7 @@ export const UserManagementPage: React.FC = () => {
               {t('table.columns.isEmailVerified')}
             </TableColumn>
             <TableColumn width="0">{t('table.columns.id')}</TableColumn>
-            <TableColumn>{t('table.columns.username')}</TableColumn>
+            <TableColumn isRowHeader>{t('table.columns.username')}</TableColumn>
             <TableColumn className="hidden md:table-cell">{t('table.columns.externalIdentifier')}</TableColumn>
             <TableColumn width="0" className="text-center">
               {t('table.columns.ssoLinked')}

--- a/apps/frontend/src/app/user-management/invite-user-modal/csv-invite/index.tsx
+++ b/apps/frontend/src/app/user-management/invite-user-modal/csv-invite/index.tsx
@@ -304,7 +304,7 @@ export function CsvInvite({ onSuccess, onError }: Props) {
       <Table data-cy="csv-invite-table">
         <TableContent aria-label="csv-invite-table">
         <TableHeader>
-          <TableColumn>{t('preview.columns.index')}</TableColumn>
+          <TableColumn isRowHeader>{t('preview.columns.index')}</TableColumn>
           <TableColumn>{t('preview.columns.username')}</TableColumn>
           <TableColumn>{t('preview.columns.email')}</TableColumn>
           <TableColumn>{t('preview.columns.permissions.label')}</TableColumn>
@@ -340,7 +340,7 @@ export function CsvInvite({ onSuccess, onError }: Props) {
           <Table>
             <TableContent aria-label="csv-invite-errors">
             <TableHeader>
-              <TableColumn>{t('errors.columns.row')}</TableColumn>
+              <TableColumn isRowHeader>{t('errors.columns.row')}</TableColumn>
               <TableColumn>{t('errors.columns.field')}</TableColumn>
               <TableColumn>{t('errors.columns.message')}</TableColumn>
               <TableColumn>{t('errors.columns.value')}</TableColumn>

--- a/apps/frontend/src/components/IntroductionsManagement/history/index.tsx
+++ b/apps/frontend/src/components/IntroductionsManagement/history/index.tsx
@@ -70,7 +70,7 @@ export function IntroductionHistoryModal(props: Readonly<Props>) {
                   <Table>
                     <TableContent aria-label={t('table.ariaLabel')}>
                     <TableHeader>
-                      <TableColumn>{t('table.columns.date')}</TableColumn>
+                      <TableColumn isRowHeader>{t('table.columns.date')}</TableColumn>
                       <TableColumn>{t('table.columns.action')}</TableColumn>
                       <TableColumn>{t('table.columns.comment')}</TableColumn>
                     </TableHeader>

--- a/apps/frontend/src/components/userSelectionList/index.tsx
+++ b/apps/frontend/src/components/userSelectionList/index.tsx
@@ -119,7 +119,7 @@ export function UserSelectionList<TUser extends User = User>(props: Readonly<Pro
       <Table {...tableProps}>
         <TableContent aria-label={t('table.ariaLabel')}>
         <TableHeader>
-          <TableColumn>{t('selectedUsers.columns.user')}</TableColumn>
+          <TableColumn isRowHeader>{t('selectedUsers.columns.user')}</TableColumn>
           {
             (additionalColumns ?? []).map((col) => (
               <TableColumn className={col.headerClassName} key={col.key} id={col.key}>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

HeroUI v3 / react-aria 4.x throws `A table must have at least one Column with the isRowHeader prop set to true`. The crash showed up on `/attractap/readers`; the same trap exists in every other `<TableColumn>` table in `apps/frontend/src` and would fire as soon as those tables hit a different render path.

Added `isRowHeader` to one semantically row-identifying column in each table (22 files). For dynamic header lists (`csv-export/base-modal`, `NfcCardList`, resource-usage `tableHeaders`), the flag is set on the first column at render time.

## Changes

- Static tables: marked first/semantic column (`name`, `username`, `date`, `start`, `domain`, `group`, `id`, `resource`, `user`, `type`, `row`, `index`) with `isRowHeader`.
- `csv-export/base-modal`: `isRowHeader={column.key === selectedColumns[0]?.key}`.
- `NfcCardList`: `isRowHeader={idx === 0}` in `headers.map`.
- `HistoryTable/utils/tableHeaders`: `user` column gets `isRowHeader` when shown; otherwise the first machine/door column does.
- `resourceBillingInfo`: header has two blank columns — marked first.

## Verification

- `pnpm nx typecheck frontend` — pass.
- `pnpm nx lint frontend` — pass.
- Precommit (`affected -t lint,typecheck,build,test,e2e`) — pass during commit.
- Did not load the dev server in a browser for each of the 22 tables; the fix is a 1-line invariant per table covered by ts/lint.

## Linear

[ATT-285](https://linear.app/attraccess/issue/ATT-285/fixfrontend-attractapreaders-crashes-tablecolumn-needs-isrowheader-in)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Ensure all frontend tables define a row header column to satisfy HeroUI v3/react-aria requirements and prevent table rendering crashes.

Bug Fixes:
- Fix table rendering crash by guaranteeing at least one TableColumn has isRowHeader set in affected views.

Enhancements:
- Improve table accessibility semantics by explicitly marking the primary identifying column as the row header across static and dynamically generated tables.