### PR TITLE
fix(frontend): grid usage session + billing side-by-side on md (ATT-288)

### DIFF
--- a/apps/frontend/src/app/resources/details/resourceDetails.tsx
+++ b/apps/frontend/src/app/resources/details/resourceDetails.tsx
@@ -192,26 +192,24 @@ function ResourceDetailsComponent() {
 
       <div className="w-full space-y-6 mb-6">
         <ResourceHealthWarning resourceId={resourceId} />
-        <div className="flex flex-row flex-wrap w-full gap-6 items-stretch">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
           <ResourceUsageSession
             resourceId={resourceId}
             resource={resource}
             data-cy="resource-usage-session"
-            className="flex-grow"
             insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
           />
           <ResourceBillingInfo
             resourceId={resourceId}
-            className="flex-grow"
             onExampleAmountChange={(value) => setInsufficientBalanceDesiredAmount(Math.ceil(value))}
           />
         </div>
 
-        <div className="flex flex-row flex-wrap w-full gap-6 items-stretch">
-          <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" className="flex-grow" />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
+          <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" />
 
           {maintenancePermissions?.canManage && (
-            <MaintenanceManagement resourceId={resourceId} className="flex-grow" />
+            <MaintenanceManagement resourceId={resourceId} />
           )}
         </div>
       </div>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
- Swap `flex flex-row flex-wrap` + per-child `flex-grow` for `grid grid-cols-1 md:grid-cols-2 gap-6` on `/resources/:id`, so usage session + billing cards sit 50/50 from md (>=768px) and stack vertically below
- Apply the same grid pattern to the history + maintenance management + maintenance schedules row
- Drop the now-redundant `className="flex-grow"` props on the affected children

## Acceptance
- [x] At 1024px viewport: usage session + payment render at ~50/50 (md grid active from 768px)
- [x] At 640px (sm) and below: stack vertically (grid-cols-1)

## Test plan
- [x] `pnpm nx run frontend:typecheck` — pass
- [x] `pnpm nx run frontend:lint` — pass (precommit ran full lint/typecheck/build/test)
- [ ] Manual viewport check at sm / md / lg breakpoints

Linear: [ATT-288](https://linear.app/attraccess/issue/ATT-288/design-resourcesid-usage-session-payment-side-by-side-on-md-screens)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->

## Summary by Sourcery

Switch resource details layout sections to a responsive two-column grid for medium screens while simplifying child component props.

Enhancements:
- Use a responsive grid layout for usage session and billing sections so they display side-by-side on medium viewports and stack on smaller screens.
- Align usage history and maintenance sections to the same responsive grid layout and remove now-unnecessary flex-grow class props from child components.