### PR TITLE
fix(frontend): /resources filter Drawer needs DrawerDialog wrapper (v3)

### DIFF
--- a/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { DrawerBody, Drawer, DrawerContent, DrawerHeader, Switch, useOverlayState } from '@heroui/react';
+import { DrawerBackdrop, DrawerBody, Drawer, DrawerContent, DrawerDialog, DrawerHeader, Switch, useOverlayState } from '@heroui/react';
 
 import de from './de.json';
 import en from './en.json';
@@ -22,25 +22,28 @@ export function ResourceFilter(props: Props & Omit<FilterProps, 'onSearchChanged
     <>
       {children({ onOpen: open })}
       <Drawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerBackdrop />
         <DrawerContent>
-          <DrawerHeader>{t('drawer.title')}</DrawerHeader>
-          <DrawerBody>
-            <Switch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
-              {t('drawer.options.onlyInUseByMe')}
-            </Switch>
-            <Switch
-              isSelected={filterProps.onlyWithPermissions}
-              onChange={filterProps.onOnlyWithPermissionsChanged}
-            >
-              {t('drawer.options.onlyWithPermissions')}
-            </Switch>
-            <Switch
-              isSelected={filterProps.hideEmptyResourceGroups}
-              onChange={filterProps.onHideEmptyResourceGroupsChanged}
-            >
-              {t('drawer.options.hideEmptyResourceGroups')}
-            </Switch>
-          </DrawerBody>
+          <DrawerDialog>
+            <DrawerHeader>{t('drawer.title')}</DrawerHeader>
+            <DrawerBody>
+              <Switch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
+                {t('drawer.options.onlyInUseByMe')}
+              </Switch>
+              <Switch
+                isSelected={filterProps.onlyWithPermissions}
+                onChange={filterProps.onOnlyWithPermissionsChanged}
+              >
+                {t('drawer.options.onlyWithPermissions')}
+              </Switch>
+              <Switch
+                isSelected={filterProps.hideEmptyResourceGroups}
+                onChange={filterProps.onHideEmptyResourceGroupsChanged}
+              >
+                {t('drawer.options.hideEmptyResourceGroups')}
+              </Switch>
+            </DrawerBody>
+          </DrawerDialog>
         </DrawerContent>
       </Drawer>
     </>

--- a/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
@@ -1,4 +1,4 @@
-import { Accordion, AccordionItem, AccordionHeading, AccordionTrigger, AccordionPanel, AccordionBody, Separator, Drawer, DrawerBody, DrawerContent, DrawerHeader, TextArea, useOverlayState } from '@heroui/react';
+import { Accordion, AccordionItem, AccordionHeading, AccordionTrigger, AccordionPanel, AccordionBody, Separator, Drawer, DrawerBackdrop, DrawerBody, DrawerContent, DrawerDialog, DrawerHeader, TextArea, useOverlayState } from '@heroui/react';
 import { PageHeader } from '../../../../../components/pageHeader';
 import { useDateTimeFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import {
@@ -87,40 +87,43 @@ export function LogViewer(props: Props) {
     <>
       {props.children(open)}
       <Drawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerBackdrop />
         <DrawerContent>
-          <DrawerHeader>
-            <PageHeader title={t('title')} noMargin />
-          </DrawerHeader>
+          <DrawerDialog>
+            <DrawerHeader>
+              <PageHeader title={t('title')} noMargin />
+            </DrawerHeader>
 
-          <DrawerBody>
-            <div className="flex flex-col gap-4">
-              {Object.entries(logsByRunId).map(([runId, logsOfRun], index, self) => (
-                <div key={`${runId}-logs`}>
-                  <div>
-                    <PageHeader
-                      title={t('nodes.' + (firstNodeOfRun(runId)?.node?.type ?? 'flow') + '.title')}
-                      subtitle={formatDateTime(firstNodeOfRun(runId)?.createdAt)}
-                      noMargin
-                    />
+            <DrawerBody>
+              <div className="flex flex-col gap-4">
+                {Object.entries(logsByRunId).map(([runId, logsOfRun], index, self) => (
+                  <div key={`${runId}-logs`}>
+                    <div>
+                      <PageHeader
+                        title={t('nodes.' + (firstNodeOfRun(runId)?.node?.type ?? 'flow') + '.title')}
+                        subtitle={formatDateTime(firstNodeOfRun(runId)?.createdAt)}
+                        noMargin
+                      />
 
-                    <Accordion className="mt-2">
-                      {logsOfRun.map((log) => (
-                        <AccordionItem key={`${runId}-${log.id}`}>
-                          <AccordionHeading><AccordionTrigger>{log.title}</AccordionTrigger></AccordionHeading>
-                          <AccordionPanel><AccordionBody>
-                            {log.payload && (
-                              <TextArea readOnly value={JSON.stringify(JSON.parse(log.payload), null, 2)} />
-                            )}
-                          </AccordionBody></AccordionPanel>
-                        </AccordionItem>
-                      ))}
-                    </Accordion>
+                      <Accordion className="mt-2">
+                        {logsOfRun.map((log) => (
+                          <AccordionItem key={`${runId}-${log.id}`}>
+                            <AccordionHeading><AccordionTrigger>{log.title}</AccordionTrigger></AccordionHeading>
+                            <AccordionPanel><AccordionBody>
+                              {log.payload && (
+                                <TextArea readOnly value={JSON.stringify(JSON.parse(log.payload), null, 2)} />
+                              )}
+                            </AccordionBody></AccordionPanel>
+                          </AccordionItem>
+                        ))}
+                      </Accordion>
+                    </div>
+                    {index < self.length - 1 && <Separator className="my-4" />}
                   </div>
-                  {index < self.length - 1 && <Separator className="my-4" />}
-                </div>
-              ))}
-            </div>
-          </DrawerBody>
+                ))}
+              </div>
+            </DrawerBody>
+          </DrawerDialog>
         </DrawerContent>
       </Drawer>
     </>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes [ATT-284](https://linear.app/attraccess/issue/ATT-284/fixfrontend-resources-filter-drawer-needs-drawerdialog-wrapper-v3).

`/resources` filter button activated the backdrop but never rendered the drawer body, leaving the page unclickable. Same bug existed in the resource flow `LogViewer`. HeroUI v3 requires the new compound `<Drawer> > <DrawerBackdrop /> + <DrawerContent> > <DrawerDialog>` shape — the previous code skipped `DrawerBackdrop` and `DrawerDialog`.

## Changes

- `apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx` — added `DrawerBackdrop` + `DrawerDialog` wrapper around header/body, matching the working `DonationPrompt` pattern from fd98aad.
- `apps/frontend/src/app/resources/details/flows/logViewer/index.tsx` — same migration; this drawer was the only other `<Drawer>` usage still on the v2 shape per `grep -rn "<Drawer\\b"`.

## Verification

- `pnpm nx run frontend:typecheck` — passes.
- `pnpm nx run frontend:lint` — passes (max-warnings=0).
- HeroUI v3 export check: `node_modules/@heroui/react/dist/components/drawer/index.d.ts` confirms `DrawerBackdrop`/`DrawerContent`/`DrawerDialog` are the canonical compound parts (no `DrawerContainer`); the structure matches the proven `DonationPrompt` fix.
- Browser run was deferred — the worktree has no API/seeded user available for the authenticated `/resources` view. Code-level parity with the known-good drawer is the validation here.

## Acceptance

- Filter button opens visible drawer with 3 switches — compound shape now mirrors the working DonationPrompt drawer.
- Outside click closes — `DrawerBackdrop` (default `isDismissable`) is now mounted.
- Other drawers remain functional — only one other `<Drawer>` usage existed (LogViewer), migrated in this PR.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Update remaining HeroUI Drawer usages to the v3 compound structure to restore proper drawer rendering and backdrop behavior.

Bug Fixes:
- Fix /resources filter drawer so the backdrop and drawer content render correctly and the page remains interactive.
- Fix LogViewer flow drawer so its content displays within a DrawerDialog and is dismissible via the backdrop.