### PR TITLE
fix(frontend): compose Switch.Control + Switch.Thumb for v3

### DIFF
--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -1,6 +1,7 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, CardHeader, TextField, Label, Input, Checkbox, Spinner, Switch } from "@heroui/react";
+import { Button, Card, CardHeader, TextField, Label, Input, Checkbox, Spinner } from "@heroui/react";
 import { Select } from '../../../components/select';
+import { LabeledSwitch } from '../../../components/labeledSwitch';
 import { ArrowLeft } from 'lucide-react';
 import { PasswordInput } from '../../../components/PasswordInput';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -191,7 +192,7 @@ export function EditMqttServerPage() {
               />
 
               <div className="flex items-center space-x-2">
-                <Switch
+                <LabeledSwitch
                   id="defaultPublishRetain"
                   name="defaultPublishRetain"
                   isSelected={!!formValues.defaultPublishRetain}
@@ -199,7 +200,7 @@ export function EditMqttServerPage() {
                   data-cy="edit-mqtt-server-form-default-publish-retain-checkbox"
                 >
                   {t('defaultPublishRetainLabel')}
-                </Switch>
+                </LabeledSwitch>
               </div>
 
               <Select

--- a/apps/frontend/src/app/projects/index.tsx
+++ b/apps/frontend/src/app/projects/index.tsx
@@ -15,7 +15,8 @@ import de from './de.json';
 import API_ERROR_TRANSLATIONS_EN from '../../global-translations/api-errors.en.json';
 import API_ERROR_TRANSLATIONS_DE from '../../global-translations/api-errors.de.json';
 import { PageHeader } from '../../components/pageHeader';
-import { Button, Card, CardContent, CardHeader, Chip, Skeleton, Switch } from '@heroui/react';
+import { Button, Card, CardContent, CardHeader, Chip, Skeleton } from '@heroui/react';
+import { LabeledSwitch } from '../../components/labeledSwitch';
 import { FolderIcon, PlusIcon } from 'lucide-react';
 import { UpsertProjectModal } from './upsertModal';
 import { EmptyState } from '../../components/emptyState';
@@ -203,9 +204,9 @@ export function ProjectsListPage() {
         icon={<FolderIcon />}
         actions={
           <div className="flex flex-wrap items-center gap-3">
-            <Switch isSelected={includeArchived} onChange={setIncludeArchived}>
+            <LabeledSwitch isSelected={includeArchived} onChange={setIncludeArchived}>
               {t('filters.includeArchived')}
-            </Switch>
+            </LabeledSwitch>
             <UpsertProjectModal>
               {(onOpen) => (
                 <Button variant="ghost" onPress={onOpen}><PlusIcon size="24" />

--- a/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { DrawerBody, Drawer, DrawerContent, DrawerHeader, Switch, useOverlayState } from '@heroui/react';
+import { DrawerBody, Drawer, DrawerContent, DrawerHeader, useOverlayState } from '@heroui/react';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 
 import de from './de.json';
 import en from './en.json';
@@ -25,21 +26,21 @@ export function ResourceFilter(props: Props & Omit<FilterProps, 'onSearchChanged
         <DrawerContent>
           <DrawerHeader>{t('drawer.title')}</DrawerHeader>
           <DrawerBody>
-            <Switch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
+            <LabeledSwitch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
               {t('drawer.options.onlyInUseByMe')}
-            </Switch>
-            <Switch
+            </LabeledSwitch>
+            <LabeledSwitch
               isSelected={filterProps.onlyWithPermissions}
               onChange={filterProps.onOnlyWithPermissionsChanged}
             >
               {t('drawer.options.onlyWithPermissions')}
-            </Switch>
-            <Switch
+            </LabeledSwitch>
+            <LabeledSwitch
               isSelected={filterProps.hideEmptyResourceGroups}
               onChange={filterProps.onHideEmptyResourceGroupsChanged}
             >
               {t('drawer.options.hideEmptyResourceGroups')}
-            </Switch>
+            </LabeledSwitch>
           </DrawerBody>
         </DrawerContent>
       </Drawer>

--- a/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
@@ -17,11 +17,11 @@ import {
   NumberFieldGroup,
   NumberFieldIncrementButton,
   NumberFieldInput,
-  Switch,
   TextArea,
 } from '@heroui/react';
 import { Select } from '../../../../../../../components/select';
 import { MqttServerSelect } from '../../../../../../../components/mqttServerSelect';
+import { LabeledSwitch } from '../../../../../../../components/labeledSwitch';
 import { PlusIcon, XIcon } from 'lucide-react';
 import { TFunction } from '@attraccess/plugins-frontend-ui';
 import { useCallback, useMemo, useState } from 'react';
@@ -424,9 +424,9 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
 
     case 'boolean':
       return (
-        <Switch isSelected={value as boolean} onChange={(newValue) => onChange(newValue as TValue)}>
+        <LabeledSwitch isSelected={value as boolean} onChange={(newValue) => onChange(newValue as TValue)}>
           {!hideLabel ? t('nodes.' + nodeType + '.config.' + name + '.label') : null}
-        </Switch>
+        </LabeledSwitch>
       );
   }
 

--- a/apps/frontend/src/app/resources/details/forms/FormEditorPage.tsx
+++ b/apps/frontend/src/app/resources/details/forms/FormEditorPage.tsx
@@ -29,9 +29,9 @@ import {
   Input,
   Selection,
   Spinner,
-  Switch,
 } from '@heroui/react';
 import { useToastMessage } from '../../../../components/toastProvider';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { useQueryClient } from '@tanstack/react-query';
 import { PageHeader } from '../../../../components/pageHeader';
 import { DeleteConfirmationModal } from '../../../../components/deleteConfirmationModal';
@@ -254,24 +254,24 @@ export function FormEditorPage() {
             </div>
 
             <div className="grid gap-2">
-              <Switch
+              <LabeledSwitch
                 isSelected={form.isRequiredOnResourceUsageStart}
                 onChange={(value) => setForm((prev) => ({ ...prev, isRequiredOnResourceUsageStart: value }))}
               >
                 {t('editor.resourceUsageStart')}
-              </Switch>
-              <Switch
+              </LabeledSwitch>
+              <LabeledSwitch
                 isSelected={form.isRequiredOnResourceUsageTakeOver}
                 onChange={(value) => setForm((prev) => ({ ...prev, isRequiredOnResourceUsageTakeOver: value }))}
               >
                 {t('editor.resourceUsageTakeover')}
-              </Switch>
-              <Switch
+              </LabeledSwitch>
+              <LabeledSwitch
                 isSelected={form.isRequiredOnResourceUsageEnd}
                 onChange={(value) => setForm((prev) => ({ ...prev, isRequiredOnResourceUsageEnd: value }))}
               >
                 {t('editor.resourceUsageEnd')}
-              </Switch>
+              </LabeledSwitch>
             </div>
 
             <Separator />

--- a/apps/frontend/src/app/resources/details/forms/components/FieldOptionsEditor.tsx
+++ b/apps/frontend/src/app/resources/details/forms/components/FieldOptionsEditor.tsx
@@ -1,4 +1,5 @@
-import { Button, TextField, Label, Input, Switch } from '@heroui/react';
+import { Button, TextField, Label, Input } from '@heroui/react';
+import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { Plus, X } from 'lucide-react';
 import { FormFieldType } from '@attraccess/react-query-client';
 import { EditableFormField, TextFieldOptions, NumberFieldOptions, SelectFieldOptions } from '../types';
@@ -50,12 +51,12 @@ function renderOptionsByType(
             <Label>{t('fields.options.text.placeholder')}</Label>
             <Input />
           </TextField>
-          <Switch
+          <LabeledSwitch
             isSelected={Boolean(textOptions.multiline)}
             onChange={(value) => updateOptions({ multiline: value })}
           >
             {t('fields.options.text.multiline')}
-          </Switch>
+          </LabeledSwitch>
         </div>
       );
     }

--- a/apps/frontend/src/app/resources/details/forms/components/FormFieldEditor.tsx
+++ b/apps/frontend/src/app/resources/details/forms/components/FormFieldEditor.tsx
@@ -1,5 +1,6 @@
-import { Button, TextField, Label, Input, Switch, TextArea } from "@heroui/react";
+import { Button, TextField, Label, Input, TextArea } from "@heroui/react";
 import { Select } from '../../../../../components/select';
+import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { Trash2 } from 'lucide-react';
 import { FormFieldType } from '@attraccess/react-query-client';
 import { EditableFormField, createDefaultFieldOptions } from '../types';
@@ -53,9 +54,9 @@ export function FormFieldEditor(props: FormFieldEditorProps) {
       </div>
 
       <div className="flex items-center justify-between">
-        <Switch isSelected={field.isRequired} onChange={(value) => onChange({ ...field, isRequired: value })}>
+        <LabeledSwitch isSelected={field.isRequired} onChange={(value) => onChange({ ...field, isRequired: value })}>
           {t('fields.required')}
-        </Switch>
+        </LabeledSwitch>
         <Button variant="danger-soft"
 
           onPress={onRemove}

--- a/apps/frontend/src/app/resources/details/forms/components/FormPreview.tsx
+++ b/apps/frontend/src/app/resources/details/forms/components/FormPreview.tsx
@@ -1,5 +1,6 @@
-import { Card, CardContent, CardHeader, Input, Switch, TextArea } from "@heroui/react";
+import { Card, CardContent, CardHeader, Input, TextArea } from "@heroui/react";
 import { Select } from '../../../../../components/select';
+import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { FormFieldType } from '@attraccess/react-query-client';
 import { EditableFormField, TextFieldOptions, NumberFieldOptions, SelectFieldOptions } from '../types';
 
@@ -83,7 +84,7 @@ function renderPreviewBoolean(t: (key: string) => string) {
   return (
     <div className="flex items-center gap-3">
       <span className="text-xs text-default-500">{t('preview.booleanNo')}</span>
-      <Switch aria-label={t('preview.booleanLabel')} />
+      <LabeledSwitch aria-label={t('preview.booleanLabel')} />
       <span className="text-xs text-default-500">{t('preview.booleanYes')}</span>
     </div>
   );

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -5,7 +5,6 @@ import {
   CardHeader,
   CardProps,
   cn,
-  Switch,
   Table,
   TableBody,
   TableCell,
@@ -16,6 +15,7 @@ import {
 } from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import { MaintenanceReasonDisplay } from '../../../../components/MaintenanceReasonDisplay';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { ResourceMaintenance, useResourceMaintenancesServiceFindMaintenances } from '@attraccess/react-query-client';
 import { useMemo, useState } from 'react';
 import { DateTimeDisplay, useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -79,9 +79,9 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children'>
           noMargin
           actions={
             <>
-              <Switch isSelected={includePast} onChange={setIncludePast}>
+              <LabeledSwitch isSelected={includePast} onChange={setIncludePast}>
                 {t('filters.includePast')}
-              </Switch>
+              </LabeledSwitch>
               <ResourceMaintenanceUpsertModal resourceId={resourceId}>
                 {(open) => (
                   <Button variant="primary"

--- a/apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx
@@ -13,7 +13,6 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
-  Switch,
   TextArea,
   useOverlayState,
 } from '@heroui/react';
@@ -21,6 +20,7 @@ import de from './de.json';
 import en from './en.json';
 import { PageHeader } from '../../../../../components/pageHeader';
 import { MaintenanceReasonDisplay } from '../../../../../components/MaintenanceReasonDisplay';
+import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { parseAbsolute, type DateValue, type ZonedDateTime, toZoned } from '@internationalized/date';
 import { CalendarIcon } from 'lucide-react';
@@ -132,9 +132,9 @@ export function ResourceMaintenanceUpsertModal(props: Props) {
                     <Form onSubmit={onSubmit} ref={formRef}>
                       <DatePicker value={startTime} isRequired hideTimeZone onChange={setStartTime} />
 
-                      <Switch isSelected={hasEndDate} onChange={onHasEndDateChange}>
+                      <LabeledSwitch isSelected={hasEndDate} onChange={onHasEndDateChange}>
                         {t('inputs.hasEndDate.label')}
-                      </Switch>
+                      </LabeledSwitch>
                       {hasEndDate && <DatePicker value={endTime} isRequired hideTimeZone onChange={setEndTime} />}
 
                       <div>

--- a/apps/frontend/src/app/resources/details/maintenance-schedules/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-schedules/index.tsx
@@ -4,7 +4,6 @@ import {
   CardContent,
   CardHeader,
   CardProps,
-  Switch,
   Table,
   TableBody,
   TableCell,
@@ -26,6 +25,7 @@ import de from './de.json';
 import en from './en.json';
 import { CalendarClockIcon, PencilIcon, PlusIcon, TrashIcon } from 'lucide-react';
 import { EmptyState } from '../../../../components/emptyState';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { useQueryClient } from '@tanstack/react-query';
 import { MaintenanceScheduleUpsertModal } from './upsert';
 import { ScheduleDeleteModal } from './ScheduleDeleteModal';
@@ -139,7 +139,7 @@ export function MaintenanceSchedules(props: Props & Omit<CardProps, 'children'>)
                 <TableCell>{t(`triggerType.${schedule.triggerType}`)}</TableCell>
                 <TableCell>{configSummary(schedule, t)}</TableCell>
                 <TableCell>
-                  <Switch
+                  <LabeledSwitch
                     isSelected={schedule.enabled}
                     onChange={(enabled) => handleEnabledChange(schedule, enabled)}
                     isDisabled={isUpdating}

--- a/apps/frontend/src/app/resources/details/maintenance-schedules/upsert/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-schedules/upsert/index.tsx
@@ -13,11 +13,11 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
-  Switch,
   TextField,
   useOverlayState,
 } from '@heroui/react';
 import { Select } from '../../../../../components/select';
+import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -317,9 +317,9 @@ export function MaintenanceScheduleUpsertModal(props: Props) {
                         </>
                       )}
 
-                      <Switch isSelected={enabled} onChange={setEnabled}>
+                      <LabeledSwitch isSelected={enabled} onChange={setEnabled}>
                         {t('inputs.enabled.label')}
-                      </Switch>
+                      </LabeledSwitch>
 
                       {error && (
                         <Alert status="danger">

--- a/apps/frontend/src/app/resources/editModal/tabs/door.tsx
+++ b/apps/frontend/src/app/resources/editModal/tabs/door.tsx
@@ -1,11 +1,11 @@
-import { Switch } from '@heroui/react';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { EditorTabProps } from './props';
 
 export function DoorTab(props: EditorTabProps) {
   const { t, formData, setField } = props;
   return (
     <div className="flex flex-col gap-2">
-      <Switch
+      <LabeledSwitch
         isSelected={formData.separateUnlockAndUnlatch}
         onChange={(value) => setField('separateUnlockAndUnlatch', value)}
         data-cy="resource-edit-modal-separate-unlock-and-unlatch-switch"
@@ -14,7 +14,7 @@ export function DoorTab(props: EditorTabProps) {
           <span className="text-small">{t('inputs.door.separateUnlockAndUnlatch.label')}</span>
           <span className="text-tiny text-default-400">{t('inputs.door.separateUnlockAndUnlatch.description')}</span>
         </div>
-      </Switch>
+      </LabeledSwitch>
     </div>
   );
 }

--- a/apps/frontend/src/app/resources/editModal/tabs/machine.tsx
+++ b/apps/frontend/src/app/resources/editModal/tabs/machine.tsx
@@ -1,4 +1,4 @@
-import { Switch } from '@heroui/react';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { EditorTabProps } from './props';
 
 export function MachineTab(props: EditorTabProps) {
@@ -6,7 +6,7 @@ export function MachineTab(props: EditorTabProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      <Switch
+      <LabeledSwitch
         isSelected={formData.allowTakeOver}
         onChange={(value) => setField('allowTakeOver', value)}
         data-cy="resource-edit-modal-allow-takeover-switch"
@@ -15,7 +15,7 @@ export function MachineTab(props: EditorTabProps) {
           <span className="text-small">{t('inputs.machine.allowTakeOver.label')}</span>
           <span className="text-tiny text-default-400">{t('inputs.machine.allowTakeOver.description')}</span>
         </div>
-      </Switch>
+      </LabeledSwitch>
     </div>
   );
 }

--- a/apps/frontend/src/app/resources/forms/components/ResourceFormsModal.tsx
+++ b/apps/frontend/src/app/resources/forms/components/ResourceFormsModal.tsx
@@ -11,10 +11,10 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
-  Switch,
   TextArea,
 } from '@heroui/react';
 import { Select } from '../../../../components/select';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { FormFieldType, FormResponseDto, FormSubmissionRequestDto } from '@attraccess/react-query-client';
 import {
@@ -332,7 +332,7 @@ function renderBooleanInput(
     <div className="space-y-1">
       <div className="flex items-center gap-3">
         <span className="text-xs text-default-500">{t('modal.booleanNo')}</span>
-        <Switch
+        <LabeledSwitch
           isSelected={isChecked}
           onChange={(checked) => onChange(checked)}
           aria-label={t('modal.booleanLabel')}

--- a/apps/frontend/src/app/settings/forms/MetricsSettingsForm/index.tsx
+++ b/apps/frontend/src/app/settings/forms/MetricsSettingsForm/index.tsx
@@ -8,7 +8,6 @@ import {
   NumberFieldIncrementButton,
   NumberFieldInput,
   Separator,
-  Switch,
   TextField,
   Label,
   InputGroup,
@@ -37,6 +36,7 @@ import {
   useSettingsServiceUpdateMetricsSettings,
 } from '@attraccess/react-query-client';
 import { useToastMessage } from '../../../../components/toastProvider';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import en from './en.json';
 import de from './de.json';
 
@@ -206,7 +206,7 @@ export function MetricsSettingsForm() {
       <SectionHeading title={t('toggles.title')} description={t('toggles.description')} />
       <div className="flex flex-col gap-2">
         {TOGGLE_ORDER.map((subsystem) => (
-          <Switch
+          <LabeledSwitch
             key={subsystem}
             data-testid={`metrics-toggle-${subsystem}`}
             isSelected={metricsSettings.toggles[subsystem]}
@@ -225,7 +225,7 @@ export function MetricsSettingsForm() {
               </div>
               <p className="text-xs text-default-500">{t(`toggles.${subsystem}.description`)}</p>
             </div>
-          </Switch>
+          </LabeledSwitch>
         ))}
       </div>
     </div>

--- a/apps/frontend/src/app/settings/forms/SmtpSettingsForm/index.tsx
+++ b/apps/frontend/src/app/settings/forms/SmtpSettingsForm/index.tsx
@@ -9,9 +9,10 @@ import {
   useSettingsServiceUpdateSystemSettings,
   useSettingsServiceGetSystemSettingsKey,
 } from '@attraccess/react-query-client';
-import { Button, Form, TextField, Label, Input, Description, Spinner, Switch } from '@heroui/react';
+import { Button, Form, TextField, Label, Input, Description, Spinner } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PasswordInput } from '../../../../components/PasswordInput';
+import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { Select } from '../../../../components/select';
 import { useToastMessage } from '../../../../components/toastProvider';
 import API_ERROR_TRANSLATIONS_DE from '../../../../global-translations/api-errors.de.json';
@@ -181,13 +182,13 @@ export function SmtpSettingsForm({ variant, endpoint, onNext }: SmtpSettingsForm
         <Input type="number" min={1} />
         <Description>{t('inputs.port.description')}</Description>
       </TextField>
-      <Switch
+      <LabeledSwitch
         isSelected={smtpSecure}
         onChange={setSmtpSecure}
         isDisabled={smtpService !== SmtpServiceType.SMTP}
       >
         {t('inputs.secure.label')}
-      </Switch>
+      </LabeledSwitch>
       <TextField value={smtpUser} onChange={setSmtpUser}>
         <Label>{t('inputs.user.label')}</Label>
         <Input />

--- a/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
+++ b/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
@@ -33,7 +33,6 @@ import {
   DropdownItem,
   DropdownPopover,
   TextArea,
-  Switch,
   Link,
   useOverlayState,
 } from '@heroui/react';
@@ -64,6 +63,7 @@ import { AuthentikDiscoveryDialog } from './discovery/authentik';
 import { OpenIDConfiguration } from './discovery/OpenIDC.data';
 import { KeycloakDiscoveryDialog } from './discovery/keycloak';
 import { Select } from '../../../components/select';
+import { LabeledSwitch } from '../../../components/labeledSwitch';
 import { getBaseUrl } from '../../../api';
 import { hasRequiredSamlSigningMaterial } from './signingMaterial';
 
@@ -1051,34 +1051,34 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
                           </p>
 
                           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <Switch
+                            <LabeledSwitch
                               isSelected={formValues.samlConfiguration?.signRequest ?? false}
                               onChange={(value) => handleSamlToggleChange('signRequest', value)}
                               data-cy="sso-provider-form-saml-sign-request-switch"
                             >
                               {t('signRequest')}
-                            </Switch>
-                            <Switch
+                            </LabeledSwitch>
+                            <LabeledSwitch
                               isSelected={formValues.samlConfiguration?.wantAssertionsSigned ?? false}
                               onChange={(value) => handleSamlToggleChange('wantAssertionsSigned', value)}
                               data-cy="sso-provider-form-saml-assertions-signed-switch"
                             >
                               {t('wantAssertionsSigned')}
-                            </Switch>
-                            <Switch
+                            </LabeledSwitch>
+                            <LabeledSwitch
                               isSelected={formValues.samlConfiguration?.wantAuthnResponseSigned ?? true}
                               onChange={(value) => handleSamlToggleChange('wantAuthnResponseSigned', value)}
                               data-cy="sso-provider-form-saml-response-signed-switch"
                             >
                               {t('wantAuthnResponseSigned')}
-                            </Switch>
-                            <Switch
+                            </LabeledSwitch>
+                            <LabeledSwitch
                               isSelected={formValues.samlConfiguration?.forceAuthn ?? false}
                               onChange={(value) => handleSamlToggleChange('forceAuthn', value)}
                               data-cy="sso-provider-form-saml-force-authn-switch"
                             >
                               {t('forceAuthn')}
-                            </Switch>
+                            </LabeledSwitch>
                           </div>
                         </>
                       )}

--- a/apps/frontend/src/app/user-management/details/components/permissionsForm/index.tsx
+++ b/apps/frontend/src/app/user-management/details/components/permissionsForm/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Card, CardHeader, CardContent, CardFooter, Switch } from '@heroui/react';
+import { Button, Card, CardHeader, CardContent, CardFooter } from '@heroui/react';
+import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useToastMessage } from '../../../../../components/toastProvider';
 import {
@@ -130,16 +131,15 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
           </div>
         ) : null}
         {Object.keys(permissions).map((permission) => (
-          <Switch
+          <LabeledSwitch
             key={permission}
             isSelected={permissions[permission as keyof SystemPermissions]}
             onChange={handlePermissionChange(permission as keyof SystemPermissions)}
-           
             isDisabled={isPermissionSsoManaged(permission)}
             data-cy={`user-permission-form-${permission}-checkbox`}
           >
             {t(`permissions.${permission}`)}
-          </Switch>
+          </LabeledSwitch>
         ))}
       </CardContent>
 

--- a/apps/frontend/src/components/labeledSwitch.tsx
+++ b/apps/frontend/src/components/labeledSwitch.tsx
@@ -1,0 +1,19 @@
+import { Switch } from '@heroui/react';
+import type { ComponentProps, ReactNode } from 'react';
+
+type SwitchProps = ComponentProps<typeof Switch>;
+
+export interface LabeledSwitchProps extends Omit<SwitchProps, 'children'> {
+  children?: ReactNode;
+}
+
+export function LabeledSwitch({ children, ...rest }: LabeledSwitchProps) {
+  return (
+    <Switch {...rest}>
+      <Switch.Control>
+        <Switch.Thumb />
+      </Switch.Control>
+      {children != null && children !== false ? <Switch.Content>{children}</Switch.Content> : null}
+    </Switch>
+  );
+}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

HeroUI v3 `<Switch>` is a compound component — the root only renders a `data-slot="switch"` wrapper. The visible track and thumb come from `<Switch.Control><Switch.Thumb/></Switch.Control>` children. Existing code passed only a label string, so switches rendered as plain text with no visible toggle (role and aria-checked were still correct, only the visual was missing).

- Add `LabeledSwitch` helper (`apps/frontend/src/components/labeledSwitch.tsx`) that composes `Switch.Control + Switch.Thumb` and wraps any `children` in `Switch.Content`. Forwards all root props (including `isSelected`, `onChange`, `isDisabled`, `aria-label`, `data-cy`, `className`).
- Migrate all 19 affected files to `LabeledSwitch`, replacing the bare `<Switch>{label}</Switch>` form.

## Verification

- `pnpm nx typecheck frontend` — pass
- `pnpm nx lint frontend` — pass
- `pnpm nx test frontend` — 72 / 72 pass
- `pre-commit` hook ran the affected lint/typecheck/build/test/e2e targets.
- Browser smoke test via Browser MCP / claude-in-chrome was not possible (no extension connected in this environment). Type-level shape verified against `node_modules/@heroui/react/dist/components/switch/index.d.ts`, which declares `Switch` as a callable with static `Root`, `Control`, `Thumb`, `Content`, and `Icon` — matching the helper.

## Linear

[ATT-286](https://linear.app/attraccess/issue/ATT-286/fixfrontend-switches-render-as-text-compose-switchcontrol-switchthumb)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Introduce a reusable labeled switch helper and migrate all boolean toggle UIs to use it for proper HeroUI v3 Switch rendering.

Bug Fixes:
- Fix HeroUI v3 switches rendering as plain text by composing Switch.Control and Switch.Thumb for all labeled switches.

Enhancements:
- Add a LabeledSwitch component that forwards Switch root props and wraps labels in Switch.Content to standardize toggle presentation across the frontend.