### PR TITLE
refactor(frontend): unwrap Cards from all forms on user details page (ATT-313)

### DIFF
--- a/apps/frontend/src/app/user-management/details/components/permissionsForm/index.tsx
+++ b/apps/frontend/src/app/user-management/details/components/permissionsForm/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Card } from '@heroui/react';
+import { Button } from '@heroui/react';
 import { LabeledSwitch } from '../../../../../components/labeledSwitch';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useToastMessage } from '../../../../../components/toastProvider';
@@ -12,7 +12,6 @@ import {
   useUsersServiceFindManyKey,
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
-import { PageHeader } from '../../../../../components/pageHeader';
 
 import en from './en.json';
 import de from './de.json';
@@ -115,12 +114,14 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
   }
 
   return (
-    <Card data-cy="user-permission-form-card">
-      <Card.Header>
-        <PageHeader title={t('title')} noMargin />
-      </Card.Header>
-
-      <Card.Content className="flex flex-col gap-2">
+    <div className="w-full flex flex-col gap-6" data-cy="user-permission-form-card">
+      <section
+        className="w-full flex flex-col gap-4"
+        data-cy="user-permission-form-section"
+      >
+        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+          {t('title')}
+        </h3>
         {isSsoManaged ? (
           <div
             className="rounded-md border border-warning-200 bg-warning-50 px-3 py-2 text-warning-700"
@@ -130,21 +131,24 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
             <p className="text-sm">{t('ssoManaged.description', { providers: ssoProvidersLabel })}</p>
           </div>
         ) : null}
-        {Object.keys(permissions).map((permission) => (
-          <LabeledSwitch
-            key={permission}
-            isSelected={permissions[permission as keyof SystemPermissions]}
-            onChange={handlePermissionChange(permission as keyof SystemPermissions)}
-            isDisabled={isPermissionSsoManaged(permission)}
-            data-cy={`user-permission-form-${permission}-checkbox`}
-          >
-            {t(`permissions.${permission}`)}
-          </LabeledSwitch>
-        ))}
-      </Card.Content>
+        <div className="flex flex-col gap-2">
+          {Object.keys(permissions).map((permission) => (
+            <LabeledSwitch
+              key={permission}
+              isSelected={permissions[permission as keyof SystemPermissions]}
+              onChange={handlePermissionChange(permission as keyof SystemPermissions)}
+              isDisabled={isPermissionSsoManaged(permission)}
+              data-cy={`user-permission-form-${permission}-checkbox`}
+            >
+              {t(`permissions.${permission}`)}
+            </LabeledSwitch>
+          ))}
+        </div>
+      </section>
 
-      <Card.Footer className="flex justify-end">
-        <Button variant="primary"
+      <div className="flex justify-end">
+        <Button
+          variant="primary"
           onPress={handleSave}
           isPending={isSavingPermissions}
           isDisabled={allPermissionsSsoManaged}
@@ -152,7 +156,7 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
         >
           {t('actions.save')}
         </Button>
-      </Card.Footer>
-    </Card>
+      </div>
+    </div>
   );
 };

