### PR TITLE
feat(dev): parallel-safe dev servers via port-resolving launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ bom.json
 .claude/worktrees
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+
+docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+Short reference for agents working in this repo. See `CLAUDE.md` for tooling.
+
+## Dev servers — always use `pnpm serve`
+
+`pnpm serve` is safe to run in parallel from multiple worktrees. It auto-resolves free ports for API and frontend, printing them in a banner at startup:
+
+```
+┌─────────────────────────────────────────────┐
+│ Attraccess dev servers                      │
+│   API      → http://localhost:3001          │
+│   Frontend → http://localhost:4201          │
+└─────────────────────────────────────────────┘
+```
+
+**Never assume ports 3000/4200 are yours.** Parse the banner (first ~6 lines of stdout) to learn the actual ports.
+
+Flags:
+
+- `pnpm serve --only=api` — API only
+- `pnpm serve --only=frontend` — frontend only
+- `pnpm serve` — both (default)
+
+Pin a port (strict — fails on collision):
+
+- `PORT=3010 pnpm serve`
+- `VITE_PORT=4250 pnpm serve`
+
+Solo `pnpm nx serve api` is **not** wrapped — it still hard-fails on busy 3000. Prefer `pnpm serve --only=api`.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,33 @@ This installs Node (via nvm if needed), pnpm, and project deps. You must install
 
 ## Development
 
-Start the api and frontend in development mode (HMR):
+Start the API and frontend in development mode (HMR), with automatic port resolution:
 
 ```bash
-pnpm nx run-many -t serve --projects=api,frontend
+pnpm serve
 ```
 
