### PR TITLE
fix(frontend): align Select wrapper props with v3 API (ATT-300)

### DIFF
--- a/apps/frontend/src/app/attractap/AttractapSelect/index.tsx
+++ b/apps/frontend/src/app/attractap/AttractapSelect/index.tsx
@@ -42,8 +42,8 @@ export function AttractapSelect(props: Props) {
       label={props.label}
       aria-label={props.ariaLabel}
       placeholder={readers?.find((r) => r.id === props.selection)?.name ?? props.placeholder}
-      selectedKey={props.selection ? props.selection.toString() : ''}
-      onSelectionChange={(key) => props.onSelectionChange(Number(key))}
+      value={props.selection ? props.selection.toString() : ''}
+      onChange={(key) => props.onSelectionChange(Number(key))}
       data-cy="attractap-select"
     />
   );

--- a/apps/frontend/src/app/billing/administration/sumup/configuration/currency/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/currency/index.tsx
@@ -93,8 +93,8 @@ export function CurrencyCard(props: Omit<CardProps, 'children'>) {
               label: currency,
             }))}
             label={t('inputs.currency.label')}
-            selectedKey={currency}
-            onSelectionChange={(key) => setCurrency(key as Currency)}
+            value={currency}
+            onChange={(key) => setCurrency(key as Currency)}
           />
 
           <input type="submit" hidden />

--- a/apps/frontend/src/app/billing/dashboard/topup/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/topup/index.tsx
@@ -176,8 +176,8 @@ export function BillingDashboardTopupCard(props: Props) {
             <Select
               items={readers?.map((reader) => ({ key: reader.id, label: reader.name })) ?? []}
               label={t('inputs.reader.label')}
-              selectedKey={readerId}
-              onSelectionChange={(key) => setReaderId(key as string)}
+              value={readerId}
+              onChange={(key) => setReaderId(key as string)}
             />
           )}
 

--- a/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
@@ -130,8 +130,8 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
 
       <Select
         label={t('defaultPublishQosLabel')}
-        selectedKey={String(formValues.defaultPublishQos ?? 0)}
-        onSelectionChange={(key) => setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }))}
+        value={String(formValues.defaultPublishQos ?? 0)}
+        onChange={(key) => setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }))}
         data-cy="create-mqtt-server-form-default-publish-qos-input"
         items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
       />
@@ -148,8 +148,8 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
 
       <Select
         label={t('defaultSubscribeQosLabel')}
-        selectedKey={String(formValues.defaultSubscribeQos ?? 0)}
-        onSelectionChange={(key) => setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }))}
+        value={String(formValues.defaultSubscribeQos ?? 0)}
+        onChange={(key) => setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }))}
         data-cy="create-mqtt-server-form-default-subscribe-qos-input"
         items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
       />

--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -183,8 +183,8 @@ export function EditMqttServerPage() {
 
               <Select
                 label={t('defaultPublishQosLabel')}
-                selectedKey={String(formValues.defaultPublishQos ?? 0)}
-                onSelectionChange={(key) => {
+                value={String(formValues.defaultPublishQos ?? 0)}
+                onChange={(key) => {
                   setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }));
                 }}
                 data-cy="edit-mqtt-server-form-default-publish-qos-input"
@@ -205,8 +205,8 @@ export function EditMqttServerPage() {
 
               <Select
                 label={t('defaultSubscribeQosLabel')}
-                selectedKey={String(formValues.defaultSubscribeQos ?? 0)}
-                onSelectionChange={(key) => {
+                value={String(formValues.defaultSubscribeQos ?? 0)}
+                onChange={(key) => {
                   setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }));
                 }}
                 data-cy="edit-mqtt-server-form-default-subscribe-qos-input"

