### PR TITLE
fix(frontend): wrap v3 Drawer body in DrawerDialog for filter + logViewer

### DIFF
--- a/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { DrawerBody, Drawer, DrawerContent, DrawerHeader, useOverlayState } from '@heroui/react';
+import { DrawerBackdrop, DrawerBody, Drawer, DrawerContent, DrawerDialog, DrawerHeader, useOverlayState } from '@heroui/react';
 import { LabeledSwitch } from '../../../../components/labeledSwitch';
 
 import de from './de.json';
@@ -23,25 +23,28 @@ export function ResourceFilter(props: Props & Omit<FilterProps, 'onSearchChanged
     <>
       {children({ onOpen: open })}
       <Drawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerBackdrop />
         <DrawerContent>
-          <DrawerHeader>{t('drawer.title')}</DrawerHeader>
-          <DrawerBody>
-            <LabeledSwitch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
-              {t('drawer.options.onlyInUseByMe')}
-            </LabeledSwitch>
-            <LabeledSwitch
-              isSelected={filterProps.onlyWithPermissions}
-              onChange={filterProps.onOnlyWithPermissionsChanged}
-            >
-              {t('drawer.options.onlyWithPermissions')}
-            </LabeledSwitch>
-            <LabeledSwitch
-              isSelected={filterProps.hideEmptyResourceGroups}
-              onChange={filterProps.onHideEmptyResourceGroupsChanged}
-            >
-              {t('drawer.options.hideEmptyResourceGroups')}
-            </LabeledSwitch>
-          </DrawerBody>
+          <DrawerDialog>
+            <DrawerHeader>{t('drawer.title')}</DrawerHeader>
+            <DrawerBody>
+              <LabeledSwitch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
+                {t('drawer.options.onlyInUseByMe')}
+              </LabeledSwitch>
+              <LabeledSwitch
+                isSelected={filterProps.onlyWithPermissions}
+                onChange={filterProps.onOnlyWithPermissionsChanged}
+              >
+                {t('drawer.options.onlyWithPermissions')}
+              </LabeledSwitch>
+              <LabeledSwitch
+                isSelected={filterProps.hideEmptyResourceGroups}
+                onChange={filterProps.onHideEmptyResourceGroupsChanged}
+              >
+                {t('drawer.options.hideEmptyResourceGroups')}
+              </LabeledSwitch>
+            </DrawerBody>
+          </DrawerDialog>
         </DrawerContent>
       </Drawer>
     </>

--- a/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
@@ -1,10 +1,11 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { DrawerBackdrop, DrawerBody, Drawer, DrawerContent, DrawerDialog, DrawerHeader, useOverlayState } from '@heroui/react';
+import { DrawerBody, DrawerHeader, useOverlayState } from '@heroui/react';
 import { LabeledSwitch } from '../../../../components/labeledSwitch';
 
 import de from './de.json';
 import en from './en.json';
 import { FilterProps } from '../../filterProps';
+import { StandardDrawer } from '../../../../components/standardDrawer';
 
 interface Props {
   children: (props: { onOpen: () => void }) => React.ReactNode;
@@ -22,31 +23,26 @@ export function ResourceFilter(props: Props & Omit<FilterProps, 'onSearchChanged
   return (
     <>
       {children({ onOpen: open })}
-      <Drawer isOpen={isOpen} onOpenChange={setOpen}>
-        <DrawerBackdrop />
-        <DrawerContent>
-          <DrawerDialog>
-            <DrawerHeader>{t('drawer.title')}</DrawerHeader>
-            <DrawerBody>
-              <LabeledSwitch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
-                {t('drawer.options.onlyInUseByMe')}
-              </LabeledSwitch>
-              <LabeledSwitch
-                isSelected={filterProps.onlyWithPermissions}
-                onChange={filterProps.onOnlyWithPermissionsChanged}
-              >
-                {t('drawer.options.onlyWithPermissions')}
-              </LabeledSwitch>
-              <LabeledSwitch
-                isSelected={filterProps.hideEmptyResourceGroups}
-                onChange={filterProps.onHideEmptyResourceGroupsChanged}
-              >
-                {t('drawer.options.hideEmptyResourceGroups')}
-              </LabeledSwitch>
-            </DrawerBody>
-          </DrawerDialog>
-        </DrawerContent>
-      </Drawer>
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerHeader>{t('drawer.title')}</DrawerHeader>
+        <DrawerBody>
+          <LabeledSwitch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
+            {t('drawer.options.onlyInUseByMe')}
+          </LabeledSwitch>
+          <LabeledSwitch
+            isSelected={filterProps.onlyWithPermissions}
+            onChange={filterProps.onOnlyWithPermissionsChanged}
+          >
+            {t('drawer.options.onlyWithPermissions')}
+          </LabeledSwitch>
+          <LabeledSwitch
+            isSelected={filterProps.hideEmptyResourceGroups}
+            onChange={filterProps.onHideEmptyResourceGroupsChanged}
+          >
+            {t('drawer.options.hideEmptyResourceGroups')}
+          </LabeledSwitch>
+        </DrawerBody>
+      </StandardDrawer>
     </>
   );
 }

--- a/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
@@ -1,4 +1,4 @@
-import { Accordion, AccordionItem, AccordionHeading, AccordionTrigger, AccordionPanel, AccordionBody, Separator, Drawer, DrawerBody, DrawerContent, DrawerHeader, TextArea, useOverlayState } from '@heroui/react';
+import { Accordion, AccordionItem, AccordionHeading, AccordionTrigger, AccordionPanel, AccordionBody, Separator, Drawer, DrawerBackdrop, DrawerBody, DrawerContent, DrawerDialog, DrawerHeader, TextArea, useOverlayState } from '@heroui/react';
 import { PageHeader } from '../../../../../components/pageHeader';
 import { useDateTimeFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import {
@@ -87,40 +87,43 @@ export function LogViewer(props: Props) {
     <>
       {props.children(open)}
       <Drawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerBackdrop />
         <DrawerContent>
-          <DrawerHeader>
-            <PageHeader title={t('title')} noMargin />
-          </DrawerHeader>
+          <DrawerDialog>
+            <DrawerHeader>
+              <PageHeader title={t('title')} noMargin />
+            </DrawerHeader>
 
-          <DrawerBody>
-            <div className="flex flex-col gap-4">
-              {Object.entries(logsByRunId).map(([runId, logsOfRun], index, self) => (
-                <div key={`${runId}-logs`}>
-                  <div>
-                    <PageHeader
-                      title={t('nodes.' + (firstNodeOfRun(runId)?.node?.type ?? 'flow') + '.title')}
-                      subtitle={formatDateTime(firstNodeOfRun(runId)?.createdAt)}
-                      noMargin
-                    />
+            <DrawerBody>
+              <div className="flex flex-col gap-4">
+                {Object.entries(logsByRunId).map(([runId, logsOfRun], index, self) => (
+                  <div key={`${runId}-logs`}>
+                    <div>
+                      <PageHeader
+                        title={t('nodes.' + (firstNodeOfRun(runId)?.node?.type ?? 'flow') + '.title')}
+                        subtitle={formatDateTime(firstNodeOfRun(runId)?.createdAt)}
+                        noMargin
+                      />
 
-                    <Accordion className="mt-2">
-                      {logsOfRun.map((log) => (
-                        <AccordionItem key={`${runId}-${log.id}`}>
-                          <AccordionHeading><AccordionTrigger>{log.title}</AccordionTrigger></AccordionHeading>
-                          <AccordionPanel><AccordionBody>
-                            {log.payload && (
-                              <TextArea readOnly value={JSON.stringify(JSON.parse(log.payload), null, 2)} />
-                            )}
-                          </AccordionBody></AccordionPanel>
-                        </AccordionItem>
-                      ))}
-                    </Accordion>
+                      <Accordion className="mt-2">
+                        {logsOfRun.map((log) => (
+                          <AccordionItem key={`${runId}-${log.id}`}>
+                            <AccordionHeading><AccordionTrigger>{log.title}</AccordionTrigger></AccordionHeading>
+                            <AccordionPanel><AccordionBody>
+                              {log.payload && (
+                                <TextArea readOnly value={JSON.stringify(JSON.parse(log.payload), null, 2)} />
+                              )}
+                            </AccordionBody></AccordionPanel>
+                          </AccordionItem>
+                        ))}
+                      </Accordion>
+                    </div>
+                    {index < self.length - 1 && <Separator className="my-4" />}
                   </div>
-                  {index < self.length - 1 && <Separator className="my-4" />}
-                </div>
-              ))}
-            </div>
-          </DrawerBody>
+                ))}
+              </div>
+            </DrawerBody>
+          </DrawerDialog>
         </DrawerContent>
       </Drawer>
     </>

--- a/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
@@ -1,5 +1,6 @@
-import { Accordion, AccordionItem, AccordionHeading, AccordionTrigger, AccordionPanel, AccordionBody, Separator, Drawer, DrawerBackdrop, DrawerBody, DrawerContent, DrawerDialog, DrawerHeader, TextArea, useOverlayState } from '@heroui/react';
+import { Accordion, AccordionItem, AccordionHeading, AccordionTrigger, AccordionPanel, AccordionBody, Separator, DrawerBody, DrawerHeader, TextArea, useOverlayState } from '@heroui/react';
 import { PageHeader } from '../../../../../components/pageHeader';
+import { StandardDrawer } from '../../../../../components/standardDrawer';
 import { useDateTimeFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import {
   ResourceFlowLog,
@@ -86,46 +87,41 @@ export function LogViewer(props: Props) {
   return (
     <>
       {props.children(open)}
-      <Drawer isOpen={isOpen} onOpenChange={setOpen}>
-        <DrawerBackdrop />
-        <DrawerContent>
-          <DrawerDialog>
-            <DrawerHeader>
-              <PageHeader title={t('title')} noMargin />
-            </DrawerHeader>
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerHeader>
+          <PageHeader title={t('title')} noMargin />
+        </DrawerHeader>
 
-            <DrawerBody>
-              <div className="flex flex-col gap-4">
-                {Object.entries(logsByRunId).map(([runId, logsOfRun], index, self) => (
-                  <div key={`${runId}-logs`}>
-                    <div>
-                      <PageHeader
-                        title={t('nodes.' + (firstNodeOfRun(runId)?.node?.type ?? 'flow') + '.title')}
-                        subtitle={formatDateTime(firstNodeOfRun(runId)?.createdAt)}
-                        noMargin
-                      />
+        <DrawerBody>
+          <div className="flex flex-col gap-4">
+            {Object.entries(logsByRunId).map(([runId, logsOfRun], index, self) => (
+              <div key={`${runId}-logs`}>
+                <div>
+                  <PageHeader
+                    title={t('nodes.' + (firstNodeOfRun(runId)?.node?.type ?? 'flow') + '.title')}
+                    subtitle={formatDateTime(firstNodeOfRun(runId)?.createdAt)}
+                    noMargin
+                  />
 
-                      <Accordion className="mt-2">
-                        {logsOfRun.map((log) => (
-                          <AccordionItem key={`${runId}-${log.id}`}>
-                            <AccordionHeading><AccordionTrigger>{log.title}</AccordionTrigger></AccordionHeading>
-                            <AccordionPanel><AccordionBody>
-                              {log.payload && (
-                                <TextArea readOnly value={JSON.stringify(JSON.parse(log.payload), null, 2)} />
-                              )}
-                            </AccordionBody></AccordionPanel>
-                          </AccordionItem>
-                        ))}
-                      </Accordion>
-                    </div>
-                    {index < self.length - 1 && <Separator className="my-4" />}
-                  </div>
-                ))}
+                  <Accordion className="mt-2">
+                    {logsOfRun.map((log) => (
+                      <AccordionItem key={`${runId}-${log.id}`}>
+                        <AccordionHeading><AccordionTrigger>{log.title}</AccordionTrigger></AccordionHeading>
+                        <AccordionPanel><AccordionBody>
+                          {log.payload && (
+                            <TextArea readOnly value={JSON.stringify(JSON.parse(log.payload), null, 2)} />
+                          )}
+                        </AccordionBody></AccordionPanel>
+                      </AccordionItem>
+                    ))}
+                  </Accordion>
+                </div>
+                {index < self.length - 1 && <Separator className="my-4" />}
               </div>
-            </DrawerBody>
-          </DrawerDialog>
-        </DrawerContent>
-      </Drawer>
+            ))}
+          </div>
+        </DrawerBody>
+      </StandardDrawer>
     </>
   );
 }

--- a/apps/frontend/src/components/DonationPrompt/index.tsx
+++ b/apps/frontend/src/components/DonationPrompt/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, Drawer, DrawerBackdrop, DrawerBody, DrawerContent, DrawerDialog, DrawerFooter, DrawerHeader } from '@heroui/react';
+import { Button, DrawerBody, DrawerFooter, DrawerHeader } from '@heroui/react';
+import { StandardDrawer } from '../standardDrawer';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { HeartHandshake, Share2 } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
@@ -92,35 +93,33 @@ export function DonationPrompt() {
   }
 
   return (
-    <Drawer
+    <StandardDrawer
       isOpen={isVisible}
       onOpenChange={(open) => setIsVisible(open)}
+      backdropProps={{ variant: 'blur', isDismissable: false }}
+      contentProps={{ placement: 'bottom' }}
+      dialogProps={{ className: 'w-full max-w-[680px] mx-auto' }}
     >
-      <DrawerBackdrop variant="blur" isDismissable={false} />
-      <DrawerContent placement="bottom">
-        <DrawerDialog className="w-full max-w-[680px] mx-auto">
-          <DrawerHeader className="flex flex-col gap-1">
-            <div className="text-base font-semibold">{t('title')}</div>
-            <div className="text-sm text-default-500">{t('subtitle')}</div>
-          </DrawerHeader>
-          <DrawerBody>
-            <div className="text-sm text-default-600 dark:text-default-400">{t('body')}</div>
-          </DrawerBody>
-          <DrawerFooter className="flex flex-wrap gap-2 justify-end">
-            <Button variant="primary" onPress={onDonate}>
-              <HeartHandshake size={16} />
-              {t('actions.donate')}
-            </Button>
-            <Button variant="secondary" onPress={onShare}>
-              <Share2 size={16} />
-              {t('actions.share')}
-            </Button>
-            <Button variant="ghost" onPress={onHideForMonth}>
-              {t('actions.hideForMonth')}
-            </Button>
-          </DrawerFooter>
-        </DrawerDialog>
-      </DrawerContent>
-    </Drawer>
+      <DrawerHeader className="flex flex-col gap-1">
+        <div className="text-base font-semibold">{t('title')}</div>
+        <div className="text-sm text-default-500">{t('subtitle')}</div>
+      </DrawerHeader>
+      <DrawerBody>
+        <div className="text-sm text-default-600 dark:text-default-400">{t('body')}</div>
+      </DrawerBody>
+      <DrawerFooter className="flex flex-wrap gap-2 justify-end">
+        <Button variant="primary" onPress={onDonate}>
+          <HeartHandshake size={16} />
+          {t('actions.donate')}
+        </Button>
+        <Button variant="secondary" onPress={onShare}>
+          <Share2 size={16} />
+          {t('actions.share')}
+        </Button>
+        <Button variant="ghost" onPress={onHideForMonth}>
+          {t('actions.hideForMonth')}
+        </Button>
+      </DrawerFooter>
+    </StandardDrawer>
   );
 }

--- a/apps/frontend/src/components/standardDrawer.tsx
+++ b/apps/frontend/src/components/standardDrawer.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react';
+import {
+  Drawer,
+  DrawerBackdrop,
+  DrawerContent,
+  DrawerDialog,
+  type DrawerBackdropProps,
+  type DrawerContentProps,
+  type DrawerDialogProps,
+} from '@heroui/react';
+
+interface Props {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+  backdropProps?: Omit<DrawerBackdropProps, 'children'>;
+  contentProps?: Omit<DrawerContentProps, 'children'>;
+  dialogProps?: Omit<DrawerDialogProps, 'children'>;
+}
+
+export function StandardDrawer(props: Props) {
+  const { isOpen, onOpenChange, children, backdropProps, contentProps, dialogProps } = props;
+
+  return (
+    <Drawer isOpen={isOpen} onOpenChange={onOpenChange}>
+      <DrawerBackdrop {...backdropProps} />
+      <DrawerContent {...contentProps}>
+        <DrawerDialog {...dialogProps}>{children}</DrawerDialog>
+      </DrawerContent>
+    </Drawer>
+  );
+}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

On `/resources`, clicking the filter icon previously only activated the backdrop and froze the page — the drawer dialog never mounted. HeroUI v3 requires the new compound API: `DrawerBackdrop` + `DrawerDialog` wrapping `DrawerHeader`/`DrawerBody` inside `DrawerContent`. The same v2-shape bug was still present on the resource flow `LogViewer`.

Mirrors the working pattern shipped for `DonationPrompt` in `fd98aad`.

## Changes

- `apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx` — add `DrawerBackdrop`, wrap body in `DrawerDialog`
- `apps/frontend/src/app/resources/details/flows/logViewer/index.tsx` — same v3 compound wrapper

## Audit

`grep -rn '<Drawer\b'` from repo root returned 3 files. `DonationPrompt` already used the v3 shape; the other two are fixed here. No remaining v2-shape drawers in the codebase.

## Verification

- `pnpm nx run frontend:typecheck` — pass
- `pnpm nx run frontend:lint` — pass
- `pnpm nx run frontend:test` — 72 tests pass
- v3 compound parts confirmed via `node_modules/@heroui/react/dist/components/drawer/index.d.ts` — `DrawerBackdrop`, `DrawerContent`, `DrawerDialog` are the canonical parts (no `DrawerContainer`)
- Browser run deferred: worktree has no API/seeded user for the authenticated `/resources` view; validation rests on code-level parity with the known-good `DonationPrompt` drawer plus the v3 type defs

## Linear

https://linear.app/attraccess/issue/ATT-284/fixfrontend-resources-filter-drawer-needs-drawerdialog-wrapper-v3

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Update remaining HeroUI v3 drawers to use the correct compound structure so resource filters and log viewer panels render properly.

Bug Fixes:
- Fix resource overview filter drawer so it opens correctly by adding the required backdrop and dialog wrapper components.
- Fix log viewer drawer so logs are displayed in a properly mounted drawer using the v3 dialog structure.