### PR TITLE
refactor(frontend): unwrap Card from email templates editor (ATT-308)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ bom.json
 .claude/worktrees
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+
+docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+Short reference for agents working in this repo. See `CLAUDE.md` for tooling.
+
+## Dev servers — always use `pnpm serve`
+
+`pnpm serve` is safe to run in parallel from multiple worktrees. It auto-resolves free ports for API and frontend, printing them in a banner at startup:
+
+```
+┌─────────────────────────────────────────────┐
+│ Attraccess dev servers                      │
+│   API      → http://localhost:3001          │
+│   Frontend → http://localhost:4201          │
+└─────────────────────────────────────────────┘
+```
+
+**Never assume ports 3000/4200 are yours.** Parse the banner (first ~6 lines of stdout) to learn the actual ports.
+
+Flags:
+
+- `pnpm serve --only=api` — API only
+- `pnpm serve --only=frontend` — frontend only
+- `pnpm serve` — both (default)
+
+Pin a port (strict — fails on collision):
+
+- `PORT=3010 pnpm serve`
+- `VITE_PORT=4250 pnpm serve`
+
+Solo `pnpm nx serve api` is **not** wrapped — it still hard-fails on busy 3000. Prefer `pnpm serve --only=api`.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,33 @@ This installs Node (via nvm if needed), pnpm, and project deps. You must install
 
 ## Development
 
-Start the api and frontend in development mode (HMR):
+Start the API and frontend in development mode (HMR), with automatic port resolution:
 
 ```bash
-pnpm nx run-many -t serve --projects=api,frontend
+pnpm serve
 ```
 
-The API will be available at `http://localhost:3000`
-and the Frontend at `http://localhost:4200`
+The launcher probes for free ports and prints them at startup. Defaults:
+
+- API: 3000 (searches 3000–3099)
+- Frontend: 4200 (searches 4200–4299)
+- Vite preview: 4300 (searches 4300–4399)
+
+Run only one service:
+
+```bash
+pnpm serve --only=api
+pnpm serve --only=frontend
+```
+
+Pin a specific port (fails loudly if busy):
+
+```bash
+PORT=3010 pnpm serve              # API on 3010
+VITE_PORT=4250 pnpm serve         # Frontend on 4250
+```
+
+The frontend dev proxy automatically targets whichever port the API resolved to (via `VITE_API_PROXY_TARGET`).
 
 ## API Documentation
 

--- a/apps/frontend/src/app/email-templates/edit/de.json
+++ b/apps/frontend/src/app/email-templates/edit/de.json
@@ -26,6 +26,7 @@
   "actions": {
     "close": "Schließen",
     "cancel": "Abbrechen",
-    "save": "Änderungen speichern"
+    "save": "Änderungen speichern",
+    "expand": "Editor vergrößern"
   }
 }

--- a/apps/frontend/src/app/email-templates/edit/en.json
+++ b/apps/frontend/src/app/email-templates/edit/en.json
@@ -26,6 +26,7 @@
   "actions": {
     "close": "Close",
     "cancel": "Cancel",
-    "save": "Save Changes"
+    "save": "Save Changes",
+    "expand": "Expand editor"
   }
 }

--- a/apps/frontend/src/app/email-templates/edit/index.tsx
+++ b/apps/frontend/src/app/email-templates/edit/index.tsx
@@ -6,10 +6,27 @@ import {
   useEmailTemplatesServiceEmailTemplateControllerPreviewMjml,
   EmailTemplateType,
 } from '@attraccess/react-query-client';
-import { Button, Card, Form, Input, Label, Link, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, TextField, useTheme } from '@heroui/react';
+import {
+  Button,
+  Form,
+  Input,
+  Label,
+  Link,
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalContainer,
+  ModalDialog,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  TextField,
+  useTheme,
+} from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PageHeader } from '../../../components/pageHeader';
 import Editor from '@monaco-editor/react';
+import { Maximize } from 'lucide-react';
 
 import * as enTranslationsFile from './en.json';
 import * as deTranslationsFile from './de.json';
