### PR TITLE
feat(frontend): visual hierarchy on resource details (ATT-289)

### DIFF
--- a/apps/frontend/src/app/resources/details/flatSection.tsx
+++ b/apps/frontend/src/app/resources/details/flatSection.tsx
@@ -1,0 +1,25 @@
+// Shared flat sidebar section wrapper for icon, title, actions, body
+// FEATURE: Resource details visual hierarchy (ATT-289 secondary sidebar chrome)
+import { cn } from '@heroui/react';
+import { HTMLAttributes, ReactNode } from 'react';
+
+interface FlatSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
+  icon: ReactNode;
+  title: ReactNode;
+  actions?: ReactNode;
+}
+
+export function FlatSection({ icon, title, actions, children, className, ...rest }: FlatSectionProps) {
+  return (
+    <section className={cn('w-full', className)} {...rest}>
+      <header className="flex items-center justify-between gap-2 flex-wrap border-b border-divider pb-2 mb-3">
+        <div className="flex items-center gap-2 text-foreground-700">
+          {icon}
+          <h3 className="text-xs font-semibold uppercase tracking-wider">{title}</h3>
+        </div>
+        {actions ? <div className="flex items-center gap-2 flex-wrap">{actions}</div> : null}
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -11,7 +11,7 @@ import de from './de.json';
 import en from './en.json';
 import { ResourceMaintenanceUpsertModal } from './upsert';
 import { MarkDoneModal } from './mark-done';
-import { CheckCircleIcon, CogIcon, ConstructionIcon, PlusIcon } from 'lucide-react';
+import { CheckCircleIcon, CogIcon, ConstructionIcon, ExternalLinkIcon, PlusIcon } from 'lucide-react';
 import { useNow } from '../../../../hooks/useNow';
 import { EmptyState } from '../../../../components/emptyState';
 
@@ -76,6 +76,31 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children' 
           <Button variant="primary" onPress={open}>
             <PlusIcon className="w-4 h-4" />
             {t('actions.create.label')}
+          </Button>
+        )}
+      </ResourceMaintenanceUpsertModal>
+    </>
+  );
+
+  const flatActions = (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        isIconOnly
+        onPress={() => navigate(`/resources/${resourceId}/maintenance`)}
+        data-cy="manage-maintenance-button"
+        aria-label={t('actions.manageHub.label')}
+      >
+        <ExternalLinkIcon className="w-4 h-4" />
+      </Button>
+      <LabeledSwitch isSelected={includePast} onChange={setIncludePast}>
+        {t('filters.includePast')}
+      </LabeledSwitch>
+      <ResourceMaintenanceUpsertModal resourceId={resourceId}>
+        {(open) => (
+          <Button variant="primary" size="sm" isIconOnly onPress={open} aria-label={t('actions.create.label')}>
+            <PlusIcon className="w-4 h-4" />
           </Button>
         )}
       </ResourceMaintenanceUpsertModal>
@@ -154,7 +179,7 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children' 
             <ConstructionIcon className="w-4 h-4" />
             <h3 className="text-xs font-semibold uppercase tracking-wider">{t('title')}</h3>
           </div>
-          <div className="flex items-center gap-2 flex-wrap">{actions}</div>
+          <div className="flex items-center gap-2 flex-wrap">{flatActions}</div>
         </header>
         {maintenanceWithStatus.length === 0 ? (
           <EmptyState />

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -17,10 +17,11 @@ import { EmptyState } from '../../../../components/emptyState';
 
 interface Props {
   resourceId: number;
+  variant?: 'card' | 'flat';
 }
 
-export function MaintenanceManagement(props: Props & Omit<CardProps, 'children'>) {
-  const { resourceId, ...cardProps } = props;
+export function MaintenanceManagement(props: Props & Omit<CardProps, 'children' | 'variant'>) {
+  const { resourceId, variant = 'card', ...cardProps } = props;
 
   const { t } = useTranslations({
     de,
@@ -59,42 +60,30 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children'>
     [maintenances?.data, now],
   );
 
-  return (
-    <Card {...cardProps}>
-      <Card.Header>
-        <PageHeader
-          title={t('title')}
-          icon={<ConstructionIcon />}
-          noMargin
-          actions={
-            <>
-              <Button variant="ghost"
-                onPress={() => navigate(`/resources/${resourceId}/maintenance`)}
-                data-cy="manage-maintenance-button"
-              >
-                {t('actions.manageHub.label')}
-              </Button>
-              <LabeledSwitch isSelected={includePast} onChange={setIncludePast}>
-                {t('filters.includePast')}
-              </LabeledSwitch>
-              <ResourceMaintenanceUpsertModal resourceId={resourceId}>
-                {(open) => (
-                  <Button variant="primary"
-                    onPress={open}
+  const actions = (
+    <>
+      <Button variant="ghost"
+        onPress={() => navigate(`/resources/${resourceId}/maintenance`)}
+        data-cy="manage-maintenance-button"
+      >
+        {t('actions.manageHub.label')}
+      </Button>
+      <LabeledSwitch isSelected={includePast} onChange={setIncludePast}>
+        {t('filters.includePast')}
+      </LabeledSwitch>
+      <ResourceMaintenanceUpsertModal resourceId={resourceId}>
+        {(open) => (
+          <Button variant="primary" onPress={open}>
+            <PlusIcon className="w-4 h-4" />
+            {t('actions.create.label')}
+          </Button>
+        )}
+      </ResourceMaintenanceUpsertModal>
+    </>
+  );
 
-                   
-                  ><PlusIcon className="w-4 h-4" />
-                    {t('actions.create.label')}
-                  </Button>
-                )}
-              </ResourceMaintenanceUpsertModal>
-            </>
-          }
-        />
-      </Card.Header>
-
-      <Card.Content>
-        <Table>
+  const tableContent = (
+    <Table>
           <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
             <TableColumn isRowHeader>{t('table.columns.start')}</TableColumn>
@@ -155,7 +144,74 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children'>
           </TableBody>
           </TableContent>
         </Table>
-      </Card.Content>
+  );
+
+  if (variant === 'flat') {
+    return (
+      <section className={cn('w-full', (cardProps as { className?: string }).className)}>
+        <header className="flex items-center justify-between gap-2 flex-wrap border-b border-divider pb-2 mb-3">
+          <div className="flex items-center gap-2 text-foreground-700">
+            <ConstructionIcon className="w-4 h-4" />
+            <h3 className="text-xs font-semibold uppercase tracking-wider">{t('title')}</h3>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">{actions}</div>
+        </header>
+        {maintenanceWithStatus.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <ul className="text-sm divide-y divide-divider">
+            {maintenanceWithStatus.map((maintenance) => (
+              <li
+                key={maintenance.id}
+                className={cn(
+                  'flex items-start justify-between gap-3 py-2',
+                  maintenance.isActive && 'border-l-4 border-l-warning pl-2',
+                  maintenance.isPast && 'line-through opacity-60',
+                )}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-foreground-700 text-xs">
+                    <DateTimeDisplay date={maintenance.startTime} />
+                    {maintenance.endTime && (
+                      <>
+                        {' – '}
+                        <DateTimeDisplay date={maintenance.endTime} />
+                      </>
+                    )}
+                  </div>
+                  <div className="text-foreground truncate">
+                    <MaintenanceReasonDisplay reason={maintenance.reason} />
+                  </div>
+                </div>
+                {maintenance.isActive && (
+                  <MarkDoneModal resourceId={resourceId} maintenanceId={maintenance.id}>
+                    {(openMarkDone: () => void) => (
+                      <Button variant="tertiary" isIconOnly onPress={openMarkDone}>
+                        <CheckCircleIcon className="w-4 h-4" />
+                      </Button>
+                    )}
+                  </MarkDoneModal>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    );
+  }
+
+  return (
+    <Card {...cardProps}>
+      <Card.Header>
+        <PageHeader
+          title={t('title')}
+          icon={<ConstructionIcon />}
+          noMargin
+          actions={actions}
+        />
+      </Card.Header>
+
+      <Card.Content>{tableContent}</Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -1,9 +1,9 @@
-import { Button, Card, CardProps, cn, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import { Button, Card, cn, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import { MaintenanceReasonDisplay } from '../../../../components/MaintenanceReasonDisplay';
 import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { ResourceMaintenance, useResourceMaintenancesServiceFindMaintenances } from '@attraccess/react-query-client';
-import { useMemo, useState } from 'react';
+import { HTMLAttributes, useMemo, useState } from 'react';
 import { DateTimeDisplay, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useNavigate } from 'react-router-dom';
 
@@ -14,14 +14,15 @@ import { MarkDoneModal } from './mark-done';
 import { CheckCircleIcon, CogIcon, ConstructionIcon, ExternalLinkIcon, PlusIcon } from 'lucide-react';
 import { useNow } from '../../../../hooks/useNow';
 import { EmptyState } from '../../../../components/emptyState';
+import { FlatSection } from '../flatSection';
 
-interface Props {
+interface Props extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
   resourceId: number;
   variant?: 'card' | 'flat';
 }
 
-export function MaintenanceManagement(props: Props & Omit<CardProps, 'children' | 'variant'>) {
-  const { resourceId, variant = 'card', ...cardProps } = props;
+export function MaintenanceManagement(props: Props) {
+  const { resourceId, variant = 'card', className, ...htmlProps } = props;
 
   const { t } = useTranslations({
     de,
@@ -173,14 +174,13 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children' 
 
   if (variant === 'flat') {
     return (
-      <section className={cn('w-full', (cardProps as { className?: string }).className)}>
-        <header className="flex items-center justify-between gap-2 flex-wrap border-b border-divider pb-2 mb-3">
-          <div className="flex items-center gap-2 text-foreground-700">
-            <ConstructionIcon className="w-4 h-4" />
-            <h3 className="text-xs font-semibold uppercase tracking-wider">{t('title')}</h3>
-          </div>
-          <div className="flex items-center gap-2 flex-wrap">{flatActions}</div>
-        </header>
+      <FlatSection
+        icon={<ConstructionIcon className="w-4 h-4" />}
+        title={t('title')}
+        actions={flatActions}
+        className={className}
+        {...htmlProps}
+      >
         {maintenanceWithStatus.length === 0 ? (
           <EmptyState />
         ) : (
@@ -221,12 +221,12 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children' 
             ))}
           </ul>
         )}
-      </section>
+      </FlatSection>
     );
   }
 
   return (
-    <Card {...cardProps}>
+    <Card className={className} {...htmlProps}>
       <Card.Header>
         <PageHeader
           title={t('title')}

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -195,7 +195,7 @@ export function MaintenanceManagement(props: Props & Omit<CardProps, 'children' 
                 )}
               >
                 <div className="flex-1 min-w-0">
-                  <div className="text-foreground-700 text-xs">
+                  <div className="text-foreground-700 text-xs whitespace-nowrap overflow-hidden text-ellipsis">
                     <DateTimeDisplay date={maintenance.startTime} />
                     {maintenance.endTime && (
                       <>

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -19,10 +19,11 @@ import { dbCurrencyToUserCurrency } from '@attraccess/shared';
 interface Props {
   resourceId: number;
   onExampleAmountChange?: (amount: number) => void;
+  variant?: 'card' | 'flat';
 }
 
-export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children'>) {
-  const { resourceId, onExampleAmountChange, ...cardProps } = props;
+export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children' | 'variant'>) {
+  const { resourceId, onExampleAmountChange, variant = 'card', ...cardProps } = props;
 
   const { t } = useTranslations({ en, de });
   const { data: configuration } = useBillingServiceGetBillingConfiguration();
@@ -118,26 +119,9 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children'>) 
     return null;
   }
 
-  return (
-    <Card {...cardProps}>
-      <Card.Header className="flex items-center justify-between py-3">
-        <PageHeader
-          title={t('title')}
-          icon={<CreditCard />}
-          actions={
-            <ResourceBillingInfoEditor resourceId={resourceId}>
-              {(onOpen) => (
-                <Button variant="primary" isIconOnly onPress={onOpen} ><Edit2Icon size={12} /></Button>
-              )}
-            </ResourceBillingInfoEditor>
-          }
-          noMargin
-        />
-      </Card.Header>
-
-      <Card.Content>
-        <Table>
-          <TableContent aria-label={t('table.ariaLabel')}>
+  const tableContent = (
+    <Table>
+      <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
             <TableColumn isRowHeader> </TableColumn>
             <TableColumn> </TableColumn>
@@ -221,7 +205,43 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children'>) 
           </TableBody>
           </TableContent>
         </Table>
-      </Card.Content>
+  );
+
+  const editorAction = (
+    <ResourceBillingInfoEditor resourceId={resourceId}>
+      {(onOpen) => (
+        <Button variant="primary" isIconOnly onPress={onOpen}><Edit2Icon size={12} /></Button>
+      )}
+    </ResourceBillingInfoEditor>
+  );
+
+  if (variant === 'flat') {
+    return (
+      <section className={cn('w-full', (cardProps as { className?: string }).className)}>
+        <header className="flex items-center justify-between border-b border-divider pb-2 mb-3">
+          <div className="flex items-center gap-2 text-foreground-700">
+            <CreditCard className="w-4 h-4" />
+            <h3 className="text-xs font-semibold uppercase tracking-wider">{t('title')}</h3>
+          </div>
+          {editorAction}
+        </header>
+        <div className="text-sm">{tableContent}</div>
+      </section>
+    );
+  }
+
+  return (
+    <Card {...cardProps}>
+      <Card.Header className="flex items-center justify-between py-3">
+        <PageHeader
+          title={t('title')}
+          icon={<CreditCard />}
+          actions={editorAction}
+          noMargin
+        />
+      </Card.Header>
+
+      <Card.Content>{tableContent}</Card.Content>
     </Card>
   );
 }

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardProps, cn, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, Skeleton, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from "@heroui/react";
+import { Button, Card, cn, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, Skeleton, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from "@heroui/react";
 import { CreditCard, Edit2Icon } from 'lucide-react';
 import {
   useBillingServiceGetBillingBalance,
@@ -12,18 +12,19 @@ import de from './de.json';
 import en from './en.json';
 import { PageHeader } from '../../../../components/pageHeader';
 import { ResourceBillingInfoEditor } from './editor';
-import { useEffect, useMemo, useState } from 'react';
+import { HTMLAttributes, useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../../../../hooks/useAuth';
 import { dbCurrencyToUserCurrency } from '@attraccess/shared';
+import { FlatSection } from '../flatSection';
 
-interface Props {
+interface Props extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
   resourceId: number;
   onExampleAmountChange?: (amount: number) => void;
   variant?: 'card' | 'flat';
 }
 
-export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children' | 'variant'>) {
-  const { resourceId, onExampleAmountChange, variant = 'card', ...cardProps } = props;
+export function ResourceBillingInfo(props: Props) {
+  const { resourceId, onExampleAmountChange, variant = 'card', className, ...htmlProps } = props;
 
   const { t } = useTranslations({ en, de });
   const { data: configuration } = useBillingServiceGetBillingConfiguration();
@@ -217,21 +218,20 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children' | 
 
   if (variant === 'flat') {
     return (
-      <section className={cn('w-full', (cardProps as { className?: string }).className)}>
-        <header className="flex items-center justify-between border-b border-divider pb-2 mb-3">
-          <div className="flex items-center gap-2 text-foreground-700">
-            <CreditCard className="w-4 h-4" />
-            <h3 className="text-xs font-semibold uppercase tracking-wider">{t('title')}</h3>
-          </div>
-          {editorAction}
-        </header>
+      <FlatSection
+        icon={<CreditCard className="w-4 h-4" />}
+        title={t('title')}
+        actions={editorAction}
+        className={className}
+        {...htmlProps}
+      >
         <div className="text-sm">{tableContent}</div>
-      </section>
+      </FlatSection>
     );
   }
 
   return (
-    <Card {...cardProps}>
+    <Card className={className} {...htmlProps}>
       <Card.Header className="flex items-center justify-between py-3">
         <PageHeader
           title={t('title')}

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -129,7 +129,7 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children' | 
           <TableBody>
             <TableRow className="border-b-4 border-divider">
               <TableCell>{t('balance.label')}</TableCell>
-              <TableCell className={cn(adjustedBalance < 0 ? 'text-danger' : 'text-success')}>
+              <TableCell className={cn('whitespace-nowrap text-right', adjustedBalance < 0 ? 'text-danger' : 'text-success')}>
                 {t('billingValue', {
                   credits: formatNumber(adjustedBalance),
                   currency: configuration.currency,
@@ -138,13 +138,13 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children' | 
             </TableRow>
             <TableRow>
               <TableCell>{t('perUse.label')}</TableCell>
-              <TableCell className="text-warning">
+              <TableCell className="text-warning whitespace-nowrap text-right">
                 {t('billingValue', { credits: formatNumber(creditsPerUsage), currency: configuration.currency })}
               </TableCell>
             </TableRow>
             <TableRow>
               <TableCell>{t('perMinute.label')}</TableCell>
-              <TableCell className="text-warning">
+              <TableCell className="text-warning whitespace-nowrap text-right">
                 {t('billingValue', {
                   credits: formatNumber(creditsPerMinute),
                   currency: configuration.currency,
@@ -155,7 +155,7 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children' | 
               resourceBillingConfiguration.additionalItems.map((item) => (
                 <TableRow key={JSON.stringify(item)} id={JSON.stringify(item)}>
                   <TableCell>{item.name}</TableCell>
-                  <TableCell className="text-warning">
+                  <TableCell className="text-warning whitespace-nowrap text-right">
                     {t('billingValue', {
                       credits: formatNumber(
                         dbCurrencyToUserCurrency(item.unitPrice * item.quantity, configuration.minorUnit),
@@ -185,7 +185,7 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children' | 
                   </NumberFieldGroup>
                 </NumberField>
               </TableCell>
-              <TableCell>
+              <TableCell className="whitespace-nowrap text-right">
                 {t('billingValue', {
                   credits: formatNumber(exampleCost),
                   currency: configuration.currency,
@@ -195,7 +195,7 @@ export function ResourceBillingInfo(props: Props & Omit<CardProps, 'children' | 
             </TableRow>
             <TableRow>
               <TableCell>{t('exampleResultingBalance.label')}</TableCell>
-              <TableCell className={cn(exampleResultingBalance < 0 ? 'text-danger' : 'text-success')}>
+              <TableCell className={cn('whitespace-nowrap text-right', exampleResultingBalance < 0 ? 'text-danger' : 'text-success')}>
                 {t('billingValue', {
                   credits: formatNumber(exampleResultingBalance),
                   currency: configuration.currency,

--- a/apps/frontend/src/app/resources/details/resourceDetails.tsx
+++ b/apps/frontend/src/app/resources/details/resourceDetails.tsx
@@ -190,18 +190,24 @@ function ResourceDetailsComponent() {
         }
       />
 
-      <div className="w-full space-y-6 mb-6">
+      <div className="mb-6">
         <ResourceHealthWarning resourceId={resourceId} />
+      </div>
 
-        <ResourceUsageSession
-          resourceId={resourceId}
-          resource={resource}
-          data-cy="resource-usage-session"
-          insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
-          className="border-l-4 border-l-primary shadow-medium"
-        />
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6 lg:items-start">
+        <div className="lg:col-span-2 space-y-6">
+          <ResourceUsageSession
+            resourceId={resourceId}
+            resource={resource}
+            data-cy="resource-usage-session"
+            insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
+            className="border-l-4 border-l-primary shadow-medium"
+          />
 
-        <div className="space-y-8">
+          <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" />
+        </div>
+
+        <aside className="lg:col-span-1 space-y-8">
           <ResourceBillingInfo
             variant="flat"
             resourceId={resourceId}
@@ -210,9 +216,7 @@ function ResourceDetailsComponent() {
           {maintenancePermissions?.canManage && (
             <MaintenanceManagement variant="flat" resourceId={resourceId} />
           )}
-        </div>
-
-        <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" />
+        </aside>
       </div>
 
       <div className="flex flex-row flex-wrap w-full gap-6 items-stretch">

--- a/apps/frontend/src/app/resources/details/resourceDetails.tsx
+++ b/apps/frontend/src/app/resources/details/resourceDetails.tsx
@@ -193,29 +193,26 @@ function ResourceDetailsComponent() {
       <div className="w-full space-y-6 mb-6">
         <ResourceHealthWarning resourceId={resourceId} />
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
-          <div className="lg:col-span-2 space-y-6">
-            <ResourceUsageSession
-              resourceId={resourceId}
-              resource={resource}
-              data-cy="resource-usage-session"
-              insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
-              className="border-l-4 border-l-primary shadow-medium"
-            />
-            <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" />
-          </div>
+        <ResourceUsageSession
+          resourceId={resourceId}
+          resource={resource}
+          data-cy="resource-usage-session"
+          insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
+          className="border-l-4 border-l-primary shadow-medium"
+        />
 
-          <aside className="lg:col-span-1 space-y-8">
-            <ResourceBillingInfo
-              variant="flat"
-              resourceId={resourceId}
-              onExampleAmountChange={(value) => setInsufficientBalanceDesiredAmount(Math.ceil(value))}
-            />
-            {maintenancePermissions?.canManage && (
-              <MaintenanceManagement variant="flat" resourceId={resourceId} />
-            )}
-          </aside>
+        <div className="space-y-8">
+          <ResourceBillingInfo
+            variant="flat"
+            resourceId={resourceId}
+            onExampleAmountChange={(value) => setInsufficientBalanceDesiredAmount(Math.ceil(value))}
+          />
+          {maintenancePermissions?.canManage && (
+            <MaintenanceManagement variant="flat" resourceId={resourceId} />
+          )}
         </div>
+
+        <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" />
       </div>
 
       <div className="flex flex-row flex-wrap w-full gap-6 items-stretch">

--- a/apps/frontend/src/app/resources/details/resourceDetails.tsx
+++ b/apps/frontend/src/app/resources/details/resourceDetails.tsx
@@ -192,25 +192,29 @@ function ResourceDetailsComponent() {
 
       <div className="w-full space-y-6 mb-6">
         <ResourceHealthWarning resourceId={resourceId} />
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
-          <ResourceUsageSession
-            resourceId={resourceId}
-            resource={resource}
-            data-cy="resource-usage-session"
-            insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
-          />
-          <ResourceBillingInfo
-            resourceId={resourceId}
-            onExampleAmountChange={(value) => setInsufficientBalanceDesiredAmount(Math.ceil(value))}
-          />
-        </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-stretch">
-          <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+          <div className="lg:col-span-2 space-y-6">
+            <ResourceUsageSession
+              resourceId={resourceId}
+              resource={resource}
+              data-cy="resource-usage-session"
+              insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
+              className="border-l-4 border-l-primary shadow-medium"
+            />
+            <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" />
+          </div>
 
-          {maintenancePermissions?.canManage && (
-            <MaintenanceManagement resourceId={resourceId} />
-          )}
+          <aside className="lg:col-span-1 space-y-8">
+            <ResourceBillingInfo
+              variant="flat"
+              resourceId={resourceId}
+              onExampleAmountChange={(value) => setInsufficientBalanceDesiredAmount(Math.ceil(value))}
+            />
+            {maintenancePermissions?.canManage && (
+              <MaintenanceManagement variant="flat" resourceId={resourceId} />
+            )}
+          </aside>
         </div>
       </div>
 

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableHeaders.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableHeaders.tsx
@@ -24,7 +24,7 @@ export function generateHeaderColumns(
         {t('headers.machine.endTime')}
       </TableColumn>,
       <TableColumn key="duration" id="duration">{t('headers.machine.duration')}</TableColumn>,
-      <TableColumn key="project" id="project" className="hidden md:table-cell">
+      <TableColumn key="project" id="project" className="hidden 2xl:table-cell">
         {t('headers.machine.project')}
       </TableColumn>,
       <TableColumn key="icons" id="icons">{''}</TableColumn>,

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableRows.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableRows.tsx
@@ -32,13 +32,13 @@ export function generateRowCells(
 
   if (resource.type === 'machine') {
     cells.push(
-      <TableCell key={`start-${session.id}`}>
+      <TableCell key={`start-${session.id}`} className="whitespace-nowrap">
         <DateTimeDisplay date={session.startTime} />
       </TableCell>,
-      <TableCell key={`end-${session.id}`} className="hidden md:table-cell">
+      <TableCell key={`end-${session.id}`} className="hidden md:table-cell whitespace-nowrap">
         <DateTimeDisplay date={session.endTime} />
       </TableCell>,
-      <TableCell key={`duration-${session.id}`}>
+      <TableCell key={`duration-${session.id}`} className="whitespace-nowrap">
         <DurationDisplay
           minutes={session.usageInMinutes >= 0 ? session.usageInMinutes : null}
           alternativeText={
@@ -48,7 +48,7 @@ export function generateRowCells(
           }
         />
       </TableCell>,
-      <TableCell key={`project-${session.id}`} className="hidden md:table-cell">
+      <TableCell key={`project-${session.id}`} className="hidden 2xl:table-cell">
         {projectCellRenderer ? projectCellRenderer(session) : session.project?.name}
       </TableCell>,
       <TableCell key={`icons-${session.id}`} className="flex items-center gap-2">


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Implements [ATT-289](https://linear.app/attraccess/issue/ATT-289/design-resourcesid-visual-hierarchy-de-emphasize-payment-secondary) — variant C from the design mocks. Restructures `/resources/:id` so the primary action (start a session) is visually dominant and ancillary info (payment, maintenance metadata) reads as a secondary sidebar.

- 2/3 left column: `ResourceUsageSession` card with accent left border + stronger shadow, `ResourceUsageHistory` card below.
- 1/3 right sidebar: `ResourceBillingInfo` and `MaintenanceManagement` rendered as flat sections (no card chrome, uppercase tracked heading, divider).
- Maintenance flat variant renders a compact list instead of the 7-column table, so it actually fits the narrow sidebar.
- Grid stacks single-column below `lg`.

## Implementation

- `ResourceBillingInfo` and `MaintenanceManagement` gain a `variant?: 'card' | 'flat'` prop. Card path is unchanged for any other consumer.
- A11y heading order preserved (`PageHeader` still `h1`; flat section headings use `h3`, same level the cards used).

## Test plan

- [x] `pnpm nx typecheck frontend`
- [x] `pnpm nx lint frontend --max-warnings=0`
- [x] `pnpm nx test frontend` (76 tests passing)
- [x] Manual: logged in as devadmin on real seeded data, dark mode, screenshots in the Linear issue
- [ ] Verify mobile/<lg> stacking on a real device
- [ ] Verify `ResourceHealthWarning` triggered state (couldn't reproduce in seeded data)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Update the resource details page layout to emphasize starting a session while moving billing and maintenance information into a secondary sidebar.

New Features:
- Add a `variant` prop to `ResourceBillingInfo` and `MaintenanceManagement` to support both card and flat section presentations.

Enhancements:
- Introduce a flat, compact list layout for maintenance management suitable for a narrow sidebar.
- Refine the resource details grid to a 2/3 main column and 1/3 sidebar layout, with responsive stacking below large screens.
- Visually emphasize the resource usage session card with accent border and stronger shadow while preserving heading hierarchy.