--- a/apps/frontend/src/app/user-management/details/components/permissionsForm/index.tsx
+++ b/apps/frontend/src/app/user-management/details/components/permissionsForm/index.tsx
@@ -114,39 +114,36 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
   }
 
   return (
-    <div className="w-full flex flex-col gap-6" data-cy="user-permission-form-card">
-      <section
-        className="w-full flex flex-col gap-4"
-        data-cy="user-permission-form-section"
-      >
-        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-          {t('title')}
-        </h3>
-        {isSsoManaged ? (
-          <div
-            className="rounded-md border border-warning-200 bg-warning-50 px-3 py-2 text-warning-700"
-            data-cy="user-permission-form-sso-managed"
-          >
-            <p className="text-sm font-semibold">{t('ssoManaged.title')}</p>
-            <p className="text-sm">{t('ssoManaged.description', { providers: ssoProvidersLabel })}</p>
-          </div>
-        ) : null}
-        <div className="flex flex-col gap-2">
-          {Object.keys(permissions).map((permission) => (
-            <LabeledSwitch
-              key={permission}
-              isSelected={permissions[permission as keyof SystemPermissions]}
-              onChange={handlePermissionChange(permission as keyof SystemPermissions)}
-              isDisabled={isPermissionSsoManaged(permission)}
-              data-cy={`user-permission-form-${permission}-checkbox`}
-            >
-              {t(`permissions.${permission}`)}
-            </LabeledSwitch>
-          ))}
+    <section
+      className="w-full flex flex-col gap-4"
+      data-cy="user-permission-form-section"
+    >
+      <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+        {t('title')}
+      </h3>
+      {isSsoManaged ? (
+        <div
+          className="rounded-md border border-warning-200 bg-warning-50 px-3 py-2 text-warning-700"
+          data-cy="user-permission-form-sso-managed"
+        >
+          <p className="text-sm font-semibold">{t('ssoManaged.title')}</p>
+          <p className="text-sm">{t('ssoManaged.description', { providers: ssoProvidersLabel })}</p>
         </div>
-      </section>
-
-      <div className="flex justify-end">
+      ) : null}
+      <div className="flex flex-col gap-2">
+        {Object.keys(permissions).map((permission) => (
+          <LabeledSwitch
+            key={permission}
+            isSelected={permissions[permission as keyof SystemPermissions]}
+            onChange={handlePermissionChange(permission as keyof SystemPermissions)}
+            isDisabled={isPermissionSsoManaged(permission)}
+            data-cy={`user-permission-form-${permission}-checkbox`}
+          >
+            {t(`permissions.${permission}`)}
+          </LabeledSwitch>
+        ))}
+      </div>
+      <div className="flex w-full justify-end">
         <Button
           variant="primary"
           onPress={handleSave}
@@ -157,6 +154,6 @@ export const UserPermissionForm: React.FC<UserPermissionFormProps> = ({ user, ss
           {t('actions.save')}
         </Button>
       </div>
-    </div>
+    </section>
   );
 };

--- a/apps/frontend/src/app/user-management/details/index.tsx
+++ b/apps/frontend/src/app/user-management/details/index.tsx
@@ -19,7 +19,7 @@ import { ChangeEmailForm } from './components/changeEmail';
 
 import en from './en.json';
 import de from './de.json';
-import { Button, Card, Chip, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, Separator, useOverlayState } from '@heroui/react';
+import { Button, Chip, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, Separator, useOverlayState } from '@heroui/react';
 import { useToastMessage } from '../../../components/toastProvider';
 import API_ERROR_TRANSLATIONS_EN from '../../../global-translations/api-errors.en.json';
 import API_ERROR_TRANSLATIONS_DE from '../../../global-translations/api-errors.de.json';
@@ -154,112 +154,123 @@ export function UserManagementDetailsPage() {
         backTo="/users"
       />
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3 auto-rows-fr items-stretch">
-        {user && (
-          <>
-            <div className="w-full">
-              <UserPermissionForm
-                user={user}
-                ssoManagedProviders={ssoManagedProviders}
-                ssoManagedPermissionKeys={ssoManagedPermissionKeys}
-              />
+      {user && (
+        <div className="w-full flex flex-col gap-8" data-cy="user-details-sections">
+          <UserPermissionForm
+            user={user}
+            ssoManagedProviders={ssoManagedProviders}
+            ssoManagedPermissionKeys={ssoManagedPermissionKeys}
+          />
+
+          <section
+            className="w-full flex flex-col gap-4 pt-6 border-t border-default-200"
+            data-cy="user-details-username-section"
+          >
+            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+              {t('profile.usernameTitle')}
+            </h3>
+            <ChangeUsernameForm userId={user.id} />
+          </section>
+
+          <section
+            className="w-full flex flex-col gap-4 pt-6 border-t border-default-200"
+            data-cy="user-details-email-section"
+          >
+            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+              {t('profile.emailTitle')}
+            </h3>
+            <ChangeEmailForm userId={user.id} />
+          </section>
+
+          <section
+            className="w-full flex flex-col gap-4 pt-6 border-t border-default-200"
+            data-cy="user-details-password-section"
+          >
+            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+              {t('profile.passwordTitle')}
+            </h3>
+            <SetPasswordForm userId={user.id} />
+          </section>
+
+          <section
+            className="w-full flex flex-col gap-4 pt-6 border-t border-default-200"
+            data-cy="user-details-sso-section"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                {t('sso.title')}
+              </h3>
+              <Chip
+                color={ssoDetails.length > 0 ? 'accent' : 'default'}
+                variant={ssoDetails.length > 0 ? 'secondary' : 'primary'}
+              >
+                {ssoDetails.length > 0 ? t('sso.linked', { count: ssoDetails.length }) : t('sso.notLinkedChip')}
+              </Chip>
             </div>
-            <Card className="w-full">
-              <Card.Header>
-                <PageHeader title={t('profile.usernameTitle')} noMargin />
-              </Card.Header>
-              <Card.Content className="flex flex-col gap-8">
-                <ChangeUsernameForm userId={user.id} />
-              </Card.Content>
-            </Card>
-
-            <Card className="w-full">
-              <Card.Header>
-                <PageHeader title={t('profile.emailTitle')} noMargin />
-              </Card.Header>
-              <Card.Content className="flex flex-col gap-8">
-                <ChangeEmailForm userId={user.id} />
-              </Card.Content>
-            </Card>
-
-            <Card className="w-full">
-              <Card.Header>
-                <PageHeader title={t('profile.passwordTitle')} noMargin />
-              </Card.Header>
-              <Card.Content className="flex flex-col gap-8">
-                <SetPasswordForm userId={user.id} />
-              </Card.Content>
-            </Card>
-
-            <Card className="w-full">
-              <Card.Header className="flex items-center justify-between">
-                <PageHeader title={t('sso.title')} noMargin />
-                <Chip
-                  color={ssoDetails.length > 0 ? 'accent' : 'default'}
-                  variant={ssoDetails.length > 0 ? 'secondary' : 'primary'}
-                >
-                  {ssoDetails.length > 0 ? t('sso.linked', { count: ssoDetails.length }) : t('sso.notLinkedChip')}
+            {ssoDetails.length === 0 ? (
+              <div className="flex items-center gap-2">
+                <Chip color="default" variant="soft">
+                  {t('sso.notLinked')}
                 </Chip>
-              </Card.Header>
-              <Card.Content>
-                {ssoDetails.length === 0 ? (
-                  <div className="flex items-center gap-2">
-                    <Chip color="default" variant="soft">
-                      {t('sso.notLinked')}
-                    </Chip>
-                    <span className="text-sm text-default-500">{t('sso.notLinkedHint')}</span>
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-4">
-                    {ssoDetails.map((detail, index) => {
-                      const providerName = detail.providerId ? providersById.get(detail.providerId)?.name : undefined;
-                      const providerLabel =
-                        providerName ??
-                        (detail.providerType && detail.providerId
-                          ? `${detail.providerType} #${detail.providerId}`
-                          : (detail.providerType ?? '-'));
-                      const itemKey = `${detail.providerId ?? 'unknown'}-${detail.ssoSubject ?? 'unknown'}-${
-                        detail.providerType ?? 'unknown'
-                      }`;
-                      return (
-                        <div key={itemKey} className="flex flex-col gap-2">
-                          <div className="flex flex-col gap-1">
-                            <span className="text-xs uppercase tracking-wide text-default-500">
-                              {t('sso.provider')}
-                            </span>
-                            <div className="text-sm font-semibold text-default-900 break-words">{providerLabel}</div>
-                            <div className="text-xs text-default-500">{detail.providerType ?? '-'}</div>
-                          </div>
-                          <div className="flex flex-col gap-1">
-                            <span className="text-xs uppercase tracking-wide text-default-500">{t('sso.userId')}</span>
-                            <div className="font-mono text-xs text-default-800 break-all">
-                              {detail.ssoSubject ?? '-'}
-                            </div>
-                          </div>
-                          {index < ssoDetails.length - 1 ? <Separator /> : null}
+                <span className="text-sm text-default-500">{t('sso.notLinkedHint')}</span>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4">
+                {ssoDetails.map((detail, index) => {
+                  const providerName = detail.providerId ? providersById.get(detail.providerId)?.name : undefined;
+                  const providerLabel =
+                    providerName ??
+                    (detail.providerType && detail.providerId
+                      ? `${detail.providerType} #${detail.providerId}`
+                      : (detail.providerType ?? '-'));
+                  const itemKey = `${detail.providerId ?? 'unknown'}-${detail.ssoSubject ?? 'unknown'}-${
+                    detail.providerType ?? 'unknown'
+                  }`;
+                  return (
+                    <div key={itemKey} className="flex flex-col gap-2">
+                      <div className="flex flex-col gap-1">
+                        <span className="text-xs uppercase tracking-wide text-default-500">
+                          {t('sso.provider')}
+                        </span>
+                        <div className="text-sm font-semibold text-default-900 break-words">{providerLabel}</div>
+                        <div className="text-xs text-default-500">{detail.providerType ?? '-'}</div>
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-xs uppercase tracking-wide text-default-500">{t('sso.userId')}</span>
+                        <div className="font-mono text-xs text-default-800 break-all">
+                          {detail.ssoSubject ?? '-'}
                         </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </Card.Content>
-            </Card>
+                      </div>
+                      {index < ssoDetails.length - 1 ? <Separator /> : null}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
 
-            <Card className="w-full">
-              <Card.Header>
-                <PageHeader title={t('delete.title')} noMargin />
-              </Card.Header>
-              <Card.Content className="flex flex-col gap-4">
-                <p className="text-sm text-default-500">{t('delete.description')}</p>
-                <Button variant="danger-soft" onPress={open} isDisabled={isSelf} data-cy="admin-delete-user-open-modal">
-                  {t('delete.actions.open')}
-                </Button>
-                {isSelf ? <p className="text-xs text-default-400">{t('delete.selfDisabled')}</p> : null}
-              </Card.Content>
-            </Card>
-          </>
-        )}
-      </div>
+          <section
+            className="w-full flex flex-col gap-4 pt-6 border-t border-default-200"
+            data-cy="user-details-delete-section"
+          >
+            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+              {t('delete.title')}
+            </h3>
+            <p className="text-sm text-default-500">{t('delete.description')}</p>
+            <div className="flex w-full justify-end">
+              <Button
+                variant="danger-soft"
+                onPress={open}
+                isDisabled={isSelf}
+                data-cy="admin-delete-user-open-modal"
+              >
+                {t('delete.actions.open')}
+              </Button>
+            </div>
+            {isSelf ? <p className="text-xs text-default-400">{t('delete.selfDisabled')}</p> : null}
+          </section>
+        </div>
+      )}
 
       <Modal isOpen={isOpen} onOpenChange={setOpen}>
         <ModalBackdrop>


### PR DESCRIPTION
## Summary

Extends ATT-313 to every sub-block on the user details page. Drops the `Card` chrome around `UserPermissionForm`, `ChangeUsernameForm`, `ChangeEmailForm`, `SetPasswordForm`, the SSO summary, and the delete-user block, and restructures the page as a single vertical stack of `<section>`s separated by a thin top divider — same pattern as `EditMqttServerPage` (ATT-294).

- Each section uses a `text-sm uppercase tracking-wide font-semibold text-default-700` `<h3>` header.
- The `md:grid-cols-2 xl:grid-cols-3 auto-rows-fr` grid is gone — single column at every breakpoint.
- SSO chip moved into the section header next to the title; delete button wrapped in a right-aligned flex row to match the form save buttons.
- The permissions form's outer wrapper collapses into a single `<section>` so all six sections share the same shape.
- New `data-cy="user-details-*-section"` markers; existing `user-permission-form-*` IDs preserved.

Linear: [ATT-313](https://linear.app/attraccess/issue/ATT-313/design-unwrap-cards-from-all-forms-on-user-details-page-att-294)

## Test plan

- [x] `pnpm nx lint frontend` (typecheck + lint) green
- [x] `pnpm nx affected -t lint,typecheck,build,test,e2e` via precommit green
- [x] Browser-verified on desktop (1280px) — screenshots posted on Linear
- [x] Browser-verified on mobile (390px) — screenshots posted on Linear

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->