### PR TITLE
refactor(frontend): unwrap Card from manual transactions (ATT-312)

### DIFF
--- a/apps/frontend/src/app/billing/administration/index.tsx
+++ b/apps/frontend/src/app/billing/administration/index.tsx
@@ -5,7 +5,7 @@ import de from './de.json';
 import { ManualTransactionsCard } from './manualTransactions';
 import { useState } from 'react';
 import { User } from '@attraccess/react-query-client';
-import { Button, Card } from '@heroui/react';
+import { Button } from '@heroui/react';
 import { useNavigate } from 'react-router-dom';
 import { SummaryCard } from '../dashboard/summary';
 import { SumUpIcon } from '../../../components/icons/sumup.icon';
@@ -32,14 +32,10 @@ export function BillingAdministrationPage() {
       />
 
       <div className="flex flex-row flex-wrap gap-4">
-        <Card className="flex-grow">
-          <Card.Header>
-            <PageHeader title={t('inputs.user')} noMargin />
-          </Card.Header>
-          <Card.Content>
-            <UserSearch onSelectionChange={setUser} />
-          </Card.Content>
-        </Card>
+        <section className="flex-grow w-full flex flex-col gap-4">
+          <PageHeader title={t('inputs.user')} noMargin />
+          <UserSearch onSelectionChange={setUser} />
+        </section>
 
         {user && (
           <>

--- a/apps/frontend/src/app/billing/administration/manualTransactions/index.tsx
+++ b/apps/frontend/src/app/billing/administration/manualTransactions/index.tsx
@@ -1,10 +1,10 @@
-import { Button, Card, CardProps, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput } from "@heroui/react";
+import { Button, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput } from "@heroui/react";
 import { PageHeader } from '../../../../components/pageHeader';
 import { HandCoinsIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
-import { useCallback, useState } from 'react';
+import { HTMLAttributes, useCallback, useState } from 'react';
 import {
   useBillingServiceCreateManualTransaction,
   UseBillingServiceGetBillingBalanceKeyFn,
@@ -21,8 +21,8 @@ interface Props {
   userId?: number;
 }
 
-export function ManualTransactionsCard(props: Props & Omit<CardProps, 'children'>) {
-  const { userId, ...cardProps } = props;
+export function ManualTransactionsCard(props: Props & Omit<HTMLAttributes<HTMLElement>, 'children'>) {
+  const { userId, className, ...sectionProps } = props;
   const { t, tExists } = useTranslations({
     en: {
       ...en,
@@ -80,26 +80,22 @@ export function ManualTransactionsCard(props: Props & Omit<CardProps, 'children'
   }, [userId, amount, createManualTransaction, configuration]);
 
   return (
-    <Card {...cardProps}>
-      <Card.Header>
-        <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<HandCoinsIcon />} noMargin />
-      </Card.Header>
+    <section {...sectionProps} className={`w-full flex flex-col gap-4 ${className ?? ''}`}>
+      <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<HandCoinsIcon />} noMargin />
 
-      <Card.Content className="flex flex-col gap-4">
-        <NumberField aria-label={t('inputs.amount')} value={amount} onChange={(value) => setAmount(value)}>
-          <NumberFieldGroup>
-            <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
-            <NumberFieldInput />
-            <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
-          </NumberFieldGroup>
-        </NumberField>
-      </Card.Content>
+      <NumberField aria-label={t('inputs.amount')} value={amount} onChange={(value) => setAmount(value)}>
+        <NumberFieldGroup>
+          <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
+          <NumberFieldInput />
+          <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
+        </NumberFieldGroup>
+      </NumberField>
 
-      <Card.Footer>
+      <div className="flex justify-end">
         <Button variant="primary" onPress={handleCreateTransaction} isPending={isCreatingManualTransaction}>
           {t('actions.createTransaction')}
         </Button>
-      </Card.Footer>
-    </Card>
+      </div>
+    </section>
   );
 }

--- a/apps/frontend/src/app/billing/administration/manualTransactions/index.tsx
+++ b/apps/frontend/src/app/billing/administration/manualTransactions/index.tsx
@@ -4,7 +4,8 @@ import { HandCoinsIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
-import { HTMLAttributes, useCallback, useState } from 'react';
+import { ComponentPropsWithoutRef, useCallback, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
 import {
   useBillingServiceCreateManualTransaction,
   UseBillingServiceGetBillingBalanceKeyFn,
@@ -21,7 +22,7 @@ interface Props {
   userId?: number;
 }
 
-export function ManualTransactionsCard(props: Props & Omit<HTMLAttributes<HTMLElement>, 'children'>) {
+export function ManualTransactionsCard(props: Props & Omit<ComponentPropsWithoutRef<'section'>, 'children'>) {
   const { userId, className, ...sectionProps } = props;
   const { t, tExists } = useTranslations({
     en: {
@@ -80,7 +81,7 @@ export function ManualTransactionsCard(props: Props & Omit<HTMLAttributes<HTMLEl
   }, [userId, amount, createManualTransaction, configuration]);
 
   return (
-    <section {...sectionProps} className={`w-full flex flex-col gap-4 ${className ?? ''}`}>
+    <section {...sectionProps} className={twMerge('w-full flex flex-col gap-4', className)}>
       <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<HandCoinsIcon />} noMargin />
 
       <NumberField aria-label={t('inputs.amount')} value={amount} onChange={(value) => setAmount(value)}>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Drops the `Card` + `Card.Header/Content/Footer` chrome around the manual
balance adjustment form per the HeroUI v3 idiom (cards = visualization,
not form containers). Replaces it with a flat `<section>` matching the
pattern established for `EditMqttServerPage`.

- Function signature now accepts `Omit<HTMLAttributes<HTMLElement>, 'children'>` instead of `CardProps`, preserving `className` passthrough so the parent flex row layout still works alongside the remaining Card-wrapped siblings.
- Behavior (validation, balance/transactions invalidation, toast on success/error) unchanged.

## Test plan

- [x] `nx typecheck frontend` clean
- [x] Browser-verified at `/billing/administration` — manual transactions section renders flat with `HandCoinsIcon` + title/subtitle, NumberField group, and right-aligned "Transaktion erstellen" button.
- [ ] Visual regression review alongside still-Card-wrapped siblings (Manage Billing Factor, Summary).

Linear: [ATT-312](https://linear.app/attraccess/issue/ATT-312/design-unwrap-card-from-billing-manual-transactions-att-294)
Parent: ATT-294

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Enhancements:
- Replace the Card-based layout of the manual transactions form with a flat section that aligns with the newer page layout pattern and keeps className passthrough for layout integration.