### PR TITLE
fix(frontend): add id to AccordionItem in flows logViewer (ATT-297)

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
@@ -105,7 +105,7 @@ export function LogViewer(props: Props) {
 
                   <Accordion className="mt-2">
                     {logsOfRun.map((log) => (
-                      <AccordionItem key={`${runId}-${log.id}`}>
+                      <AccordionItem key={`${runId}-${log.id}`} id={`${runId}-${log.id}`}>
                         <AccordionHeading><AccordionTrigger>{log.title}</AccordionTrigger></AccordionHeading>
                         <AccordionPanel><AccordionBody>
                           {log.payload && (


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

HeroUI v3 collection items (Accordion, Dropdown, Listbox, Select, etc.) use `id` (and `textValue` when content is non-text) for selection/state identity — React's `key` is only for list reconciliation. Without `id`, the Accordion expand/collapse state in the flows `LogViewer` was unstable.

Adds `id={`${runId}-${log.id}`}` to the `AccordionItem` alongside the existing `key`.

```tsx
<AccordionItem key={`${runId}-${log.id}`} id={`${runId}-${log.id}`}>
```

## Acceptance

- [x] Each accordion item has both `key` (for React) and `id` (for v3 collection state)
- [x] Expand/collapse works correctly

Linear: [ATT-297](https://linear.app/attraccess/issue/ATT-297/heroui-v3-accordionitem-missing-id-flows-logviewer)

## Test plan

- [ ] Open a flow with logs in the resource details drawer
- [ ] Verify each log entry's accordion expands and collapses independently

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Add explicit ids to AccordionItem entries in the flows LogViewer so their expand/collapse state remains stable.