### PR TITLE
fix(frontend): replace v2 fullWidth with className w-full (ATT-299)

### DIFF
--- a/apps/frontend/src/app/attractap/HardwareSetup/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/index.tsx
@@ -72,7 +72,7 @@ function Content(props: ContentProps) {
           </AlertContent>
         </Alert>
 
-        <Button variant="primary" onPress={() => espTools.current.connectToDevice()} fullWidth>
+        <Button variant="primary" onPress={() => espTools.current.connectToDevice()} className="w-full">
           {t('connect.button.label')}
         </Button>
       </div>

--- a/apps/frontend/src/app/confirm-delete-account/index.tsx
+++ b/apps/frontend/src/app/confirm-delete-account/index.tsx
@@ -106,7 +106,7 @@ export function ConfirmDeleteAccount() {
             <p className="text-sm text-gray-600 dark:text-gray-400 text-center">{t('success.message')}</p>
           </Card.Content>
           <Card.Footer>
-            <Button variant="primary" fullWidth onPress={() => navigate('/')} data-cy="confirm-delete-success-button">
+            <Button variant="primary" className="w-full" onPress={() => navigate('/')} data-cy="confirm-delete-success-button">
               {t('success.backToLogin')}
             </Button>
           </Card.Footer>
@@ -133,7 +133,7 @@ export function ConfirmDeleteAccount() {
           <Card.Footer className="flex flex-col gap-2">
             {allowRetry && (
               <Button variant="primary"
-                fullWidth
+                className="w-full"
                 onPress={() => confirm(true)}
                 isDisabled={confirmDelete.isPending}
                 data-cy="confirm-delete-error-try-again-button"
@@ -142,7 +142,7 @@ export function ConfirmDeleteAccount() {
               </Button>
             )}
             <Button variant="outline"
-              fullWidth
+              className="w-full"
               onPress={() => navigate('/')}
               data-cy="confirm-delete-error-back-button"
             >

--- a/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
@@ -113,7 +113,7 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
         placeholder={t('passwordPlaceholder')}
         value={formValues.password}
         onChange={(v: string) => setFormValues((p) => ({ ...p, password: v }))}
-        fullWidth
+        className="w-full"
         data-cy="create-mqtt-server-form-password-input"
         autoComplete="off"
       />

--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -163,7 +163,7 @@ export function EditMqttServerPage() {
                 placeholder={t('passwordPlaceholder')}
                 value={formValues.password}
                 onChange={(v: string) => setFormValues((p) => ({ ...p, password: v }))}
-                fullWidth
+                className="w-full"
                 data-cy="edit-mqtt-server-form-password-input"
                 autoComplete="off"
               />

--- a/apps/frontend/src/app/reset-password/resetPassword.tsx
+++ b/apps/frontend/src/app/reset-password/resetPassword.tsx
@@ -61,7 +61,7 @@ export function ResetPassword() {
           </Card.Content>
           <Card.Footer>
             <Button variant="primary"
-              fullWidth
+              className="w-full"
               onPress={() => navigate('/')}
               data-cy="reset-password-success-go-to-login-button"
             >
@@ -110,7 +110,7 @@ export function ResetPassword() {
           />
         </Card.Content>
         <Card.Footer>
-          <Button variant="primary" fullWidth type="submit" data-cy="reset-password-submit-button">
+          <Button variant="primary" className="w-full" type="submit" data-cy="reset-password-submit-button">
             {t('submit')}
           </Button>
         </Card.Footer>

--- a/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/index.tsx
@@ -128,7 +128,7 @@ export function ActiveSessionDisplay({ resourceId, startTime }: ActiveSessionDis
 
         <FlowButtons resourceId={resourceId} />
 
-        <ButtonGroup fullWidth>
+        <ButtonGroup className="w-full">
           <Button
             isPending={endSession.isPending}
             onPress={immediatelyEndSession}

--- a/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/index.tsx
@@ -202,7 +202,7 @@ export function OtherUserSessionDisplay({ resourceId }: OtherUserSessionDisplayP
         {canTakeover && (
           <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">{t('takeover.available')}</p>
-            <ButtonGroup fullWidth>
+            <ButtonGroup className="w-full">
               <Button
                 isPending={startSession.isPending}
                 onPress={handleImmediateTakeover}
@@ -231,7 +231,7 @@ export function OtherUserSessionDisplay({ resourceId }: OtherUserSessionDisplayP
         {canStopOtherUserSession && (
           <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">{t('stopOtherUserSession.available')}</p>
-            <ButtonGroup fullWidth>
+            <ButtonGroup className="w-full">
               <Button
                 isPending={startSession.isPending}
                 onPress={handleImmediateStopOtherUserSession}

--- a/apps/frontend/src/app/resources/usage/components/StartSessionControls/MachineStartControls.tsx
+++ b/apps/frontend/src/app/resources/usage/components/StartSessionControls/MachineStartControls.tsx
@@ -30,7 +30,7 @@ export function MachineStartControls({
         label={t('machine.project.label')}
         placeholder={t('machine.project.placeholder')}
       />
-      <ButtonGroup fullWidth>
+      <ButtonGroup className="w-full">
         <Button isPending={isStarting} onPress={onStart}><PlayIcon className="w-4 h-4" />
           {t('machine.startSession')}
         </Button>

--- a/apps/frontend/src/app/unauthorized/accessDenied.tsx
+++ b/apps/frontend/src/app/unauthorized/accessDenied.tsx
@@ -45,7 +45,7 @@ export const AccessDenied = memo(function AccessDeniedComponent() {
 
           <Button variant="primary"
             onPress={handleGoBack}
-            fullWidth
+            className="w-full"
             data-cy="access-denied-go-back-button"
           ><ArrowLeft className="w-4 h-4" />
             {t('goBack')}
@@ -53,7 +53,7 @@ export const AccessDenied = memo(function AccessDeniedComponent() {
 
           <Button variant="outline"
             onPress={handleGoHome}
-            fullWidth
+            className="w-full"
             data-cy="access-denied-go-home-button"
           ><Home className="w-4 h-4" />
             {t('goHome')}

--- a/apps/frontend/src/app/unauthorized/loginForm.tsx
+++ b/apps/frontend/src/app/unauthorized/loginForm.tsx
@@ -164,7 +164,7 @@ function LoginFormContent(props: LoginFormProps & { t: TFunction; tExists: TExis
       </div>
       <Button variant="primary"
         type="submit"
-        fullWidth
+        className="w-full"
         isPending={isPending}
         isDisabled={isPending}
         data-cy="login-form-sign-in-button"

--- a/apps/frontend/src/app/unauthorized/password-reset/passwordResetForm.tsx
+++ b/apps/frontend/src/app/unauthorized/password-reset/passwordResetForm.tsx
@@ -60,7 +60,7 @@ export function PasswordResetForm({ onGoBack }: PasswordResetFormProps) {
 
       <Button variant="primary"
         onPress={() => requestPasswordReset({ requestBody: { email } })}
-        fullWidth
+        className="w-full"
         isPending={isPending}
         isDisabled={isPending}
         data-cy="password-reset-form-submit-button"

--- a/apps/frontend/src/app/unauthorized/registrationForm.tsx
+++ b/apps/frontend/src/app/unauthorized/registrationForm.tsx
@@ -220,7 +220,7 @@ export function RegistrationForm({ onHasAccount }: RegisterFormProps) {
 
         <Button
           variant="primary"
-          fullWidth
+          className="w-full"
           type="submit"
           isPending={isPending}
           isDisabled={!canSubmit}

--- a/apps/frontend/src/app/unauthorized/ssoLogin.tsx
+++ b/apps/frontend/src/app/unauthorized/ssoLogin.tsx
@@ -22,7 +22,7 @@ function SSOLoginButton(props: Readonly<SSOLoginButtonProps>) {
   const loginHref = useCallbackURL(provider.id, provider.type);
 
   return (
-    <a href={loginHref} target="_self" className="w-full block" data-cy={`sso-login-button-${provider.name}`}>
+    <a href={loginHref} target="_self" className="block" data-cy={`sso-login-button-${provider.name}`}>
       <Button className="w-full">
         {t('loginWith', { provider: provider.name })}
       </Button>

--- a/apps/frontend/src/app/unauthorized/ssoLogin.tsx
+++ b/apps/frontend/src/app/unauthorized/ssoLogin.tsx
@@ -23,7 +23,7 @@ function SSOLoginButton(props: Readonly<SSOLoginButtonProps>) {
 
   return (
     <a href={loginHref} target="_self" className="w-full block" data-cy={`sso-login-button-${provider.name}`}>
-      <Button fullWidth>
+      <Button className="w-full">
         {t('loginWith', { provider: provider.name })}
       </Button>
     </a>

--- a/apps/frontend/src/app/verify-email/index.tsx
+++ b/apps/frontend/src/app/verify-email/index.tsx
@@ -83,7 +83,7 @@ export function VerifyEmail() {
             <p className="text-sm text-gray-600 dark:text-gray-400 text-center">{t('success.message')}</p>
           </Card.Content>
           <Card.Footer>
-            <Button variant="primary" fullWidth onPress={() => navigate('/')} data-cy="verify-email-success-login-button">
+            <Button variant="primary" className="w-full" onPress={() => navigate('/')} data-cy="verify-email-success-login-button">
               {t('success.goToLogin')}
             </Button>
           </Card.Footer>
@@ -111,7 +111,7 @@ export function VerifyEmail() {
           </Card.Content>
           <Card.Footer className="flex flex-col gap-2">
             <Button variant="primary"
-              fullWidth
+              className="w-full"
               onPress={activateEmail}
               isDisabled={verifyEmail.isPending}
               data-cy="verify-email-error-try-again-button"
@@ -119,7 +119,7 @@ export function VerifyEmail() {
               {t('error.tryAgain')}
             </Button>
             <Button variant="outline"
-              fullWidth
+              className="w-full"
               onPress={() => navigate('/')}
               data-cy="verify-email-error-back-to-login-button"
             >


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

HeroUI v3 removed the `fullWidth` prop on `Button` and `ButtonGroup` (and on the `TextField` base that `PasswordInput` extends). Under v3 the prop is a no-op / type error. This PR replaces every remaining `fullWidth` usage in the frontend with Tailwind `className="w-full"` so previously full-width controls keep rendering full width.

- 21 sites across 14 files updated (Button, ButtonGroup, and PasswordInput pass-through)
- No `fullWidth` prop remains in `apps/frontend` (verified with grep)
- `nx run frontend:typecheck` clean
- `nx run frontend:lint` clean

Linear: [ATT-299](https://linear.app/attraccess/issue/ATT-299/heroui-v3-replace-buttonbuttongroup-fullwidth-with-classnamew-full)

## Test plan
- [ ] Visual check: login form submit button renders full width
- [ ] Visual check: SSO login button renders full width
- [ ] Visual check: registration submit + accessDenied + password-reset + verify-email + confirm-delete buttons render full width
- [ ] Visual check: ActiveSession / OtherUserSession / MachineStart ButtonGroups span full row
- [ ] Visual check: Attractap HardwareSetup connect button full width
- [ ] Visual check: MQTT Create/Edit PasswordInput full width

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Enhancements:
- Ensure Buttons, ButtonGroups, and PasswordInput-based fields remain visually full width using `className="w-full"` in authentication, session management, MQTT, and hardware setup flows.