@@ -123,57 +140,81 @@ export function EditEmailTemplatePage() {
   );
 
   return (
-    <div>
+    <div className="max-w-7xl mx-auto px-4 py-8" data-cy="edit-email-template-page">
       <PageHeader title={t('templateType.' + templateType)} subtitle={t('subtitle')} backTo="/email-templates" />
-      <Form onSubmit={onSubmit}>
-        <div className="flex flex-col flex-wrap gap-4 w-full lg:flex-row">
-          <Card className="flex-1">
-            <Card.Header className="flex flex-row justify-between">
-              <span>{t('sections.template')}</span>
-              <Button isIconOnly onPress={() => setEditorIsExpanded(true)} />
-            </Card.Header>
-            <Card.Content className="flex flex-col gap-4">
-              {editor}
+      <Form onSubmit={onSubmit} className="gap-8" data-cy="edit-email-template-form">
+        <div className="flex flex-col flex-wrap gap-8 w-full lg:flex-row lg:gap-6">
+          <section
+            className="flex-1 min-w-0 w-full flex flex-col gap-4"
+            data-cy="edit-email-template-section-template"
+          >
+            <div className="flex flex-row items-center justify-between">
+              <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                {t('sections.template')}
+              </h3>
+              <Button
+                isIconOnly
+                variant="ghost"
+                size="sm"
+                onPress={() => setEditorIsExpanded(true)}
+                aria-label={t('actions.expand')}
+                data-cy="edit-email-template-expand-button"
+              >
+                <Maximize size={16} />
+              </Button>
+            </div>
+            {editor}
 
-              <Modal isOpen={editorIsExpanded} onOpenChange={setEditorIsExpanded}>
-                <ModalBackdrop>
-                  <ModalContainer size="cover">
-                    <ModalDialog>
-                      {({ close }) => (
-                        <>
-                          <ModalHeader>
-                            <ModalHeading>{t('templateType.' + templateType)}</ModalHeading>
-                          </ModalHeader>
-                          <ModalBody>{editor}</ModalBody>
-                          <ModalFooter>
-                            <Button onPress={close}>{t('actions.close')}</Button>
-                          </ModalFooter>
-                        </>
-                      )}
-                    </ModalDialog>
-                  </ModalContainer>
-                </ModalBackdrop>
-              </Modal>
-            </Card.Content>
-          </Card>
+            <Modal isOpen={editorIsExpanded} onOpenChange={setEditorIsExpanded}>
+              <ModalBackdrop>
+                <ModalContainer size="cover">
+                  <ModalDialog>
+                    {({ close }) => (
+                      <>
+                        <ModalHeader>
+                          <ModalHeading>{t('templateType.' + templateType)}</ModalHeading>
+                        </ModalHeader>
+                        <ModalBody>{editor}</ModalBody>
+                        <ModalFooter>
+                          <Button onPress={close}>{t('actions.close')}</Button>
+                        </ModalFooter>
+                      </>
+                    )}
+                  </ModalDialog>
+                </ModalContainer>
+              </ModalBackdrop>
+            </Modal>
+          </section>
 
-          <Card className="flex-1">
-            <Card.Header>{t('sections.preview')}</Card.Header>
-            <Card.Content>
-              <iframe
-                srcDoc={previewHtml}
-                title={t('preview.iframeTitle')}
-                className="w-full h-full min-h-[435px] border-0"
-              />
-            </Card.Content>
-          </Card>
+          <section
+            className="flex-1 min-w-0 w-full flex flex-col gap-4"
+            data-cy="edit-email-template-section-preview"
+          >
+            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+              {t('sections.preview')}
+            </h3>
+            <iframe
+              srcDoc={previewHtml}
+              title={t('preview.iframeTitle')}
+              className="w-full h-full min-h-[435px] border-0 rounded-md bg-default-50"
+            />
+          </section>
         </div>
 
-        <div className="flex flex-row gap-4 w-full justify-end">
-          <Button variant="ghost" onPress={() => navigate('/email-templates')}>
+        <div className="flex flex-row gap-4 w-full justify-end mt-4">
+          <Button
+            variant="ghost"
+            onPress={() => navigate('/email-templates')}
+            data-cy="edit-email-template-cancel-button"
+          >
             {t('actions.cancel')}
           </Button>
-          <Button variant="primary" type="submit" isPending={updateTemplate.isPending}>
+          <Button
+            variant="primary"
+            type="submit"
+            isPending={updateTemplate.isPending}
+            data-cy="edit-email-template-save-button"
+          >
             {t('actions.save')}
           </Button>
         </div>

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -16,24 +16,24 @@ export default defineConfig(({ command }) => {
   root: __dirname,
   cacheDir: '../../node_modules/.vite/apps/frontend',
   server: {
-    port: 4200,
+    port: Number(process.env.VITE_PORT) || 4200,
     host: '0.0.0.0',
     ...(isDev ? {
       proxy: {
         '/api': {
-          target: 'http://localhost:3000',
+          target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:3000',
           changeOrigin: true,
           ws: true,
         },
         '/cdn': {
-          target: 'http://localhost:3000',
+          target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:3000',
           changeOrigin: true,
         },
       },
     } : {}),
   },
   preview: {
-    port: 4300,
+    port: Number(process.env.VITE_PREVIEW_PORT) || 4300,
     host: '0.0.0.0',
   },
   plugins: [

--- a/docs/de/developer/overview.md
+++ b/docs/de/developer/overview.md
@@ -38,23 +38,22 @@ cd Attraccess
 pnpm install
 ```
 
-### 3. Backend starten
+### 3. Entwicklungsserver starten
+
+Den port-auflösenden Launcher verwenden:
 
 ```bash
-pnpm nx serve api
+pnpm serve
 ```
 
-Der API-Server startet standardmäßig unter `http://localhost:3000`. Die Swagger-Dokumentation ist unter `http://localhost:3000/api` verfügbar.
+Der Launcher sucht freie Ports beginnend bei den Standardwerten (API 3000, Frontend 4200, Preview 4300) und gibt sie beim Start aus. Mehrere Instanzen können gleichzeitig laufen, ohne dass Ports manuell konfiguriert werden müssen.
 
-### 4. Frontend starten
+Flags:
 
-In einem separaten Terminal:
+- `--only=api` / `--only=frontend` / `--only=both` (Standard `both`)
+- `PORT=<n>` fixiert den API-Port; `VITE_PORT=<n>` fixiert das Frontend (strikt — bricht ab, falls belegt)
 
-```bash
-pnpm nx serve frontend
-```
-
-Der Frontend-Entwicklungsserver startet unter `http://localhost:4200`. API-Anfragen werden automatisch an das Backend weitergeleitet.
+Der Vite-Dev-Proxy wird automatisch auf den vom Launcher gewählten API-Port konfiguriert.
 
 ## Entwicklungsablauf
 
@@ -71,8 +70,9 @@ Das Repository ist als NX-Monorepo organisiert. Siehe [Architektur](developer/ar
 
 | Befehl | Beschreibung |
 |--------|-------------|
-| `pnpm nx serve api` | Backend im Entwicklungsmodus starten |
-| `pnpm nx serve frontend` | Frontend im Entwicklungsmodus starten |
+| `pnpm serve` | Backend und Frontend mit dem Port-auflösenden Launcher starten |
+| `pnpm serve --only=api` | Nur das Backend starten |
+| `pnpm serve --only=frontend` | Nur das Frontend starten |
 | `pnpm nx test api` | Backend-Tests ausführen |
 | `pnpm nx test frontend` | Frontend-Tests ausführen |
 | `pnpm nx build api` | Backend für Produktion erstellen |

--- a/docs/en/developer/overview.md
+++ b/docs/en/developer/overview.md
@@ -38,23 +38,22 @@ cd Attraccess
 pnpm install
 ```
 
-### 3. Start the Backend
+### 3. Running dev servers
+
+Use the port-resolving launcher:
 
 ```bash
-pnpm nx serve api
+pnpm serve
 ```
 
-The API server starts on `http://localhost:3000` by default. Swagger documentation is available at `http://localhost:3000/api`.
+The launcher probes free ports starting from defaults (API 3000, Frontend 4200, Preview 4300) and prints them at startup. Run multiple instances concurrently without manual port juggling.
 
-### 4. Start the Frontend
+Flags:
 
-In a separate terminal:
+- `--only=api` / `--only=frontend` / `--only=both` (default `both`)
+- `PORT=<n>` to pin API; `VITE_PORT=<n>` to pin frontend (strict — fails if busy)
 
-```bash
-pnpm nx serve frontend
-```
-
-The frontend development server starts on `http://localhost:4200`. It automatically proxies API requests to the backend.
+The Vite dev proxy is wired to whichever API port the launcher resolved.
 
 ## Development Workflow
 
@@ -71,8 +70,9 @@ The repository is organized as an NX monorepo. See [Architecture](developer/arch
 
 | Command | Description |
 |---------|-------------|
-| `pnpm nx serve api` | Start the backend in development mode |
-| `pnpm nx serve frontend` | Start the frontend in development mode |
+| `pnpm serve` | Start backend and frontend with the port-resolving launcher |
+| `pnpm serve --only=api` | Start only the backend |
+| `pnpm serve --only=frontend` | Start only the frontend |
 | `pnpm nx test api` | Run backend tests |
 | `pnpm nx test frontend` | Run frontend tests |
 | `pnpm nx build api` | Build the backend for production |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.2",
   "license": "MIT",
   "scripts": {
-    "serve": "nx run-many -t serve --projects=api,frontend",
+    "serve": "node --experimental-strip-types scripts/dev-serve.mts",
     "lint:strict": "nx affected -t lint -- --max-warnings=0",
     "prepare": "husky",
     "precommit": "pnpm nx affected --uncommitted --nxBail --target=lint,typecheck,build,test,e2e",

--- a/scripts/dev-serve.mts
+++ b/scripts/dev-serve.mts
@@ -1,0 +1,119 @@
+// Dev-server launcher that auto-resolves ports and spawns nx serve
+// FEATURE: dev-server-port-isolation
+
+import { spawn } from 'node:child_process';
+import { findFreePort, isPortFree } from './lib/find-free-port.mts';
+
+type Target = 'api' | 'frontend' | 'both';
+
+interface Resolved {
+  apiPort?: number;
+  frontendPort?: number;
+  previewPort?: number;
+}
+
+function parseArgs(argv: string[]): { only: Target; passthroughArgs: string[] } {
+  let only: Target = 'both';
+  const passthroughArgs: string[] = [];
+  const args = argv.slice(2);
+  let sawDelimiter = false;
+  for (const arg of args) {
+    if (sawDelimiter) {
+      passthroughArgs.push(arg);
+      continue;
+    }
+    if (arg === '--') {
+      sawDelimiter = true;
+      continue;
+    }
+    const m = arg.match(/^--only=(.+)$/);
+    if (m) {
+      if (m[1] === 'api' || m[1] === 'frontend' || m[1] === 'both') {
+        only = m[1] as Target;
+      } else {
+        throw new Error(`Invalid value for --only: "${m[1]}". Must be api, frontend, or both.`);
+      }
+    } else if (arg === '--only') {
+      throw new Error('--only requires a value: api|frontend|both');
+    } else {
+      passthroughArgs.push(arg);
+    }
+  }
+  return { only, passthroughArgs };
+}
+
+async function resolvePort(envName: string, defaultStart: number, label: string): Promise<number> {
+  const explicit = process.env[envName];
+  if (explicit !== undefined && explicit !== '') {
+    const port = Number(explicit);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(`${envName}="${explicit}" is not a valid port`);
+    }
+    if (!(await isPortFree(port))) {
+      throw new Error(`${label} port ${port} (from ${envName}) is already in use. Free it or unset ${envName}.`);
+    }
+    return port;
+  }
+  return findFreePort(defaultStart, 100);
+}
+
+function banner(r: Resolved): string {
+  const lines: string[] = [];
+  lines.push('┌─────────────────────────────────────────────┐');
+  lines.push('│ Attraccess dev servers                      │');
+  if (r.apiPort !== undefined) lines.push(`│   API      → http://localhost:${String(r.apiPort).padEnd(14)}│`);
+  if (r.frontendPort !== undefined) lines.push(`│   Frontend → http://localhost:${String(r.frontendPort).padEnd(14)}│`);
+  if (r.previewPort !== undefined) lines.push(`│   Preview  → http://localhost:${String(r.previewPort).padEnd(14)}│`);
+  lines.push('└─────────────────────────────────────────────┘');
+  return lines.join('\n');
+}
+
+async function main() {
+  const { only, passthroughArgs } = parseArgs(process.argv);
+  const resolved: Resolved = {};
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+
+  if (only === 'api' || only === 'both') {
+    resolved.apiPort = await resolvePort('PORT', 3000, 'API');
+    childEnv.PORT = String(resolved.apiPort);
+  }
+  if (only === 'frontend' || only === 'both') {
+    resolved.frontendPort = await resolvePort('VITE_PORT', 4200, 'Frontend');
+    resolved.previewPort = await resolvePort('VITE_PREVIEW_PORT', 4300, 'Preview');
+    childEnv.VITE_PORT = String(resolved.frontendPort);
+    childEnv.VITE_PREVIEW_PORT = String(resolved.previewPort);
+    if (resolved.apiPort !== undefined) {
+      childEnv.VITE_API_PROXY_TARGET = `http://localhost:${resolved.apiPort}`;
+    }
+  }
+
+  console.log(banner(resolved));
+
+  const projects = only === 'both' ? 'api,frontend' : only;
+  const child = spawn(
+    'pnpm',
+    ['nx', 'run-many', '-t', 'serve', `--projects=${projects}`, '--outputStyle=stream', ...passthroughArgs],
+    { stdio: 'inherit', env: childEnv },
+  );
+
+  const forward = (sig: NodeJS.Signals) => {
+    if (!child.killed) child.kill(sig);
+  };
+  process.on('SIGINT', () => forward('SIGINT'));
+  process.on('SIGTERM', () => forward('SIGTERM'));
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.removeAllListeners('SIGINT');
+      process.removeAllListeners('SIGTERM');
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 0);
+    }
+  });
+}
+
+main().catch((err) => {
+  console.error(`[dev-serve] ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/lib/find-free-port.mts
+++ b/scripts/lib/find-free-port.mts
@@ -1,0 +1,23 @@
+// Pure port-probing helpers for dev-server launcher
+// FEATURE: dev-server-port-isolation
+
+import { createServer } from 'node:net';
+
+export async function isPortFree(port: number, host = '0.0.0.0'): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, host);
+  });
+}
+
+export async function findFreePort(start: number, maxAttempts = 100, host = '0.0.0.0'): Promise<number> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const candidate = start + i;
+    if (await isPortFree(candidate, host)) return candidate;
+  }
+  throw new Error(`No free port found in range ${start}-${start + maxAttempts - 1}`);
+}

--- a/scripts/lib/find-free-port.spec.mts
+++ b/scripts/lib/find-free-port.spec.mts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { createServer } from 'node:net';
+import { findFreePort, isPortFree } from './find-free-port.mts';
+
+describe('isPortFree', () => {
+  it('returns true for a port nothing is bound to', async () => {
+    const free = await isPortFree(0);
+    expect(free).toBe(true);
+  });
+
+  it('returns false for a port that is currently bound', async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, '0.0.0.0', resolve));
+    const port = (server.address() as { port: number }).port;
+    try {
+      expect(await isPortFree(port)).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+describe('findFreePort', () => {
+  it('returns the starting port when it is free', async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, '0.0.0.0', resolve));
+    const port = (server.address() as { port: number }).port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    expect(await findFreePort(port, 10)).toBe(port);
+  });
+
+  it('skips occupied ports and returns the next free one', async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve) => blocker.listen(0, '0.0.0.0', resolve));
+    const blocked = (blocker.address() as { port: number }).port;
+    try {
+      const result = await findFreePort(blocked, 10);
+      expect(result).toBeGreaterThan(blocked);
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+  });
+
+  it('throws when no port is free within maxAttempts', async () => {
+    const blockers: ReturnType<typeof createServer>[] = [];
+    try {
+      const blocker = createServer();
+      await new Promise<void>((resolve) => blocker.listen(0, '0.0.0.0', resolve));
+      const start = (blocker.address() as { port: number }).port;
+      blockers.push(blocker);
+      await expect(findFreePort(start, 1)).rejects.toThrow(/No free port/);
+    } finally {
+      for (const b of blockers) {
+        await new Promise<void>((resolve) => b.close(() => resolve()));
+      }
+    }
+  });
+});


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Removes the two `Card` wrappers from the email templates editor and replaces them with the flat sectioned pattern established in `EditMqttServerPage` (parent ATT-294).

- `apps/frontend/src/app/email-templates/edit/index.tsx`: drops `Card` / `Card.Header` / `Card.Content` for both the template-editing column and the preview column. Each side is now a `<section>` with a small uppercase `h3` heading.
- Side-by-side responsive layout preserved (`lg:flex-row`, stacked on mobile).
- Restored a visible `Maximize` icon (lucide-react) on the expand-editor button — the prior v3 cleanup had stripped the button's only child, so it was rendering blank.
- Added `actions.expand` translation (en / de) for the new icon button's `aria-label`.
- Added `edit-email-template-*` `data-cy` attributes (none existed before; the previous Card-wrapped form had no `data-cy` coverage).
- Validation, `Form` submit handler, Monaco editor wiring, MJML preview hook, and the cover-size expand modal all preserved.

Branch also carries a cherry-pick of `feat(dev): parallel-safe dev servers via port-resolving launcher` (#845) from `main` so the worktree can `pnpm serve` without colliding with other worktrees on 3000/4200.

Linear issue: https://linear.app/attraccess/issue/ATT-308/design-unwrap-card-from-email-templates-editor-att-294

## Test plan

- [x] `nx run frontend:typecheck` clean
- [x] `eslint apps/frontend/src/app/email-templates/edit/index.tsx --max-warnings=0` clean
- [x] Browser-verified at 1440×900 (desktop), 390×844 (mobile), and with the expand modal open — screenshots posted on the Linear ticket
- [x] Subject + body persist via existing `useUpdateEmailTemplate` mutation (no controller changes)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Refactor the email templates editor layout to remove Card wrappers in favor of section-based panels while introducing a parallel-safe dev server launcher with automatic port resolution and updating related tooling and documentation.

New Features:
- Add a dev-server launcher script that auto-resolves free ports for API, frontend, and preview servers and supports selective service startup via flags.
- Introduce environment-configurable ports and API proxy target for the frontend Vite dev and preview servers.
- Add agent-facing guidance for using the new dev-server launcher in AGENTS.md.

Enhancements:
- Rework the email template edit page layout to use responsive section-based panels with improved spacing and headings instead of Card components.
- Restore a visible maximize icon expand button for the email editor and wire it with accessibility labels and test hooks via data-cy attributes.
- Add data-cy attributes to key email template editing controls and sections to improve end-to-end testability.

Build:
- Change the root serve script to use the new TypeScript-based dev-serve launcher instead of directly calling nx run-many.

Documentation:
- Update README and developer overview docs (EN/DE) to document the new pnpm serve launcher, its flags, and dynamic port behavior.
- Add AGENTS.md with concise instructions for automated agents on using pnpm serve and interpreting its port banner.