### PR TITLE
fix(frontend): add id to csv-export ListBoxItem for HeroUI v3 (ATT-298)

### DIFF
--- a/apps/frontend/src/app/csv-export/base-modal/index.tsx
+++ b/apps/frontend/src/app/csv-export/base-modal/index.tsx
@@ -132,7 +132,7 @@ export function BaseCsvExportModal<TData extends Row>(props: Props<TData>) {
             data-cy="resource-usage-export-columns-listbox"
           >
             {(column) => (
-              <ListBoxItem key={column.key} textValue={column.label}>
+              <ListBoxItem key={column.key} id={column.key} textValue={column.label}>
                 {column.label}
               </ListBoxItem>
             )}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

HeroUI v3 `ListBox` reads selection state from `id`, not React's `key`. Without `id`, `onSelectionChange` fires but `selectedColumnKeys` never updates — CSV export column selection is broken.

Fix: add `id={column.key}` to the `ListBoxItem` in `apps/frontend/src/app/csv-export/base-modal/index.tsx:135`.

Per the [v3 ListBox migration guide](https://heroui-git-docs-migration-heroui.vercel.app/docs/react/migration/listbox.mdx): use `id` for state/focus, `textValue` for accessibility, and keep `key` for React reconciliation.

## Linear

[ATT-298](https://linear.app/attraccess/issue/ATT-298/heroui-v3-listboxitem-missing-id-csv-export-base-modal)

## Test plan

- [ ] Open CSV export modal (resource usage)
- [ ] Select/deselect columns — verify `selectedColumnKeys` reflects the choices
- [ ] Confirm exported CSV contains only selected columns

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Fix CSV export modal column selection by assigning an id to each ListBoxItem so selection state updates properly.