--- a/apps/frontend/src/app/projects/details/components/inviteMemberModal/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/inviteMemberModal/index.tsx
@@ -130,8 +130,8 @@ export function InviteProjectMemberModal(props: Readonly<InviteProjectMemberModa
                     />
                     <Select
                       label={t('inputs.role')}
-                      selectedKey={role}
-                      onSelectionChange={(key) => {
+                      value={role}
+                      onChange={(key) => {
                         if (key) setRole(key as ProjectMember['role']);
                       }}
                       items={roleOptions.map((value) => ({ key: value, label: t(`roles.${value}`) }))}

--- a/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
@@ -160,8 +160,8 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
           <Select
             label={!hideLabel ? t('nodes.' + nodeType + '.config.' + name + '.label') : undefined}
             aria-label={t('nodes.' + nodeType + '.config.' + name + '.label')}
-            selectedKey={String(value ?? schema.default ?? '')}
-            onSelectionChange={(newValue) => onChange(newValue as TValue)}
+            value={String(value ?? schema.default ?? '')}
+            onChange={(newValue) => onChange(newValue as TValue)}
             items={schema.enum.map((enumValue) => ({
               key: String(enumValue),
               label: t('nodes.' + nodeType + '.config.' + name + '.enum.' + enumValue),
@@ -201,15 +201,15 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
       const enumValues = schema.enum ?? (isQosField ? [0, 1, 2] : undefined);
 
       if (enumValues) {
-        const selectedKey =
+        const selectedValue =
           value !== undefined ? String(value) : schema.default !== undefined ? String(schema.default) : undefined;
 
         return (
           <Select
             label={!hideLabel ? t('nodes.' + nodeType + '.config.' + name + '.label') : undefined}
             aria-label={t('nodes.' + nodeType + '.config.' + name + '.label')}
-            selectedKey={selectedKey}
-            onSelectionChange={(newValue) => {
+            value={selectedValue}
+            onChange={(newValue) => {
               if (newValue == null) return;
               setValue(Number(newValue) as TValue);
             }}

--- a/apps/frontend/src/app/resources/details/forms/components/FormFieldEditor.tsx
+++ b/apps/frontend/src/app/resources/details/forms/components/FormFieldEditor.tsx
@@ -45,8 +45,8 @@ export function FormFieldEditor(props: FormFieldEditorProps) {
 
         <Select
           label={t('fields.type')}
-          selectedKey={field.type}
-          onSelectionChange={(key) => {
+          value={field.type}
+          onChange={(key) => {
             handleTypeChange((key as FormFieldType) ?? FormFieldType.TEXT);
           }}
           items={FIELD_TYPE_OPTIONS.map((option) => ({ key: option.value, label: t(option.labelKey) }))}

--- a/apps/frontend/src/app/resources/details/maintenance-schedules/upsert/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-schedules/upsert/index.tsx
@@ -259,8 +259,8 @@ export function MaintenanceScheduleUpsertModal(props: Props) {
 
                       <Select
                         label={t('inputs.triggerType.label')}
-                        selectedKey={triggerType}
-                        onSelectionChange={(key) => {
+                        value={triggerType}
+                        onChange={(key) => {
                           if (key) setTriggerType(key as ResourceMaintenanceScheduleTriggerType);
                         }}
                         items={TRIGGER_OPTIONS.map((opt) => ({
@@ -277,8 +277,8 @@ export function MaintenanceScheduleUpsertModal(props: Props) {
                           </TextField>
                           <Select
                             label={t('inputs.unit.label')}
-                            selectedKey={usageHoursUnit}
-                            onSelectionChange={(key) => {
+                            value={usageHoursUnit}
+                            onChange={(key) => {
                               if (key) setUsageHoursUnit(key as UsageDurationUnit);
                             }}
                             items={Object.values(UsageDurationUnit).map((unit) => ({
@@ -304,8 +304,8 @@ export function MaintenanceScheduleUpsertModal(props: Props) {
                           </TextField>
                           <Select
                             label={t('inputs.unit.label')}
-                            selectedKey={timeIntervalUnit}
-                            onSelectionChange={(key) => {
+                            value={timeIntervalUnit}
+                            onChange={(key) => {
                               if (key) setTimeIntervalUnit(key as UsageDurationUnit);
                             }}
                             items={Object.values(UsageDurationUnit).map((unit) => ({

--- a/apps/frontend/src/app/resources/details/qrcode/index.tsx
+++ b/apps/frontend/src/app/resources/details/qrcode/index.tsx
@@ -83,8 +83,8 @@ export function ResourceQrCode(props: Props & Omit<ButtonProps, 'children' | 'st
 
                   <ModalBody>
                     <Select
-                      selectedKey={action}
-                      onSelectionChange={(key) => setAction(key as QrCodeAction)}
+                      value={action}
+                      onChange={(key) => setAction(key as QrCodeAction)}
                       label={t('modal.action.label')}
                       items={Object.values(QrCodeAction).map((val) => ({
                         key: val,

--- a/apps/frontend/src/app/resources/forms/components/ResourceFormsModal.tsx
+++ b/apps/frontend/src/app/resources/forms/components/ResourceFormsModal.tsx
@@ -360,8 +360,8 @@ function renderSelectInput(
       placeholder={options.length ? t('modal.selectPlaceholder') : t('modal.selectUnavailable')}
       isDisabled={!options.length}
       aria-label={fieldName}
-      selectedKey={selectedKey}
-      onSelectionChange={(key) => onChange(key ?? '')}
+      value={selectedKey}
+      onChange={(key) => onChange(key ?? '')}
       items={options.map((option) => ({ key: option, label: option }))}
     />
   );

--- a/apps/frontend/src/app/settings/forms/SmtpSettingsForm/index.tsx
+++ b/apps/frontend/src/app/settings/forms/SmtpSettingsForm/index.tsx
@@ -150,8 +150,8 @@ export function SmtpSettingsForm({ variant, endpoint, onNext }: SmtpSettingsForm
     >
       <Select
         label={t('inputs.service.label')}
-        selectedKey={smtpService}
-        onSelectionChange={(key) => {
+        value={smtpService}
+        onChange={(key) => {
           const next = key as SmtpServiceType;
           setSmtpService(next);
           if (next === SmtpServiceType.OUTLOOK365) {

--- a/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
+++ b/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
@@ -729,8 +729,8 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
                         <label className="text-sm font-medium">{t('type')}</label>
                         <Select
                           items={Object.values(SSOProviderType).map((type) => ({ key: type, label: type }))}
-                          selectedKey={formValues.type}
-                          onSelectionChange={(key) => {
+                          value={formValues.type}
+                          onChange={(key) => {
                             if (key) handleSelectChange(key as SSOProviderType);
                           }}
                           isRequired

--- a/apps/frontend/src/app/user-management/invite-user-modal/csv-invite/index.tsx
+++ b/apps/frontend/src/app/user-management/invite-user-modal/csv-invite/index.tsx
@@ -258,8 +258,8 @@ export function CsvInvite({ onSuccess, onError }: Props) {
 
       <Select
         label={t('inputs.fieldMapping.email')}
-        selectedKey={emailKey ?? ''}
-        onSelectionChange={setEmailKey}
+        value={emailKey ?? ''}
+        onChange={setEmailKey}
         items={csvHeaders.map((header) => ({
           label: header,
           key: header,
@@ -269,8 +269,8 @@ export function CsvInvite({ onSuccess, onError }: Props) {
 
       <Select
         label={t('inputs.fieldMapping.username')}
-        selectedKey={usernameKey ?? ''}
-        onSelectionChange={setUsernameKey}
+        value={usernameKey ?? ''}
+        onChange={setUsernameKey}
         items={csvHeaders.map((header) => ({
           label: header,
           key: header,
@@ -283,8 +283,8 @@ export function CsvInvite({ onSuccess, onError }: Props) {
           <Select
             className="flex-1"
             label={t('inputs.fieldMapping.' + permission)}
-            selectedKey={mapping.keyMapping}
-            onSelectionChange={(key) => updatePermissionKeyMapping(permission as keyof SystemPermissions, key)}
+            value={mapping.keyMapping}
+            onChange={(key) => updatePermissionKeyMapping(permission as keyof SystemPermissions, key)}
             items={csvHeaders.map((header) => ({
               label: header,
               key: header,

--- a/apps/frontend/src/app/user-management/two-factor-policy-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/two-factor-policy-modal/index.tsx
@@ -133,8 +133,8 @@ export function TwoFactorPolicyModal(props: Props) {
                     <Select
                       label={t('inputs.policy.label')}
                       isDisabled={isLoading}
-                      selectedKey={selectedPolicy ?? undefined}
-                      onSelectionChange={(key) => {
+                      value={selectedPolicy ?? undefined}
+                      onChange={(key) => {
                         if (key) setSelectedPolicy(key as TwoFactorPolicy);
                       }}
                       items={policyOptions.map((option) => ({

--- a/apps/frontend/src/components/mqttServerSelect/index.tsx
+++ b/apps/frontend/src/components/mqttServerSelect/index.tsx
@@ -13,7 +13,7 @@ export function MqttServerSelect(
   props: Props &
     Omit<
       SelectProps,
-      'items' | 'label' | 'placeholder' | 'selectedKey' | 'onSelectionChange' | 'data-cy' | 'isLoading' | 'children'
+      'items' | 'label' | 'placeholder' | 'value' | 'onChange' | 'data-cy' | 'isLoading' | 'children'
     >,
 ) {
   const { selectedId, onSelectionChange, placeholder, ...selectProps } = props;
@@ -23,8 +23,8 @@ export function MqttServerSelect(
     <Select
       items={(servers ?? []).map((server) => ({ key: server.id.toString(), label: server.name }))}
       placeholder={servers?.find((r) => r.id === selectedId)?.name ?? placeholder}
-      selectedKey={selectedId?.toString() ?? ''}
-      onSelectionChange={(key) => onSelectionChange(Number(key))}
+      value={selectedId?.toString() ?? ''}
+      onChange={(key) => onSelectionChange(Number(key))}
       data-cy="mqtt-server-select"
       {...selectProps}
     />

--- a/apps/frontend/src/components/projectsSelect/index.tsx
+++ b/apps/frontend/src/components/projectsSelect/index.tsx
@@ -34,8 +34,8 @@ export function ProjectsSelect(props: Props) {
       {...selectProps}
       items={items}
       placeholder={projects?.data?.find((r) => r.id === resolvedValue)?.name ?? props.placeholder}
-      selectedKey={resolvedValue ? resolvedValue.toString() : ''}
-      onSelectionChange={(key) => {
+      value={resolvedValue ? resolvedValue.toString() : ''}
+      onChange={(key) => {
         if (key === UNASSIGNED_KEY || key === '') {
           handleChange(undefined);
           return;

--- a/apps/frontend/src/components/select/index.tsx
+++ b/apps/frontend/src/components/select/index.tsx
@@ -19,41 +19,56 @@ interface SelectItem {
 }
 
 export interface Props {
-  selectedKey?: string;
-  defaultSelectedKey?: string;
-  onSelectionChange?: (key: string) => unknown;
+  value?: string;
+  defaultValue?: string;
+  onChange?: (key: string) => unknown;
   items: SelectItem[];
   label?: ReactNode;
   placeholder?: string;
   className?: string;
   isDisabled?: boolean;
   isRequired?: boolean;
+  isInvalid?: boolean;
+  name?: string;
+  disabledKeys?: Iterable<string | number>;
+  variant?: 'primary' | 'secondary';
+  fullWidth?: boolean;
   'aria-label'?: string;
   'data-cy'?: string;
   isLoading?: boolean;
 }
 
 export function Select({
-  selectedKey,
-  defaultSelectedKey,
-  onSelectionChange,
+  value,
+  defaultValue,
+  onChange,
   items,
   label,
   placeholder,
   className,
   isDisabled,
   isRequired,
+  isInvalid,
+  name,
+  disabledKeys,
+  variant,
+  fullWidth,
   'aria-label': ariaLabel,
   'data-cy': dataCy,
 }: Props) {
   return (
     <HeroUiSelect<SelectItem>
-      selectedKey={selectedKey}
-      defaultSelectedKey={defaultSelectedKey}
-      onSelectionChange={(key) => onSelectionChange?.(key as string)}
+      value={value}
+      defaultValue={defaultValue}
+      onChange={(key) => onChange?.(key as string)}
       placeholder={placeholder}
       isDisabled={isDisabled}
       isRequired={isRequired}
+      isInvalid={isInvalid}
+      name={name}
+      disabledKeys={disabledKeys}
+      variant={variant}
+      fullWidth={fullWidth}
       className={className}
       aria-label={ariaLabel}
       data-cy={dataCy}


### PR DESCRIPTION
Assignee: [Jan Jaap](https://linear.app/attraccess/profiles/jappy)

## Summary

The shared `Select` wrapper at `apps/frontend/src/components/select/index.tsx` was passing v2 prop names (`selectedKey` / `defaultSelectedKey` / `onSelectionChange`) through to the underlying HeroUI v3 `Select`, which expects `value` / `defaultValue` / `onChange`.

This PR keeps the wrapper (still useful — flattens v3's verbose compound API into a single `items` array, auto-adds `data-cy` selectors, narrows the change handler to `(string) => unknown` for the single-select case) and aligns its public prop names with v3.

### Changes

- Rename wrapper props: `selectedKey` → `value`, `defaultSelectedKey` → `defaultValue`, `onSelectionChange` → `onChange`.
- Add passthroughs for v3 props the wrapper previously hid: `isInvalid`, `name`, `disabledKeys`, `variant`, `fullWidth`.
- Update all 17 callers (including the `ProjectsSelect` and `MqttServerSelect` helpers that wrap the wrapper).

### Verification

- `nx run frontend:typecheck` — passes
- `nx run frontend:lint` — passes
- precommit hook (`lint,typecheck,build,test,e2e` for affected projects) — passes

Closes [ATT-300](https://linear.app/attraccess/issue/ATT-300/heroui-v3-shared-select-wrapper-uses-v2-prop-api).

---
> **Tip:** I will respond to comments that @ mention @gieselaschlepptop1 on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Align the shared frontend Select wrapper and all its usages with the HeroUI v3 value/onChange API.

New Features:
- Expose additional HeroUI v3 Select props (validation, name, disabled keys, variant, layout) through the shared Select wrapper to callers.

Bug Fixes:
- Fix mismatch between the Select wrapper props and the underlying HeroUI v3 Select component by renaming selectedKey/defaultSelectedKey/onSelectionChange to value/defaultValue/onChange across the codebase.

Enhancements:
- Update all Select consumers, including helper components like ProjectsSelect and MqttServerSelect, to use the new value/onChange prop names for consistency with the v3 API.