### PR TITLE
fix(frontend): wrap FirmwareSelector Card content in button for v3 (ATT-296)

### DIFF
--- a/apps/frontend/src/app/attractap/HardwareSetup/FirmwareSelector/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/FirmwareSelector/index.tsx
@@ -23,7 +23,7 @@ export function FirmwareSelector(props: Props) {
         <Card key={`${firmware.name}-${firmware.variant}`}>
           <button
             type="button"
-            className="w-full cursor-pointer text-left transition-colors hover:bg-default-100 active:bg-default-200"
+            className="w-full cursor-pointer text-left transition-colors hover:bg-default-100 active:bg-default-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             onClick={() => props.onSelect(firmware)}
           >
             <Card.Header>

--- a/apps/frontend/src/app/attractap/HardwareSetup/FirmwareSelector/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/FirmwareSelector/index.tsx
@@ -20,17 +20,23 @@ export function FirmwareSelector(props: Props) {
         </ProgressCircle>
       )}
       {firmwares?.map((firmware) => (
-        <Card onClick={() => props.onSelect(firmware)} key={`${firmware.name}-${firmware.variant}`}>
-          <Card.Header>
-            <PageHeader title={firmware.friendlyName} noMargin />
-          </Card.Header>
-          <Card.Content className="flex flex-wrap gap-2 flex-row">
-            {firmware.variantFriendlyName.split(',').map((variantFeature) => (
-              <Chip color="accent" key={`${firmware.name}-${firmware.variant}-${variantFeature}`}>
-                {variantFeature}
-              </Chip>
-            ))}
-          </Card.Content>
+        <Card key={`${firmware.name}-${firmware.variant}`}>
+          <button
+            type="button"
+            className="w-full cursor-pointer text-left transition-colors hover:bg-default-100 active:bg-default-200"
+            onClick={() => props.onSelect(firmware)}
+          >
+            <Card.Header>
+              <PageHeader title={firmware.friendlyName} noMargin />
+            </Card.Header>
+            <Card.Content className="flex flex-wrap gap-2 flex-row">
+              {firmware.variantFriendlyName.split(',').map((variantFeature) => (
+                <Chip color="accent" key={`${firmware.name}-${firmware.variant}-${variantFeature}`}>
+                  {variantFeature}
+                </Chip>
+              ))}
+            </Card.Content>
+          </button>
         </Card>
       ))}
     </div>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

HeroUI v3 `Card` no longer supports `onClick`, `isPressable`, or `onPress`. The v2 `<Card onClick=...>` in `FirmwareSelector` silently stopped firing, breaking firmware selection during hardware setup.

## Changes

- `apps/frontend/src/app/attractap/HardwareSetup/FirmwareSelector/index.tsx` — wrap `CardHeader` + `CardContent` in a native `<button type="button">` with `w-full cursor-pointer text-left` and a `hover:bg-default-100 active:bg-default-200` transition for the visual press state.

## Acceptance

- [x] Firmware cards trigger `onSelect` on press (button click handler).
- [x] Keyboard accessible — native `<button>` handles Enter/Space.
- [x] Visual hover/press states preserved via Tailwind utilities.

## Linear

[ATT-296](https://linear.app/attraccess/issue/ATT-296/heroui-v3-card-onclick-not-supported-firmwareselector)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->

## Summary by Sourcery

Restore click and keyboard interaction for firmware selection cards in the hardware setup flow by making the card contents a native button.

Bug Fixes:
- Fix firmware selection cards not triggering the onSelect handler after HeroUI v3 Card removed click support.

Enhancements:
- Improve accessibility and visual feedback of firmware selection cards by using a full-width button with hover and active states wrapping the card header and content.