### PR TITLE
fix(frontend): add AlertIndicator to v3 warning/danger Alerts (ATT-287)

### DIFF
--- a/apps/frontend/src/app/attractap/AttractapList/de.json
+++ b/apps/frontend/src/app/attractap/AttractapList/de.json
@@ -7,6 +7,7 @@
       "openSerialConsole": "Serielle Konsole"
     }
   },
+  "workInProgressTitle": "In Arbeit",
   "workInProgress": "Dieses Feature ist noch in Arbeit, benutzung auf eigene Gefahr!",
   "error": {
     "fetchReaders": "Attractap konnten nicht abgerufen werden"

--- a/apps/frontend/src/app/attractap/AttractapList/en.json
+++ b/apps/frontend/src/app/attractap/AttractapList/en.json
@@ -7,6 +7,7 @@
       "openSerialConsole": "Serial Console"
     }
   },
+  "workInProgressTitle": "Work in progress",
   "workInProgress": "This feature is still in development, use at your own risk!",
   "error": {
     "fetchReaders": "Could not fetch Attractaps"

--- a/apps/frontend/src/app/attractap/AttractapList/index.tsx
+++ b/apps/frontend/src/app/attractap/AttractapList/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, AlertContent, AlertDescription, Button, Card, CardContent, CardHeader, Chip, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertIndicator, AlertTitle, Button, Card, CardContent, CardHeader, Chip, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { buttonVariants } from '@heroui/styles';
-import { ArrowRightIcon, CpuIcon, LogsIcon, MoreVertical, PencilIcon, Trash2Icon } from 'lucide-react';
+import { AlertTriangleIcon, ArrowRightIcon, CpuIcon, LogsIcon, MoreVertical, PencilIcon, Trash2Icon } from 'lucide-react';
 import { EmptyState } from '../../../components/emptyState';
 import { useDateTimeFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { AttractapEditor } from '../AttractapEditor/AttractapEditor';
@@ -145,7 +145,11 @@ export function AttractapList() {
       />
 
       <Alert status="danger" className="mb-4">
+        <AlertIndicator>
+          <AlertTriangleIcon />
+        </AlertIndicator>
         <AlertContent>
+          <AlertTitle>{t('workInProgressTitle')}</AlertTitle>
           <AlertDescription>{t('workInProgress')}</AlertDescription>
         </AlertContent>
       </Alert>

--- a/apps/frontend/src/app/attractap/AttractapList/index.tsx
+++ b/apps/frontend/src/app/attractap/AttractapList/index.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, AlertContent, AlertDescription, AlertIndicator, AlertTitle, Button, Card, CardContent, CardHeader, Chip, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card, CardContent, CardHeader, Chip, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { buttonVariants } from '@heroui/styles';
-import { AlertTriangleIcon, ArrowRightIcon, CpuIcon, LogsIcon, MoreVertical, PencilIcon, Trash2Icon } from 'lucide-react';
+import { ArrowRightIcon, CpuIcon, LogsIcon, MoreVertical, PencilIcon, Trash2Icon } from 'lucide-react';
+import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 import { EmptyState } from '../../../components/emptyState';
 import { useDateTimeFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { AttractapEditor } from '../AttractapEditor/AttractapEditor';
@@ -145,9 +146,7 @@ export function AttractapList() {
       />
 
       <Alert status="danger" className="mb-4">
-        <AlertIndicator>
-          <AlertTriangleIcon />
-        </AlertIndicator>
+        <AlertStatusIcon status="danger" />
         <AlertContent>
           <AlertTitle>{t('workInProgressTitle')}</AlertTitle>
           <AlertDescription>{t('workInProgress')}</AlertDescription>

--- a/apps/frontend/src/app/attractap/HardwareSetup/SerialConfigurator/Auth/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/SerialConfigurator/Auth/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Alert, AlertContent, AlertDescription, AlertIndicator, Button, Input, Label, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle, TextField } from '@heroui/react';
-import { AlertCircleIcon } from 'lucide-react';
+import { Alert, AlertContent, AlertDescription, Button, Input, Label, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle, TextField } from '@heroui/react';
+import { AlertStatusIcon } from '../../../../../components/AlertStatusIcon';
 import {
   createContext,
   useCallback,
@@ -255,9 +255,7 @@ export function AttractapSerialCommGate({ children }: PropsWithChildren) {
           <Input maxLength={4} inputMode="numeric" required />
         </TextField>
         {error && <Alert status="danger">
-          <AlertIndicator>
-            <AlertCircleIcon />
-          </AlertIndicator>
+          <AlertStatusIcon status="danger" />
           <AlertContent>
             <AlertDescription>{error}</AlertDescription>
           </AlertContent>

--- a/apps/frontend/src/app/attractap/HardwareSetup/SerialConfigurator/Auth/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/SerialConfigurator/Auth/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Alert, AlertContent, AlertDescription, Button, Input, Label, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle, TextField } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertIndicator, Button, Input, Label, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle, TextField } from '@heroui/react';
+import { AlertCircleIcon } from 'lucide-react';
 import {
   createContext,
   useCallback,
@@ -254,6 +255,9 @@ export function AttractapSerialCommGate({ children }: PropsWithChildren) {
           <Input maxLength={4} inputMode="numeric" required />
         </TextField>
         {error && <Alert status="danger">
+          <AlertIndicator>
+            <AlertCircleIcon />
+          </AlertIndicator>
           <AlertContent>
             <AlertDescription>{error}</AlertDescription>
           </AlertContent>

--- a/apps/frontend/src/app/attractap/HardwareSetup/SerialConfigurator/Pin/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/SerialConfigurator/Pin/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Alert, AlertContent, AlertDescription, AlertIndicator, Button, Input, Label, TextField, cn } from '@heroui/react';
-import { AlertCircleIcon } from 'lucide-react';
+import { Alert, AlertContent, AlertDescription, Button, Input, Label, TextField, cn } from '@heroui/react';
+import { AlertStatusIcon } from '../../../../../components/AlertStatusIcon';
 import { useCallback, useState, type FormEvent } from 'react';
 import { PageHeader } from '../../../../../components/pageHeader';
 import { useAttractapSerialComm } from '../Auth';
@@ -106,9 +106,7 @@ export function AttractapSerialConfiguratorPin({ className, mode = 'change' }: A
           <Input maxLength={4} inputMode="numeric" required />
         </TextField>
         {error && <Alert status="danger">
-          <AlertIndicator>
-            <AlertCircleIcon />
-          </AlertIndicator>
+          <AlertStatusIcon status="danger" />
           <AlertContent>
             <AlertDescription>{error}</AlertDescription>
           </AlertContent>

--- a/apps/frontend/src/app/attractap/HardwareSetup/SerialConfigurator/Pin/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/SerialConfigurator/Pin/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Alert, AlertContent, AlertDescription, Button, Input, Label, TextField, cn } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertIndicator, Button, Input, Label, TextField, cn } from '@heroui/react';
+import { AlertCircleIcon } from 'lucide-react';
 import { useCallback, useState, type FormEvent } from 'react';
 import { PageHeader } from '../../../../../components/pageHeader';
 import { useAttractapSerialComm } from '../Auth';
@@ -105,6 +106,9 @@ export function AttractapSerialConfiguratorPin({ className, mode = 'change' }: A
           <Input maxLength={4} inputMode="numeric" required />
         </TextField>
         {error && <Alert status="danger">
+          <AlertIndicator>
+            <AlertCircleIcon />
+          </AlertIndicator>
           <AlertContent>
             <AlertDescription>{error}</AlertDescription>
           </AlertContent>

--- a/apps/frontend/src/app/attractap/NfcCardList/de.json
+++ b/apps/frontend/src/app/attractap/NfcCardList/de.json
@@ -1,4 +1,5 @@
 {
+  "workInProgressTitle": "In Arbeit",
   "workInProgress": "Dieses Feature ist noch in Arbeit, benutzung auf eigene Gefahr!",
   "nfcCards": "NFC-Karten",
   "readers": "Attractap-Reader",

--- a/apps/frontend/src/app/attractap/NfcCardList/en.json
+++ b/apps/frontend/src/app/attractap/NfcCardList/en.json
@@ -1,4 +1,5 @@
 {
+  "workInProgressTitle": "Work in progress",
   "workInProgress": "This feature is still in development, use at your own risk!",
   "nfcCards": "NFC Cards",
   "readers": "Attractap Readers",

--- a/apps/frontend/src/app/attractap/NfcCardList/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/index.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
-  AlertIndicator,
   AlertTitle,
   Button,
   Modal,
@@ -38,7 +37,8 @@ import de from './de.json';
 import en from './en.json';
 import { NfcCardDeactivateModal } from './deactivate';
 import { NfcCardActivateModal } from './activate';
-import { AlertTriangleIcon, CheckIcon, PlusIcon, ServerIcon, Trash2Icon, XIcon } from 'lucide-react';
+import { CheckIcon, PlusIcon, ServerIcon, Trash2Icon, XIcon } from 'lucide-react';
+import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 import { PageHeader } from '../../../components/pageHeader';
 import { useAuth } from '../../../hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
@@ -318,9 +318,7 @@ export function NfcCardList() {
       />
 
       <Alert status="warning" className="mb-4">
-        <AlertIndicator>
-          <AlertTriangleIcon />
-        </AlertIndicator>
+        <AlertStatusIcon status="warning" />
         <AlertContent>
           <AlertTitle>{t('workInProgressTitle')}</AlertTitle>
           <AlertDescription>{t('workInProgress')}</AlertDescription>

--- a/apps/frontend/src/app/attractap/NfcCardList/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/index.tsx
@@ -2,6 +2,8 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
+  AlertIndicator,
+  AlertTitle,
   Button,
   Modal,
   ModalBackdrop,
@@ -36,7 +38,7 @@ import de from './de.json';
 import en from './en.json';
 import { NfcCardDeactivateModal } from './deactivate';
 import { NfcCardActivateModal } from './activate';
-import { CheckIcon, PlusIcon, ServerIcon, Trash2Icon, XIcon } from 'lucide-react';
+import { AlertTriangleIcon, CheckIcon, PlusIcon, ServerIcon, Trash2Icon, XIcon } from 'lucide-react';
 import { PageHeader } from '../../../components/pageHeader';
 import { useAuth } from '../../../hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
@@ -316,7 +318,11 @@ export function NfcCardList() {
       />
 
       <Alert status="warning" className="mb-4">
+        <AlertIndicator>
+          <AlertTriangleIcon />
+        </AlertIndicator>
         <AlertContent>
+          <AlertTitle>{t('workInProgressTitle')}</AlertTitle>
           <AlertDescription>{t('workInProgress')}</AlertDescription>
         </AlertContent>
       </Alert>

--- a/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
+++ b/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
+  AlertIndicator,
   Button,
   Modal,
   ModalBackdrop,
@@ -26,6 +27,7 @@ import {
   useMqttServiceMqttServersGetAllKey,
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
+import { AlertCircleIcon, AlertTriangleIcon } from 'lucide-react';
 
 // Define ServerListItem component inline
 interface ServerListItemProps {
@@ -120,6 +122,9 @@ export function MqttServerList() {
   if (error) {
     return (
       <Alert status="danger" data-cy="mqtt-server-list-error-alert">
+        <AlertIndicator>
+          <AlertCircleIcon />
+        </AlertIndicator>
         <AlertContent>
           <AlertDescription>{t('errorLoading')}</AlertDescription>
         </AlertContent>
@@ -130,6 +135,9 @@ export function MqttServerList() {
   if (servers.length === 0) {
     return (
       <Alert status="warning" data-cy="mqtt-server-list-no-servers-alert">
+        <AlertIndicator>
+          <AlertTriangleIcon />
+        </AlertIndicator>
         <AlertContent>
           <AlertDescription>{t('noServersConfigured')}</AlertDescription>
         </AlertContent>

--- a/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
+++ b/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
-  AlertIndicator,
   Button,
   Modal,
   ModalBackdrop,
@@ -27,7 +26,7 @@ import {
   useMqttServiceMqttServersGetAllKey,
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
-import { AlertCircleIcon, AlertTriangleIcon } from 'lucide-react';
+import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 
 // Define ServerListItem component inline
 interface ServerListItemProps {
@@ -122,9 +121,7 @@ export function MqttServerList() {
   if (error) {
     return (
       <Alert status="danger" data-cy="mqtt-server-list-error-alert">
-        <AlertIndicator>
-          <AlertCircleIcon />
-        </AlertIndicator>
+        <AlertStatusIcon status="danger" />
         <AlertContent>
           <AlertDescription>{t('errorLoading')}</AlertDescription>
         </AlertContent>
@@ -135,9 +132,7 @@ export function MqttServerList() {
   if (servers.length === 0) {
     return (
       <Alert status="warning" data-cy="mqtt-server-list-no-servers-alert">
-        <AlertIndicator>
-          <AlertTriangleIcon />
-        </AlertIndicator>
+        <AlertStatusIcon status="warning" />
         <AlertContent>
           <AlertDescription>{t('noServersConfigured')}</AlertDescription>
         </AlertContent>

--- a/apps/frontend/src/app/plugins/PluginsList.de.json
+++ b/apps/frontend/src/app/plugins/PluginsList.de.json
@@ -1,4 +1,5 @@
 {
+  "workInProgressAlertTitle": "In Arbeit",
   "workInProgressAlert": "Diese Funktionen sind noch in Arbeit und werden bald verfügbar sein.",
   "title": "Installierte Plugins",
   "uploadButton": "Plugin hochladen",

--- a/apps/frontend/src/app/plugins/PluginsList.de.json
+++ b/apps/frontend/src/app/plugins/PluginsList.de.json
@@ -1,6 +1,6 @@
 {
-  "workInProgressAlertTitle": "In Arbeit",
-  "workInProgressAlert": "Diese Funktionen sind noch in Arbeit und werden bald verfügbar sein.",
+  "workInProgressTitle": "In Arbeit",
+  "workInProgress": "Diese Funktionen sind noch in Arbeit und werden bald verfügbar sein.",
   "title": "Installierte Plugins",
   "uploadButton": "Plugin hochladen",
   "noPlugins": "Keine Plugins installiert",

--- a/apps/frontend/src/app/plugins/PluginsList.en.json
+++ b/apps/frontend/src/app/plugins/PluginsList.en.json
@@ -1,6 +1,6 @@
 {
-  "workInProgressAlertTitle": "Work in progress",
-  "workInProgressAlert": "This feature is still under development and will be available soon.",
+  "workInProgressTitle": "Work in progress",
+  "workInProgress": "This feature is still under development and will be available soon.",
   "title": "Installed Plugins",
   "uploadButton": "Upload Plugin",
   "noPlugins": "No plugins installed",

--- a/apps/frontend/src/app/plugins/PluginsList.en.json
+++ b/apps/frontend/src/app/plugins/PluginsList.en.json
@@ -1,4 +1,5 @@
 {
+  "workInProgressAlertTitle": "Work in progress",
   "workInProgressAlert": "This feature is still under development and will be available soon.",
   "title": "Installed Plugins",
   "uploadButton": "Upload Plugin",

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -4,7 +4,6 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
-  AlertIndicator,
   AlertTitle,
   Button,
   Card,
@@ -29,7 +28,8 @@ import {
   Tooltip,
   TooltipContent,
 } from '@heroui/react';
-import { AlertTriangleIcon, Trash2, Upload } from 'lucide-react';
+import { Trash2, Upload } from 'lucide-react';
+import { AlertStatusIcon } from '../../components/AlertStatusIcon';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { UploadPluginModal } from './UploadPluginModal';
 import { useToastMessage } from '../../components/toastProvider';
@@ -89,12 +89,10 @@ export function PluginsList() {
   return (
     <>
       <Alert status="danger" className="mb-4" data-cy="plugins-list-work-in-progress-alert">
-        <AlertIndicator>
-          <AlertTriangleIcon />
-        </AlertIndicator>
+        <AlertStatusIcon status="danger" />
         <AlertContent>
-          <AlertTitle>{t('workInProgressAlertTitle')}</AlertTitle>
-          <AlertDescription>{t('workInProgressAlert')}</AlertDescription>
+          <AlertTitle>{t('workInProgressTitle')}</AlertTitle>
+          <AlertDescription>{t('workInProgress')}</AlertDescription>
         </AlertContent>
       </Alert>
       <Card className="w-full" data-cy="plugins-list-card">

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -4,6 +4,8 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
+  AlertIndicator,
+  AlertTitle,
   Button,
   Card,
   CardContent,
@@ -27,7 +29,7 @@ import {
   Tooltip,
   TooltipContent,
 } from '@heroui/react';
-import { Trash2, Upload } from 'lucide-react';
+import { AlertTriangleIcon, Trash2, Upload } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { UploadPluginModal } from './UploadPluginModal';
 import { useToastMessage } from '../../components/toastProvider';
@@ -87,7 +89,11 @@ export function PluginsList() {
   return (
     <>
       <Alert status="danger" className="mb-4" data-cy="plugins-list-work-in-progress-alert">
+        <AlertIndicator>
+          <AlertTriangleIcon />
+        </AlertIndicator>
         <AlertContent>
+          <AlertTitle>{t('workInProgressAlertTitle')}</AlertTitle>
           <AlertDescription>{t('workInProgressAlert')}</AlertDescription>
         </AlertContent>
       </Alert>

--- a/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
-  AlertIndicator,
   Button,
   Form,
   Modal,
@@ -25,7 +24,7 @@ import {
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
-import { AlertCircleIcon } from 'lucide-react';
+import { AlertStatusIcon } from '../../../../../components/AlertStatusIcon';
 
 interface Props {
   resourceId: number;
@@ -104,9 +103,7 @@ export function MarkDoneModal(props: Props) {
                       />
                       {error ? (
                         <Alert status="danger">
-                          <AlertIndicator>
-                            <AlertCircleIcon />
-                          </AlertIndicator>
+                          <AlertStatusIcon status="danger" />
                           <AlertContent>
                             <AlertDescription>{(error as Error).message}</AlertDescription>
                           </AlertContent>

--- a/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
+  AlertIndicator,
   Button,
   Form,
   Modal,
@@ -24,6 +25,7 @@ import {
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
+import { AlertCircleIcon } from 'lucide-react';
 
 interface Props {
   resourceId: number;
@@ -102,6 +104,9 @@ export function MarkDoneModal(props: Props) {
                       />
                       {error ? (
                         <Alert status="danger">
+                          <AlertIndicator>
+                            <AlertCircleIcon />
+                          </AlertIndicator>
                           <AlertContent>
                             <AlertDescription>{(error as Error).message}</AlertDescription>
                           </AlertContent>

--- a/apps/frontend/src/app/resources/usage/components/IntroductionRequiredDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/IntroductionRequiredDisplay/index.tsx
@@ -1,5 +1,5 @@
-import { Alert, AlertContent, AlertDescription, Separator, Spinner } from '@heroui/react';
-import { Users } from 'lucide-react';
+import { Alert, AlertContent, AlertDescription, AlertIndicator, Separator, Spinner } from '@heroui/react';
+import { AlertTriangleIcon, Users } from 'lucide-react';
 import { useTranslations, AttraccessUser } from '@attraccess/plugins-frontend-ui';
 import { useAccessControlServiceResourceIntroducersGetMany } from '@attraccess/react-query-client';
 import en from './translations/en.json';
@@ -28,6 +28,9 @@ export function IntroductionRequiredDisplay({ resourceId }: Readonly<Introductio
   return (
     <div className="space-y-4">
       <Alert status="warning">
+        <AlertIndicator>
+          <AlertTriangleIcon />
+        </AlertIndicator>
         <AlertContent>
           <AlertDescription>{t('needsIntroduction')}</AlertDescription>
         </AlertContent>

--- a/apps/frontend/src/app/resources/usage/components/IntroductionRequiredDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/IntroductionRequiredDisplay/index.tsx
@@ -1,5 +1,6 @@
-import { Alert, AlertContent, AlertDescription, AlertIndicator, Separator, Spinner } from '@heroui/react';
-import { AlertTriangleIcon, Users } from 'lucide-react';
+import { Alert, AlertContent, AlertDescription, Separator, Spinner } from '@heroui/react';
+import { Users } from 'lucide-react';
+import { AlertStatusIcon } from '../../../../../components/AlertStatusIcon';
 import { useTranslations, AttraccessUser } from '@attraccess/plugins-frontend-ui';
 import { useAccessControlServiceResourceIntroducersGetMany } from '@attraccess/react-query-client';
 import en from './translations/en.json';
@@ -28,9 +29,7 @@ export function IntroductionRequiredDisplay({ resourceId }: Readonly<Introductio
   return (
     <div className="space-y-4">
       <Alert status="warning">
-        <AlertIndicator>
-          <AlertTriangleIcon />
-        </AlertIndicator>
+        <AlertStatusIcon status="warning" />
         <AlertContent>
           <AlertDescription>{t('needsIntroduction')}</AlertDescription>
         </AlertContent>

--- a/apps/frontend/src/app/unauthorized/ssoLinkingRequiredModal/index.tsx
+++ b/apps/frontend/src/app/unauthorized/ssoLinkingRequiredModal/index.tsx
@@ -1,4 +1,5 @@
-import { Alert, AlertContent, AlertDescription, Button, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertIndicator, Button, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader } from '@heroui/react';
+import { AlertTriangleIcon } from 'lucide-react';
 import { PageHeader } from '../../../components/pageHeader';
 import { useTranslations, useUrlQuery } from '@attraccess/plugins-frontend-ui';
 import { PasswordInput } from '../../../components/PasswordInput';
@@ -108,6 +109,9 @@ export function SSOLinkingRequiredModal(props: Props) {
 
         <ModalBody>
           <Alert status="warning">
+            <AlertIndicator>
+              <AlertTriangleIcon />
+            </AlertIndicator>
             <AlertContent>
               <AlertDescription>{t('description', { email })}</AlertDescription>
             </AlertContent>

--- a/apps/frontend/src/app/unauthorized/ssoLinkingRequiredModal/index.tsx
+++ b/apps/frontend/src/app/unauthorized/ssoLinkingRequiredModal/index.tsx
@@ -1,5 +1,5 @@
-import { Alert, AlertContent, AlertDescription, AlertIndicator, Button, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader } from '@heroui/react';
-import { AlertTriangleIcon } from 'lucide-react';
+import { Alert, AlertContent, AlertDescription, Button, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader } from '@heroui/react';
+import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 import { PageHeader } from '../../../components/pageHeader';
 import { useTranslations, useUrlQuery } from '@attraccess/plugins-frontend-ui';
 import { PasswordInput } from '../../../components/PasswordInput';
@@ -109,9 +109,7 @@ export function SSOLinkingRequiredModal(props: Props) {
 
         <ModalBody>
           <Alert status="warning">
-            <AlertIndicator>
-              <AlertTriangleIcon />
-            </AlertIndicator>
+            <AlertStatusIcon status="warning" />
             <AlertContent>
               <AlertDescription>{t('description', { email })}</AlertDescription>
             </AlertContent>

--- a/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
@@ -8,7 +8,6 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
-  AlertIndicator,
   Button,
   InputGroup,
   Label,
@@ -31,7 +30,8 @@ import {
 } from '@heroui/react';
 import { EmptyState } from '../../../components/emptyState';
 import { PageHeader } from '../../../components/pageHeader';
-import { AlertTriangleIcon, PlusIcon, Settings2Icon, Trash2Icon } from 'lucide-react';
+import { PlusIcon, Settings2Icon, Trash2Icon } from 'lucide-react';
+import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import en from './en.json';
 import de from './de.json';
@@ -134,9 +134,7 @@ export function AllowedSignupDomainsEditorModal(props: Props) {
 
                   <ModalBody>
                     <Alert status="warning" className="whitespace-pre-wrap">
-                      <AlertIndicator>
-                        <AlertTriangleIcon />
-                      </AlertIndicator>
+                      <AlertStatusIcon status="warning" />
                       <AlertContent>
                         <AlertDescription>{t('noteAboutNoneAndWildcard')}</AlertDescription>
                       </AlertContent>

--- a/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
@@ -8,6 +8,7 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
+  AlertIndicator,
   Button,
   InputGroup,
   Label,
@@ -30,7 +31,7 @@ import {
 } from '@heroui/react';
 import { EmptyState } from '../../../components/emptyState';
 import { PageHeader } from '../../../components/pageHeader';
-import { PlusIcon, Settings2Icon, Trash2Icon } from 'lucide-react';
+import { AlertTriangleIcon, PlusIcon, Settings2Icon, Trash2Icon } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import en from './en.json';
 import de from './de.json';
@@ -133,6 +134,9 @@ export function AllowedSignupDomainsEditorModal(props: Props) {
 
                   <ModalBody>
                     <Alert status="warning" className="whitespace-pre-wrap">
+                      <AlertIndicator>
+                        <AlertTriangleIcon />
+                      </AlertIndicator>
                       <AlertContent>
                         <AlertDescription>{t('noteAboutNoneAndWildcard')}</AlertDescription>
                       </AlertContent>

--- a/apps/frontend/src/components/AlertStatusIcon.tsx
+++ b/apps/frontend/src/components/AlertStatusIcon.tsx
@@ -1,0 +1,25 @@
+import { AlertIndicator } from '@heroui/react';
+import { AlertCircleIcon, AlertTriangleIcon, CheckCircle2Icon, InfoIcon } from 'lucide-react';
+
+type AlertStatus = 'default' | 'accent' | 'success' | 'warning' | 'danger';
+
+const iconByStatus = {
+  default: InfoIcon,
+  accent: InfoIcon,
+  success: CheckCircle2Icon,
+  warning: AlertTriangleIcon,
+  danger: AlertCircleIcon,
+} as const;
+
+interface Props {
+  status: AlertStatus;
+}
+
+export function AlertStatusIcon({ status }: Props) {
+  const Icon = iconByStatus[status];
+  return (
+    <AlertIndicator>
+      <Icon />
+    </AlertIndicator>
+  );
+}

--- a/apps/frontend/src/components/CommunityLicenseButton/index.tsx
+++ b/apps/frontend/src/components/CommunityLicenseButton/index.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
+  AlertIndicator,
   Button,
   Modal,
   ModalBackdrop,
@@ -12,7 +13,7 @@ import {
   ModalHeader,
   useOverlayState,
 } from '@heroui/react';
-import { HeartHandshakeIcon } from 'lucide-react';
+import { AlertTriangleIcon, HeartHandshakeIcon } from 'lucide-react';
 import { I18nTransComponent, useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
@@ -80,6 +81,9 @@ export function CommunityLicenseButton({ onAccept, isDisabled, ...rest }: Commun
                       />
                     </p>
                     <Alert status="warning">
+                      <AlertIndicator>
+                        <AlertTriangleIcon />
+                      </AlertIndicator>
                       <AlertContent>
                         <AlertDescription>{t('modal.commercialNotice')}</AlertDescription>
                       </AlertContent>

--- a/apps/frontend/src/components/CommunityLicenseButton/index.tsx
+++ b/apps/frontend/src/components/CommunityLicenseButton/index.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
-  AlertIndicator,
   Button,
   Modal,
   ModalBackdrop,
@@ -13,7 +12,8 @@ import {
   ModalHeader,
   useOverlayState,
 } from '@heroui/react';
-import { AlertTriangleIcon, HeartHandshakeIcon } from 'lucide-react';
+import { HeartHandshakeIcon } from 'lucide-react';
+import { AlertStatusIcon } from '../AlertStatusIcon';
 import { I18nTransComponent, useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
@@ -81,9 +81,7 @@ export function CommunityLicenseButton({ onAccept, isDisabled, ...rest }: Commun
                       />
                     </p>
                     <Alert status="warning">
-                      <AlertIndicator>
-                        <AlertTriangleIcon />
-                      </AlertIndicator>
+                      <AlertStatusIcon status="warning" />
                       <AlertContent>
                         <AlertDescription>{t('modal.commercialNotice')}</AlertDescription>
                       </AlertContent>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

- HeroUI v3 redesigned Alert: only `.alert__indicator` and `.alert__title` receive the status color. Alerts rendered with just `AlertContent`/`AlertDescription` looked like colorless white cards.
- Added `AlertIndicator` (Lucide icon) to every `warning`/`danger` Alert site in `apps/frontend/src` that was missing one — 11 files, ~12 Alerts.
- For the three "work in progress" banners (`NfcCardList`, `AttractapList`, `PluginsList`) also added `AlertTitle` (+ a new `workInProgressTitle` translation key in `en`/`de`) per the issue spec.
- Default/success Alerts left untouched; sites that already render an `AlertTitle` were left untouched — they already get a color cue from `.alert__title`.

## Acceptance criteria

- [x] Warning alerts visibly orange (icon at minimum, icon + title on WIP banners)
- [x] Danger alerts visibly red
- [x] No regression in other Alert usages — change is additive only

## Linear

- [ATT-287](https://linear.app/attraccess/issue/ATT-287/fixfrontend-heroui-v3-alert-renders-white-add-alertindicator)

## Test plan

- [x] `pnpm nx typecheck frontend` — clean
- [x] `pnpm nx lint frontend` — clean
- [x] `pnpm nx test frontend` — 72/72 pass
- [ ] Manual: open `/attractap/nfc-cards`, `/attractap/readers`, `/plugins` — banners should be visibly orange / red (not white). Browser verification deferred — app requires auth + backend seed; markup matches the v3 spec in the issue and typecheck/lint/tests pass.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Ensure warning and danger alerts in the frontend use visual indicators consistent with the HeroUI v3 design.

Bug Fixes:
- Add status-specific AlertIndicator icons to warning and danger alerts that previously rendered as colorless cards.

Enhancements:
- Add AlertTitle headings and corresponding i18n keys for work-in-progress banners to improve visual prominence and clarity.