### PR TITLE
refactor(frontend): adopt Card compound subcomponents for HeroUI v3 (ATT-301)

### DIFF
--- a/apps/frontend/src/app/account/index.tsx
+++ b/apps/frontend/src/app/account/index.tsx
@@ -1,19 +1,5 @@
 import { PageHeader } from '../../components/pageHeader';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
-  useOverlayState,
-} from '@heroui/react';
+import { Button, Card, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, useOverlayState } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
@@ -61,35 +47,35 @@ export default function AccountPage() {
 
       <div className="flex flex-row flex-wrap gap-4">
         <Card className="max-w-md">
-          <CardHeader>
+          <Card.Header>
             <PageHeader title={t('sections.profile')} noMargin />
-          </CardHeader>
-          <CardContent className="flex flex-col gap-6">
+          </Card.Header>
+          <Card.Content className="flex flex-col gap-6">
             <EmailForm />
             <UsernameForm />
-          </CardContent>
+          </Card.Content>
         </Card>
 
         <Card className="max-w-md">
-          <CardHeader>
+          <Card.Header>
             <PageHeader title={t('sections.security')} noMargin />
-          </CardHeader>
-          <CardContent className="flex flex-col gap-6">
+          </Card.Header>
+          <Card.Content className="flex flex-col gap-6">
             {me && <SetPasswordForm userId={me.id} />}
             {me && <TwoFactorCard />}
-          </CardContent>
+          </Card.Content>
         </Card>
 
         <Card className="max-w-md">
-          <CardHeader>
+          <Card.Header>
             <PageHeader title={t('sections.dangerZone')} noMargin />
-          </CardHeader>
-          <CardContent className="flex flex-col gap-4">
+          </Card.Header>
+          <Card.Content className="flex flex-col gap-4">
             <p className="text-sm text-default-500">{t('deleteAccount.description')}</p>
             <Button variant="danger-soft" onPress={open} data-cy="delete-account-open-modal">
               {t('deleteAccount.actions.request')}
             </Button>
-          </CardContent>
+          </Card.Content>
         </Card>
       </div>
 

--- a/apps/frontend/src/app/attractap/AttractapList/index.tsx
+++ b/apps/frontend/src/app/attractap/AttractapList/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card, CardContent, CardHeader, Chip, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card, Chip, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { buttonVariants } from '@heroui/styles';
 import { ArrowRightIcon, CpuIcon, LogsIcon, MoreVertical, PencilIcon, Trash2Icon } from 'lucide-react';
 import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
@@ -163,14 +163,14 @@ export function AttractapList() {
       <div className="flex flex-col gap-4">
         {[activeReaders, staleReaders].map((readers, tableIndex) => (
           <Card key={tableIndex}>
-            <CardHeader>
+            <Card.Header>
               <PageHeader
                 noMargin
                 title={t(`table.${tableIndex === 0 ? 'active' : 'stale'}.title`)}
                 subtitle={t(`table.${tableIndex === 0 ? 'active' : 'stale'}.description`)}
               />
-            </CardHeader>
-            <CardContent>
+            </Card.Header>
+            <Card.Content>
               <Table
                 data-cy={`attractap-list-table-${tableIndex === 0 ? 'active' : 'stale'}`}
               >
@@ -220,7 +220,7 @@ export function AttractapList() {
                 </TableBody>
                 </TableContent>
               </Table>
-            </CardContent>
+            </Card.Content>
           </Card>
         ))}
       </div>

--- a/apps/frontend/src/app/attractap/HardwareSetup/FirmwareSelector/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/FirmwareSelector/index.tsx
@@ -1,5 +1,5 @@
 import { AttractapFirmware, useAttractapServiceGetFirmwares } from '@attraccess/react-query-client';
-import { Card, CardContent, CardHeader, Chip, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle } from "@heroui/react";
+import { Card, Chip, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle } from "@heroui/react";
 import { PageHeader } from '../../../../components/pageHeader';
 
 interface Props {
@@ -21,16 +21,16 @@ export function FirmwareSelector(props: Props) {
       )}
       {firmwares?.map((firmware) => (
         <Card onClick={() => props.onSelect(firmware)} key={`${firmware.name}-${firmware.variant}`}>
-          <CardHeader>
+          <Card.Header>
             <PageHeader title={firmware.friendlyName} noMargin />
-          </CardHeader>
-          <CardContent className="flex flex-wrap gap-2 flex-row">
+          </Card.Header>
+          <Card.Content className="flex flex-wrap gap-2 flex-row">
             {firmware.variantFriendlyName.split(',').map((variantFeature) => (
               <Chip color="accent" key={`${firmware.name}-${firmware.variant}-${variantFeature}`}>
                 {variantFeature}
               </Chip>
             ))}
-          </CardContent>
+          </Card.Content>
         </Card>
       ))}
     </div>

--- a/apps/frontend/src/app/balena/index.tsx
+++ b/apps/frontend/src/app/balena/index.tsx
@@ -1,6 +1,6 @@
 import { PageHeader } from '../../components/pageHeader';
 import { ComputerIcon, PowerIcon, RefreshCcwIcon } from 'lucide-react';
-import { Card, CardHeader, CardContent, Button } from '@heroui/react';
+import { Button, Card } from '@heroui/react';
 import { BalenaIcon } from './balena-icon';
 import { useSystemServiceRebootHost, useSystemServiceShutdownHost } from '@attraccess/react-query-client';
 import { useCallback, useEffect, useState } from 'react';
@@ -60,10 +60,10 @@ export function BalenaPage() {
 
       <div className="flex flex-row flex-wrap gap-4">
         <Card className="w-full">
-          <CardHeader>
+          <Card.Header>
             <PageHeader title="Host Machine" icon={<ComputerIcon />} />
-          </CardHeader>
-          <CardContent className="flex flex-col gap-4">
+          </Card.Header>
+          <Card.Content className="flex flex-col gap-4">
             {/* TODO(heroui-v3): map dynamic color/variant to new variant prop */}
             <Button
              
@@ -80,7 +80,7 @@ export function BalenaPage() {
             ><PowerIcon />
               {shutdownIsConfirmed ? 'Confirm Shutdown' : 'Shutdown'}
             </Button>
-          </CardContent>
+          </Card.Content>
         </Card>
       </div>
     </>

--- a/apps/frontend/src/app/billing/administration/billingFactor/index.tsx
+++ b/apps/frontend/src/app/billing/administration/billingFactor/index.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, CardContent, CardFooter, CardHeader, CardProps, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput } from "@heroui/react";
+import { Button, Card, CardProps, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput } from "@heroui/react";
 import { PageHeader } from '../../../../components/pageHeader';
 import { useToastMessage } from '../../../../components/toastProvider';
 import { HandCoinsIcon } from 'lucide-react';
@@ -73,11 +73,11 @@ export function ManageBillingFactorCard(props: Props & Omit<CardProps, 'children
 
   return (
     <Card {...cardProps}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<HandCoinsIcon />} noMargin />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent className="flex flex-col gap-4">
+      <Card.Content className="flex flex-col gap-4">
         <NumberField
           aria-label={t('inputs.amount')}
           value={value}
@@ -90,13 +90,13 @@ export function ManageBillingFactorCard(props: Props & Omit<CardProps, 'children
             <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
           </NumberFieldGroup>
         </NumberField>
-      </CardContent>
+      </Card.Content>
 
-      <CardFooter>
+      <Card.Footer>
         <Button variant="primary" onPress={handleUpdate} isPending={isChangingBillingFactor}>
           {t('actions.update')}
         </Button>
-      </CardFooter>
+      </Card.Footer>
     </Card>
   );
 }

--- a/apps/frontend/src/app/billing/administration/index.tsx
+++ b/apps/frontend/src/app/billing/administration/index.tsx
@@ -5,7 +5,7 @@ import de from './de.json';
 import { ManualTransactionsCard } from './manualTransactions';
 import { useState } from 'react';
 import { User } from '@attraccess/react-query-client';
-import { Button, Card, CardContent, CardHeader } from '@heroui/react';
+import { Button, Card } from '@heroui/react';
 import { useNavigate } from 'react-router-dom';
 import { SummaryCard } from '../dashboard/summary';
 import { SumUpIcon } from '../../../components/icons/sumup.icon';
@@ -33,12 +33,12 @@ export function BillingAdministrationPage() {
 
       <div className="flex flex-row flex-wrap gap-4">
         <Card className="flex-grow">
-          <CardHeader>
+          <Card.Header>
             <PageHeader title={t('inputs.user')} noMargin />
-          </CardHeader>
-          <CardContent>
+          </Card.Header>
+          <Card.Content>
             <UserSearch onSelectionChange={setUser} />
-          </CardContent>
+          </Card.Content>
         </Card>
 
         {user && (

--- a/apps/frontend/src/app/billing/administration/manualTransactions/index.tsx
+++ b/apps/frontend/src/app/billing/administration/manualTransactions/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardContent, CardFooter, CardHeader, CardProps, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput } from "@heroui/react";
+import { Button, Card, CardProps, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput } from "@heroui/react";
 import { PageHeader } from '../../../../components/pageHeader';
 import { HandCoinsIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -81,11 +81,11 @@ export function ManualTransactionsCard(props: Props & Omit<CardProps, 'children'
 
   return (
     <Card {...cardProps}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<HandCoinsIcon />} noMargin />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent className="flex flex-col gap-4">
+      <Card.Content className="flex flex-col gap-4">
         <NumberField aria-label={t('inputs.amount')} value={amount} onChange={(value) => setAmount(value)}>
           <NumberFieldGroup>
             <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
@@ -93,13 +93,13 @@ export function ManualTransactionsCard(props: Props & Omit<CardProps, 'children'
             <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
           </NumberFieldGroup>
         </NumberField>
-      </CardContent>
+      </Card.Content>
 
-      <CardFooter>
+      <Card.Footer>
         <Button variant="primary" onPress={handleCreateTransaction} isPending={isCreatingManualTransaction}>
           {t('actions.createTransaction')}
         </Button>
-      </CardFooter>
+      </Card.Footer>
     </Card>
   );
 }

--- a/apps/frontend/src/app/billing/administration/sumup/configuration/apiKey/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/apiKey/index.tsx
@@ -7,7 +7,7 @@ import {
   useBillingServiceGetSumUpReadersKey,
   useBillingServiceSetSumUpApiKey,
 } from '@attraccess/react-query-client';
-import { Button, Card, CardContent, CardHeader, Form, Chip, Spinner, Link, CardFooter, CardProps } from '@heroui/react';
+import { Button, Card, CardProps, Chip, Form, Link, Spinner } from '@heroui/react';
 import { PageHeader } from '../../../../../../components/pageHeader';
 import { PasswordInput } from '../../../../../../components/PasswordInput';
 import { useCallback, useRef, useState } from 'react';
@@ -76,7 +76,7 @@ export function ApiKeyCard(props: Omit<CardProps, 'children'>) {
 
   return (
     <Card {...props}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader
           icon={<WebhookIcon size={20} />}
           title={t('title')}
@@ -104,9 +104,9 @@ export function ApiKeyCard(props: Omit<CardProps, 'children'>) {
             </Chip>
           }
         />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent className="flex flex-col gap-2">
+      <Card.Content className="flex flex-col gap-2">
         <Form
           onSubmit={(e) => {
             e.preventDefault();
@@ -131,12 +131,12 @@ export function ApiKeyCard(props: Omit<CardProps, 'children'>) {
 
           <input type="submit" hidden />
         </Form>
-      </CardContent>
-      <CardFooter>
+      </Card.Content>
+      <Card.Footer>
         <Button variant="primary" onPress={onSubmitApiKey} isPending={isPendingSetSumUpApiKey}>
           {t('actions.save')}
         </Button>
-      </CardFooter>
+      </Card.Footer>
     </Card>
   );
 }

--- a/apps/frontend/src/app/billing/administration/sumup/configuration/currency/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/currency/index.tsx
@@ -7,7 +7,7 @@ import {
   useBillingServiceGetBillingConfigurationKey,
   useBillingServiceSetBillingConfiguration,
 } from '@attraccess/react-query-client';
-import { Button, Card, CardContent, CardHeader, Form, CardProps, CardFooter } from '@heroui/react';
+import { Button, Card, CardProps, Form } from '@heroui/react';
 import { PageHeader } from '../../../../../../components/pageHeader';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useToastMessage } from '../../../../../../components/toastProvider';
@@ -75,10 +75,10 @@ export function CurrencyCard(props: Omit<CardProps, 'children'>) {
 
   return (
     <Card {...props}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader icon={<EuroIcon size={20} />} title={t('title')} subtitle={t('subtitle')} noMargin />
-      </CardHeader>
-      <CardContent>
+      </Card.Header>
+      <Card.Content>
         <Form
           onSubmit={(e) => {
             e.preventDefault();
@@ -100,12 +100,12 @@ export function CurrencyCard(props: Omit<CardProps, 'children'>) {
           <input type="submit" hidden />
         </Form>
 
-        <CardFooter>
+        <Card.Footer>
           <Button variant="primary" onPress={onSubmitConfiguration} isPending={isPendingSetConfiguration}>
             {t('actions.save')}
           </Button>
-        </CardFooter>
-      </CardContent>
+        </Card.Footer>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/billing/administration/sumup/readers/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/readers/index.tsx
@@ -1,20 +1,7 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardProps,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableContent,
-  TableHeader,
-  TableRow,
-} from '@heroui/react';
+import { Button, Card, CardProps, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { PageHeader } from '../../../../../components/pageHeader';
 import { SmartphoneNfcIcon, Trash2Icon } from 'lucide-react';
 import {
@@ -40,7 +27,7 @@ export function SumUpReadersCard(props: Omit<CardProps, 'children'>) {
 
   return (
     <Card {...props}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader
           icon={<SmartphoneNfcIcon />}
           title={t('title')}
@@ -56,9 +43,9 @@ export function SumUpReadersCard(props: Omit<CardProps, 'children'>) {
             </SumUpReadersPairing>
           }
         />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent>
+      <Card.Content>
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
@@ -94,7 +81,7 @@ export function SumUpReadersCard(props: Omit<CardProps, 'children'>) {
           </TableBody>
           </TableContent>
         </Table>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/billing/dashboard/summary/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/index.tsx
@@ -1,22 +1,5 @@
 import { DateTimeDisplay, useNumberFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardProps,
-  Chip,
-  cn,
-  Skeleton,
-  Spinner,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableContent,
-  TableHeader,
-  TableRow,
-} from '@heroui/react';
+import { Button, Card, CardProps, Chip, cn, Skeleton, Spinner, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import de from './de.json';
 import en from './en.json';
@@ -158,10 +141,10 @@ export function SummaryCard(props: Omit<CardProps, 'children'> & Props) {
 
   return (
     <Card {...cardProps}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={t('title')} noMargin icon={<CreditCardIcon />} />
-      </CardHeader>
-      <CardContent>
+      </Card.Header>
+      <Card.Content>
         <div className="mb-4">
           {isLoadingBalance ? (
             <Spinner />
@@ -224,7 +207,7 @@ export function SummaryCard(props: Omit<CardProps, 'children'> & Props) {
             onClose={() => setIsOpenDetails(false)}
           />
         )}
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/billing/dashboard/topup/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/topup/index.tsx
@@ -1,7 +1,7 @@
 import { useNumberFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
-import { Alert, AlertContent, AlertTitle, Button, Card, CardContent, CardFooter, CardHeader, CardProps, Form, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, Spinner, cn } from '@heroui/react';
+import { Alert, AlertContent, AlertTitle, Button, Card, CardProps, cn, Form, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, Spinner } from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import { SumUpIcon } from '../../../../components/icons/sumup.icon';
 import {
@@ -118,12 +118,12 @@ export function BillingDashboardTopupCard(props: Props) {
   if (isLoadingSumUpConfiguration) {
     return (
       <Card {...cardProps} className={cn('max-w-full', cardProps.className)}>
-        <CardHeader>
+        <Card.Header>
           <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
-        </CardHeader>
-        <CardContent className="flex justify-center py-8">
+        </Card.Header>
+        <Card.Content className="flex justify-center py-8">
           <Spinner />
-        </CardContent>
+        </Card.Content>
       </Card>
     );
   }
@@ -131,10 +131,10 @@ export function BillingDashboardTopupCard(props: Props) {
   if (isSumUpConfigurationError || !sumUpConfiguration?.enabled) {
     return (
       <Card {...cardProps} className={cn('max-w-full', cardProps.className)}>
-        <CardHeader>
+        <Card.Header>
           <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
-        </CardHeader>
-        <CardContent>
+        </Card.Header>
+        <Card.Content>
           <Alert status={isSumUpConfigurationError ? 'danger' : 'warning'}
           >
             <AlertContent>
@@ -142,7 +142,7 @@ export function BillingDashboardTopupCard(props: Props) {
             </AlertContent>
             <p className="text-sm">{t('unavailable.description')}</p>
           </Alert>
-        </CardContent>
+        </Card.Content>
       </Card>
     );
   }
@@ -161,11 +161,11 @@ export function BillingDashboardTopupCard(props: Props) {
 
   return (
     <Card {...cardProps} className={cn('max-w-full', props.className)}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent>
+      <Card.Content>
         <Form
           onSubmit={(e) => {
             e.preventDefault();
@@ -204,9 +204,9 @@ export function BillingDashboardTopupCard(props: Props) {
             <p className="max-w-[600px] text-sm whitespace-pre-wrap text-wrap">{t('topUpInstructions.description')}</p>
           </Alert>
         </div>
-      </CardContent>
+      </Card.Content>
 
-      <CardFooter>
+      <Card.Footer>
         <Button variant="primary"
           onPress={onSubmit}
           isPending={isPendingTopUpWithSumUpReader}
@@ -214,7 +214,7 @@ export function BillingDashboardTopupCard(props: Props) {
         >
           {t('actions.topUp', { amount: formatNumber(amount), currency: configuration?.currency })}
         </Button>
-      </CardFooter>
+      </Card.Footer>
     </Card>
   );
 }

--- a/apps/frontend/src/app/billing/dashboard/topup/transactionProcessingStatus/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/topup/transactionProcessingStatus/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle } from "@heroui/react";
+import { Card, ProgressCircle, ProgressCircleFillCircle, ProgressCircleTrack, ProgressCircleTrackCircle } from "@heroui/react";
 import { PageHeader } from '../../../../../components/pageHeader';
 import { CheckCircle2Icon, XCircleIcon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
@@ -84,10 +84,10 @@ export function TransactionProcessingCard(props: Props) {
 
   return (
     <Card>
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={t('title')} subtitle={t('description')} noMargin />
-      </CardHeader>
-      <CardContent className="flex items-center justify-center">
+      </Card.Header>
+      <Card.Content className="flex items-center justify-center">
         {status === BillingTransactionStatus.PENDING && (
           <ProgressCircle
             value={COUNTER_MAX_VALUE - counter}
@@ -105,7 +105,7 @@ export function TransactionProcessingCard(props: Props) {
           <CheckCircle2Icon size={128} className="text-success animate-pulse" />
         )}
         {status === BillingTransactionStatus.FAILED && <XCircleIcon size={128} className="text-danger animate-pulse" />}
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/confirm-delete-account/index.tsx
+++ b/apps/frontend/src/app/confirm-delete-account/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useUrlQuery, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useNavigate } from 'react-router-dom';
 import { Loading } from '../loading';
-import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card, CardContent, CardFooter, CardHeader } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card } from '@heroui/react';
 import en from './en.json';
 import de from './de.json';
 import {
@@ -99,17 +99,17 @@ export function ConfirmDeleteAccount() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Card className="max-w-md w-full" data-cy="confirm-delete-success-card">
-          <CardHeader className="text-center">
+          <Card.Header className="text-center">
             <h2 className="text-3xl font-bold">{t('success.title')}</h2>
-          </CardHeader>
-          <CardContent>
+          </Card.Header>
+          <Card.Content>
             <p className="text-sm text-gray-600 dark:text-gray-400 text-center">{t('success.message')}</p>
-          </CardContent>
-          <CardFooter>
+          </Card.Content>
+          <Card.Footer>
             <Button variant="primary" fullWidth onPress={() => navigate('/')} data-cy="confirm-delete-success-button">
               {t('success.backToLogin')}
             </Button>
-          </CardFooter>
+          </Card.Footer>
         </Card>
       </div>
     );
@@ -119,18 +119,18 @@ export function ConfirmDeleteAccount() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Card className="max-w-md w-full" data-cy="confirm-delete-error-card">
-          <CardHeader className="text-center">
+          <Card.Header className="text-center">
             <h2 className="text-3xl font-bold">{t('error.title')}</h2>
-          </CardHeader>
-          <CardContent>
+          </Card.Header>
+          <Card.Content>
             <Alert status="danger" data-cy="confirm-delete-error-alert" >
               <AlertContent>
                 <AlertTitle>{t('error.errorTitle')}</AlertTitle>
                 <AlertDescription>{error}</AlertDescription>
               </AlertContent>
             </Alert>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-2">
+          </Card.Content>
+          <Card.Footer className="flex flex-col gap-2">
             {allowRetry && (
               <Button variant="primary"
                 fullWidth
@@ -148,7 +148,7 @@ export function ConfirmDeleteAccount() {
             >
               {t('error.backToLogin')}
             </Button>
-          </CardFooter>
+          </Card.Footer>
         </Card>
       </div>
     );

--- a/apps/frontend/src/app/csv-export/index.tsx
+++ b/apps/frontend/src/app/csv-export/index.tsx
@@ -1,20 +1,5 @@
 import { useDateTimeFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  DateValue,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalHeader,
-  RangeCalendar,
-  RangeValue,
-} from '@heroui/react';
+import { Button, Card, DateValue, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalHeader, RangeCalendar, RangeValue } from '@heroui/react';
 import de from './de.json';
 import en from './en.json';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -71,8 +56,8 @@ export function CsvExport() {
   return (
     <>
       <Card>
-        <CardHeader>{t('title')}</CardHeader>
-        <CardContent>
+        <Card.Header>{t('title')}</Card.Header>
+        <Card.Content>
           <span className="font-bold">{t('rangeCalendar.selection.label')}</span>
           <div className="flex gap-4 flex-row flex-wrap">
             <RangeCalendar
@@ -90,8 +75,8 @@ export function CsvExport() {
               {t('rangeCalendar.selection.end', { date: dateRangeEndFormatted })}
             </p>
           </div>
-        </CardContent>
-        <CardFooter>
+        </Card.Content>
+        <Card.Footer>
           {exportTypes.map((exportType) => (
             <Button
               key={exportType.key}
@@ -104,7 +89,7 @@ export function CsvExport() {
               {t(`exports.${exportType.key}.button`)}
             </Button>
           ))}
-        </CardFooter>
+        </Card.Footer>
       </Card>
 
       <Modal

--- a/apps/frontend/src/app/dependencies/index.tsx
+++ b/apps/frontend/src/app/dependencies/index.tsx
@@ -3,7 +3,7 @@ import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import de from './de.json';
 import en from './en.json';
 import { useQuery } from '@tanstack/react-query';
-import { Card, CardContent, CardFooter, Link, Skeleton } from '@heroui/react';
+import { Card, Link, Skeleton } from '@heroui/react';
 import { PageHeader } from '../../components/pageHeader';
 
 interface Dependency {
@@ -26,7 +26,7 @@ function getDomainFromUrl(url: string): string {
 function CardSkeleton() {
   return (
     <Card className="w-full">
-      <CardContent className="p-4">
+      <Card.Content className="p-4">
         <div className="space-y-3">
           <div>
             <Skeleton className="h-6 w-3/4 rounded-lg mb-2" />
@@ -45,10 +45,10 @@ function CardSkeleton() {
             </div>
           </div>
         </div>
-      </CardContent>
-      <CardFooter className="flex justify-end">
+      </Card.Content>
+      <Card.Footer className="flex justify-end">
         <Skeleton className="h-4 w-24 rounded-lg" />
-      </CardFooter>
+      </Card.Footer>
     </Card>
   );
 }
@@ -80,7 +80,7 @@ export function Dependencies() {
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-4">
           {dependencies?.map((dependency) => (
             <Card key={dependency.name} className="w-full">
-              <CardContent className="p-4">
+              <Card.Content className="p-4">
                 <div className="space-y-3">
                   <div>
                     <h3 className="text-lg font-semibold text-foreground">{dependency.name}</h3>
@@ -99,8 +99,8 @@ export function Dependencies() {
                     </div>
                   </div>
                 </div>
-              </CardContent>
-              <CardFooter className="flex justify-end">
+              </Card.Content>
+              <Card.Footer className="flex justify-end">
                 <Link
                   href={dependency.url}
                   target="_blank"
@@ -110,7 +110,7 @@ export function Dependencies() {
                 >
                   {getDomainFromUrl(dependency.url)}
                 </Link>
-              </CardFooter>
+              </Card.Footer>
             </Card>
           ))}
         </div>

--- a/apps/frontend/src/app/email-templates/edit/index.tsx
+++ b/apps/frontend/src/app/email-templates/edit/index.tsx
@@ -6,25 +6,7 @@ import {
   useEmailTemplatesServiceEmailTemplateControllerPreviewMjml,
   EmailTemplateType,
 } from '@attraccess/react-query-client';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  TextField,
-  Label,
-  Input,
-  Form,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
-  Link,
-} from '@heroui/react';
+import { Button, Card, Form, Input, Label, Link, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, TextField, useTheme } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PageHeader } from '../../../components/pageHeader';
 import Editor from '@monaco-editor/react';
@@ -32,7 +14,6 @@ import Editor from '@monaco-editor/react';
 import * as enTranslationsFile from './en.json';
 import * as deTranslationsFile from './de.json';
 import { useDebounce } from '../../../hooks/useDebounce';
-import { useTheme } from '@heroui/react';
 
 export function EditEmailTemplatePage() {
   const navigate = useNavigate();
@@ -147,11 +128,11 @@ export function EditEmailTemplatePage() {
       <Form onSubmit={onSubmit}>
         <div className="flex flex-col flex-wrap gap-4 w-full lg:flex-row">
           <Card className="flex-1">
-            <CardHeader className="flex flex-row justify-between">
+            <Card.Header className="flex flex-row justify-between">
               <span>{t('sections.template')}</span>
               <Button isIconOnly onPress={() => setEditorIsExpanded(true)} />
-            </CardHeader>
-            <CardContent className="flex flex-col gap-4">
+            </Card.Header>
+            <Card.Content className="flex flex-col gap-4">
               {editor}
 
               <Modal isOpen={editorIsExpanded} onOpenChange={setEditorIsExpanded}>
@@ -173,18 +154,18 @@ export function EditEmailTemplatePage() {
                   </ModalContainer>
                 </ModalBackdrop>
               </Modal>
-            </CardContent>
+            </Card.Content>
           </Card>
 
           <Card className="flex-1">
-            <CardHeader>{t('sections.preview')}</CardHeader>
-            <CardContent>
+            <Card.Header>{t('sections.preview')}</Card.Header>
+            <Card.Content>
               <iframe
                 srcDoc={previewHtml}
                 title={t('preview.iframeTitle')}
                 className="w-full h-full min-h-[435px] border-0"
               />
-            </CardContent>
+            </Card.Content>
           </Card>
         </div>
 

--- a/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, CardHeader, TextField, Label, Input, Checkbox, Form } from "@heroui/react";
+import { Button, Card, Checkbox, Form, Input, Label, TextField } from "@heroui/react";
 import { Select } from '../../../components/select';
 import { ArrowLeft } from 'lucide-react';
 import { PasswordInput } from '../../../components/PasswordInput';
@@ -185,7 +185,7 @@ export function CreateMqttServerPage(props?: Readonly<CreateMqttServerPageProps>
 
   return (
     <Card data-cy="create-mqtt-server-page-card">
-      <CardHeader>
+      <Card.Header>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <Button variant="ghost"
@@ -199,7 +199,7 @@ export function CreateMqttServerPage(props?: Readonly<CreateMqttServerPageProps>
             <h2>{t('addNewMqttServer')}</h2>
           </div>
         </div>
-      </CardHeader>
+      </Card.Header>
       <div style={{ padding: '1rem' }}>
         <CreateMqttServerForm {...props} onCancel={handleCancel} />
       </div>

--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, CardHeader, TextField, Label, Input, Checkbox, Spinner } from "@heroui/react";
+import { Button, Card, Checkbox, Input, Label, Spinner, TextField } from "@heroui/react";
 import { Select } from '../../../components/select';
 import { LabeledSwitch } from '../../../components/labeledSwitch';
 import { ArrowLeft } from 'lucide-react';
@@ -113,7 +113,7 @@ export function EditMqttServerPage() {
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">
       <Card data-cy="edit-mqtt-server-page-card">
-        <CardHeader>
+        <Card.Header>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
               <Button variant="ghost"
@@ -127,7 +127,7 @@ export function EditMqttServerPage() {
               <h2>{t('editMqttServer')}</h2>
             </div>
           </div>
-        </CardHeader>
+        </Card.Header>
         <div style={{ padding: '1rem' }}>
           <form onSubmit={handleSubmit} className="space-y-6" data-cy="edit-mqtt-server-form">
             <div className="space-y-4">

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -1,33 +1,6 @@
 import { usePluginsServiceDeletePlugin, usePluginsServiceGetPlugins } from '@attraccess/react-query-client';
 import { useState } from 'react';
-import {
-  Alert,
-  AlertContent,
-  AlertDescription,
-  AlertTitle,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Chip,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableContent,
-  TableHeader,
-  TableRow,
-  Tooltip,
-  TooltipContent,
-} from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card, Chip, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, Tooltip, TooltipContent } from '@heroui/react';
 import { Trash2, Upload } from 'lucide-react';
 import { AlertStatusIcon } from '../../components/AlertStatusIcon';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -96,7 +69,7 @@ export function PluginsList() {
         </AlertContent>
       </Alert>
       <Card className="w-full" data-cy="plugins-list-card">
-        <CardHeader className="flex justify-between items-center">
+        <Card.Header className="flex justify-between items-center">
           <h1 className="text-xl font-bold">{t('title')}</h1>
           <Button
             variant="primary"
@@ -106,8 +79,8 @@ export function PluginsList() {
             <Upload size={18} />
             {t('uploadButton')}
           </Button>
-        </CardHeader>
-        <CardContent>
+        </Card.Header>
+        <Card.Content>
           <Table data-cy="plugins-list-table">
             <TableContent aria-label="Plugins table">
             <TableHeader>
@@ -144,7 +117,7 @@ export function PluginsList() {
             </TableBody>
             </TableContent>
           </Table>
-        </CardContent>
+        </Card.Content>
 
         <Modal
           isOpen={deleteModalOpen}

--- a/apps/frontend/src/app/projects/details/components/projectSummaryCards/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectSummaryCards/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, Skeleton } from '@heroui/react';
+import { Card, Skeleton } from '@heroui/react';
 import { useTranslations, useNumberFormatter } from '@attraccess/plugins-frontend-ui';
 import { ActivityIcon, CircleDollarSignIcon, Clock3Icon } from 'lucide-react';
 import { useProjectsServiceGetProjectUsageStats } from '@attraccess/react-query-client';
@@ -50,14 +50,14 @@ export function ProjectSummaryCards({ projectId }: ProjectSummaryCardsProps) {
     <div className="grid gap-4 grid-cols-1 md:grid-cols-3">
       {cards.map((card) => (
         <Card key={card.key}>
-          <CardHeader className="flex items-center gap-4">
+          <Card.Header className="flex items-center gap-4">
             <IconWrapper>{card.icon}</IconWrapper>
             <div>
               <p className="text-sm font-semibold">{card.title}</p>
               <p className="text-xs text-default-500">{card.description}</p>
             </div>
-          </CardHeader>
-          <CardContent>
+          </Card.Header>
+          <Card.Content>
             {isLoading ? (
               <Skeleton className="h-6 w-24" />
             ) : card.value ? (
@@ -65,7 +65,7 @@ export function ProjectSummaryCards({ projectId }: ProjectSummaryCardsProps) {
             ) : (
               <p className="text-default-400 text-sm">{t('summary.empty')}</p>
             )}
-          </CardContent>
+          </Card.Content>
         </Card>
       ))}
     </div>

--- a/apps/frontend/src/app/projects/details/components/projectTeam/TeamInviteCard.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectTeam/TeamInviteCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardContent, CardHeader } from '@heroui/react';
+import { Button, Card } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { InviteProjectMemberModal } from '../inviteMemberModal';
 import { UserPlus2Icon } from 'lucide-react';
@@ -20,11 +20,11 @@ export function TeamInviteCard(props: Readonly<TeamInviteCardProps>) {
 
   return (
     <Card>
-      <CardHeader className="flex flex-col gap-2">
+      <Card.Header className="flex flex-col gap-2">
         <p className="text-large font-semibold">{t('sections.invite.title')}</p>
         <p className="text-small text-default-500">{t('sections.invite.description')}</p>
-      </CardHeader>
-      <CardContent>
+      </Card.Header>
+      <Card.Content>
         <InviteProjectMemberModal projectId={projectId}>
           {(onOpen) => (
             <Button variant="primary" onPress={onOpen}><UserPlus2Icon className="size-4" />
@@ -32,7 +32,7 @@ export function TeamInviteCard(props: Readonly<TeamInviteCardProps>) {
             </Button>
           )}
         </InviteProjectMemberModal>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/projects/details/components/projectTeam/TeamMembersCard.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectTeam/TeamMembersCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Button, Card, CardContent, CardHeader, Chip, Skeleton } from '@heroui/react';
+import { Button, Card, Chip, Skeleton } from '@heroui/react';
 import {
   ApiError,
   ProjectsServiceRemoveProjectMemberMutationResult,
@@ -107,10 +107,10 @@ export function TeamMembersCard(props: Readonly<TeamMembersCardProps>) {
 
   return (
     <Card>
-      <CardHeader>
+      <Card.Header>
         <p className="text-large font-semibold">{t('sections.members.title')}</p>
-      </CardHeader>
-      <CardContent className="space-y-4">
+      </Card.Header>
+      <Card.Content className="space-y-4">
         <div className="flex items-center justify-between gap-4 rounded-medium border border-default-200 p-3">
           {data?.owner ? <AttraccessUser user={data.owner} /> : <Skeleton className="h-10 w-full" />}
           <Chip color="accent" variant="soft">
@@ -118,7 +118,7 @@ export function TeamMembersCard(props: Readonly<TeamMembersCardProps>) {
           </Chip>
         </div>
         <div className="space-y-3">{memberRows}</div>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/projects/details/components/projectTeam/TeamPendingInvitesCard.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectTeam/TeamPendingInvitesCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Button, Card, CardContent, CardHeader, Chip, Skeleton } from '@heroui/react';
+import { Button, Card, Chip, Skeleton } from '@heroui/react';
 import {
   ApiError,
   ProjectInvitation,
@@ -117,15 +117,15 @@ export function TeamPendingInvitesCard(props: Readonly<TeamPendingInvitesCardPro
 
   return (
     <Card>
-      <CardHeader className="flex items-center justify-between gap-4">
+      <Card.Header className="flex items-center justify-between gap-4">
         <p className="text-large font-semibold">{t('sections.pending.title')}</p>
         <Chip variant="soft">
           {pendingInvitations.length}
         </Chip>
-      </CardHeader>
-      <CardContent>
+      </Card.Header>
+      <Card.Content>
         <div className="space-y-3">{content}</div>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/projects/details/components/projectUsageCharts/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectUsageCharts/index.tsx
@@ -1,16 +1,4 @@
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  Skeleton,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableContent,
-  TableHeader,
-  TableRow,
-} from '@heroui/react';
+import { Card, Skeleton, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { useMemo, useCallback, useEffect, useState } from 'react';
 import { useTranslations, useNumberFormatter, useDateTimeFormatter } from '@attraccess/plugins-frontend-ui';
 import { useProjectsServiceGetProjectUsageStats } from '@attraccess/react-query-client';
@@ -155,13 +143,13 @@ export function ProjectUsageCharts({ projectId }: ProjectUsageChartsProps) {
   return (
     <div className="grid gap-4 grid-cols-1 lg:grid-cols-2">
       <Card className="min-h-[360px]">
-        <CardHeader>
+        <Card.Header>
           <div>
             <p className="font-semibold">{t('charts.timeSeries.title')}</p>
             <p className="text-xs text-default-500">{t('charts.title')}</p>
           </div>
-        </CardHeader>
-        <CardContent className="h-[320px]">
+        </Card.Header>
+        <Card.Content className="h-[320px]">
           {isLoading ? (
             <Skeleton className="w-full h-full" />
           ) : chartData.length === 0 ? (
@@ -202,17 +190,17 @@ export function ProjectUsageCharts({ projectId }: ProjectUsageChartsProps) {
               </LineChart>
             </ResponsiveContainer>
           )}
-        </CardContent>
+        </Card.Content>
       </Card>
 
       <Card className="min-h-[360px]">
-        <CardHeader>
+        <Card.Header>
           <div>
             <p className="font-semibold">{t('charts.topResources.title')}</p>
             <p className="text-xs text-default-500">{t('charts.title')}</p>
           </div>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
+        </Card.Header>
+        <Card.Content className="flex flex-col gap-4">
           {isLoading ? (
             <>
               <Skeleton className="h-6 w-full" />
@@ -294,7 +282,7 @@ export function ProjectUsageCharts({ projectId }: ProjectUsageChartsProps) {
               </Table>
             </>
           )}
-        </CardContent>
+        </Card.Content>
       </Card>
     </div>
   );

--- a/apps/frontend/src/app/projects/details/components/projectUsageHistory/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectUsageHistory/index.tsx
@@ -1,16 +1,5 @@
 import { useState, useCallback } from 'react';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  Table,
-  TableContent,
-  TableHeader,
-  TableColumn,
-  TableBody,
-  TableRow,
-  TableCell,
-} from '@heroui/react';
+import { Card, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { DateTimeDisplay, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useProjectsServiceGetProjectUsageHistory, ResourceUsage } from '@attraccess/react-query-client';
 import en from './en.json';
@@ -54,15 +43,15 @@ export function ProjectUsageHistory({ projectId }: ProjectUsageHistoryProps) {
   return (
     <>
       <Card>
-        <CardHeader>
+        <Card.Header>
           <HistoryHeader
             title={t('history.title')}
             showAllUsers={false}
             setShowAllUsers={() => undefined}
             canManageResources={false}
           />
-        </CardHeader>
-        <CardContent>
+        </Card.Header>
+        <Card.Content>
           <Table data-cy="project-usage-history-table">
             <TableContent aria-label={t('history.title')}>
             <TableHeader>
@@ -102,7 +91,7 @@ export function ProjectUsageHistory({ projectId }: ProjectUsageHistoryProps) {
             </TableBody>
             </TableContent>
           </Table>
-        </CardContent>
+        </Card.Content>
       </Card>
 
       <UsageNotesModal isOpen={isModalOpen} onClose={closeModal} session={selectedSession} />

--- a/apps/frontend/src/app/projects/details/team/index.tsx
+++ b/apps/frontend/src/app/projects/details/team/index.tsx
@@ -1,4 +1,4 @@
-import { Skeleton, Card, CardContent } from '@heroui/react';
+import { Card, Skeleton } from '@heroui/react';
 import { useParams } from 'react-router-dom';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PageHeader } from '../../../../components/pageHeader';
@@ -47,9 +47,9 @@ export function ProjectTeamPage() {
       <div className="mt-6 space-y-6">
         {!isOwner && (
           <Card>
-            <CardContent>
+            <Card.Content>
               <p className="text-small text-default-500">{t('messages.ownerOnly')}</p>
-            </CardContent>
+            </Card.Content>
           </Card>
         )}
         <TeamInviteCard projectId={projectId} isOwner={isOwner} />

--- a/apps/frontend/src/app/projects/index.tsx
+++ b/apps/frontend/src/app/projects/index.tsx
@@ -15,7 +15,7 @@ import de from './de.json';
 import API_ERROR_TRANSLATIONS_EN from '../../global-translations/api-errors.en.json';
 import API_ERROR_TRANSLATIONS_DE from '../../global-translations/api-errors.de.json';
 import { PageHeader } from '../../components/pageHeader';
-import { Button, Card, CardContent, CardHeader, Chip, Skeleton } from '@heroui/react';
+import { Button, Card, Chip, Skeleton } from '@heroui/react';
 import { LabeledSwitch } from '../../components/labeledSwitch';
 import { FolderIcon, PlusIcon } from 'lucide-react';
 import { UpsertProjectModal } from './upsertModal';
@@ -220,11 +220,11 @@ export function ProjectsListPage() {
 
       {(isLoadingInvitations || hasInvitations) && (
         <Card className="mb-6">
-          <CardHeader className="flex flex-col items-start gap-1">
+          <Card.Header className="flex flex-col items-start gap-1">
             <p className="text-large font-semibold">{t('invitations.title')}</p>
             <p className="text-small text-default-500">{t('invitations.description')}</p>
-          </CardHeader>
-          <CardContent className="space-y-3">{invitationContent}</CardContent>
+          </Card.Header>
+          <Card.Content className="space-y-3">{invitationContent}</Card.Content>
         </Card>
       )}
 

--- a/apps/frontend/src/app/projects/projectCard/index.tsx
+++ b/apps/frontend/src/app/projects/projectCard/index.tsx
@@ -1,5 +1,5 @@
 import { Project } from '@attraccess/react-query-client';
-import { Card, CardContent, CardFooter, Chip, Link } from '@heroui/react';
+import { Card, Chip, Link } from '@heroui/react';
 import { filenameToUrl } from '../../../api';
 
 interface Props {
@@ -12,14 +12,14 @@ export function ProjectCard(props: Props) {
 
   return (
     <Link href={`/projects/${project.id}`} className="block"><Card>
-      <CardContent className="overflow-visible p-0">
+      <Card.Content className="overflow-visible p-0">
         <img
           alt={project.name}
           className="w-full object-cover h-[240px] hover:object-contain transition-all duration-300 rounded-lg shadow-sm"
           src={filenameToUrl(project.logo) || '/project-no-thumbnail.svg'}
         />
-      </CardContent>
-      <CardFooter className="flex-col items-start justify-start gap-2">
+      </Card.Content>
+      <Card.Footer className="flex-col items-start justify-start gap-2">
         <div className="flex w-full items-center justify-between gap-2">
           <b className="text-ellipsis overflow-hidden line-clamp-1">{project.name}</b>
           {project.archivedAt && (
@@ -31,7 +31,7 @@ export function ProjectCard(props: Props) {
         <p className="text-small leading-5 text-default-500 text-ellipsis overflow-hidden line-clamp-2 min-h-[2.5rem]">
           {project.description}
         </p>
-      </CardFooter>
+      </Card.Footer>
     </Card></Link>
   );
 }

--- a/apps/frontend/src/app/reset-password/resetPassword.tsx
+++ b/apps/frontend/src/app/reset-password/resetPassword.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useUrlQuery } from '@attraccess/plugins-frontend-ui';
 import { useNavigate } from 'react-router-dom';
 import { Loading } from '../loading';
-import { Button, Card, CardContent, CardFooter, CardHeader, Form } from '@heroui/react';
+import { Button, Card, Form } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PasswordInput } from '../../components/PasswordInput';
 import en from './en.json';
@@ -55,11 +55,11 @@ export function ResetPassword() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Card className="max-w-md w-full" data-cy="reset-password-success-card">
-          <CardHeader className="text-center">{t('success.title')}</CardHeader>
-          <CardContent>
+          <Card.Header className="text-center">{t('success.title')}</Card.Header>
+          <Card.Content>
             <p className="text-sm text-gray-600 dark:text-gray-400 text-center">{t('success.message')}</p>
-          </CardContent>
-          <CardFooter>
+          </Card.Content>
+          <Card.Footer>
             <Button variant="primary"
               fullWidth
               onPress={() => navigate('/')}
@@ -67,7 +67,7 @@ export function ResetPassword() {
             >
               {t('success.goToLogin')}
             </Button>
-          </CardFooter>
+          </Card.Footer>
         </Card>
       </div>
     );
@@ -82,8 +82,8 @@ export function ResetPassword() {
         }}
         data-cy="reset-password-form"
       >
-        <CardHeader>{t('title')}</CardHeader>
-        <CardContent>
+        <Card.Header>{t('title')}</Card.Header>
+        <Card.Content>
           <PasswordInput
             label={t('inputs.password')}
             value={password}
@@ -108,12 +108,12 @@ export function ResetPassword() {
             data-cy="reset-password-confirm-password-input"
             autoComplete="new-password"
           />
-        </CardContent>
-        <CardFooter>
+        </Card.Content>
+        <Card.Footer>
           <Button variant="primary" fullWidth type="submit" data-cy="reset-password-submit-button">
             {t('submit')}
           </Button>
-        </CardFooter>
+        </Card.Footer>
       </Form>
     </Card>
   );

--- a/apps/frontend/src/app/resource-groups/GroupDetailsForm/index.tsx
+++ b/apps/frontend/src/app/resource-groups/GroupDetailsForm/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Card, CardHeader, CardContent, TextField, Label, Input, TextArea, Button, Spinner, CardProps } from '@heroui/react';
+import { Button, Card, CardProps, Input, Label, Spinner, TextArea, TextField } from '@heroui/react';
 import { Save, Edit3, Trash2Icon } from 'lucide-react';
 import {
   useResourcesServiceResourceGroupsGetOne,
@@ -98,12 +98,12 @@ export function GroupDetailsForm(props: Readonly<GroupDetailsFormProps & Omit<Ca
   if (isLoading) {
     return (
       <Card {...rest}>
-        <CardContent>
+        <Card.Content>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '32px 0' }}>
             <Spinner />
             <span style={{ marginLeft: '8px', opacity: 0.7 }}>{t('states.loading')}</span>
           </div>
-        </CardContent>
+        </Card.Content>
       </Card>
     );
   }
@@ -111,7 +111,7 @@ export function GroupDetailsForm(props: Readonly<GroupDetailsFormProps & Omit<Ca
   if (error || !group) {
     return (
       <Card {...rest}>
-        <CardContent>
+        <Card.Content>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <Edit3 size={20} color="red" />
             <div>
@@ -119,17 +119,17 @@ export function GroupDetailsForm(props: Readonly<GroupDetailsFormProps & Omit<Ca
               <p style={{ fontSize: '14px', opacity: 0.7 }}>{t('errors.load.description')}</p>
             </div>
           </div>
-        </CardContent>
+        </Card.Content>
       </Card>
     );
   }
 
   return (
     <Card {...rest}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={t('form.title')} subtitle={t('form.subtitle')} icon={<Edit3 size={20} />} noMargin={true} />
-      </CardHeader>
-      <CardContent>
+      </Card.Header>
+      <Card.Content>
         <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
           <TextField value={name} onChange={setName} isRequired>
             <Label>{t('form.fields.name.label')}</Label>
@@ -166,7 +166,7 @@ export function GroupDetailsForm(props: Readonly<GroupDetailsFormProps & Omit<Ca
             isDeleting={isDeleting}
           />
         </form>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resource-groups/IntroducerManagement/index.tsx
+++ b/apps/frontend/src/app/resource-groups/IntroducerManagement/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardProps } from '@heroui/react';
+import { Card, CardProps } from '@heroui/react';
 import { AlertCircle } from 'lucide-react';
 import {
   useAccessControlServiceResourceGroupIntroducersGetMany,
@@ -86,7 +86,7 @@ export function ResoureGroupIntroducerManagement(
   if (error) {
     return (
       <Card {...cardProps}>
-        <CardContent>
+        <Card.Content>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <AlertCircle size={20} color="red" />
             <div>
@@ -94,7 +94,7 @@ export function ResoureGroupIntroducerManagement(
               <p style={{ fontSize: '14px', opacity: 0.7 }}>{t('load.errorDescription')}</p>
             </div>
           </div>
-        </CardContent>
+        </Card.Content>
       </Card>
     );
   }

--- a/apps/frontend/src/app/resource-groups/IntroductionsManagement/index.tsx
+++ b/apps/frontend/src/app/resource-groups/IntroductionsManagement/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { Card, CardContent, CardProps, useOverlayState } from '@heroui/react';
+import { Card, CardProps, useOverlayState } from '@heroui/react';
 import { AlertCircle } from 'lucide-react';
 import {
   UseAccessControlServiceResourceGroupIntroductionsGetHistoryKeyFn,
@@ -115,7 +115,7 @@ export function ResourceGroupIntroductionsManagement(
   if (error) {
     return (
       <Card {...rest}>
-        <CardContent>
+        <Card.Content>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <AlertCircle size={20} color="red" />
             <div>
@@ -123,7 +123,7 @@ export function ResourceGroupIntroductionsManagement(
               <p style={{ fontSize: '14px', opacity: 0.7 }}>{t('loadErrorDescription')}</p>
             </div>
           </div>
-        </CardContent>
+        </Card.Content>
       </Card>
     );
   }

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
@@ -3,22 +3,7 @@ import {
   useResourcesServiceGetAllResources,
   useResourcesServiceResourceGroupsGetOne,
 } from '@attraccess/react-query-client';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardProps,
-  Skeleton,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableContent,
-  TableHeader,
-  TableRow,
-} from '@heroui/react';
+import { Button, Card, CardProps, Skeleton, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { EmptyState } from '../../../components/emptyState';
 import { PageHeader } from '../../../components/pageHeader';
 import { useMemo, useState } from 'react';
@@ -129,7 +114,7 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
 
   return (
     <Card aria-label={accessibleTitle} {...cardProps}>
-      <CardHeader className="flex flex-row justify-between">
+      <Card.Header className="flex flex-row justify-between">
         {groupIsFetched ? (
           <PageHeader title={title} subtitle={subtitle} noMargin />
         ) : (
@@ -143,9 +128,9 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
             aria-label={t('actions.openGroupSettings')}
           />
         )}
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent>
+      <Card.Content>
         <Table>
           <TableContent aria-label={tableAriaLabel}>
           <TableHeader>
@@ -184,13 +169,13 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
           </TableBody>
           </TableContent>
         </Table>
-      </CardContent>
+      </Card.Content>
 
-      <CardFooter className="flex w-full justify-center">
+      <Card.Footer className="flex w-full justify-center">
         {isFetchedResources && (
           <SimplePagination showControls page={page} total={totalPages} onChange={(page) => setPage(page)} />
         )}
-      </CardFooter>
+      </Card.Footer>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resources/IntroducerManagement/index.tsx
+++ b/apps/frontend/src/app/resources/IntroducerManagement/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardProps } from '@heroui/react';
+import { Card, CardProps } from '@heroui/react';
 import { AlertCircle } from 'lucide-react';
 import {
   useAccessControlServiceResourceIntroducersGetMany,
@@ -80,7 +80,7 @@ export function ResoureIntroducerManagement(
   if (error) {
     return (
       <Card {...rest}>
-        <CardContent>
+        <Card.Content>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <AlertCircle size={20} color="red" />
             <div>
@@ -88,7 +88,7 @@ export function ResoureIntroducerManagement(
               <p style={{ fontSize: '14px', opacity: 0.7 }}>{t('load.errorDescription')}</p>
             </div>
           </div>
-        </CardContent>
+        </Card.Content>
       </Card>
     );
   }

--- a/apps/frontend/src/app/resources/IntroductionsManagement/index.tsx
+++ b/apps/frontend/src/app/resources/IntroductionsManagement/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { Card, CardContent, CardProps, useOverlayState } from '@heroui/react';
+import { Card, CardProps, useOverlayState } from '@heroui/react';
 import { AlertCircle } from 'lucide-react';
 import {
   UseAccessControlServiceResourceIntroductionsGetHistoryKeyFn,
@@ -115,7 +115,7 @@ export function ResourceIntroductionsManagement(
   if (error) {
     return (
       <Card {...rest}>
-        <CardContent>
+        <Card.Content>
           <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <AlertCircle size={20} color="red" />
             <div>
@@ -123,7 +123,7 @@ export function ResourceIntroductionsManagement(
               <p style={{ fontSize: '14px', opacity: 0.7 }}>{t('loadErrorDescription')}</p>
             </div>
           </div>
-        </CardContent>
+        </Card.Content>
       </Card>
     );
   }

--- a/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
@@ -1,24 +1,5 @@
 import { ResourceFlowNodeDto, useBillingServiceGetBillingConfiguration } from '@attraccess/react-query-client';
-import {
-  Button,
-  Card,
-  CardContent,
-  TextField,
-  Label,
-  Input,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalHeader,
-  NumberField,
-  NumberFieldDecrementButton,
-  NumberFieldGroup,
-  NumberFieldIncrementButton,
-  NumberFieldInput,
-  TextArea,
-} from '@heroui/react';
+import { Button, Card, Input, Label, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalHeader, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, TextArea, TextField } from '@heroui/react';
 import { Select } from '../../../../../../../components/select';
 import { MqttServerSelect } from '../../../../../../../components/mqttServerSelect';
 import { LabeledSwitch } from '../../../../../../../components/labeledSwitch';
@@ -250,9 +231,9 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
         if (Object.entries((value ?? {}) as Record<string, unknown>)?.length === 0) {
           content = (
             <Card>
-              <CardContent>
+              <Card.Content>
                 <p className="text-sm text-gray-500">{t('nodes.' + nodeType + '.config.' + name + '.empty')}</p>
-              </CardContent>
+              </Card.Content>
             </Card>
           );
         } else {
@@ -319,9 +300,9 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
       if (arrayValue.length === 0) {
         content = (
           <Card>
-            <CardContent>
+            <Card.Content>
               <p className="text-sm text-gray-500">{emptyText}</p>
-            </CardContent>
+            </Card.Content>
           </Card>
         );
       } else {
@@ -329,7 +310,7 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
           <div className="flex flex-col gap-2 w-full">
             {arrayValue.map((row, index) => (
               <Card key={index} className="p-2 w-full">
-                <CardContent className="p-0">
+                <Card.Content className="p-0">
                   <div className="grid grid-cols-[1fr_auto] gap-2 items-start">
                     <div className="flex flex-col gap-2 p-2 w-full">
                       {items && items.type === 'object' && items.properties ? (
@@ -385,7 +366,7 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
                       </Button>
                     </div>
                   </div>
-                </CardContent>
+                </Card.Content>
               </Card>
             ))}
           </div>

--- a/apps/frontend/src/app/resources/details/flows/node/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/index.tsx
@@ -1,7 +1,7 @@
 import { ResourceFlowLogType, ResourceFlowNodeSchemaDto } from '@attraccess/react-query-client';
 
 import { NodeProps } from '@xyflow/react';
-import { Button, Card, CardContent, CardHeader, cn, Tooltip, TooltipContent, TooltipTrigger, useOverlayState } from '@heroui/react';
+import { Button, Card, cn, Tooltip, TooltipContent, TooltipTrigger, useOverlayState } from '@heroui/react';
 import { Handle, NodeToolbar, Position, useNodeId } from '@xyflow/react';
 import { Edit2Icon, Trash2Icon, TriangleAlertIcon } from 'lucide-react';
 import { useFlowContext } from '../flowContext';
@@ -177,7 +177,7 @@ export function AttraccessNode(props: Props) {
             </div>
           </NodeToolbar>
           <Card className={cardClasses} onDoubleClick={isEditable ? openEditor : undefined}>
-            <CardHeader className="flex flex-col gap-1">
+            <Card.Header className="flex flex-col gap-1">
               <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center min-w-0">
                   <span className="font-bold text-sm truncate">{t('nodes.' + schema.type + '.title')}</span>
@@ -213,10 +213,10 @@ export function AttraccessNode(props: Props) {
               {previewMode && (
                 <span className="text-xs text-default-500 text-wrap">{t('nodes.' + schema.type + '.description')}</span>
               )}
-            </CardHeader>
+            </Card.Header>
 
             {!previewMode && previewRows.length > 0 && (
-              <CardContent className="pt-0">
+              <Card.Content className="pt-0">
                 <div className="flex flex-col gap-2">
                   {previewRows.map((row) => (
                     <div className="flex flex-col gap-2" key={row.label}>
@@ -230,7 +230,7 @@ export function AttraccessNode(props: Props) {
                     </div>
                   ))}
                 </div>
-              </CardContent>
+              </Card.Content>
             )}
           </Card>
 

--- a/apps/frontend/src/app/resources/details/forms/FormEditorPage.tsx
+++ b/apps/frontend/src/app/resources/details/forms/FormEditorPage.tsx
@@ -12,24 +12,7 @@ import {
   UseResourceFormsServiceResourceFormsGetOneKeyFn,
   UseResourceFormsServiceResourceFormsListKeyFn,
 } from '@attraccess/react-query-client';
-import {
-  Accordion,
-  AccordionItem,
-  AccordionHeading,
-  AccordionTrigger,
-  AccordionPanel,
-  AccordionBody,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Separator,
-  TextField,
-  Label,
-  Input,
-  Selection,
-  Spinner,
-} from '@heroui/react';
+import { Accordion, AccordionBody, AccordionHeading, AccordionItem, AccordionPanel, AccordionTrigger, Button, Card, Input, Label, Selection, Separator, Spinner, TextField } from '@heroui/react';
 import { useToastMessage } from '../../../../components/toastProvider';
 import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { useQueryClient } from '@tanstack/react-query';
@@ -241,7 +224,7 @@ export function FormEditorPage() {
 
       <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
         <Card>
-          <CardContent className="space-y-6">
+          <Card.Content className="space-y-6">
             <div className="grid gap-4 md:grid-cols-2">
               <TextField
                 isRequired
@@ -331,16 +314,16 @@ export function FormEditorPage() {
                 {t('editor.save')}
               </Button>
             </div>
-          </CardContent>
+          </Card.Content>
         </Card>
 
         <Card>
-          <CardHeader>
+          <Card.Header>
             <p className="font-semibold text-default-700">{t('editor.previewTitle')}</p>
-          </CardHeader>
-          <CardContent>
+          </Card.Header>
+          <Card.Content>
             <FormPreview fields={form.fields} t={t} />
-          </CardContent>
+          </Card.Content>
         </Card>
       </div>
 

--- a/apps/frontend/src/app/resources/details/forms/FormListPage.tsx
+++ b/apps/frontend/src/app/resources/details/forms/FormListPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardContent, CardFooter, CardHeader, Chip, Spinner } from '@heroui/react';
+import { Button, Card, Chip, Spinner } from '@heroui/react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PageHeader } from '../../../../components/pageHeader';
@@ -58,7 +58,7 @@ export function FormListPage() {
               onClick={() => navigate(`/resources/${resourceId}/forms/${form.id}`)}
               className="border border-default-200 dark:border-default-100"
             >
-              <CardHeader className="flex flex-col items-start gap-2">
+              <Card.Header className="flex flex-col items-start gap-2">
                 <p className="text-base font-semibold text-default-700">{form.name}</p>
                 <div className="flex flex-wrap gap-2">
                   {form.isRequiredOnResourceUsageStart && (
@@ -77,14 +77,14 @@ export function FormListPage() {
                     </Chip>
                   )}
                 </div>
-              </CardHeader>
-              <CardContent>
+              </Card.Header>
+              <Card.Content>
                 <p className="text-sm text-default-500">{t('list.fieldCount', { count: form.fields.length })}</p>
-              </CardContent>
-              <CardFooter className="flex justify-between text-xs text-default-400">
+              </Card.Content>
+              <Card.Footer className="flex justify-between text-xs text-default-400">
                 <span>{t('list.updated')}</span>
                 <DateTimeDisplay date={form.updatedAt} />
-              </CardFooter>
+              </Card.Footer>
             </Card>
           ))}
         </div>

--- a/apps/frontend/src/app/resources/details/forms/components/FormPreview.tsx
+++ b/apps/frontend/src/app/resources/details/forms/components/FormPreview.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, Input, TextArea } from "@heroui/react";
+import { Card, Input, TextArea } from "@heroui/react";
 import { Select } from '../../../../../components/select';
 import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { FormFieldType } from '@attraccess/react-query-client';
@@ -13,9 +13,9 @@ export function FormPreview({ fields, t }: FormPreviewProps) {
   if (!fields.length) {
     return (
       <Card className="h-full">
-        <CardHeader>
+        <Card.Header>
           <p className="text-sm font-medium text-default-500">{t('preview.empty')}</p>
-        </CardHeader>
+        </Card.Header>
       </Card>
     );
   }
@@ -24,14 +24,14 @@ export function FormPreview({ fields, t }: FormPreviewProps) {
     <div className="space-y-4">
       {fields.map((field) => (
         <Card key={field.id ?? field.name}>
-          <CardHeader className="flex flex-col items-start gap-1 pb-0">
+          <Card.Header className="flex flex-col items-start gap-1 pb-0">
             <p className="text-base font-semibold text-default-700">
               {field.name}
               {field.isRequired && <span className="text-danger-500 ml-1">*</span>}
             </p>
             {field.description && <p className="text-sm text-default-500">{field.description}</p>}
-          </CardHeader>
-          <CardContent className="pt-2">{renderPreviewField(field, t)}</CardContent>
+          </Card.Header>
+          <Card.Content className="pt-2">{renderPreviewField(field, t)}</Card.Content>
         </Card>
       ))}
     </div>

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -1,18 +1,4 @@
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardProps,
-  cn,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableContent,
-  TableHeader,
-  TableRow,
-} from '@heroui/react';
+import { Button, Card, CardProps, cn, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import { MaintenanceReasonDisplay } from '../../../../components/MaintenanceReasonDisplay';
 import { LabeledSwitch } from '../../../../components/labeledSwitch';
@@ -72,7 +58,7 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children'>
 
   return (
     <Card {...cardProps}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader
           title={t('title')}
           icon={<ConstructionIcon />}
@@ -96,9 +82,9 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children'>
             </>
           }
         />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent>
+      <Card.Content>
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
@@ -160,7 +146,7 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children'>
           </TableBody>
           </TableContent>
         </Table>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resources/details/maintenance-schedules/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-schedules/index.tsx
@@ -1,17 +1,4 @@
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardProps,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableContent,
-  TableHeader,
-  TableRow,
-} from '@heroui/react';
+import { Button, Card, CardProps, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import {
   ResourceMaintenanceSchedule,
@@ -101,7 +88,7 @@ export function MaintenanceSchedules(props: Props & Omit<CardProps, 'children'>)
 
   return (
     <Card {...cardProps}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader
           title={t('title')}
           icon={<CalendarClockIcon />}
@@ -117,9 +104,9 @@ export function MaintenanceSchedules(props: Props & Omit<CardProps, 'children'>)
             </MaintenanceScheduleUpsertModal>
           }
         />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent>
+      <Card.Content>
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
@@ -167,7 +154,7 @@ export function MaintenanceSchedules(props: Props & Omit<CardProps, 'children'>)
           </TableBody>
           </TableContent>
         </Table>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardProps, Table, TableContent, TableHeader, TableBody, TableRow, TableCell, TableColumn, Button, cn, Skeleton, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput } from "@heroui/react";
+import { Button, Card, CardProps, cn, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, Skeleton, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from "@heroui/react";
 import { CreditCard, Edit2Icon } from 'lucide-react';
 import {
   useBillingServiceGetBillingBalance,
@@ -120,7 +120,7 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children'>) 
 
   return (
     <Card {...cardProps}>
-      <CardHeader className="flex items-center justify-between py-3">
+      <Card.Header className="flex items-center justify-between py-3">
         <PageHeader
           title={t('title')}
           icon={<CreditCard />}
@@ -133,9 +133,9 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children'>) 
           }
           noMargin
         />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent>
+      <Card.Content>
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
@@ -221,7 +221,7 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children'>) 
           </TableBody>
           </TableContent>
         </Table>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resources/documentation/DocumentationEditor.tsx
+++ b/apps/frontend/src/app/resources/documentation/DocumentationEditor.tsx
@@ -1,24 +1,6 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  TextField,
-  Label,
-  Input,
-  FieldError,
-  Radio,
-  RadioGroup,
-  Spinner,
-  Tab,
-  TabList,
-  TabPanel,
-  Tabs,
-  TextArea,
-} from '@heroui/react';
+import { Button, Card, FieldError, Input, Label, Radio, RadioGroup, Spinner, Tab, TabList, TabPanel, Tabs, TextArea, TextField } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { ArrowLeft, Save } from 'lucide-react';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -157,13 +139,13 @@ function DocumentationEditorComponent() {
   if (isResourceError) {
     return (
       <Card className="max-w-xl mx-auto my-8">
-        <CardHeader>
+        <Card.Header>
           <h2 className="text-xl">{t('error.title')}</h2>
-        </CardHeader>
-        <CardContent>
+        </Card.Header>
+        <Card.Content>
           <p className="text-danger">{resourceError instanceof Error ? resourceError.message : t('error.unknown')}</p>
-        </CardContent>
-        <CardFooter className="flex justify-center gap-4">
+        </Card.Content>
+        <Card.Footer className="flex justify-center gap-4">
           <Button variant="primary" onPress={() => refetchResource()} data-cy="documentation-editor-error-retry-button">
             {t('actions.retry')}
           </Button>
@@ -173,7 +155,7 @@ function DocumentationEditorComponent() {
           ><ArrowLeft size={16} />
             {t('actions.backToResources')}
           </Button>
-        </CardFooter>
+        </Card.Footer>
       </Card>
     );
   }
@@ -182,20 +164,20 @@ function DocumentationEditorComponent() {
   if (!resource) {
     return (
       <Card className="max-w-xl mx-auto my-8">
-        <CardHeader>
+        <Card.Header>
           <h2 className="text-xl">{t('notFound.title')}</h2>
-        </CardHeader>
-        <CardContent>
+        </Card.Header>
+        <Card.Content>
           <p>{t('notFound.message')}</p>
-        </CardContent>
-        <CardFooter className="justify-center">
+        </Card.Content>
+        <Card.Footer className="justify-center">
           <Button variant="secondary"
             onPress={() => navigate('/resources')}
             data-cy="documentation-editor-not-found-back-to-resources-button"
           ><ArrowLeft size={16} />
             {t('actions.backToResources')}
           </Button>
-        </CardFooter>
+        </Card.Footer>
       </Card>
     );
   }
@@ -218,7 +200,7 @@ function DocumentationEditorComponent() {
       />
 
       <Card className="mt-6">
-        <CardHeader>
+        <Card.Header>
           <RadioGroup
            
             orientation="horizontal"
@@ -234,8 +216,8 @@ function DocumentationEditorComponent() {
               {t('documentationType.url')}
             </Radio>
           </RadioGroup>
-        </CardHeader>
-        <CardContent>
+        </Card.Header>
+        <Card.Content>
           {documentationType === DocumentationType.MARKDOWN && (
             <Tabs
               selectedKey={selectedTab}
@@ -280,8 +262,8 @@ function DocumentationEditorComponent() {
               {validationErrors.url && <FieldError>{validationErrors.url}</FieldError>}
             </TextField>
           )}
-        </CardContent>
-        <CardFooter>
+        </Card.Content>
+        <Card.Footer>
           <div className="flex justify-end space-x-2">
             <Button variant="ghost"
               onPress={() => navigate(`/resources/${resourceId}`)}
@@ -298,7 +280,7 @@ function DocumentationEditorComponent() {
               {t('actions.save')}
             </Button>
           </div>
-        </CardFooter>
+        </Card.Footer>
       </Card>
     </div>
   );

--- a/apps/frontend/src/app/resources/documentation/DocumentationView.tsx
+++ b/apps/frontend/src/app/resources/documentation/DocumentationView.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Button, Card, CardContent, CardFooter, CardHeader, Spinner } from '@heroui/react';
+import { Button, Card, Spinner } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { ArrowLeft, Edit, RefreshCw } from 'lucide-react';
 import { PageHeader } from '../../../components/pageHeader';
@@ -49,13 +49,13 @@ function DocumentationViewComponent() {
   if (isResourceError) {
     return (
       <Card className="max-w-xl mx-auto my-8">
-        <CardHeader>
+        <Card.Header>
           <h2 className="text-xl">{t('error.title')}</h2>
-        </CardHeader>
-        <CardContent>
+        </Card.Header>
+        <Card.Content>
           <p className="text-danger">{resourceError instanceof Error ? resourceError.message : t('error.unknown')}</p>
-        </CardContent>
-        <CardFooter className="flex justify-center gap-4">
+        </Card.Content>
+        <Card.Footer className="flex justify-center gap-4">
           <Button variant="primary"
             onPress={() => refetchResource()}
             data-cy="documentation-view-error-retry-button"
@@ -68,7 +68,7 @@ function DocumentationViewComponent() {
           ><ArrowLeft size={16} />
             {t('actions.backToResources')}
           </Button>
-        </CardFooter>
+        </Card.Footer>
       </Card>
     );
   }
@@ -77,20 +77,20 @@ function DocumentationViewComponent() {
   if (!resource) {
     return (
       <Card className="max-w-xl mx-auto my-8">
-        <CardHeader>
+        <Card.Header>
           <h2 className="text-xl">{t('notFound.title')}</h2>
-        </CardHeader>
-        <CardContent>
+        </Card.Header>
+        <Card.Content>
           <p>{t('notFound.message')}</p>
-        </CardContent>
-        <CardFooter className="justify-center">
+        </Card.Content>
+        <Card.Footer className="justify-center">
           <Button variant="secondary"
             onPress={() => navigate('/resources')}
             data-cy="documentation-view-not-found-back-to-resources-button"
           ><ArrowLeft size={16} />
             {t('actions.backToResources')}
           </Button>
-        </CardFooter>
+        </Card.Footer>
       </Card>
     );
   }
@@ -124,10 +124,10 @@ function DocumentationViewComponent() {
       />
 
       <Card className="mt-6">
-        <CardHeader>
+        <Card.Header>
           <h2 className="text-xl font-semibold">{resource.name}</h2>
-        </CardHeader>
-        <CardContent className="relative">
+        </Card.Header>
+        <Card.Content className="relative">
           {isFetching && (
             <div className="absolute inset-0 bg-background/80 flex items-center justify-center z-10">
               <Spinner data-cy="documentation-view-fetching-spinner" />
@@ -150,7 +150,7 @@ function DocumentationViewComponent() {
               sandbox="allow-scripts allow-same-origin allow-forms"
             />
           )}
-        </CardContent>
+        </Card.Content>
       </Card>
     </div>
   );

--- a/apps/frontend/src/app/resources/groups/index.tsx
+++ b/apps/frontend/src/app/resources/groups/index.tsx
@@ -8,22 +8,7 @@ import {
   useResourcesServiceResourceGroupsGetMany,
   useResourcesServiceResourceGroupsRemoveResource,
 } from '@attraccess/react-query-client';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardProps,
-  Checkbox,
-  Link,
-  Table,
-  TableBody,
-  TableCell,
-  TableColumn,
-  TableContent,
-  TableHeader,
-  TableRow,
-} from '@heroui/react';
+import { Button, Card, CardProps, Checkbox, Link, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { EmptyState } from '../../../components/emptyState';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { GroupIcon, PlusIcon } from 'lucide-react';
@@ -124,7 +109,7 @@ export function ManageResourceGroups({
 
   return (
     <Card {...cardProps}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader
           title={t('title')}
           subtitle={t('subtitle')}
@@ -145,8 +130,8 @@ export function ManageResourceGroups({
             </ResourceGroupUpsertModal>
           }
         />
-      </CardHeader>
-      <CardContent>
+      </Card.Header>
+      <Card.Content>
         <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
@@ -180,7 +165,7 @@ export function ManageResourceGroups({
           </TableBody>
           </TableContent>
         </Table>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Card, CardContent, CardHeader, Spinner } from '@heroui/react';
+import { Card, Spinner } from '@heroui/react';
 import { Clock } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useAuth } from '../../../../../hooks/useAuth';
@@ -113,13 +113,13 @@ export function ResourceUsageSession({
 
   return (
     <Card {...rest}>
-      <CardHeader>
+      <Card.Header>
         <div className="flex items-center">
           <Clock className="w-5 h-5 mr-2" />
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{t('title.' + resource.type)}: </h3>
         </div>
-      </CardHeader>
-      <CardContent>{renderContent()}</CardContent>
+      </Card.Header>
+      <Card.Content>{renderContent()}</Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resources/usage/resourceUsageHistory.tsx
+++ b/apps/frontend/src/app/resources/usage/resourceUsageHistory.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useAuth } from '../../../hooks/useAuth';
-import { Card, CardHeader, CardContent } from '@heroui/react';
+import { Card } from '@heroui/react';
 import {
   ResourceUsage,
   useResourcesServiceResourceUsageUpdateSessionProject,
@@ -135,16 +135,16 @@ export function ResourceUsageHistory({ resourceId, ...rest }: ResourceUsageHisto
 
   return (
     <Card {...rest}>
-      <CardHeader className="flex justify-between items-center">
+      <Card.Header className="flex justify-between items-center">
         <HistoryHeader
           title={t('usageHistory')}
           showAllUsers={showAllUsers}
           setShowAllUsers={setShowAllUsers}
           canManageResources={canManageResources}
         />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent>
+      <Card.Content>
         <HistoryTable
           resourceId={resourceId}
           showAllUsers={showAllUsers}
@@ -155,7 +155,7 @@ export function ResourceUsageHistory({ resourceId, ...rest }: ResourceUsageHisto
           updatingSessionIds={updatingSessionIds}
           onProjectChange={handleProjectChange}
         />
-      </CardContent>
+      </Card.Content>
 
       <UsageNotesModal
         isOpen={isModalOpen}

--- a/apps/frontend/src/app/settings/cards/AppSettingsCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/AppSettingsCard/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, Chip } from '@heroui/react';
+import { Card, Chip } from '@heroui/react';
 import { CheckIcon, Settings2Icon, XIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PageHeader } from '../../../../components/pageHeader';
@@ -33,7 +33,7 @@ export function AppSettingsCard({ variant, onNext }: AppSettingsCardProps) {
 
   return (
     <Card className="flex-1 min-w-[300px]">
-      <CardHeader>
+      <Card.Header>
         <PageHeader
           title={t('title')}
           subtitle={t('subtitle')}
@@ -41,10 +41,10 @@ export function AppSettingsCard({ variant, onNext }: AppSettingsCardProps) {
           noMargin
           actions={licenseChip}
         />
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
         <AppSettingsForm variant={variant} endpoint="settings" onNext={onNext} />
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/settings/cards/MetricsSettingsCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/MetricsSettingsCard/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, Chip } from '@heroui/react';
+import { Card, Chip } from '@heroui/react';
 import { ActivityIcon, CheckIcon, XIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PageHeader } from '../../../../components/pageHeader';
@@ -24,7 +24,7 @@ export function MetricsSettingsCard() {
 
   return (
     <Card className="flex-1 min-w-[300px]">
-      <CardHeader>
+      <Card.Header>
         <PageHeader
           title={t('title')}
           subtitle={t('subtitle')}
@@ -32,10 +32,10 @@ export function MetricsSettingsCard() {
           noMargin
           actions={statusChip}
         />
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
         <MetricsSettingsForm />
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/settings/cards/SmtpSettingsCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/SmtpSettingsCard/index.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, Chip } from '@heroui/react';
+import { Card, Chip } from '@heroui/react';
 import { CheckIcon, MailIcon, XIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PageHeader } from '../../../../components/pageHeader';
@@ -33,7 +33,7 @@ export function SmtpSettingsCard({ variant, onNext }: SmtpSettingsCardProps) {
 
   return (
     <Card className="flex-1 min-w-[300px]">
-      <CardHeader>
+      <Card.Header>
         <PageHeader
           title={t('title')}
           subtitle={t('subtitle')}
@@ -41,10 +41,10 @@ export function SmtpSettingsCard({ variant, onNext }: SmtpSettingsCardProps) {
           noMargin
           actions={passwordChip}
         />
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4">
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
         <SmtpSettingsForm variant={variant} endpoint="settings" onNext={onNext} />
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
+++ b/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
@@ -1,41 +1,5 @@
 import React, { useState, forwardRef, useImperativeHandle, useCallback } from 'react';
-import {
-  Button,
-  Table,
-  TableHeader,
-  TableColumn,
-  TableBody,
-  TableRow,
-  TableCell,
-  TableContent,
-  Tooltip,
-  TooltipContent,
-  TextField,
-  Label,
-  Input,
-  InputGroup,
-  Description,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
-  Separator,
-  Card,
-  CardContent,
-  CardHeader,
-  Dropdown,
-  DropdownTrigger,
-  DropdownMenu,
-  DropdownItem,
-  DropdownPopover,
-  TextArea,
-  Link,
-  useOverlayState,
-} from '@heroui/react';
+import { Button, Card, Description, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Input, InputGroup, Label, Link, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, Separator, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, TextArea, TextField, Tooltip, TooltipContent, useOverlayState } from '@heroui/react';
 import { buttonVariants } from '@heroui/styles';
 import { Pencil, Trash, Key, FileCode, Eye, EyeOff, MoreVertical, Copy, Info } from 'lucide-react';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -1085,11 +1049,11 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
 
                       <Separator className="my-4" />
                       <Card className="border border-default-200" data-cy="sso-provider-form-setup-card">
-                        <CardHeader className="flex items-center gap-2">
+                        <Card.Header className="flex items-center gap-2">
                           <Info size={16} />
                           <span className="font-semibold">{t('setupInstructions')}</span>
-                        </CardHeader>
-                        <CardContent className="flex flex-col gap-3">
+                        </Card.Header>
+                        <Card.Content className="flex flex-col gap-3">
                           <p className="text-xs text-default-500">{t('setupInstructionsHint')}</p>
                           <div className="flex flex-col gap-3">
                             {!isSamlProvider && (
@@ -1152,7 +1116,7 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
                               <Link href={docsAuthentikPermissionsUrl}>{t('docsAuthentikPermissions')}</Link>
                             )}
                           </div>
-                        </CardContent>
+                        </Card.Content>
                       </Card>
                     </div>
                   </ModalBody>

--- a/apps/frontend/src/app/two-factor-gate/index.tsx
+++ b/apps/frontend/src/app/two-factor-gate/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardContent, CardHeader } from '@heroui/react';
+import { Button, Card } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { TwoFactorCard } from '../account/two-factor';
 import { useTwoFactorGate } from '../../hooks/useTwoFactorGate';
@@ -20,13 +20,13 @@ export function TwoFactorGate({ children }: TwoFactorGateProps) {
   return (
     <div className="flex w-full justify-center">
       <Card className="max-w-2xl w-full">
-        <CardHeader className="flex flex-col gap-2">
+        <Card.Header className="flex flex-col gap-2">
           <h2 className="text-2xl font-bold">{t('title')}</h2>
           <p className="text-sm text-default-500">
             {gate.needsTwoFactorSetup ? t('requiredDescription') : t('optionalDescription')}
           </p>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-6">
+        </Card.Header>
+        <Card.Content className="flex flex-col gap-6">
           <TwoFactorCard />
           {gate.canSkip && (
             <div className="flex justify-end">
@@ -35,7 +35,7 @@ export function TwoFactorGate({ children }: TwoFactorGateProps) {
               </Button>
             </div>
           )}
-        </CardContent>
+        </Card.Content>
       </Card>
     </div>
   );

--- a/apps/frontend/src/app/unauthorized/accessDenied.tsx
+++ b/apps/frontend/src/app/unauthorized/accessDenied.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { Button, Card, CardContent, CardFooter, CardHeader } from '@heroui/react';
+import { Button, Card } from '@heroui/react';
 import { ShieldX, ArrowLeft, Home } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -23,7 +23,7 @@ export const AccessDenied = memo(function AccessDeniedComponent() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen">
       <Card className="w-full max-w-md">
-        <CardHeader className="flex flex-col items-center justify-center">
+        <Card.Header className="flex flex-col items-center justify-center">
           {/* Icon */}
           <div className="flex justify-center mb-6">
             <div className="w-20 h-20 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center">
@@ -33,14 +33,14 @@ export const AccessDenied = memo(function AccessDeniedComponent() {
 
           {/* Title */}
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{t('title')}</h1>
-        </CardHeader>
+        </Card.Header>
 
-        <CardContent>
+        <Card.Content>
           {/* Description */}
           <p className="text-center text-gray-600 dark:text-gray-300 leading-relaxed">{t('description')}</p>
-        </CardContent>
+        </Card.Content>
 
-        <CardFooter className="flex flex-col gap-2">
+        <Card.Footer className="flex flex-col gap-2">
           {/* Action Buttons */}
 
           <Button variant="primary"
@@ -58,7 +58,7 @@ export const AccessDenied = memo(function AccessDeniedComponent() {
           ><Home className="w-4 h-4" />
             {t('goHome')}
           </Button>
-        </CardFooter>
+        </Card.Footer>
       </Card>
     </div>
   );

--- a/apps/frontend/src/app/user-management/details/components/permissionsForm/index.tsx
+++ b/apps/frontend/src/app/user-management/details/components/permissionsForm/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Card, CardHeader, CardContent, CardFooter } from '@heroui/react';
+import { Button, Card } from '@heroui/react';
 import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useToastMessage } from '../../../../../components/toastProvider';
@@ -116,11 +116,11 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
 
   return (
     <Card data-cy="user-permission-form-card">
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={t('title')} noMargin />
-      </CardHeader>
+      </Card.Header>
 
-      <CardContent className="flex flex-col gap-2">
+      <Card.Content className="flex flex-col gap-2">
         {isSsoManaged ? (
           <div
             className="rounded-md border border-warning-200 bg-warning-50 px-3 py-2 text-warning-700"
@@ -141,9 +141,9 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
             {t(`permissions.${permission}`)}
           </LabeledSwitch>
         ))}
-      </CardContent>
+      </Card.Content>
 
-      <CardFooter className="flex justify-end">
+      <Card.Footer className="flex justify-end">
         <Button variant="primary"
           onPress={handleSave}
           isPending={isSavingPermissions}
@@ -152,7 +152,7 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
         >
           {t('actions.save')}
         </Button>
-      </CardFooter>
+      </Card.Footer>
     </Card>
   );
 };

--- a/apps/frontend/src/app/user-management/details/index.tsx
+++ b/apps/frontend/src/app/user-management/details/index.tsx
@@ -19,22 +19,7 @@ import { ChangeEmailForm } from './components/changeEmail';
 
 import en from './en.json';
 import de from './de.json';
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Chip,
-  Separator,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  useOverlayState,
-} from '@heroui/react';
+import { Button, Card, Chip, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, Separator, useOverlayState } from '@heroui/react';
 import { useToastMessage } from '../../../components/toastProvider';
 import API_ERROR_TRANSLATIONS_EN from '../../../global-translations/api-errors.en.json';
 import API_ERROR_TRANSLATIONS_DE from '../../../global-translations/api-errors.de.json';
@@ -180,34 +165,34 @@ export function UserManagementDetailsPage() {
               />
             </div>
             <Card className="w-full">
-              <CardHeader>
+              <Card.Header>
                 <PageHeader title={t('profile.usernameTitle')} noMargin />
-              </CardHeader>
-              <CardContent className="flex flex-col gap-8">
+              </Card.Header>
+              <Card.Content className="flex flex-col gap-8">
                 <ChangeUsernameForm userId={user.id} />
-              </CardContent>
+              </Card.Content>
             </Card>
 
             <Card className="w-full">
-              <CardHeader>
+              <Card.Header>
                 <PageHeader title={t('profile.emailTitle')} noMargin />
-              </CardHeader>
-              <CardContent className="flex flex-col gap-8">
+              </Card.Header>
+              <Card.Content className="flex flex-col gap-8">
                 <ChangeEmailForm userId={user.id} />
-              </CardContent>
+              </Card.Content>
             </Card>
 
             <Card className="w-full">
-              <CardHeader>
+              <Card.Header>
                 <PageHeader title={t('profile.passwordTitle')} noMargin />
-              </CardHeader>
-              <CardContent className="flex flex-col gap-8">
+              </Card.Header>
+              <Card.Content className="flex flex-col gap-8">
                 <SetPasswordForm userId={user.id} />
-              </CardContent>
+              </Card.Content>
             </Card>
 
             <Card className="w-full">
-              <CardHeader className="flex items-center justify-between">
+              <Card.Header className="flex items-center justify-between">
                 <PageHeader title={t('sso.title')} noMargin />
                 <Chip
                   color={ssoDetails.length > 0 ? 'accent' : 'default'}
@@ -215,8 +200,8 @@ export function UserManagementDetailsPage() {
                 >
                   {ssoDetails.length > 0 ? t('sso.linked', { count: ssoDetails.length }) : t('sso.notLinkedChip')}
                 </Chip>
-              </CardHeader>
-              <CardContent>
+              </Card.Header>
+              <Card.Content>
                 {ssoDetails.length === 0 ? (
                   <div className="flex items-center gap-2">
                     <Chip color="default" variant="soft">
@@ -257,20 +242,20 @@ export function UserManagementDetailsPage() {
                     })}
                   </div>
                 )}
-              </CardContent>
+              </Card.Content>
             </Card>
 
             <Card className="w-full">
-              <CardHeader>
+              <Card.Header>
                 <PageHeader title={t('delete.title')} noMargin />
-              </CardHeader>
-              <CardContent className="flex flex-col gap-4">
+              </Card.Header>
+              <Card.Content className="flex flex-col gap-4">
                 <p className="text-sm text-default-500">{t('delete.description')}</p>
                 <Button variant="danger-soft" onPress={open} isDisabled={isSelf} data-cy="admin-delete-user-open-modal">
                   {t('delete.actions.open')}
                 </Button>
                 {isSelf ? <p className="text-xs text-default-400">{t('delete.selfDisabled')}</p> : null}
-              </CardContent>
+              </Card.Content>
             </Card>
           </>
         )}

--- a/apps/frontend/src/app/verify-email/index.tsx
+++ b/apps/frontend/src/app/verify-email/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useUrlQuery } from '@attraccess/plugins-frontend-ui';
 import { useNavigate } from 'react-router-dom';
 import { Loading } from '../loading';
-import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card, CardContent, CardFooter, CardHeader } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
@@ -76,17 +76,17 @@ export function VerifyEmail() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Card className="max-w-md w-full" data-cy="verify-email-success-card">
-          <CardHeader className="text-center">
+          <Card.Header className="text-center">
             <h2 className="text-3xl font-bold">{t('success.title')}</h2>
-          </CardHeader>
-          <CardContent>
+          </Card.Header>
+          <Card.Content>
             <p className="text-sm text-gray-600 dark:text-gray-400 text-center">{t('success.message')}</p>
-          </CardContent>
-          <CardFooter>
+          </Card.Content>
+          <Card.Footer>
             <Button variant="primary" fullWidth onPress={() => navigate('/')} data-cy="verify-email-success-login-button">
               {t('success.goToLogin')}
             </Button>
-          </CardFooter>
+          </Card.Footer>
         </Card>
       </div>
     );
@@ -96,10 +96,10 @@ export function VerifyEmail() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <Card className="max-w-md w-full" data-cy="verify-email-error-card">
-          <CardHeader className="text-center">
+          <Card.Header className="text-center">
             <h2 className="text-3xl font-bold">{t('error.title')}</h2>
-          </CardHeader>
-          <CardContent>
+          </Card.Header>
+          <Card.Content>
             <Alert status="danger"
               data-cy="verify-email-error-alert"
             >
@@ -108,8 +108,8 @@ export function VerifyEmail() {
                 <AlertDescription>{error}</AlertDescription>
               </AlertContent>
             </Alert>
-          </CardContent>
-          <CardFooter className="flex flex-col gap-2">
+          </Card.Content>
+          <Card.Footer className="flex flex-col gap-2">
             <Button variant="primary"
               fullWidth
               onPress={activateEmail}
@@ -125,7 +125,7 @@ export function VerifyEmail() {
             >
               {t('error.backToLogin')}
             </Button>
-          </CardFooter>
+          </Card.Footer>
         </Card>
       </div>
     );

--- a/apps/frontend/src/components/IntroducerManagement/index.tsx
+++ b/apps/frontend/src/components/IntroducerManagement/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Card, CardHeader, CardContent, CardProps } from '@heroui/react';
+import { Card, CardProps } from '@heroui/react';
 import { Trash2Icon, AwardIcon } from 'lucide-react';
 import { User, ResourceIntroducer } from '@attraccess/react-query-client';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -29,10 +29,10 @@ export function IntroducerManagement(props: Readonly<IntroducerManagementProps &
 
   return (
     <Card {...rest}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<AwardIcon />} noMargin={true} />
-      </CardHeader>
-      <CardContent>
+      </Card.Header>
+      <Card.Content>
         <UserSelectionList
           selectedUsers={introducerUsers ?? []}
           onAddToSelection={onGrantIntroducer}
@@ -51,7 +51,7 @@ export function IntroducerManagement(props: Readonly<IntroducerManagementProps &
             },
           ]}
         />
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/components/IntroductionsManagement/index.tsx
+++ b/apps/frontend/src/components/IntroductionsManagement/index.tsx
@@ -1,21 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import {
-  Card,
-  CardHeader,
-  CardContent,
-  CardProps,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  TextArea,
-  Button,
-  Form,
-  useOverlayState,
-} from '@heroui/react';
+import { Button, Card, CardProps, Form, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, TextArea, useOverlayState } from '@heroui/react';
 import { HistoryIcon, ShieldCheckIcon } from 'lucide-react';
 import { ResourceIntroduction, User } from '@attraccess/react-query-client';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -123,10 +107,10 @@ export function IntroductionsManagement(props: Readonly<IntroductionsManagementP
 
   return (
     <Card {...rest}>
-      <CardHeader>
+      <Card.Header>
         <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<ShieldCheckIcon />} noMargin={true} />
-      </CardHeader>
-      <CardContent>
+      </Card.Header>
+      <Card.Content>
         <UserSelectionList
           selectedUsers={userWithIntroductionStatus}
           onAddToSelection={(user) => onGrantIntroduction({ user })}
@@ -174,7 +158,7 @@ export function IntroductionsManagement(props: Readonly<IntroductionsManagementP
             </ModalContainer>
           </ModalBackdrop>
         </Modal>
-      </CardContent>
+      </Card.Content>
     </Card>
   );
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Migrate ~60 frontend files from HeroUI v2 flat `CardHeader`/`CardBody`/`CardContent`/`CardFooter` exports to v3 compound subcomponents `Card.Header`/`Card.Content`/`Card.Footer`.

- v3 exposes both APIs via `Object.assign(CardRoot, { Header, Content, Footer, ... })`, so this is a pure rename — same component instances, no runtime/visual changes.
- Removes the v2 named imports from `@heroui/react`, leaves only `Card`.
- Dedupes a duplicate `@heroui/react` import line in `email-templates/edit/index.tsx` that surfaced once `Card` became the sole imported symbol.
- No stale `pb-0 pt-2 px-4 flex-col items-start` v2 overrides found on `CardHeader` in the codebase; existing layout classes on `Card.Header` are legitimate customizations and kept.
- `Card.Title` / `Card.Description` adoption is out of scope for this rename pass per the acceptance criteria (mass-rename only).

## Verification

- `nx typecheck frontend` ✓
- `nx lint frontend` ✓
- `nx build frontend` ✓
- Confirmed at runtime: `Card.Header === CardHeader` (same function instance from `Object.assign`).

Linear: [ATT-301](https://linear.app/attraccess/issue/ATT-301/heroui-v3-adopt-card-compound-subcomponents-cardheadercontentfooter)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Migrate frontend usage of HeroUI Card sections to the v3 compound Card subcomponents API across multiple pages and components.

Enhancements:
- Standardize Card usage to Card.Header/Card.Content/Card.Footer compound subcomponents instead of separate CardHeader/CardContent/CardFooter components.
- Simplify HeroUI imports by relying solely on the Card component in updated files.