-The API will be available at `http://localhost:3000`
-and the Frontend at `http://localhost:4200`
+The launcher probes for free ports and prints them at startup. Defaults:
+
+- API: 3000 (searches 3000–3099)
+- Frontend: 4200 (searches 4200–4299)
+- Vite preview: 4300 (searches 4300–4399)
+
+Run only one service:
+
+```bash
+pnpm serve --only=api
+pnpm serve --only=frontend
+```
+
+Pin a specific port (fails loudly if busy):
+
+```bash
+PORT=3010 pnpm serve              # API on 3010
+VITE_PORT=4250 pnpm serve         # Frontend on 4250
+```
+
+The frontend dev proxy automatically targets whichever port the API resolved to (via `VITE_API_PROXY_TARGET`).
 
 ## API Documentation
 

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -16,24 +16,24 @@ export default defineConfig(({ command }) => {
   root: __dirname,
   cacheDir: '../../node_modules/.vite/apps/frontend',
   server: {
-    port: 4200,
+    port: Number(process.env.VITE_PORT) || 4200,
     host: '0.0.0.0',
     ...(isDev ? {
       proxy: {
         '/api': {
-          target: 'http://localhost:3000',
+          target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:3000',
           changeOrigin: true,
           ws: true,
         },
         '/cdn': {
-          target: 'http://localhost:3000',
+          target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:3000',
           changeOrigin: true,
         },
       },
     } : {}),
   },
   preview: {
-    port: 4300,
+    port: Number(process.env.VITE_PREVIEW_PORT) || 4300,
     host: '0.0.0.0',
   },
   plugins: [

--- a/docs/de/developer/overview.md
+++ b/docs/de/developer/overview.md
@@ -40,7 +40,7 @@ pnpm install
 
 ### 3. Entwicklungsserver starten
 
-Den Port-auflösenden Launcher verwenden:
+Den port-auflösenden Launcher verwenden:
 
 ```bash
 pnpm serve

--- a/docs/de/developer/overview.md
+++ b/docs/de/developer/overview.md
@@ -38,23 +38,22 @@ cd Attraccess
 pnpm install
 ```
 
-### 3. Backend starten
+### 3. Entwicklungsserver starten
+
+Den Port-auflösenden Launcher verwenden:
 
 ```bash
-pnpm nx serve api
+pnpm serve
 ```
 
-Der API-Server startet standardmäßig unter `http://localhost:3000`. Die Swagger-Dokumentation ist unter `http://localhost:3000/api` verfügbar.
+Der Launcher sucht freie Ports beginnend bei den Standardwerten (API 3000, Frontend 4200, Preview 4300) und gibt sie beim Start aus. Mehrere Instanzen können gleichzeitig laufen, ohne dass Ports manuell konfiguriert werden müssen.
 
-### 4. Frontend starten
+Flags:
 
-In einem separaten Terminal:
+- `--only=api` / `--only=frontend` / `--only=both` (Standard `both`)
+- `PORT=<n>` fixiert den API-Port; `VITE_PORT=<n>` fixiert das Frontend (strikt — bricht ab, falls belegt)
 
-```bash
-pnpm nx serve frontend
-```
-
-Der Frontend-Entwicklungsserver startet unter `http://localhost:4200`. API-Anfragen werden automatisch an das Backend weitergeleitet.
+Der Vite-Dev-Proxy wird automatisch auf den vom Launcher gewählten API-Port konfiguriert.
 
 ## Entwicklungsablauf
 
@@ -71,8 +70,9 @@ Das Repository ist als NX-Monorepo organisiert. Siehe [Architektur](developer/ar
 
 | Befehl | Beschreibung |
 |--------|-------------|
-| `pnpm nx serve api` | Backend im Entwicklungsmodus starten |
-| `pnpm nx serve frontend` | Frontend im Entwicklungsmodus starten |
+| `pnpm serve` | Backend und Frontend mit dem Port-auflösenden Launcher starten |
+| `pnpm serve --only=api` | Nur das Backend starten |
+| `pnpm serve --only=frontend` | Nur das Frontend starten |
 | `pnpm nx test api` | Backend-Tests ausführen |
 | `pnpm nx test frontend` | Frontend-Tests ausführen |
 | `pnpm nx build api` | Backend für Produktion erstellen |

--- a/docs/en/developer/overview.md
+++ b/docs/en/developer/overview.md
@@ -38,23 +38,22 @@ cd Attraccess
 pnpm install
 ```
 
-### 3. Start the Backend
+### 3. Running dev servers
+
+Use the port-resolving launcher:
 
 ```bash
-pnpm nx serve api
+pnpm serve
 ```
 
-The API server starts on `http://localhost:3000` by default. Swagger documentation is available at `http://localhost:3000/api`.
+The launcher probes free ports starting from defaults (API 3000, Frontend 4200, Preview 4300) and prints them at startup. Run multiple instances concurrently without manual port juggling.
 
-### 4. Start the Frontend
+Flags:
 
-In a separate terminal:
+- `--only=api` / `--only=frontend` / `--only=both` (default `both`)
+- `PORT=<n>` to pin API; `VITE_PORT=<n>` to pin frontend (strict — fails if busy)
 
-```bash
-pnpm nx serve frontend
-```
-
-The frontend development server starts on `http://localhost:4200`. It automatically proxies API requests to the backend.
+The Vite dev proxy is wired to whichever API port the launcher resolved.
 
 ## Development Workflow
 
@@ -71,8 +70,9 @@ The repository is organized as an NX monorepo. See [Architecture](developer/arch
 
 | Command | Description |
 |---------|-------------|
-| `pnpm nx serve api` | Start the backend in development mode |
-| `pnpm nx serve frontend` | Start the frontend in development mode |
+| `pnpm serve` | Start backend and frontend with the port-resolving launcher |
+| `pnpm serve --only=api` | Start only the backend |
+| `pnpm serve --only=frontend` | Start only the frontend |
 | `pnpm nx test api` | Run backend tests |
 | `pnpm nx test frontend` | Run frontend tests |
 | `pnpm nx build api` | Build the backend for production |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.2",
   "license": "MIT",
   "scripts": {
-    "serve": "nx run-many -t serve --projects=api,frontend --outputStyle=stream",
+    "serve": "node --experimental-strip-types scripts/dev-serve.mts",
     "lint:strict": "nx affected -t lint -- --max-warnings=0",
     "prepare": "husky",
     "precommit": "pnpm nx affected --uncommitted --nxBail --target=lint,typecheck,build,test,e2e",

--- a/scripts/dev-serve.mts
+++ b/scripts/dev-serve.mts
@@ -15,10 +15,18 @@ interface Resolved {
 function parseArgs(argv: string[]): { only: Target } {
   let only: Target = 'both';
   for (const arg of argv.slice(2)) {
-    const m = arg.match(/^--only=(api|frontend|both)$/);
-    if (m) only = m[1] as Target;
-    else if (arg === '--only') throw new Error('--only requires a value: api|frontend|both');
-    else if (arg.startsWith('--')) throw new Error(`Unknown flag: ${arg}`);
+    const m = arg.match(/^--only=(.+)$/);
+    if (m) {
+      if (m[1] === 'api' || m[1] === 'frontend' || m[1] === 'both') {
+        only = m[1] as Target;
+      } else {
+        throw new Error(`Invalid value for --only: "${m[1]}". Must be api, frontend, or both.`);
+      }
+    } else if (arg === '--only') {
+      throw new Error('--only requires a value: api|frontend|both');
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
   }
   return { only };
 }
@@ -42,9 +50,9 @@ function banner(r: Resolved): string {
   const lines: string[] = [];
   lines.push('┌─────────────────────────────────────────────┐');
   lines.push('│ Attraccess dev servers                      │');
-  if (r.apiPort !== undefined) lines.push(`│   API      → http://localhost:${String(r.apiPort).padEnd(13)}│`);
-  if (r.frontendPort !== undefined) lines.push(`│   Frontend → http://localhost:${String(r.frontendPort).padEnd(13)}│`);
-  if (r.previewPort !== undefined) lines.push(`│   Preview  → http://localhost:${String(r.previewPort).padEnd(13)}│`);
+  if (r.apiPort !== undefined) lines.push(`│   API      → http://localhost:${String(r.apiPort).padEnd(14)}│`);
+  if (r.frontendPort !== undefined) lines.push(`│   Frontend → http://localhost:${String(r.frontendPort).padEnd(14)}│`);
+  if (r.previewPort !== undefined) lines.push(`│   Preview  → http://localhost:${String(r.previewPort).padEnd(14)}│`);
   lines.push('└─────────────────────────────────────────────┘');
   return lines.join('\n');
 }
@@ -84,8 +92,13 @@ async function main() {
   process.on('SIGTERM', () => forward('SIGTERM'));
 
   child.on('exit', (code, signal) => {
-    if (signal) process.kill(process.pid, signal);
-    else process.exit(code ?? 0);
+    if (signal) {
+      process.removeAllListeners('SIGINT');
+      process.removeAllListeners('SIGTERM');
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 0);
+    }
   });
 }
 

--- a/scripts/dev-serve.mts
+++ b/scripts/dev-serve.mts
@@ -12,9 +12,20 @@ interface Resolved {
   previewPort?: number;
 }
 
-function parseArgs(argv: string[]): { only: Target } {
+function parseArgs(argv: string[]): { only: Target; passthroughArgs: string[] } {
   let only: Target = 'both';
-  for (const arg of argv.slice(2)) {
+  const passthroughArgs: string[] = [];
+  const args = argv.slice(2);
+  let sawDelimiter = false;
+  for (const arg of args) {
+    if (sawDelimiter) {
+      passthroughArgs.push(arg);
+      continue;
+    }
+    if (arg === '--') {
+      sawDelimiter = true;
+      continue;
+    }
     const m = arg.match(/^--only=(.+)$/);
     if (m) {
       if (m[1] === 'api' || m[1] === 'frontend' || m[1] === 'both') {
@@ -24,11 +35,11 @@ function parseArgs(argv: string[]): { only: Target } {
       }
     } else if (arg === '--only') {
       throw new Error('--only requires a value: api|frontend|both');
-    } else if (arg.startsWith('--')) {
-      throw new Error(`Unknown flag: ${arg}`);
+    } else {
+      passthroughArgs.push(arg);
     }
   }
-  return { only };
+  return { only, passthroughArgs };
 }
 
 async function resolvePort(envName: string, defaultStart: number, label: string): Promise<number> {
@@ -58,7 +69,7 @@ function banner(r: Resolved): string {
 }
 
 async function main() {
-  const { only } = parseArgs(process.argv);
+  const { only, passthroughArgs } = parseArgs(process.argv);
   const resolved: Resolved = {};
   const childEnv: NodeJS.ProcessEnv = { ...process.env };
 
@@ -81,7 +92,7 @@ async function main() {
   const projects = only === 'both' ? 'api,frontend' : only;
   const child = spawn(
     'pnpm',
-    ['nx', 'run-many', '-t', 'serve', `--projects=${projects}`, '--outputStyle=stream'],
+    ['nx', 'run-many', '-t', 'serve', `--projects=${projects}`, '--outputStyle=stream', ...passthroughArgs],
     { stdio: 'inherit', env: childEnv },
   );
 

--- a/scripts/dev-serve.mts
+++ b/scripts/dev-serve.mts
@@ -1,0 +1,95 @@
+// Dev-server launcher that auto-resolves ports and spawns nx serve
+// FEATURE: dev-server-port-isolation
+
+import { spawn } from 'node:child_process';
+import { findFreePort, isPortFree } from './lib/find-free-port.mts';
+
+type Target = 'api' | 'frontend' | 'both';
+
+interface Resolved {
+  apiPort?: number;
+  frontendPort?: number;
+  previewPort?: number;
+}
+
+function parseArgs(argv: string[]): { only: Target } {
+  let only: Target = 'both';
+  for (const arg of argv.slice(2)) {
+    const m = arg.match(/^--only=(api|frontend|both)$/);
+    if (m) only = m[1] as Target;
+    else if (arg === '--only') throw new Error('--only requires a value: api|frontend|both');
+    else if (arg.startsWith('--')) throw new Error(`Unknown flag: ${arg}`);
+  }
+  return { only };
+}
+
+async function resolvePort(envName: string, defaultStart: number, label: string): Promise<number> {
+  const explicit = process.env[envName];
+  if (explicit !== undefined && explicit !== '') {
+    const port = Number(explicit);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(`${envName}="${explicit}" is not a valid port`);
+    }
+    if (!(await isPortFree(port))) {
+      throw new Error(`${label} port ${port} (from ${envName}) is already in use. Free it or unset ${envName}.`);
+    }
+    return port;
+  }
+  return findFreePort(defaultStart, 100);
+}
+
+function banner(r: Resolved): string {
+  const lines: string[] = [];
+  lines.push('┌─────────────────────────────────────────────┐');
+  lines.push('│ Attraccess dev servers                      │');
+  if (r.apiPort !== undefined) lines.push(`│   API      → http://localhost:${String(r.apiPort).padEnd(13)}│`);
+  if (r.frontendPort !== undefined) lines.push(`│   Frontend → http://localhost:${String(r.frontendPort).padEnd(13)}│`);
+  if (r.previewPort !== undefined) lines.push(`│   Preview  → http://localhost:${String(r.previewPort).padEnd(13)}│`);
+  lines.push('└─────────────────────────────────────────────┘');
+  return lines.join('\n');
+}
+
+async function main() {
+  const { only } = parseArgs(process.argv);
+  const resolved: Resolved = {};
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+
+  if (only === 'api' || only === 'both') {
+    resolved.apiPort = await resolvePort('PORT', 3000, 'API');
+    childEnv.PORT = String(resolved.apiPort);
+  }
+  if (only === 'frontend' || only === 'both') {
+    resolved.frontendPort = await resolvePort('VITE_PORT', 4200, 'Frontend');
+    resolved.previewPort = await resolvePort('VITE_PREVIEW_PORT', 4300, 'Preview');
+    childEnv.VITE_PORT = String(resolved.frontendPort);
+    childEnv.VITE_PREVIEW_PORT = String(resolved.previewPort);
+    if (resolved.apiPort !== undefined) {
+      childEnv.VITE_API_PROXY_TARGET = `http://localhost:${resolved.apiPort}`;
+    }
+  }
+
+  console.log(banner(resolved));
+
+  const projects = only === 'both' ? 'api,frontend' : only;
+  const child = spawn(
+    'pnpm',
+    ['nx', 'run-many', '-t', 'serve', `--projects=${projects}`, '--outputStyle=stream'],
+    { stdio: 'inherit', env: childEnv },
+  );
+
+  const forward = (sig: NodeJS.Signals) => {
+    if (!child.killed) child.kill(sig);
+  };
+  process.on('SIGINT', () => forward('SIGINT'));
+  process.on('SIGTERM', () => forward('SIGTERM'));
+
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    else process.exit(code ?? 0);
+  });
+}
+
+main().catch((err) => {
+  console.error(`[dev-serve] ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/lib/find-free-port.mts
+++ b/scripts/lib/find-free-port.mts
@@ -1,0 +1,23 @@
+// Pure port-probing helpers for dev-server launcher
+// FEATURE: dev-server-port-isolation
+
+import { createServer } from 'node:net';
+
+export async function isPortFree(port: number, host = '0.0.0.0'): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, host);
+  });
+}
+
+export async function findFreePort(start: number, maxAttempts = 100, host = '0.0.0.0'): Promise<number> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const candidate = start + i;
+    if (await isPortFree(candidate, host)) return candidate;
+  }
+  throw new Error(`No free port found in range ${start}-${start + maxAttempts - 1}`);
+}

--- a/scripts/lib/find-free-port.spec.mts
+++ b/scripts/lib/find-free-port.spec.mts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { createServer } from 'node:net';
+import { findFreePort, isPortFree } from './find-free-port.mts';
+
+describe('isPortFree', () => {
+  it('returns true for a port nothing is bound to', async () => {
+    const free = await isPortFree(0);
+    expect(free).toBe(true);
+  });
+
+  it('returns false for a port that is currently bound', async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, '0.0.0.0', resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+      expect(await isPortFree(port)).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+describe('findFreePort', () => {
+  it('returns the starting port when it is free', async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, '0.0.0.0', resolve));
+    const port = (server.address() as { port: number }).port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    expect(await findFreePort(port, 10)).toBe(port);
+  });
+
+  it('skips occupied ports and returns the next free one', async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve) => blocker.listen(0, '0.0.0.0', resolve));
+    const blocked = (blocker.address() as { port: number }).port;
+    try {
+      const result = await findFreePort(blocked, 10);
+      expect(result).toBeGreaterThan(blocked);
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+  });
+
+  it('throws when no port is free within maxAttempts', async () => {
+    const blockers: ReturnType<typeof createServer>[] = [];
+    try {
+      const blocker = createServer();
+      await new Promise<void>((resolve) => blocker.listen(0, '0.0.0.0', resolve));
+      const start = (blocker.address() as { port: number }).port;
+      blockers.push(blocker);
+      await expect(findFreePort(start, 1)).rejects.toThrow(/No free port/);
+    } finally {
+      for (const b of blockers) {
+        await new Promise<void>((resolve) => b.close(() => resolve()));
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Replace root \`pnpm serve\` with a launcher (\`scripts/dev-serve.mts\`) that probes free ports and spawns \`nx run-many -t serve\` with resolved env vars. Multiple agents/devs can now run \`pnpm serve\` in parallel from different worktrees without port collisions.
- Frontend \`vite.config.ts\` reads \`VITE_PORT\`, \`VITE_API_PROXY_TARGET\`, \`VITE_PREVIEW_PORT\` with original hardcoded values as fallback — solo \`nx serve frontend\` still works unchanged.
- Explicit \`PORT\` / \`VITE_PORT\` overrides are honored strictly: launcher fails loudly if the pinned port is busy, never re-routes silently.

## Behavior

| Invocation | API port | Frontend port |
|---|---|---|
| \`pnpm serve\` | 3000 → 3001 → … (auto) | 4200 → 4201 → … (auto) |
| \`pnpm serve --only=api\` | auto | not started |
| \`pnpm serve --only=frontend\` | not started | auto |
| \`PORT=3010 pnpm serve\` | 3010 (strict — fails if busy) | auto |
| \`pnpm nx serve api\` (solo) | 3000 only — unchanged | n/a |

Launcher prints a banner with resolved ports at startup so agents can parse the actual ports from stdout.

## Docs

- \`README.md\` — Development section rewritten
- \`docs/en/developer/overview.md\` + \`docs/de/developer/overview.md\` — same content localized
- \`AGENTS.md\` (new, repo root) — short reference for agents
- \`docs/superpowers/specs/2026-05-15-dev-server-port-isolation-design.md\` + matching plan — design rationale and implementation plan

## Test plan

- [x] \`pnpm vitest run scripts/lib/find-free-port.spec.mts\` — 5/5 pass
- [x] \`pnpm nx affected -t lint,typecheck\` — pass
- [x] Smoke: \`pnpm serve\` starts both servers, frontend proxies to resolved API port
- [x] Smoke: concurrent \`pnpm serve\` in two worktrees → second auto-bumps to 3001/4201
- [x] Smoke: \`PORT=3000 pnpm serve\` while port held → exits 1 with \`API port 3000 (from PORT) is already in use. Free it or unset PORT.\`
- [x] Smoke: SIGINT to launcher propagates to children and exits with code 130
- [ ] Reviewer to verify on Linux CI runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a port-resolving dev-server launcher and wire the monorepo dev workflow through it to support concurrent local development without port collisions.

New Features:
- Add a TypeScript-based dev-server launcher that auto-resolves free ports, supports selective service startup via a --only flag, and spawns Nx serve commands with the resolved environment.
- Expose frontend dev, preview, and API proxy ports via environment variables so the frontend can dynamically target the correct backend instance.

Enhancements:
- Update the frontend Vite configuration to read ports and API proxy targets from environment variables while preserving sensible defaults.
- Replace the root pnpm serve script to use the new launcher instead of calling Nx directly.

Documentation:
- Rewrite and expand development instructions in the main README and English/German developer docs to document the new port-resolving dev workflow and flags.
- Add AGENTS.md and superpowers design/plan documents describing the dev server port isolation design and usage.

Tests:
- Add unit tests for the new port-probing helper used by the dev launcher.