### PR TITLE
fix(frontend): normalize Modal header/size/spacing for HeroUI v3 (ATT-295)

### DIFF
--- a/apps/frontend/src/app/account/index.tsx
+++ b/apps/frontend/src/app/account/index.tsx
@@ -81,7 +81,7 @@ export default function AccountPage() {
 
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
@@ -100,10 +100,10 @@ export function AttractapEditor(props: Readonly<Props>) {
   );
 
   return (
-    <Form onSubmit={onSubmit} data-cy="attractap-editor-form">
+    <Form onSubmit={onSubmit} data-cy="attractap-editor-form" className="flex flex-col gap-4">
       <Modal isOpen={props.isOpen} onOpenChange={props.onCancel} data-cy="attractap-editor-modal">
         <ModalBackdrop>
-          <ModalContainer placement="top">
+          <ModalContainer placement="top" size="lg">
             <ModalDialog>
               {() => (
                 <>

--- a/apps/frontend/src/app/attractap/HardwareSetup/WebSerialConsole/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/WebSerialConsole/index.tsx
@@ -9,11 +9,11 @@ import {
   ModalContainer,
   ModalDialog,
   ModalHeader,
+  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
 import { useCallback, useRef, useState } from 'react';
 import { ESPTools, ESPToolsErrorType } from '../../../../utils/esp-tools';
-import { PageHeader } from '../../../../components/pageHeader';
 import { Terminal } from '../../../../components/Terminal';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 
@@ -72,12 +72,12 @@ export function WebSerialConsole({ children }: Props) {
 
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="lg">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} noMargin />
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
 
                   <ModalBody>

--- a/apps/frontend/src/app/attractap/HardwareSetup/de.json
+++ b/apps/frontend/src/app/attractap/HardwareSetup/de.json
@@ -18,6 +18,9 @@
     },
     "description": "Haben Sie einen komplett neuen Attractap, dann wählen Sie \"Firmware installieren\" um die neuste Firmware auf Ihren Attractap zu installieren. Wenn Sie einen bereits eingerichteten Attractap haben, dann wählen Sie \"Konfiguration vornehmen\" um die Konfiguration Ihres Attractap zu ändern."
   },
+  "actions": {
+    "back": "Zurück"
+  },
   "connect": {
     "description": "Bitte schließen Sie ihren Attractap an den USB-Port Ihres Computers an und klicken auf \"Verbinden\", im folgenden Dialog müssen Sie dann den richtigen Seriellen Port auswählen.",
     "button": {

--- a/apps/frontend/src/app/attractap/HardwareSetup/en.json
+++ b/apps/frontend/src/app/attractap/HardwareSetup/en.json
@@ -18,6 +18,9 @@
     },
     "description": "If you have a completely new Attractap, select \"Install firmware\" to install the latest firmware on your Attractap. If you have an already configured Attractap, select \"Configure\" to configure your Attractap."
   },
+  "actions": {
+    "back": "Go back"
+  },
   "connect": {
     "description": "Please connect your Attractap to the USB port of your computer and click \"Connect\", in the following dialog you need to select the correct serial port.",
     "button": {

--- a/apps/frontend/src/app/attractap/HardwareSetup/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/index.tsx
@@ -166,13 +166,13 @@ export function AttractapHardwareSetup(props: Props) {
 
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer size={state === 'configure' ? 'lg' : undefined}>
+          <ModalContainer size={state === 'configure' ? 'lg' : 'md'}>
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
                     <div className="flex w-full items-center gap-2">
-                      <Button variant="ghost" isIconOnly aria-label="Go back" onPress={onBack}>
+                      <Button variant="ghost" isIconOnly aria-label={t('actions.back')} onPress={onBack}>
                         <ArrowLeft className="w-5 h-5" />
                       </Button>
                       <div className="flex-1">

--- a/apps/frontend/src/app/attractap/HardwareSetup/index.tsx
+++ b/apps/frontend/src/app/attractap/HardwareSetup/index.tsx
@@ -10,9 +10,10 @@ import {
   ModalContainer,
   ModalDialog,
   ModalHeader,
+  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
-import { PageHeader } from '../../../components/pageHeader';
+import { ArrowLeft } from 'lucide-react';
 import { FirmwareSelector } from './FirmwareSelector';
 import { FirmwareFlasher } from './FirmwareFlasher';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -170,12 +171,15 @@ export function AttractapHardwareSetup(props: Props) {
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader
-                      title={t('title.' + state)}
-                      subtitle={t('subtitle.' + state)}
-                      noMargin
-                      onBack={onBack}
-                    />
+                    <div className="flex w-full items-center gap-2">
+                      <Button variant="ghost" isIconOnly aria-label="Go back" onPress={onBack}>
+                        <ArrowLeft className="w-5 h-5" />
+                      </Button>
+                      <div className="flex-1">
+                        <ModalHeading>{t('title.' + state)}</ModalHeading>
+                        <p className="text-sm text-muted">{t('subtitle.' + state)}</p>
+                      </div>
+                    </div>
                   </ModalHeader>
 
                   <ModalBody className="mb-4">

--- a/apps/frontend/src/app/attractap/NfcCardList/activate/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/activate/index.tsx
@@ -7,12 +7,12 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
 import de from './de.json';
 import en from './en.json';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { PageHeader } from '../../../../components/pageHeader';
 import {
   UseAttractapServiceGetAllCardsKeyFn,
   useAttractapServiceToggleCardActive,
@@ -55,12 +55,12 @@ export function NfcCardActivateModal(props: Props) {
       })}
       <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="nfc-card-activate-modal">
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close }) => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} noMargin />
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
                   <ModalBody>{t('description')}</ModalBody>
                   <ModalFooter>

--- a/apps/frontend/src/app/attractap/NfcCardList/deactivate/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/deactivate/index.tsx
@@ -7,12 +7,12 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
 import de from './de.json';
 import en from './en.json';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { PageHeader } from '../../../../components/pageHeader';
 import {
   UseAttractapServiceGetAllCardsKeyFn,
   useAttractapServiceToggleCardActive,
@@ -55,12 +55,12 @@ export function NfcCardDeactivateModal(props: Props) {
       })}
       <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="nfc-card-deactivate-modal">
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close }) => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} noMargin />
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
                   <ModalBody>{t('description')}</ModalBody>
                   <ModalFooter>

--- a/apps/frontend/src/app/attractap/NfcCardList/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/index.tsx
@@ -76,7 +76,7 @@ const NfcCardDeleteModal = (props: DeleteModalProps) => {
       data-cy="nfc-card-delete-modal"
     >
       <ModalBackdrop>
-        <ModalContainer>
+        <ModalContainer size="md">
           <ModalDialog>
             {({ close }) => (
               <>
@@ -228,7 +228,7 @@ const EnrollNfcCardButton = () => {
         data-cy="enroll-nfc-card-modal"
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/app/billing/administration/sumup/readers/pairing/de.json
+++ b/apps/frontend/src/app/billing/administration/sumup/readers/pairing/de.json
@@ -6,7 +6,8 @@
     "name": "Name"
   },
   "actions": {
-    "pair": "Karten-Lesegerät einrichten"
+    "pair": "Karten-Lesegerät einrichten",
+    "cancel": "Abbrechen"
   },
   "success": {
     "toast": {

--- a/apps/frontend/src/app/billing/administration/sumup/readers/pairing/en.json
+++ b/apps/frontend/src/app/billing/administration/sumup/readers/pairing/en.json
@@ -6,7 +6,8 @@
     "name": "Name"
   },
   "actions": {
-    "pair": "Pair"
+    "pair": "Pair",
+    "cancel": "Cancel"
   },
   "success": {
     "toast": {

--- a/apps/frontend/src/app/billing/administration/sumup/readers/pairing/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/readers/pairing/index.tsx
@@ -14,9 +14,9 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
-import { PageHeader } from '../../../../../../components/pageHeader';
 import { PasswordInput } from '../../../../../../components/PasswordInput';
 import { useCallback, useRef, useState } from 'react';
 import { useBillingServiceGetSumUpReadersKey, useBillingServicePairSumUpReader } from '@attraccess/react-query-client';
@@ -87,15 +87,16 @@ export function SumUpReadersPairing(props: Props) {
 
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {({ close }) => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} subtitle={t('subtitle')} noMargin onBack={close} />
+                    <ModalHeading>{t('title')}</ModalHeading>
+                    <p className="text-sm text-muted">{t('subtitle')}</p>
                   </ModalHeader>
                   <ModalBody>
-                    <Form onSubmit={onSubmit} ref={formRef}>
+                    <Form onSubmit={onSubmit} ref={formRef} className="flex flex-col gap-4">
                       <PasswordInput
                         label={t('inputs.pairingCode')}
                         value={pairingCode}

--- a/apps/frontend/src/app/billing/administration/sumup/readers/pairing/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/readers/pairing/index.tsx
@@ -117,6 +117,9 @@ export function SumUpReadersPairing(props: Props) {
                   </ModalBody>
 
                   <ModalFooter>
+                    <Button variant="secondary" onPress={close}>
+                      {t('actions.cancel')}
+                    </Button>
                     <Button variant="primary" onPress={onSubmit} isPending={isPairingReader}>
                       {t('actions.pair')}
                     </Button>

--- a/apps/frontend/src/app/billing/dashboard/summary/transactionDetailsModal/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/transactionDetailsModal/index.tsx
@@ -8,6 +8,7 @@ import {
   ModalContainer,
   ModalDialog,
   ModalHeader,
+  ModalHeading,
   Table,
   TableBody,
   TableCell,
@@ -20,7 +21,6 @@ import {
 import de from './de.json';
 import en from './en.json';
 import { AttraccessUser, useTranslations } from '@attraccess/plugins-frontend-ui';
-import { PageHeader } from '../../../../../components/pageHeader';
 import {
   BillingTransaction,
   BillingTransactionStatus,
@@ -91,24 +91,21 @@ export function TransactionDetailsModal(props: Props) {
       {children && children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="lg">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader
-                      title={t('title')}
-                      noMargin
-                      actions={
-                        <RefundModal transactionId={transactionId}>
-                          {(onOpen) => (
-                            <Button variant="danger-soft" onPress={onOpen}>
-                              {t('actions.refund')}
-                            </Button>
-                          )}
-                        </RefundModal>
-                      }
-                    />
+                    <div className="flex w-full items-center justify-between gap-2">
+                      <ModalHeading>{t('title')}</ModalHeading>
+                      <RefundModal transactionId={transactionId}>
+                        {(onOpen) => (
+                          <Button variant="danger-soft" onPress={onOpen}>
+                            {t('actions.refund')}
+                          </Button>
+                        )}
+                      </RefundModal>
+                    </div>
                   </ModalHeader>
                   <ModalBody>
                     {!transaction ? (

--- a/apps/frontend/src/app/billing/dashboard/summary/transactionDetailsModal/refund/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/transactionDetailsModal/refund/index.tsx
@@ -9,6 +9,7 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   NumberField,
   NumberFieldDecrementButton,
   NumberFieldGroup,
@@ -16,7 +17,6 @@ import {
   NumberFieldInput,
   useOverlayState,
 } from '@heroui/react';
-import { PageHeader } from '../../../../../../components/pageHeader';
 import en from './en.json';
 import de from './de.json';
 import { useCallback, useEffect, useState } from 'react';
@@ -110,16 +110,16 @@ export function RefundModal(props: Props) {
       {children && children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} noMargin />
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
 
                   <ModalBody>
-                    <Form onSubmit={onSubmit}>
+                    <Form onSubmit={onSubmit} className="flex flex-col gap-4">
                       <NumberField
                         aria-label={t('inputs.amount')}
                         value={dbCurrencyToUserCurrency(amount, configuration.minorUnit)}

--- a/apps/frontend/src/app/csv-export/index.tsx
+++ b/apps/frontend/src/app/csv-export/index.tsx
@@ -100,7 +100,7 @@ export function CsvExport() {
         data-cy="csv-export-modal"
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {() => (
                 <>

--- a/apps/frontend/src/app/email-templates/edit/index.tsx
+++ b/apps/frontend/src/app/email-templates/edit/index.tsx
@@ -137,7 +137,7 @@ export function EditEmailTemplatePage() {
 
               <Modal isOpen={editorIsExpanded} onOpenChange={setEditorIsExpanded}>
                 <ModalBackdrop>
-                  <ModalContainer>
+                  <ModalContainer size="cover">
                     <ModalDialog>
                       {({ close }) => (
                         <>

--- a/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
+++ b/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
@@ -165,7 +165,7 @@ export function MqttServerList() {
         data-cy="mqtt-server-list-delete-confirmation-modal"
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -125,7 +125,7 @@ export function PluginsList() {
           data-cy="plugins-list-delete-confirmation-modal"
         >
           <ModalBackdrop>
-            <ModalContainer>
+            <ModalContainer size="sm">
               <ModalDialog>
                 {({ close }) => (
                   <>

--- a/apps/frontend/src/app/plugins/UploadPluginModal.tsx
+++ b/apps/frontend/src/app/plugins/UploadPluginModal.tsx
@@ -91,7 +91,7 @@ export function UploadPluginModal({ isOpen, onClose }: UploadPluginModalProps) {
       data-cy="upload-plugin-modal"
     >
       <ModalBackdrop>
-        <ModalContainer>
+        <ModalContainer size="md">
           <ModalDialog>
             {({ close }) => (
               <>

--- a/apps/frontend/src/app/projects/details/components/inviteMemberModal/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/inviteMemberModal/index.tsx
@@ -111,14 +111,14 @@ export function InviteProjectMemberModal(props: Readonly<InviteProjectMemberModa
       {children(open)}
       <Modal isOpen={isOpen} onOpenChange={handleOpenChange}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close }) => (
                 <>
                   <ModalHeader>
                     <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
-                  <ModalBody className="gap-4">
+                  <ModalBody className="flex flex-col gap-4">
                     <p className="text-small text-default-500">{t('description')}</p>
                     <UserSearch
                       label={t('inputs.user')}

--- a/apps/frontend/src/app/projects/upsertModal/index.tsx
+++ b/apps/frontend/src/app/projects/upsertModal/index.tsx
@@ -11,10 +11,10 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   TextArea,
   useOverlayState,
 } from '@heroui/react';
-import { PageHeader } from '../../../components/pageHeader';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
@@ -152,12 +152,12 @@ export function UpsertProjectModal(props: Props) {
       {children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={projectId ? t('title.update') : t('title.create')} noMargin />
+                    <ModalHeading>{projectId ? t('title.update') : t('title.create')}</ModalHeading>
                   </ModalHeader>
 
                   <ModalBody>
@@ -167,6 +167,7 @@ export function UpsertProjectModal(props: Props) {
                         e.preventDefault();
                         onSubmit();
                       }}
+                      className="flex flex-col gap-4"
                     >
                       <TextField value={name} onChange={setName}>
                         <Label>{t('inputs.name.label')}</Label>

--- a/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.tsx
+++ b/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.tsx
@@ -184,7 +184,7 @@ export function ResourceGroupUpsertModal(props: Readonly<Props>) {
       {props.children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="resource-group-upsert-modal">
         <ModalBackdrop>
-          <ModalContainer placement="top">
+          <ModalContainer placement="top" size="md">
             <ModalDialog>
               {({ close }) => (
                 <Form onSubmit={handleSubmit}>

--- a/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/index.tsx
@@ -227,7 +227,7 @@ export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessi
         onOpenChange={(open) => { if (!open && !isEndingAll) setIsModalOpen(false); }}
       >
         <ModalBackdrop isDismissable={!isEndingAll} />
-        <ModalContainer>
+        <ModalContainer size="md">
           <ModalDialog>
             {({ close }) => (
               <>

--- a/apps/frontend/src/app/resourceOverview/toolbar/scanner/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/toolbar/scanner/index.tsx
@@ -45,7 +45,7 @@ export function ResourceScanner(props: Props) {
       {props.children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>{() => <Scanner onScan={onScan} components={{ tracker: boundingBox }} />}</ModalDialog>
           </ModalContainer>
         </ModalBackdrop>

--- a/apps/frontend/src/app/resources/details/flows/node/editor/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/editor/index.tsx
@@ -9,10 +9,10 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
 import { useNodeId, useNodesData } from '@xyflow/react';
-import { PageHeader } from '../../../../../../components/pageHeader';
 import { useFlowContext } from '../../flowContext';
 import { Property, PropertyInput } from './property-input';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -60,20 +60,17 @@ export function NodeEditor(props: Props) {
       {props.children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="lg">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader
-                      title={t('nodes.' + schema.type + '.title')}
-                      subtitle={t('nodes.' + schema.type + '.description')}
-                      noMargin
-                    />
+                    <ModalHeading>{t('nodes.' + schema.type + '.title')}</ModalHeading>
+                    <p className="text-sm text-muted">{t('nodes.' + schema.type + '.description')}</p>
                   </ModalHeader>
 
                   <ModalBody className="flex flex-col gap-2">
-                    <Form onSubmit={onSave} ref={formRef}>
+                    <Form onSubmit={onSave} ref={formRef} className="flex flex-col gap-4">
                       {Object.entries(schema.configSchema.properties as Record<string, Property<unknown>>).map(
                         ([propertyName, property]) => (
                           <PropertyInput

--- a/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
@@ -107,7 +107,7 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
 
         <Modal isOpen={isCreateServerOpen} onOpenChange={setIsCreateServerOpen}>
           <ModalBackdrop>
-            <ModalContainer>
+            <ModalContainer size="md">
               <ModalDialog>
                 {({ close }) => (
                   <>

--- a/apps/frontend/src/app/resources/details/flows/nodePickerModal/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/nodePickerModal/index.tsx
@@ -103,7 +103,7 @@ export function NodePickerModal(props: Props) {
       {props.children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="lg">
             <ModalDialog>
               {() => (
                 <>

--- a/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
@@ -81,7 +81,7 @@ export function MarkDoneModal(props: Props) {
       {children(open)}
       <Modal isOpen={isOpen} onOpenChange={onOpenChangeHandler}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx
@@ -13,12 +13,13 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
+  ModalIcon,
   TextArea,
   useOverlayState,
 } from '@heroui/react';
 import de from './de.json';
 import en from './en.json';
-import { PageHeader } from '../../../../../components/pageHeader';
 import { MaintenanceReasonDisplay } from '../../../../../components/MaintenanceReasonDisplay';
 import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { useCallback, useMemo, useRef, useState } from 'react';
@@ -120,16 +121,17 @@ export function ResourceMaintenanceUpsertModal(props: Props) {
       {activator(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader icon={<CalendarIcon />} title={t('title')} noMargin />
+                    <ModalIcon><CalendarIcon /></ModalIcon>
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
 
                   <ModalBody>
-                    <Form onSubmit={onSubmit} ref={formRef}>
+                    <Form onSubmit={onSubmit} ref={formRef} className="flex flex-col gap-4">
                       <DatePicker value={startTime} isRequired hideTimeZone onChange={setStartTime} />
 
                       <LabeledSwitch isSelected={hasEndDate} onChange={onHasEndDateChange}>

--- a/apps/frontend/src/app/resources/details/maintenance-schedules/upsert/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-schedules/upsert/index.tsx
@@ -13,6 +13,8 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
+  ModalIcon,
   TextField,
   useOverlayState,
 } from '@heroui/react';
@@ -29,7 +31,6 @@ import {
   UsageDurationUnit,
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
-import { PageHeader } from '../../../../../components/pageHeader';
 import { CalendarClockIcon } from 'lucide-react';
 import de from './de.json';
 import en from './en.json';
@@ -232,16 +233,13 @@ export function MaintenanceScheduleUpsertModal(props: Props) {
       {activator(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader
-                      icon={<CalendarClockIcon />}
-                      title={scheduleId != null ? t('titleEdit') : t('titleCreate')}
-                      noMargin
-                    />
+                    <ModalIcon><CalendarClockIcon /></ModalIcon>
+                    <ModalHeading>{scheduleId != null ? t('titleEdit') : t('titleCreate')}</ModalHeading>
                   </ModalHeader>
 
                   <ModalBody>
@@ -251,6 +249,7 @@ export function MaintenanceScheduleUpsertModal(props: Props) {
                         e.preventDefault();
                         onSubmit();
                       }}
+                      className="flex flex-col gap-4"
                     >
                       <TextField value={name} onChange={setName}>
                         <Label>{t('inputs.name.label')}</Label>

--- a/apps/frontend/src/app/resources/details/qrcode/index.tsx
+++ b/apps/frontend/src/app/resources/details/qrcode/index.tsx
@@ -9,9 +9,10 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
+  ModalIcon,
   useOverlayState,
 } from '@heroui/react';
-import { PageHeader } from '../../../../components/pageHeader';
 import { QrCodeIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { QRCode } from 'react-qrcode-logo';
@@ -68,17 +69,14 @@ export function ResourceQrCode(props: Props & Omit<ButtonProps, 'children' | 'st
 
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader
-                      title={t('modal.title')}
-                      subtitle={t('modal.subtitle')}
-                      icon={<QrCodeIcon />}
-                      noMargin
-                    />
+                    <ModalIcon><QrCodeIcon /></ModalIcon>
+                    <ModalHeading>{t('modal.title')}</ModalHeading>
+                    <p className="text-sm text-muted">{t('modal.subtitle')}</p>
                   </ModalHeader>
 
                   <ModalBody>

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/editor/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/editor/index.tsx
@@ -14,6 +14,7 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   NumberField,
   NumberFieldDecrementButton,
   NumberFieldGroup,
@@ -21,7 +22,6 @@ import {
   NumberFieldInput,
   useOverlayState,
 } from '@heroui/react';
-import { PageHeader } from '../../../../../components/pageHeader';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
@@ -138,15 +138,15 @@ export function ResourceBillingInfoEditor(props: Props) {
       {props.children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} noMargin />
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
                   <ModalBody>
-                    <Form onSubmit={onSubmit}>
+                    <Form onSubmit={onSubmit} className="flex flex-col gap-4">
                       <NumberField
                         aria-label={t('inputs.creditsPerUsage.label', { currency: configuration.currency })}
                         value={creditsPerUsage}

--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
@@ -213,8 +213,8 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
       {props.children?.(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="resource-edit-modal">
         <ModalBackdrop>
-          <ModalContainer>
-            <ModalDialog className="w-screen sm:w-[90vw] sm:max-w-6xl">
+          <ModalContainer size="cover">
+            <ModalDialog>
               {({ close }) => (
                 <>
                   <ModalHeader>

--- a/apps/frontend/src/app/resources/forms/components/ResourceFormsModal.tsx
+++ b/apps/frontend/src/app/resources/forms/components/ResourceFormsModal.tsx
@@ -138,7 +138,7 @@ export function ResourceFormsModal({ isOpen, action, forms, onSubmit, onCancel }
       }}
     >
       <ModalBackdrop>
-        <ModalContainer>
+        <ModalContainer size="lg">
           <ModalDialog>
             {({ close }) => (
               <>

--- a/apps/frontend/src/app/resources/usage/components/SessionNotesModal/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/SessionNotesModal/index.tsx
@@ -45,7 +45,7 @@ export const SessionNotesModal = ({ isOpen, onClose, onConfirm, mode, isSubmitti
       }}
     >
       <ModalBackdrop>
-        <ModalContainer className="sm:max-w-md">
+        <ModalContainer size="md">
           <ModalDialog>
             {({ close }) => (
               <>

--- a/apps/frontend/src/app/resources/usage/components/StartSessionControls/insufficientBalanceModal/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/StartSessionControls/insufficientBalanceModal/index.tsx
@@ -24,7 +24,7 @@ export function InsufficientBalanceModal(props: Props) {
       }}
     >
       <ModalBackdrop>
-        <ModalContainer>
+        <ModalContainer size="md">
           <ModalDialog>
             {() => (
               <BillingDashboardTopupCard

--- a/apps/frontend/src/app/resources/usage/components/UsageNotesModal/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/UsageNotesModal/index.tsx
@@ -55,7 +55,7 @@ export const UsageNotesModal = memo(
         }}
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/app/settings/forms/MetricsSettingsForm/index.tsx
+++ b/apps/frontend/src/app/settings/forms/MetricsSettingsForm/index.tsx
@@ -365,7 +365,7 @@ export function MetricsSettingsForm() {
         }}
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close }) => (
                 <>
@@ -397,7 +397,7 @@ export function MetricsSettingsForm() {
         }}
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
+++ b/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
@@ -671,7 +671,7 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
       {/* Main Provider Form Modal */}
       <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="sso-provider-form-modal">
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="lg">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/app/sso/providers/discovery/authentik/index.tsx
+++ b/apps/frontend/src/app/sso/providers/discovery/authentik/index.tsx
@@ -10,10 +10,10 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
 import { OpenIDConfiguration } from '../OpenIDC.data';
-import { PageHeader } from '../../../../../components/pageHeader';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useCallback, useState } from 'react';
 import { useToastMessage } from '../../../../../components/toastProvider';
@@ -97,14 +97,14 @@ export function AuthentikDiscoveryDialog(props: Props) {
         }}
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {({ close }) => (
                 <>
                   <ModalHeader>
-                    <PageHeader noMargin title={t('title')} />
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
-                  <ModalBody>
+                  <ModalBody className="flex flex-col gap-4">
                     <TextField value={host} onChange={setHost}>
                       <Label>{t('host')}</Label>
                       <Input />

--- a/apps/frontend/src/app/sso/providers/discovery/keycloak/index.tsx
+++ b/apps/frontend/src/app/sso/providers/discovery/keycloak/index.tsx
@@ -10,10 +10,10 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
 import { OpenIDConfiguration } from '../OpenIDC.data';
-import { PageHeader } from '../../../../../components/pageHeader';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useCallback, useState } from 'react';
 import { useToastMessage } from '../../../../../components/toastProvider';
@@ -97,14 +97,14 @@ export function KeycloakDiscoveryDialog(props: Props) {
         }}
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {({ close }) => (
                 <>
                   <ModalHeader>
-                    <PageHeader noMargin title={t('title')} />
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
-                  <ModalBody>
+                  <ModalBody className="flex flex-col gap-4">
                     <TextField value={host} onChange={setHost}>
                       <Label>{t('host')}</Label>
                       <Input />

--- a/apps/frontend/src/app/unauthorized/registrationForm.tsx
+++ b/apps/frontend/src/app/unauthorized/registrationForm.tsx
@@ -233,7 +233,7 @@ export function RegistrationForm({ onHasAccount }: RegisterFormProps) {
 
       <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="registration-form-success-modal">
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/app/unauthorized/ssoLinkingRequiredModal/index.tsx
+++ b/apps/frontend/src/app/unauthorized/ssoLinkingRequiredModal/index.tsx
@@ -1,6 +1,5 @@
-import { Alert, AlertContent, AlertDescription, Button, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, Button, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading } from '@heroui/react';
 import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
-import { PageHeader } from '../../../components/pageHeader';
 import { useTranslations, useUrlQuery } from '@attraccess/plugins-frontend-ui';
 import { PasswordInput } from '../../../components/PasswordInput';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -100,11 +99,12 @@ export function SSOLinkingRequiredModal(props: Props) {
   return (
     <Modal isOpen={show}>
       <ModalBackdrop isDismissable={false} />
-      <ModalContainer>
+      <ModalContainer size="md">
         <ModalDialog>
           {() => (<>
         <ModalHeader>
-          <PageHeader title={t('title')} subtitle={t('subtitle')} noMargin />
+          <ModalHeading>{t('title')}</ModalHeading>
+          <p className="text-sm text-muted">{t('subtitle')}</p>
         </ModalHeader>
 
         <ModalBody>

--- a/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
@@ -18,6 +18,8 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
+  ModalIcon,
   Table,
   TableBody,
   TableCell,
@@ -29,7 +31,6 @@ import {
   useOverlayState,
 } from '@heroui/react';
 import { EmptyState } from '../../../components/emptyState';
-import { PageHeader } from '../../../components/pageHeader';
 import { PlusIcon, Settings2Icon, Trash2Icon } from 'lucide-react';
 import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -124,15 +125,17 @@ export function AllowedSignupDomainsEditorModal(props: Props) {
       {props.children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="lg">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<Settings2Icon />} noMargin={true} />
+                    <ModalIcon><Settings2Icon /></ModalIcon>
+                    <ModalHeading>{t('title')}</ModalHeading>
+                    <p className="text-sm text-muted">{t('subtitle')}</p>
                   </ModalHeader>
 
-                  <ModalBody>
+                  <ModalBody className="flex flex-col gap-4">
                     <Alert status="warning" className="whitespace-pre-wrap">
                       <AlertStatusIcon status="warning" />
                       <AlertContent>

--- a/apps/frontend/src/app/user-management/details/index.tsx
+++ b/apps/frontend/src/app/user-management/details/index.tsx
@@ -263,7 +263,7 @@ export function UserManagementDetailsPage() {
 
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="sm">
             <ModalDialog>
               {({ close: modalClose }) => (
                 <>

--- a/apps/frontend/src/app/user-management/invite-user-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/invite-user-modal/index.tsx
@@ -10,6 +10,7 @@ import {
   ModalContainer,
   ModalDialog,
   ModalHeader,
+  ModalHeading,
   Tab,
   TabList,
   TabPanel,
@@ -20,7 +21,6 @@ import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
 import { ApiError, useUsersServiceFindManyKey, useUsersServiceInviteUser } from '@attraccess/react-query-client';
-import { PageHeader } from '../../../components/pageHeader';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useToastMessage } from '../../../components/toastProvider';
 import { useQueryClient } from '@tanstack/react-query';
@@ -138,7 +138,7 @@ export function InviteUserModal(props: Props) {
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} noMargin />
+                    <ModalHeading>{t('title')}</ModalHeading>
                   </ModalHeader>
 
                   <ModalBody>

--- a/apps/frontend/src/app/user-management/two-factor-policy-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/two-factor-policy-modal/index.tsx
@@ -18,12 +18,13 @@ import {
   ModalDialog,
   ModalFooter,
   ModalHeader,
+  ModalHeading,
+  ModalIcon,
   useOverlayState,
 } from '@heroui/react';
 import { Select } from '../../../components/select';
 import { Settings2Icon } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
-import { PageHeader } from '../../../components/pageHeader';
 import { useToastMessage } from '../../../components/toastProvider';
 import API_ERROR_TRANSLATIONS_DE from '../../../global-translations/api-errors.de.json';
 import API_ERROR_TRANSLATIONS_EN from '../../../global-translations/api-errors.en.json';
@@ -116,14 +117,16 @@ export function TwoFactorPolicyModal(props: Props) {
       {props.children(open)}
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {() => (
                 <>
                   <ModalHeader>
-                    <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<Settings2Icon />} noMargin={true} />
+                    <ModalIcon><Settings2Icon /></ModalIcon>
+                    <ModalHeading>{t('title')}</ModalHeading>
+                    <p className="text-sm text-muted">{t('subtitle')}</p>
                   </ModalHeader>
-                  <ModalBody>
+                  <ModalBody className="flex flex-col gap-4">
                     <Alert status="warning">
                       <AlertContent>
                         <AlertTitle>{t('warning.title')}</AlertTitle>

--- a/apps/frontend/src/components/CommunityLicenseButton/index.tsx
+++ b/apps/frontend/src/components/CommunityLicenseButton/index.tsx
@@ -56,7 +56,7 @@ export function CommunityLicenseButton({ onAccept, isDisabled, ...rest }: Commun
         }}
       >
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {({ close: modalClose }) => (
                 <>

--- a/apps/frontend/src/components/IntroductionsManagement/history/index.tsx
+++ b/apps/frontend/src/components/IntroductionsManagement/history/index.tsx
@@ -61,7 +61,7 @@ export function IntroductionHistoryModal(props: Readonly<Props>) {
       }}
     >
       <ModalBackdrop>
-        <ModalContainer>
+        <ModalContainer size="lg">
           <ModalDialog>
             {({ close }) => (
               <>

--- a/apps/frontend/src/components/IntroductionsManagement/index.tsx
+++ b/apps/frontend/src/components/IntroductionsManagement/index.tsx
@@ -130,7 +130,7 @@ export function IntroductionsManagement(props: Readonly<IntroductionsManagementP
           }}
         >
           <ModalBackdrop>
-            <ModalContainer>
+            <ModalContainer size="md">
               <ModalDialog>
                 {() => (
                   <>

--- a/apps/frontend/src/components/UpdateNotificationBanner/index.tsx
+++ b/apps/frontend/src/components/UpdateNotificationBanner/index.tsx
@@ -107,7 +107,7 @@ export function UpdateNotificationBanner() {
 
       <Modal isOpen={isReleaseNotesOpen} onOpenChange={setIsReleaseNotesOpen}>
         <ModalBackdrop>
-          <ModalContainer>
+          <ModalContainer size="md">
             <ModalDialog>
               {({ close }) => (
                 <>

--- a/apps/frontend/src/components/deleteConfirmationModal/index.tsx
+++ b/apps/frontend/src/components/deleteConfirmationModal/index.tsx
@@ -33,7 +33,7 @@ export function DeleteConfirmationModal({
       }}
     >
       <ModalBackdrop>
-        <ModalContainer>
+        <ModalContainer size="sm">
           <ModalDialog>
             {({ close }) => (
               <>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Implements the audit recommendations from [ATT-295](https://linear.app/attraccess/issue/ATT-295/design-audit-modal-form-layout-density-and-clipped-inputs) — fixes density and clipped-header issues in modals after the HeroUI v3 migration. Drawer migration for the heaviest forms is intentionally deferred (not mechanical, needs design call).

## Root causes addressed

1. **`<PageHeader>` inside `<ModalHeader>`** — page-level `h1.text-2xl` wrapped/clipped inside default `max-w-md` modals. Replaced with v3 `<ModalHeading>` + optional `<ModalIcon>` + subtitle paragraph across 19 modals.
2. **No `size` on `<ModalContainer>`** — every modal silently defaulted to `md` (~448 px). Set explicit `xs/sm/md/lg/cover` on all ~45 callsites per modal type.
3. **`<Form>` with no spacing** — `@heroui/react`'s `Form` is bare `react-aria-components/Form` with no default gap; fields stacked flush. Added `className="flex flex-col gap-4"` to every modal form, plus `flex flex-col gap-4` on the `ModalBody` for the modals that stack fields directly (no `<Form>` wrapper).
4. **`resourceEditModal` width hack** — replaced `<ModalDialog className="w-screen sm:w-[90vw] sm:max-w-6xl">` with the canonical `<ModalContainer size="cover">`.

48 files changed, 134/-129. Type-check, lint, build, and 72 frontend tests all pass.

## What's NOT in this PR

The audit's bucket 4 (promote heavy forms — SSO providers, MetricsSettings, ResourceForms, AttractapEditor, maintenance-schedules, allowed-signup-domains — to `<Drawer>`) is deferred. It's not mechanical: Drawer slides from the side, changes UX substantially, and benefits from per-form design review. The size-bumps in this PR (those modals now get `size="lg"`) materially fix the immediate density/clipping; Drawer migration is a follow-up.

## Test plan

- [x] `pnpm nx typecheck frontend`
- [x] `pnpm nx lint frontend`
- [x] `pnpm nx build frontend`
- [x] `pnpm nx test frontend` (72/72 passing)
- [ ] Manual smoke: open every affected modal in the app and verify headings render, fields breathe, no horizontal clip. Recommended before merge; not done in this branch.

Closes ATT-295.

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Normalize modal layouts after HeroUI v3 migration by standardizing headers, sizing, and form spacing across the frontend.

Bug Fixes:
- Fix clipped or cramped modal headers by replacing PageHeader usage with ModalHeading and optional subtitle/icon components.
- Ensure appropriate modal widths by explicitly setting ModalContainer sizes per use case instead of relying on defaults.
- Improve readability of modal forms by adding consistent vertical spacing between fields via flex column gaps.

Enhancements:
- Replace ad-hoc modal width hacks with the canonical cover-sized ModalContainer variant for wide editors and forms.
- Align various confirmation and utility modals (SSO, billing, plugins, QR codes, NFC, maintenance, etc.) to a consistent design system pattern for headings and body layout.