### PR TITLE
refactor(frontend): unwrap Card from SSO providers form (ATT-309)

### DIFF
--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -1,8 +1,8 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, Checkbox, Input, Label, Spinner, TextField } from "@heroui/react";
+import { Button, Checkbox, Form, Input, Label, Spinner, TextField } from '@heroui/react';
 import { Select } from '../../../components/select';
 import { LabeledSwitch } from '../../../components/labeledSwitch';
-import { ArrowLeft } from 'lucide-react';
+import { PageHeader } from '../../../components/pageHeader';
 import { PasswordInput } from '../../../components/PasswordInput';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -37,14 +37,12 @@ export function EditMqttServerPage() {
     defaultSubscribeQos: 0,
   });
 
-  // Fetch server details
   const {
     data: server,
     isLoading: isLoadingServer,
     isError,
   } = useMqttServiceMqttServersGetOneById({ id: Number(serverId) });
 
-  // Update form values when server data is loaded
   useEffect(() => {
     if (server) {
       setFormValues({
@@ -81,7 +79,6 @@ export function EditMqttServerPage() {
     },
   });
 
-
   const qosOptions = [0, 1, 2] as const;
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -107,131 +104,154 @@ export function EditMqttServerPage() {
   }
 
   if (isError || !server) {
-    return null; // Navigate happens in onError callback
+    return null;
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8">
-      <Card data-cy="edit-mqtt-server-page-card">
-        <Card.Header>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <Button variant="ghost"
-                isIconOnly
-                onPress={handleCancel}
-                aria-label={t('back')}
-                data-cy="edit-mqtt-server-page-back-button"
-              >
-                <ArrowLeft size={20} />
-              </Button>
-              <h2>{t('editMqttServer')}</h2>
-            </div>
-          </div>
-        </Card.Header>
-        <div style={{ padding: '1rem' }}>
-          <form onSubmit={handleSubmit} className="space-y-6" data-cy="edit-mqtt-server-form">
-            <div className="space-y-4">
-              <TextField value={formValues.name} onChange={(v) => setFormValues((p) => ({ ...p, name: v }))}>
-                <Label>{t('nameLabel')}</Label>
-                <Input id="name" name="name" placeholder={t('namePlaceholder')} required data-cy="edit-mqtt-server-form-name-input" />
-              </TextField>
+    <div className="max-w-7xl mx-auto px-4 py-8" data-cy="edit-mqtt-server-page">
+      <PageHeader title={t('editMqttServer')} onBack={handleCancel} />
 
-              <TextField value={formValues.host} onChange={(v) => setFormValues((p) => ({ ...p, host: v }))}>
-                <Label>{t('hostLabel')}</Label>
-                <Input id="host" name="host" placeholder={t('hostPlaceholder')} required data-cy="edit-mqtt-server-form-host-input" />
-              </TextField>
+      <Form onSubmit={handleSubmit} className="gap-4" data-cy="edit-mqtt-server-form">
+        <TextField
+          value={formValues.name}
+          onChange={(v) => setFormValues((p) => ({ ...p, name: v }))}
+          className="w-full"
+        >
+          <Label>{t('nameLabel')}</Label>
+          <Input
+            id="name"
+            name="name"
+            placeholder={t('namePlaceholder')}
+            required
+            data-cy="edit-mqtt-server-form-name-input"
+          />
+        </TextField>
 
-              <TextField value={String(formValues.port || 1883)} onChange={(v) => setFormValues((p) => ({ ...p, port: parseInt(v, 10) }))}>
-                <Label>{t('portLabel')}</Label>
-                <Input id="port" name="port" type="number" placeholder={t('portPlaceholder')} required data-cy="edit-mqtt-server-form-port-input" />
-              </TextField>
+        <TextField
+          value={formValues.host}
+          onChange={(v) => setFormValues((p) => ({ ...p, host: v }))}
+          className="w-full"
+        >
+          <Label>{t('hostLabel')}</Label>
+          <Input
+            id="host"
+            name="host"
+            placeholder={t('hostPlaceholder')}
+            required
+            data-cy="edit-mqtt-server-form-host-input"
+          />
+        </TextField>
 
-              <TextField value={formValues.clientId} onChange={(v) => setFormValues((p) => ({ ...p, clientId: v }))}>
-                <Label>{t('clientIdLabel')}</Label>
-                <Input id="clientId" name="clientId" placeholder={t('clientIdPlaceholder')} data-cy="edit-mqtt-server-form-client-id-input" />
-              </TextField>
+        <TextField
+          value={String(formValues.port || 1883)}
+          onChange={(v) => setFormValues((p) => ({ ...p, port: parseInt(v, 10) }))}
+          className="w-full"
+        >
+          <Label>{t('portLabel')}</Label>
+          <Input
+            id="port"
+            name="port"
+            type="number"
+            placeholder={t('portPlaceholder')}
+            required
+            data-cy="edit-mqtt-server-form-port-input"
+          />
+        </TextField>
 
-              <TextField value={formValues.username} onChange={(v) => setFormValues((p) => ({ ...p, username: v }))}>
-                <Label>{t('usernameLabel')}</Label>
-                <Input id="username" name="username" placeholder={t('usernamePlaceholder')} data-cy="edit-mqtt-server-form-username-input" />
-              </TextField>
+        <TextField
+          value={formValues.clientId}
+          onChange={(v) => setFormValues((p) => ({ ...p, clientId: v }))}
+          className="w-full"
+        >
+          <Label>{t('clientIdLabel')}</Label>
+          <Input
+            id="clientId"
+            name="clientId"
+            placeholder={t('clientIdPlaceholder')}
+            data-cy="edit-mqtt-server-form-client-id-input"
+          />
+        </TextField>
 
-              <PasswordInput
-                label={t('passwordLabel')}
-                id="password"
-                name="password"
-                placeholder={t('passwordPlaceholder')}
-                value={formValues.password}
-                onChange={(v: string) => setFormValues((p) => ({ ...p, password: v }))}
-                className="w-full"
-                data-cy="edit-mqtt-server-form-password-input"
-                autoComplete="off"
-              />
+        <TextField
+          value={formValues.username}
+          onChange={(v) => setFormValues((p) => ({ ...p, username: v }))}
+          className="w-full"
+        >
+          <Label>{t('usernameLabel')}</Label>
+          <Input
+            id="username"
+            name="username"
+            placeholder={t('usernamePlaceholder')}
+            data-cy="edit-mqtt-server-form-username-input"
+          />
+        </TextField>
 
-              <div className="flex items-center space-x-2">
-                <Checkbox
-                  id="useTls"
-                  name="useTls"
-                  isSelected={formValues.useTls}
-                  onChange={(checked) => setFormValues((prev) => ({ ...prev, useTls: checked }))}
-                  data-cy="edit-mqtt-server-form-use-tls-checkbox"
-                />
-                <label htmlFor="useTls" className="text-sm">
-                  {t('useTls')}
-                </label>
-              </div>
+        <PasswordInput
+          label={t('passwordLabel')}
+          id="password"
+          name="password"
+          placeholder={t('passwordPlaceholder')}
+          value={formValues.password}
+          onChange={(v: string) => setFormValues((p) => ({ ...p, password: v }))}
+          className="w-full"
+          data-cy="edit-mqtt-server-form-password-input"
+          autoComplete="off"
+        />
 
-              <Select
-                label={t('defaultPublishQosLabel')}
-                value={String(formValues.defaultPublishQos ?? 0)}
-                onChange={(key) => {
-                  setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }));
-                }}
-                data-cy="edit-mqtt-server-form-default-publish-qos-input"
-                items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
-              />
+        <Checkbox
+          id="useTls"
+          name="useTls"
+          isSelected={formValues.useTls}
+          onChange={(checked) => setFormValues((prev) => ({ ...prev, useTls: checked }))}
+          data-cy="edit-mqtt-server-form-use-tls-checkbox"
+        >
+          {t('useTls')}
+        </Checkbox>
 
-              <div className="flex items-center space-x-2">
-                <LabeledSwitch
-                  id="defaultPublishRetain"
-                  name="defaultPublishRetain"
-                  isSelected={!!formValues.defaultPublishRetain}
-                  onChange={(checked) => setFormValues((prev) => ({ ...prev, defaultPublishRetain: checked }))}
-                  data-cy="edit-mqtt-server-form-default-publish-retain-checkbox"
-                >
-                  {t('defaultPublishRetainLabel')}
-                </LabeledSwitch>
-              </div>
+        <Select
+          label={t('defaultPublishQosLabel')}
+          value={String(formValues.defaultPublishQos ?? 0)}
+          onChange={(key) => {
+            setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }));
+          }}
+          data-cy="edit-mqtt-server-form-default-publish-qos-input"
+          items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
+        />
 
-              <Select
-                label={t('defaultSubscribeQosLabel')}
-                value={String(formValues.defaultSubscribeQos ?? 0)}
-                onChange={(key) => {
-                  setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }));
-                }}
-                data-cy="edit-mqtt-server-form-default-subscribe-qos-input"
-                items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
-              />
-            </div>
+        <LabeledSwitch
+          id="defaultPublishRetain"
+          name="defaultPublishRetain"
+          isSelected={!!formValues.defaultPublishRetain}
+          onChange={(checked) => setFormValues((prev) => ({ ...prev, defaultPublishRetain: checked }))}
+          data-cy="edit-mqtt-server-form-default-publish-retain-checkbox"
+        >
+          {t('defaultPublishRetainLabel')}
+        </LabeledSwitch>
 
-            <div className="flex justify-end space-x-3">
-              <Button variant="secondary"
-                onPress={handleCancel}
-                data-cy="edit-mqtt-server-form-cancel-button"
-              >
-                {t('cancel')}
-              </Button>
-              <Button variant="primary"
-                type="submit"
-                isPending={updateMqttServer.isPending}
-                data-cy="edit-mqtt-server-form-update-button"
-              >
-                {t('update')}
-              </Button>
-            </div>
-          </form>
+        <Select
+          label={t('defaultSubscribeQosLabel')}
+          value={String(formValues.defaultSubscribeQos ?? 0)}
+          onChange={(key) => {
+            setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }));
+          }}
+          data-cy="edit-mqtt-server-form-default-subscribe-qos-input"
+          items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
+        />
+
+        <div className="flex justify-end space-x-3 mt-4 w-full">
+          <Button variant="secondary" onPress={handleCancel} data-cy="edit-mqtt-server-form-cancel-button">
+            {t('cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            type="submit"
+            isPending={updateMqttServer.isPending}
+            data-cy="edit-mqtt-server-form-update-button"
+          >
+            {t('update')}
+          </Button>
         </div>
-      </Card>
+      </Form>
     </div>
   );
 }

--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -111,132 +111,153 @@ export function EditMqttServerPage() {
     <div className="max-w-7xl mx-auto px-4 py-8" data-cy="edit-mqtt-server-page">
       <PageHeader title={t('editMqttServer')} onBack={handleCancel} />
 
-      <Form onSubmit={handleSubmit} className="gap-4" data-cy="edit-mqtt-server-form">
-        <TextField
-          value={formValues.name}
-          onChange={(v) => setFormValues((p) => ({ ...p, name: v }))}
-          className="w-full"
-        >
-          <Label>{t('nameLabel')}</Label>
-          <Input
-            id="name"
-            name="name"
-            placeholder={t('namePlaceholder')}
-            required
-            data-cy="edit-mqtt-server-form-name-input"
+      <Form onSubmit={handleSubmit} className="gap-8" data-cy="edit-mqtt-server-form">
+        <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+          <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+            {t('sections.connection')}
+          </h3>
+          <TextField
+            value={formValues.name}
+            onChange={(v) => setFormValues((p) => ({ ...p, name: v }))}
+            className="w-full"
+          >
+            <Label>{t('nameLabel')}</Label>
+            <Input
+              id="name"
+              name="name"
+              placeholder={t('namePlaceholder')}
+              required
+              data-cy="edit-mqtt-server-form-name-input"
+            />
+          </TextField>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 w-full">
+            <TextField
+              value={formValues.host}
+              onChange={(v) => setFormValues((p) => ({ ...p, host: v }))}
+              className="md:col-span-2"
+            >
+              <Label>{t('hostLabel')}</Label>
+              <Input
+                id="host"
+                name="host"
+                placeholder={t('hostPlaceholder')}
+                required
+                data-cy="edit-mqtt-server-form-host-input"
+              />
+            </TextField>
+
+            <TextField
+              value={String(formValues.port || 1883)}
+              onChange={(v) => setFormValues((p) => ({ ...p, port: parseInt(v, 10) }))}
+            >
+              <Label>{t('portLabel')}</Label>
+              <Input
+                id="port"
+                name="port"
+                type="number"
+                placeholder={t('portPlaceholder')}
+                required
+                data-cy="edit-mqtt-server-form-port-input"
+              />
+            </TextField>
+          </div>
+        </section>
+
+        <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+          <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+            {t('sections.authentication')}
+          </h3>
+          <TextField
+            value={formValues.clientId}
+            onChange={(v) => setFormValues((p) => ({ ...p, clientId: v }))}
+            className="w-full"
+          >
+            <Label>{t('clientIdLabel')}</Label>
+            <Input
+              id="clientId"
+              name="clientId"
+              placeholder={t('clientIdPlaceholder')}
+              data-cy="edit-mqtt-server-form-client-id-input"
+            />
+          </TextField>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
+            <TextField
+              value={formValues.username}
+              onChange={(v) => setFormValues((p) => ({ ...p, username: v }))}
+            >
+              <Label>{t('usernameLabel')}</Label>
+              <Input
+                id="username"
+                name="username"
+                placeholder={t('usernamePlaceholder')}
+                data-cy="edit-mqtt-server-form-username-input"
+              />
+            </TextField>
+
+            <PasswordInput
+              label={t('passwordLabel')}
+              id="password"
+              name="password"
+              placeholder={t('passwordPlaceholder')}
+              value={formValues.password}
+              onChange={(v: string) => setFormValues((p) => ({ ...p, password: v }))}
+              data-cy="edit-mqtt-server-form-password-input"
+              autoComplete="off"
+            />
+          </div>
+
+          <Checkbox
+            id="useTls"
+            name="useTls"
+            isSelected={formValues.useTls}
+            onChange={(checked) => setFormValues((prev) => ({ ...prev, useTls: checked }))}
+            data-cy="edit-mqtt-server-form-use-tls-checkbox"
+          >
+            {t('useTls')}
+          </Checkbox>
+        </section>
+
+        <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+          <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+            {t('sections.publishDefaults')}
+          </h3>
+          <Select
+            label={t('defaultPublishQosLabel')}
+            value={String(formValues.defaultPublishQos ?? 0)}
+            onChange={(key) => {
+              setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }));
+            }}
+            data-cy="edit-mqtt-server-form-default-publish-qos-input"
+            items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
           />
-        </TextField>
 
-        <TextField
-          value={formValues.host}
-          onChange={(v) => setFormValues((p) => ({ ...p, host: v }))}
-          className="w-full"
-        >
-          <Label>{t('hostLabel')}</Label>
-          <Input
-            id="host"
-            name="host"
-            placeholder={t('hostPlaceholder')}
-            required
-            data-cy="edit-mqtt-server-form-host-input"
+          <LabeledSwitch
+            id="defaultPublishRetain"
+            name="defaultPublishRetain"
+            isSelected={!!formValues.defaultPublishRetain}
+            onChange={(checked) => setFormValues((prev) => ({ ...prev, defaultPublishRetain: checked }))}
+            data-cy="edit-mqtt-server-form-default-publish-retain-checkbox"
+          >
+            {t('defaultPublishRetainLabel')}
+          </LabeledSwitch>
+        </section>
+
+        <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+          <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+            {t('sections.subscribeDefaults')}
+          </h3>
+          <Select
+            label={t('defaultSubscribeQosLabel')}
+            value={String(formValues.defaultSubscribeQos ?? 0)}
+            onChange={(key) => {
+              setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }));
+            }}
+            data-cy="edit-mqtt-server-form-default-subscribe-qos-input"
+            items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
           />
-        </TextField>
-
-        <TextField
-          value={String(formValues.port || 1883)}
-          onChange={(v) => setFormValues((p) => ({ ...p, port: parseInt(v, 10) }))}
-          className="w-full"
-        >
-          <Label>{t('portLabel')}</Label>
-          <Input
-            id="port"
-            name="port"
-            type="number"
-            placeholder={t('portPlaceholder')}
-            required
-            data-cy="edit-mqtt-server-form-port-input"
-          />
-        </TextField>
-
-        <TextField
-          value={formValues.clientId}
-          onChange={(v) => setFormValues((p) => ({ ...p, clientId: v }))}
-          className="w-full"
-        >
-          <Label>{t('clientIdLabel')}</Label>
-          <Input
-            id="clientId"
-            name="clientId"
-            placeholder={t('clientIdPlaceholder')}
-            data-cy="edit-mqtt-server-form-client-id-input"
-          />
-        </TextField>
-
-        <TextField
-          value={formValues.username}
-          onChange={(v) => setFormValues((p) => ({ ...p, username: v }))}
-          className="w-full"
-        >
-          <Label>{t('usernameLabel')}</Label>
-          <Input
-            id="username"
-            name="username"
-            placeholder={t('usernamePlaceholder')}
-            data-cy="edit-mqtt-server-form-username-input"
-          />
-        </TextField>
-
-        <PasswordInput
-          label={t('passwordLabel')}
-          id="password"
-          name="password"
-          placeholder={t('passwordPlaceholder')}
-          value={formValues.password}
-          onChange={(v: string) => setFormValues((p) => ({ ...p, password: v }))}
-          className="w-full"
-          data-cy="edit-mqtt-server-form-password-input"
-          autoComplete="off"
-        />
-
-        <Checkbox
-          id="useTls"
-          name="useTls"
-          isSelected={formValues.useTls}
-          onChange={(checked) => setFormValues((prev) => ({ ...prev, useTls: checked }))}
-          data-cy="edit-mqtt-server-form-use-tls-checkbox"
-        >
-          {t('useTls')}
-        </Checkbox>
-
-        <Select
-          label={t('defaultPublishQosLabel')}
-          value={String(formValues.defaultPublishQos ?? 0)}
-          onChange={(key) => {
-            setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }));
-          }}
-          data-cy="edit-mqtt-server-form-default-publish-qos-input"
-          items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
-        />
-
-        <LabeledSwitch
-          id="defaultPublishRetain"
-          name="defaultPublishRetain"
-          isSelected={!!formValues.defaultPublishRetain}
-          onChange={(checked) => setFormValues((prev) => ({ ...prev, defaultPublishRetain: checked }))}
-          data-cy="edit-mqtt-server-form-default-publish-retain-checkbox"
-        >
-          {t('defaultPublishRetainLabel')}
-        </LabeledSwitch>
-
-        <Select
-          label={t('defaultSubscribeQosLabel')}
-          value={String(formValues.defaultSubscribeQos ?? 0)}
-          onChange={(key) => {
-            setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }));
-          }}
-          data-cy="edit-mqtt-server-form-default-subscribe-qos-input"
-          items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
-        />
+        </section>
 
         <div className="flex justify-end space-x-3 mt-4 w-full">
           <Button variant="secondary" onPress={handleCancel} data-cy="edit-mqtt-server-form-cancel-button">

--- a/apps/frontend/src/app/mqtt/servers/translations/edit/de.json
+++ b/apps/frontend/src/app/mqtt/servers/translations/edit/de.json
@@ -1,6 +1,12 @@
 {
   "editMqttServer": "MQTT-Server bearbeiten",
   "back": "Zurück",
+  "sections": {
+    "connection": "Verbindung",
+    "authentication": "Authentifizierung",
+    "publishDefaults": "Standards für Veröffentlichungen",
+    "subscribeDefaults": "Standards für Abonnements"
+  },
   "nameLabel": "Name",
   "namePlaceholder": "Mein MQTT-Server",
   "hostLabel": "Host",

--- a/apps/frontend/src/app/mqtt/servers/translations/edit/en.json
+++ b/apps/frontend/src/app/mqtt/servers/translations/edit/en.json
@@ -1,6 +1,12 @@
 {
   "editMqttServer": "Edit MQTT Server",
   "back": "Back",
+  "sections": {
+    "connection": "Connection",
+    "authentication": "Authentication",
+    "publishDefaults": "Publish defaults",
+    "subscribeDefaults": "Subscribe defaults"
+  },
   "nameLabel": "Name",
   "namePlaceholder": "My MQTT Server",
   "hostLabel": "Host",

--- a/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
+++ b/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
@@ -1,7 +1,7 @@
 import React, { useState, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Button, Card, Description, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Input, InputGroup, Label, Link, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, Separator, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, TextArea, TextField, Tooltip, TooltipContent, useOverlayState } from '@heroui/react';
+import { Button, Description, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Input, InputGroup, Label, Link, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, TextArea, TextField, Tooltip, TooltipContent, useOverlayState } from '@heroui/react';
 import { buttonVariants } from '@heroui/styles';
-import { Pencil, Trash, Key, FileCode, Eye, EyeOff, MoreVertical, Copy, Info } from 'lucide-react';
+import { Pencil, Trash, Key, Eye, EyeOff, MoreVertical, Copy } from 'lucide-react';
 import { useToastMessage } from '../../../components/toastProvider';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import {
@@ -679,445 +679,497 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
                     <ModalHeading>{editingProvider ? t('editProvider') : t('createNewProvider')}</ModalHeading>
                   </ModalHeader>
                   <ModalBody>
-                    <div className="space-y-4">
-                      <TextField
-                        isRequired
-                        value={formValues.name}
-                        onChange={(v) => setFormValues((prev) => ({ ...prev, name: v }))}
-                      >
-                        <Label>{t('name')}</Label>
-                        <Input placeholder="e.g. Company OIDC" data-cy="sso-provider-form-name-input" />
-                      </TextField>
-
-                      <div className="flex flex-col gap-1">
-                        <label className="text-sm font-medium">{t('type')}</label>
-                        <Select
-                          items={Object.values(SSOProviderType).map((type) => ({ key: type, label: type }))}
-                          value={formValues.type}
-                          onChange={(key) => {
-                            if (key) handleSelectChange(key as SSOProviderType);
-                          }}
+                    <div className="flex flex-col gap-8" data-cy="sso-provider-form">
+                      <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                          {t('sections.provider')}
+                        </h3>
+                        <TextField
                           isRequired
-                          data-cy="sso-provider-form-type-select"
-                        />
-                      </div>
+                          value={formValues.name}
+                          onChange={(v) => setFormValues((prev) => ({ ...prev, name: v }))}
+                        >
+                          <Label>{t('name')}</Label>
+                          <Input placeholder="e.g. Company OIDC" data-cy="sso-provider-form-name-input" />
+                        </TextField>
+
+                        <div className="flex flex-col gap-1">
+                          <label className="text-sm font-medium">{t('type')}</label>
+                          <Select
+                            items={Object.values(SSOProviderType).map((type) => ({ key: type, label: type }))}
+                            value={formValues.type}
+                            onChange={(key) => {
+                              if (key) handleSelectChange(key as SSOProviderType);
+                            }}
+                            isRequired
+                            data-cy="sso-provider-form-type-select"
+                          />
+                        </div>
+                      </section>
 
                       {formValues.type === SSOProviderType.OIDC && (
                         <>
-                          <Separator className="my-4" />
-                          <div className="flex items-center justify-between mb-2">
-                            <div className="flex items-center gap-2">
-                              <FileCode size={16} />
-                              <span className="font-semibold">{t('oidcConfiguration')}</span>
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <div className="flex items-center justify-between gap-2">
+                              <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                                {t('sections.oidcEndpoints')}
+                              </h3>
+                              <AuthentikDiscoveryDialog onDiscovery={onAutoDiscovery}>
+                                {(onOpenAuthentikDiscovery) => (
+                                  <KeycloakDiscoveryDialog onDiscovery={onAutoDiscovery}>
+                                    {(onOpenKeycloakDiscovery) => (
+                                      <Dropdown>
+                                        <DropdownTrigger className={buttonVariants({ variant: 'ghost' })}>
+                                          <MoreVertical className="w-4 h-4" />
+                                          {t('autoDiscovery.label')}
+                                        </DropdownTrigger>
+                                        <DropdownPopover>
+                                          <DropdownMenu aria-label="OIDC auto discovery options">
+                                            <DropdownItem
+                                              key="authentik"
+                                              id="authentik"
+                                              onPress={onOpenAuthentikDiscovery}
+                                              data-cy="sso-provider-form-authentik-discovery-button"
+                                            >
+                                              {t('autoDiscovery.authentik')}
+                                            </DropdownItem>
+
+                                            <DropdownItem
+                                              key="keycloak"
+                                              id="keycloak"
+                                              onPress={onOpenKeycloakDiscovery}
+                                              data-cy="sso-provider-form-keycloak-discovery-button"
+                                            >
+                                              {t('autoDiscovery.keycloak')}
+                                            </DropdownItem>
+                                          </DropdownMenu>
+                                        </DropdownPopover>
+                                      </Dropdown>
+                                    )}
+                                  </KeycloakDiscoveryDialog>
+                                )}
+                              </AuthentikDiscoveryDialog>
                             </div>
 
-                            <AuthentikDiscoveryDialog onDiscovery={onAutoDiscovery}>
-                              {(onOpenAuthentikDiscovery) => (
-                                <KeycloakDiscoveryDialog onDiscovery={onAutoDiscovery}>
-                                  {(onOpenKeycloakDiscovery) => (
-                                    <Dropdown>
-                                      <DropdownTrigger className={buttonVariants({ variant: 'ghost' })}>
-                                        <MoreVertical className="w-4 h-4" />
-                                        {t('autoDiscovery.label')}
-                                      </DropdownTrigger>
-                                      <DropdownPopover>
-                                        <DropdownMenu aria-label="OIDC auto discovery options">
-                                          <DropdownItem
-                                            key="authentik"
-                                            id="authentik"
-                                            onPress={onOpenAuthentikDiscovery}
-                                            data-cy="sso-provider-form-authentik-discovery-button"
-                                          >
-                                            {t('autoDiscovery.authentik')}
-                                          </DropdownItem>
-
-                                          <DropdownItem
-                                            key="keycloak"
-                                            id="keycloak"
-                                            onPress={onOpenKeycloakDiscovery}
-                                            data-cy="sso-provider-form-keycloak-discovery-button"
-                                          >
-                                            {t('autoDiscovery.keycloak')}
-                                          </DropdownItem>
-                                        </DropdownMenu>
-                                      </DropdownPopover>
-                                    </Dropdown>
-                                  )}
-                                </KeycloakDiscoveryDialog>
-                              )}
-                            </AuthentikDiscoveryDialog>
-                          </div>
-
-                          <TextField
-                            isRequired
-                            value={formValues.oidcConfiguration?.issuer ?? ''}
-                            onChange={(v) => setOidc('issuer', v)}
-                          >
-                            <Label>{t('issuer')}</Label>
-                            <Input
-                              placeholder="https://sso.example.com/auth/realms/example"
-                              data-cy="sso-provider-form-oidc-issuer-input"
-                            />
-                          </TextField>
-
-                          <TextField
-                            isRequired
-                            value={formValues.oidcConfiguration?.authorizationURL ?? ''}
-                            onChange={(v) => setOidc('authorizationURL', v)}
-                          >
-                            <Label>{t('authorizationURL')}</Label>
-                            <Input
-                              placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/auth"
-                              data-cy="sso-provider-form-oidc-authorization-url-input"
-                            />
-                          </TextField>
-
-                          <TextField
-                            isRequired
-                            value={formValues.oidcConfiguration?.tokenURL ?? ''}
-                            onChange={(v) => setOidc('tokenURL', v)}
-                          >
-                            <Label>{t('tokenURL')}</Label>
-                            <Input
-                              placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/token"
-                              data-cy="sso-provider-form-oidc-token-url-input"
-                            />
-                          </TextField>
-
-                          <TextField
-                            isRequired
-                            value={formValues.oidcConfiguration?.userInfoURL ?? ''}
-                            onChange={(v) => setOidc('userInfoURL', v)}
-                          >
-                            <Label>{t('userInfoURL')}</Label>
-                            <Input
-                              placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/userinfo"
-                              data-cy="sso-provider-form-oidc-user-info-url-input"
-                            />
-                          </TextField>
-
-                          <TextField
-                            isRequired
-                            value={formValues.oidcConfiguration?.clientId ?? ''}
-                            onChange={(v) => setOidc('clientId', v)}
-                          >
-                            <Label>{t('clientId')}</Label>
-                            <Input placeholder="your-client-id" data-cy="sso-provider-form-oidc-client-id-input" />
-                          </TextField>
-
-                          <TextField
-                            isRequired
-                            value={formValues.oidcConfiguration?.clientSecret ?? ''}
-                            onChange={(v) => setOidc('clientSecret', v)}
-                          >
-                            <Label>{t('clientSecret')}</Label>
-                            <InputGroup>
-                              <InputGroup.Input
-                                type={showClientSecret ? 'text' : 'password'}
-                                placeholder="••••••••••••••••"
-                                data-cy="sso-provider-form-oidc-client-secret-input"
+                            <TextField
+                              isRequired
+                              value={formValues.oidcConfiguration?.issuer ?? ''}
+                              onChange={(v) => setOidc('issuer', v)}
+                            >
+                              <Label>{t('issuer')}</Label>
+                              <Input
+                                placeholder="https://sso.example.com/auth/realms/example"
+                                data-cy="sso-provider-form-oidc-issuer-input"
                               />
-                              <InputGroup.Suffix>
+                            </TextField>
+
+                            <TextField
+                              isRequired
+                              value={formValues.oidcConfiguration?.authorizationURL ?? ''}
+                              onChange={(v) => setOidc('authorizationURL', v)}
+                            >
+                              <Label>{t('authorizationURL')}</Label>
+                              <Input
+                                placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/auth"
+                                data-cy="sso-provider-form-oidc-authorization-url-input"
+                              />
+                            </TextField>
+
+                            <TextField
+                              isRequired
+                              value={formValues.oidcConfiguration?.tokenURL ?? ''}
+                              onChange={(v) => setOidc('tokenURL', v)}
+                            >
+                              <Label>{t('tokenURL')}</Label>
+                              <Input
+                                placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/token"
+                                data-cy="sso-provider-form-oidc-token-url-input"
+                              />
+                            </TextField>
+
+                            <TextField
+                              isRequired
+                              value={formValues.oidcConfiguration?.userInfoURL ?? ''}
+                              onChange={(v) => setOidc('userInfoURL', v)}
+                            >
+                              <Label>{t('userInfoURL')}</Label>
+                              <Input
+                                placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/userinfo"
+                                data-cy="sso-provider-form-oidc-user-info-url-input"
+                              />
+                            </TextField>
+                          </section>
+
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                              {t('sections.oidcCredentials')}
+                            </h3>
+                            <TextField
+                              isRequired
+                              value={formValues.oidcConfiguration?.clientId ?? ''}
+                              onChange={(v) => setOidc('clientId', v)}
+                            >
+                              <Label>{t('clientId')}</Label>
+                              <Input placeholder="your-client-id" data-cy="sso-provider-form-oidc-client-id-input" />
+                            </TextField>
+
+                            <TextField
+                              isRequired
+                              value={formValues.oidcConfiguration?.clientSecret ?? ''}
+                              onChange={(v) => setOidc('clientSecret', v)}
+                            >
+                              <Label>{t('clientSecret')}</Label>
+                              <InputGroup>
+                                <InputGroup.Input
+                                  type={showClientSecret ? 'text' : 'password'}
+                                  placeholder="••••••••••••••••"
+                                  data-cy="sso-provider-form-oidc-client-secret-input"
+                                />
+                                <InputGroup.Suffix>
+                                  <Tooltip>
+                                    <Button
+                                      variant="ghost"
+                                      isIconOnly
+                                      onPress={() => setShowClientSecret(!showClientSecret)}
+                                      data-cy="sso-provider-form-oidc-toggle-client-secret-button"
+                                    >
+                                      {showClientSecret ? <EyeOff size={16} /> : <Eye size={16} />}
+                                    </Button>
+                                    <TooltipContent>
+                                      {showClientSecret ? t('hideClientSecret') : t('showClientSecret')}
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </InputGroup.Suffix>
+                              </InputGroup>
+                            </TextField>
+                          </section>
+
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                              {t('sections.oidcClaims')}
+                            </h3>
+                            <TextField value={scopesInput} onChange={setScopesInput}>
+                              <Label>{t('scopes')}</Label>
+                              <Input placeholder="openid, email, profile" data-cy="sso-provider-form-oidc-scopes-input" />
+                            </TextField>
+                            <TextField value={usernameClaimPathsInput} onChange={setUsernameClaimPathsInput}>
+                              <Label>{t('usernameClaimPaths')}</Label>
+                              <Input
+                                placeholder="preferred_username, email, sub"
+                                data-cy="sso-provider-form-oidc-username-claims-input"
+                              />
+                            </TextField>
+                            <TextField value={emailClaimPathsInput} onChange={setEmailClaimPathsInput}>
+                              <Label>{t('emailClaimPaths')}</Label>
+                              <Input
+                                placeholder="email, emails[0].value, upn"
+                                data-cy="sso-provider-form-oidc-email-claims-input"
+                              />
+                            </TextField>
+                          </section>
+
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                              {t('permissionMappings')}
+                            </h3>
+                            <p className="text-xs text-default-500">{t('permissionMappingsHint')}</p>
+                            {permissionKeys.map((permissionKey) => (
+                              <TextField
+                                key={`oidc-permission-${permissionKey}`}
+                                value={oidcPermissionMappingsInput[permissionKey]}
+                                onChange={(v) =>
+                                  setOidcPermissionMappingsInput((prev) => ({ ...prev, [permissionKey]: v }))
+                                }
+                              >
+                                <Label>{t(`permissionMappingLabels.${permissionKey}`)}</Label>
+                                <Input
+                                  placeholder={t('permissionMappingsPlaceholder')}
+                                  data-cy={`sso-provider-form-oidc-permission-mapping-${permissionKey}`}
+                                />
+                              </TextField>
+                            ))}
+                          </section>
+                        </>
+                      )}
+
+                      {formValues.type === SSOProviderType.SAML && (
+                        <>
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                              {t('sections.samlIdentityProvider')}
+                            </h3>
+                            <TextField
+                              isRequired
+                              value={formValues.samlConfiguration?.entryPoint ?? ''}
+                              onChange={(v) => setSaml('entryPoint', v)}
+                            >
+                              <Label>{t('entryPoint')}</Label>
+                              <Input
+                                placeholder="https://idp.example.com/realms/master/protocol/saml"
+                                data-cy="sso-provider-form-saml-entry-point-input"
+                              />
+                            </TextField>
+
+                            <TextField
+                              isRequired
+                              value={formValues.samlConfiguration?.issuer ?? ''}
+                              onChange={(v) => setSaml('issuer', v)}
+                            >
+                              <Label>{t('issuer')}</Label>
+                              <Input
+                                placeholder={window.location.origin ?? ''}
+                                data-cy="sso-provider-form-saml-issuer-input"
+                              />
+                            </TextField>
+
+                            <div className="flex flex-col gap-1">
+                              <label className="text-sm font-medium">{t('certificate')}</label>
+                              <TextArea
+                                name="samlConfiguration.certificate"
+                                value={formValues.samlConfiguration?.certificate ?? ''}
+                                onChange={(e) => setSaml('certificate', e.target.value)}
+                                placeholder="MIICmzCCAYMCBg..."
+                                required
+                                data-cy="sso-provider-form-saml-certificate-input"
+                              />
+                              <p className="text-xs text-default-500">{t('certificateHint')}</p>
+                            </div>
+
+                            <TextField
+                              value={formValues.samlConfiguration?.audience ?? ''}
+                              onChange={(v) => setSaml('audience', v)}
+                            >
+                              <Label>{t('audience')}</Label>
+                              <Input
+                                placeholder={window.location.origin ?? ''}
+                                data-cy="sso-provider-form-saml-audience-input"
+                              />
+                            </TextField>
+                          </section>
+
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                              {t('sections.samlAttributes')}
+                            </h3>
+                            <TextField value={emailAttributeKeysInput} onChange={setEmailAttributeKeysInput}>
+                              <Label>{t('emailAttributeKeys')}</Label>
+                              <Input
+                                placeholder="email, mail, urn:oid:1.2.840.113549.1.9.1"
+                                data-cy="sso-provider-form-saml-email-attribute-keys-input"
+                              />
+                              <Description>{t('emailAttributeKeysHint')}</Description>
+                            </TextField>
+                          </section>
+
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                              {t('sections.samlProvisioning')}
+                            </h3>
+                            <TextField
+                              value={formValues.samlConfiguration?.provisioningSecret ?? ''}
+                              onChange={(v) => setSaml('provisioningSecret', v)}
+                            >
+                              <Label>{t('samlProvisioningSecret')}</Label>
+                              <InputGroup>
+                                <Input
+                                  type={showSamlProvisioningSecret ? 'text' : 'password'}
+                                  placeholder="••••••••••••••••"
+                                  data-cy="sso-provider-form-saml-provisioning-secret-input"
+                                />
                                 <Tooltip>
                                   <Button
                                     variant="ghost"
                                     isIconOnly
-                                    onPress={() => setShowClientSecret(!showClientSecret)}
-                                    data-cy="sso-provider-form-oidc-toggle-client-secret-button"
+                                    onPress={() => setShowSamlProvisioningSecret(!showSamlProvisioningSecret)}
+                                    data-cy="sso-provider-form-saml-provisioning-secret-toggle-button"
                                   >
-                                    {showClientSecret ? <EyeOff size={16} /> : <Eye size={16} />}
+                                    {showSamlProvisioningSecret ? <EyeOff size={16} /> : <Eye size={16} />}
                                   </Button>
                                   <TooltipContent>
-                                    {showClientSecret ? t('hideClientSecret') : t('showClientSecret')}
+                                    {showSamlProvisioningSecret
+                                      ? t('hideSamlProvisioningSecret')
+                                      : t('showSamlProvisioningSecret')}
                                   </TooltipContent>
                                 </Tooltip>
-                              </InputGroup.Suffix>
-                            </InputGroup>
-                          </TextField>
-
-                          <Separator className="my-2" />
-                          <TextField value={scopesInput} onChange={setScopesInput}>
-                            <Label>{t('scopes')}</Label>
-                            <Input placeholder="openid, email, profile" data-cy="sso-provider-form-oidc-scopes-input" />
-                          </TextField>
-                          <TextField value={usernameClaimPathsInput} onChange={setUsernameClaimPathsInput}>
-                            <Label>{t('usernameClaimPaths')}</Label>
-                            <Input
-                              placeholder="preferred_username, email, sub"
-                              data-cy="sso-provider-form-oidc-username-claims-input"
-                            />
-                          </TextField>
-                          <TextField value={emailClaimPathsInput} onChange={setEmailClaimPathsInput}>
-                            <Label>{t('emailClaimPaths')}</Label>
-                            <Input
-                              placeholder="email, emails[0].value, upn"
-                              data-cy="sso-provider-form-oidc-email-claims-input"
-                            />
-                          </TextField>
-
-                          <Separator className="my-2" />
-                          <div className="flex items-center gap-2 mb-2">
-                            <Key size={16} />
-                            <span className="font-semibold">{t('permissionMappings')}</span>
-                          </div>
-                          <p className="text-xs text-default-500">{t('permissionMappingsHint')}</p>
-                          {permissionKeys.map((permissionKey) => (
-                            <TextField
-                              key={`oidc-permission-${permissionKey}`}
-                              value={oidcPermissionMappingsInput[permissionKey]}
-                              onChange={(v) =>
-                                setOidcPermissionMappingsInput((prev) => ({ ...prev, [permissionKey]: v }))
-                              }
-                            >
-                              <Label>{t(`permissionMappingLabels.${permissionKey}`)}</Label>
-                              <Input
-                                placeholder={t('permissionMappingsPlaceholder')}
-                                data-cy={`sso-provider-form-oidc-permission-mapping-${permissionKey}`}
-                              />
+                              </InputGroup>
+                              <Description>{t('samlProvisioningSecretHint')}</Description>
                             </TextField>
-                          ))}
+                          </section>
+
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                              {t('permissionMappings')}
+                            </h3>
+                            <p className="text-xs text-default-500">{t('permissionMappingsHint')}</p>
+                            {permissionKeys.map((permissionKey) => (
+                              <TextField
+                                key={`saml-permission-${permissionKey}`}
+                                value={samlPermissionMappingsInput[permissionKey]}
+                                onChange={(v) =>
+                                  setSamlPermissionMappingsInput((prev) => ({ ...prev, [permissionKey]: v }))
+                                }
+                              >
+                                <Label>{t(`permissionMappingLabels.${permissionKey}`)}</Label>
+                                <Input
+                                  placeholder={t('permissionMappingsPlaceholder')}
+                                  data-cy={`sso-provider-form-saml-permission-mapping-${permissionKey}`}
+                                />
+                              </TextField>
+                            ))}
+                          </section>
+
+                          <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                              {t('sections.samlSigning')}
+                            </h3>
+                            <div className="flex flex-col gap-1">
+                              <label className="text-sm font-medium">{t('spSigningCertificate')}</label>
+                              <TextArea
+                                name="samlConfiguration.spSigningCertificate"
+                                value={formValues.samlConfiguration?.spSigningCertificate ?? ''}
+                                onChange={(e) => setSaml('spSigningCertificate', e.target.value)}
+                                placeholder="MIICmzCCAYMCBg..."
+                                data-cy="sso-provider-form-saml-sp-certificate-input"
+                              />
+                              <p className="text-xs text-default-500">{t('spSigningCertificateHint')}</p>
+                            </div>
+
+                            <div className="flex flex-col gap-1">
+                              <label className="text-sm font-medium">{t('spSigningPrivateKey')}</label>
+                              <TextArea
+                                name="samlConfiguration.spSigningPrivateKey"
+                                value={formValues.samlConfiguration?.spSigningPrivateKey ?? ''}
+                                onChange={(e) => setSaml('spSigningPrivateKey', e.target.value)}
+                                placeholder="-----BEGIN PRIVATE KEY-----"
+                                data-cy="sso-provider-form-saml-sp-private-key-input"
+                              />
+                              <p className="text-xs text-default-500">
+                                {providerDetails?.samlConfiguration?.spSigningKeyEncrypted
+                                  ? t('spSigningPrivateKeyHintExisting')
+                                  : t('spSigningPrivateKeyHint')}
+                              </p>
+                            </div>
+
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                              <LabeledSwitch
+                                isSelected={formValues.samlConfiguration?.signRequest ?? false}
+                                onChange={(value) => handleSamlToggleChange('signRequest', value)}
+                                data-cy="sso-provider-form-saml-sign-request-switch"
+                              >
+                                {t('signRequest')}
+                              </LabeledSwitch>
+                              <LabeledSwitch
+                                isSelected={formValues.samlConfiguration?.wantAssertionsSigned ?? false}
+                                onChange={(value) => handleSamlToggleChange('wantAssertionsSigned', value)}
+                                data-cy="sso-provider-form-saml-assertions-signed-switch"
+                              >
+                                {t('wantAssertionsSigned')}
+                              </LabeledSwitch>
+                              <LabeledSwitch
+                                isSelected={formValues.samlConfiguration?.wantAuthnResponseSigned ?? true}
+                                onChange={(value) => handleSamlToggleChange('wantAuthnResponseSigned', value)}
+                                data-cy="sso-provider-form-saml-response-signed-switch"
+                              >
+                                {t('wantAuthnResponseSigned')}
+                              </LabeledSwitch>
+                              <LabeledSwitch
+                                isSelected={formValues.samlConfiguration?.forceAuthn ?? false}
+                                onChange={(value) => handleSamlToggleChange('forceAuthn', value)}
+                                data-cy="sso-provider-form-saml-force-authn-switch"
+                              >
+                                {t('forceAuthn')}
+                              </LabeledSwitch>
+                            </div>
+                          </section>
                         </>
                       )}
-                      {formValues.type === SSOProviderType.SAML && (
-                        <>
-                          <Separator className="my-4" />
-                          <div className="flex items-center gap-2 mb-2">
-                            <FileCode size={16} />
-                            <span className="font-semibold">{t('samlConfiguration')}</span>
-                          </div>
 
-                          <TextField
-                            isRequired
-                            value={formValues.samlConfiguration?.entryPoint ?? ''}
-                            onChange={(v) => setSaml('entryPoint', v)}
-                          >
-                            <Label>{t('entryPoint')}</Label>
-                            <Input
-                              placeholder="https://idp.example.com/realms/master/protocol/saml"
-                              data-cy="sso-provider-form-saml-entry-point-input"
-                            />
-                          </TextField>
-
-                          <TextField
-                            isRequired
-                            value={formValues.samlConfiguration?.issuer ?? ''}
-                            onChange={(v) => setSaml('issuer', v)}
-                          >
-                            <Label>{t('issuer')}</Label>
-                            <Input
-                              placeholder={window.location.origin ?? ''}
-                              data-cy="sso-provider-form-saml-issuer-input"
-                            />
-                          </TextField>
-
-                          <TextArea
-                            name="samlConfiguration.certificate"
-                            value={formValues.samlConfiguration?.certificate ?? ''}
-                            onChange={(e) => setSaml('certificate', e.target.value)}
-                            placeholder="MIICmzCCAYMCBg..."
-                            required
-                            data-cy="sso-provider-form-saml-certificate-input"
-                          />
-                          <p className="text-xs text-default-500">{t('certificateHint')}</p>
-
-                          <TextField
-                            value={formValues.samlConfiguration?.audience ?? ''}
-                            onChange={(v) => setSaml('audience', v)}
-                          >
-                            <Label>{t('audience')}</Label>
-                            <Input
-                              placeholder={window.location.origin ?? ''}
-                              data-cy="sso-provider-form-saml-audience-input"
-                            />
-                          </TextField>
-
-                          <TextField value={emailAttributeKeysInput} onChange={setEmailAttributeKeysInput}>
-                            <Label>{t('emailAttributeKeys')}</Label>
-                            <Input
-                              placeholder="email, mail, urn:oid:1.2.840.113549.1.9.1"
-                              data-cy="sso-provider-form-saml-email-attribute-keys-input"
-                            />
-                            <Description>{t('emailAttributeKeysHint')}</Description>
-                          </TextField>
-
-                          <TextField
-                            value={formValues.samlConfiguration?.provisioningSecret ?? ''}
-                            onChange={(v) => setSaml('provisioningSecret', v)}
-                          >
-                            <Label>{t('samlProvisioningSecret')}</Label>
-                            <InputGroup>
-                              <Input
-                                type={showSamlProvisioningSecret ? 'text' : 'password'}
-                                placeholder="••••••••••••••••"
-                                data-cy="sso-provider-form-saml-provisioning-secret-input"
-                              />
-                              <Tooltip>
-                                <Button
-                                  variant="ghost"
-                                  isIconOnly
-                                  onPress={() => setShowSamlProvisioningSecret(!showSamlProvisioningSecret)}
-                                  data-cy="sso-provider-form-saml-provisioning-secret-toggle-button"
+                      <section
+                        className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0"
+                        data-cy="sso-provider-form-setup-section"
+                      >
+                        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                          {t('setupInstructions')}
+                        </h3>
+                        <p className="text-xs text-default-500">{t('setupInstructionsHint')}</p>
+                        <dl className="flex flex-col gap-4">
+                          {!isSamlProvider && (
+                            <div className="flex flex-col gap-1">
+                              <dt className="text-sm font-medium">{t('authentikRedirectRegex')}</dt>
+                              <dd className="flex items-center gap-2 rounded-md border border-default-200 bg-default-50 px-3 py-2">
+                                <code
+                                  className="flex-1 text-xs break-all font-mono text-default-700"
+                                  data-cy="sso-provider-form-authentik-regex"
                                 >
-                                  {showSamlProvisioningSecret ? <EyeOff size={16} /> : <Eye size={16} />}
-                                </Button>
-                                <TooltipContent>
-                                  {showSamlProvisioningSecret
-                                    ? t('hideSamlProvisioningSecret')
-                                    : t('showSamlProvisioningSecret')}
-                                </TooltipContent>
-                              </Tooltip>
-                            </InputGroup>
-                            <Description>{t('samlProvisioningSecretHint')}</Description>
-                          </TextField>
-
-                          <Separator className="my-2" />
-                          <div className="flex items-center gap-2 mb-2">
-                            <Key size={16} />
-                            <span className="font-semibold">{t('permissionMappings')}</span>
-                          </div>
-                          <p className="text-xs text-default-500">{t('permissionMappingsHint')}</p>
-                          {permissionKeys.map((permissionKey) => (
-                            <TextField
-                              key={`saml-permission-${permissionKey}`}
-                              value={samlPermissionMappingsInput[permissionKey]}
-                              onChange={(v) =>
-                                setSamlPermissionMappingsInput((prev) => ({ ...prev, [permissionKey]: v }))
-                              }
-                            >
-                              <Label>{t(`permissionMappingLabels.${permissionKey}`)}</Label>
-                              <Input
-                                placeholder={t('permissionMappingsPlaceholder')}
-                                data-cy={`sso-provider-form-saml-permission-mapping-${permissionKey}`}
-                              />
-                            </TextField>
-                          ))}
-
-                          <TextArea
-                            name="samlConfiguration.spSigningCertificate"
-                            value={formValues.samlConfiguration?.spSigningCertificate ?? ''}
-                            onChange={(e) => setSaml('spSigningCertificate', e.target.value)}
-                            placeholder="MIICmzCCAYMCBg..."
-                            data-cy="sso-provider-form-saml-sp-certificate-input"
-                          />
-                          <p className="text-xs text-default-500">{t('spSigningCertificateHint')}</p>
-
-                          <TextArea
-                            name="samlConfiguration.spSigningPrivateKey"
-                            value={formValues.samlConfiguration?.spSigningPrivateKey ?? ''}
-                            onChange={(e) => setSaml('spSigningPrivateKey', e.target.value)}
-                            placeholder="-----BEGIN PRIVATE KEY-----"
-                            data-cy="sso-provider-form-saml-sp-private-key-input"
-                          />
-                          <p className="text-xs text-default-500">
-                            {providerDetails?.samlConfiguration?.spSigningKeyEncrypted
-                              ? t('spSigningPrivateKeyHintExisting')
-                              : t('spSigningPrivateKeyHint')}
-                          </p>
-
-                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <LabeledSwitch
-                              isSelected={formValues.samlConfiguration?.signRequest ?? false}
-                              onChange={(value) => handleSamlToggleChange('signRequest', value)}
-                              data-cy="sso-provider-form-saml-sign-request-switch"
-                            >
-                              {t('signRequest')}
-                            </LabeledSwitch>
-                            <LabeledSwitch
-                              isSelected={formValues.samlConfiguration?.wantAssertionsSigned ?? false}
-                              onChange={(value) => handleSamlToggleChange('wantAssertionsSigned', value)}
-                              data-cy="sso-provider-form-saml-assertions-signed-switch"
-                            >
-                              {t('wantAssertionsSigned')}
-                            </LabeledSwitch>
-                            <LabeledSwitch
-                              isSelected={formValues.samlConfiguration?.wantAuthnResponseSigned ?? true}
-                              onChange={(value) => handleSamlToggleChange('wantAuthnResponseSigned', value)}
-                              data-cy="sso-provider-form-saml-response-signed-switch"
-                            >
-                              {t('wantAuthnResponseSigned')}
-                            </LabeledSwitch>
-                            <LabeledSwitch
-                              isSelected={formValues.samlConfiguration?.forceAuthn ?? false}
-                              onChange={(value) => handleSamlToggleChange('forceAuthn', value)}
-                              data-cy="sso-provider-form-saml-force-authn-switch"
-                            >
-                              {t('forceAuthn')}
-                            </LabeledSwitch>
-                          </div>
-                        </>
-                      )}
-
-                      <Separator className="my-4" />
-                      <Card className="border border-default-200" data-cy="sso-provider-form-setup-card">
-                        <Card.Header className="flex items-center gap-2">
-                          <Info size={16} />
-                          <span className="font-semibold">{t('setupInstructions')}</span>
-                        </Card.Header>
-                        <Card.Content className="flex flex-col gap-3">
-                          <p className="text-xs text-default-500">{t('setupInstructionsHint')}</p>
-                          <div className="flex flex-col gap-3">
-                            {!isSamlProvider && (
-                              <TextField isReadOnly isDisabled={!hasSetupUrls} value={authentikRedirectRegexPattern}>
-                                <Label>{t('authentikRedirectRegex')}</Label>
-                                {hasSetupUrls ? (
-                                  <InputGroup>
-                                    <Input data-cy="sso-provider-form-authentik-regex" />
+                                  {hasSetupUrls ? authentikRedirectRegexPattern : t('setupUrlPending')}
+                                </code>
+                                {hasSetupUrls && (
+                                  <Tooltip>
                                     <Button
                                       variant="ghost"
+                                      isIconOnly
+                                      size="sm"
                                       onPress={() => handleCopyLoginUrl(authentikRedirectRegexPattern)}
                                       data-cy="sso-provider-form-authentik-regex-copy-button"
                                     >
-                                      <Copy size={24} />
-                                      {t('copy')}
+                                      <Copy size={16} />
                                     </Button>
-                                  </InputGroup>
-                                ) : (
-                                  <Input data-cy="sso-provider-form-authentik-regex" />
+                                    <TooltipContent>{t('copy')}</TooltipContent>
+                                  </Tooltip>
                                 )}
-                                <Description>
-                                  {hasSetupUrls ? t('authentikRedirectRegexDescription') : t('setupUrlPending')}
-                                </Description>
-                              </TextField>
-                            )}
-                            <TextField
-                              isReadOnly
-                              isDisabled={!hasSetupUrls}
-                              value={isSamlProvider ? samlCallbackUrl : oidcCallbackUrl}
-                            >
-                              <Label>{isSamlProvider ? t('samlAcsUrl') : t('oidcRedirectUri')}</Label>
-                              {hasSetupUrls ? (
-                                <InputGroup>
-                                  <Input data-cy="sso-provider-form-callback-url" />
+                              </dd>
+                              <p className="text-xs text-default-500">
+                                {hasSetupUrls ? t('authentikRedirectRegexDescription') : t('setupUrlPending')}
+                              </p>
+                            </div>
+                          )}
+                          <div className="flex flex-col gap-1">
+                            <dt className="text-sm font-medium">
+                              {isSamlProvider ? t('samlAcsUrl') : t('oidcRedirectUri')}
+                            </dt>
+                            <dd className="flex items-center gap-2 rounded-md border border-default-200 bg-default-50 px-3 py-2">
+                              <code
+                                className="flex-1 text-xs break-all font-mono text-default-700"
+                                data-cy="sso-provider-form-callback-url"
+                              >
+                                {hasSetupUrls
+                                  ? isSamlProvider
+                                    ? samlCallbackUrl
+                                    : oidcCallbackUrl
+                                  : t('setupUrlPending')}
+                              </code>
+                              {hasSetupUrls && (
+                                <Tooltip>
                                   <Button
                                     variant="ghost"
+                                    isIconOnly
+                                    size="sm"
                                     onPress={isSamlProvider ? handleCopySamlCallbackUrl : handleCopyOidcCallbackUrl}
                                     data-cy="sso-provider-form-callback-url-copy-button"
                                   >
-                                    <Copy size={24} />
-                                    {t('copy')}
+                                    <Copy size={16} />
                                   </Button>
-                                </InputGroup>
-                              ) : (
-                                <Input data-cy="sso-provider-form-callback-url" />
+                                  <TooltipContent>{t('copy')}</TooltipContent>
+                                </Tooltip>
                               )}
-                              <Description>
-                                {hasSetupUrls
-                                  ? isSamlProvider
-                                    ? t('samlAcsUrlDescription')
-                                    : t('oidcRedirectUriDescription')
-                                  : t('setupUrlPending')}
-                              </Description>
-                            </TextField>
+                            </dd>
+                            <p className="text-xs text-default-500">
+                              {hasSetupUrls
+                                ? isSamlProvider
+                                  ? t('samlAcsUrlDescription')
+                                  : t('oidcRedirectUriDescription')
+                                : t('setupUrlPending')}
+                            </p>
                           </div>
+                        </dl>
 
-                          <div className="flex flex-wrap gap-3 text-xs">
-                            {docsSsoProvidersUrl && <Link href={docsSsoProvidersUrl}>{t('docsSsoProviders')}</Link>}
-                            {docsAuthentikPermissionsUrl && (
-                              <Link href={docsAuthentikPermissionsUrl}>{t('docsAuthentikPermissions')}</Link>
-                            )}
-                          </div>
-                        </Card.Content>
-                      </Card>
+                        <div className="flex flex-wrap gap-3 text-xs">
+                          {docsSsoProvidersUrl && <Link href={docsSsoProvidersUrl}>{t('docsSsoProviders')}</Link>}
+                          {docsAuthentikPermissionsUrl && (
+                            <Link href={docsAuthentikPermissionsUrl}>{t('docsAuthentikPermissions')}</Link>
+                          )}
+                        </div>
+                      </section>
                     </div>
                   </ModalBody>
                   <ModalFooter>

--- a/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
+++ b/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
@@ -1,5 +1,6 @@
 import React, { useState, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Button, Description, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, Input, InputGroup, Label, Link, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, TextArea, TextField, Tooltip, TooltipContent, useOverlayState } from '@heroui/react';
+import { Button, Description, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, DrawerBody, DrawerFooter, DrawerHeader, Input, InputGroup, Label, Link, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, TextArea, TextField, Tooltip, TooltipContent, useOverlayState } from '@heroui/react';
+import { StandardDrawer } from '../../../components/standardDrawer';
 import { buttonVariants } from '@heroui/styles';
 import { Pencil, Trash, Key, Eye, EyeOff, MoreVertical, Copy } from 'lucide-react';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -668,17 +669,13 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
         </div>
       )}
 
-      {/* Main Provider Form Modal */}
-      <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="sso-provider-form-modal">
-        <ModalBackdrop>
-          <ModalContainer size="lg">
-            <ModalDialog>
-              {({ close }) => (
-                <>
-                  <ModalHeader>
-                    <ModalHeading>{editingProvider ? t('editProvider') : t('createNewProvider')}</ModalHeading>
-                  </ModalHeader>
-                  <ModalBody>
+      {/* Main Provider Form Drawer */}
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <div data-cy="sso-provider-form-modal" className="contents">
+        <DrawerHeader>
+          <h2 className="text-lg font-semibold">{editingProvider ? t('editProvider') : t('createNewProvider')}</h2>
+        </DrawerHeader>
+        <DrawerBody>
                     <div className="flex flex-col gap-8" data-cy="sso-provider-form">
                       <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
                         <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
@@ -1171,27 +1168,23 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
                         </div>
                       </section>
                     </div>
-                  </ModalBody>
-                  <ModalFooter>
-                    <Button variant="secondary" onPress={close} data-cy="sso-provider-form-cancel-button">
-                      {t('cancel')}
-                    </Button>
-                    <Button
-                      variant="primary"
-                      onPress={handleSubmit}
-                      isDisabled={isSaveDisabled}
-                      isPending={isMutationPending}
-                      data-cy="sso-provider-form-save-button"
-                    >
-                      {t('save')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+        </DrawerBody>
+        <DrawerFooter>
+          <Button variant="secondary" onPress={() => setOpen(false)} data-cy="sso-provider-form-cancel-button">
+            {t('cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            onPress={handleSubmit}
+            isDisabled={isSaveDisabled}
+            isPending={isMutationPending}
+            data-cy="sso-provider-form-save-button"
+          >
+            {t('save')}
+          </Button>
+        </DrawerFooter>
+        </div>
+      </StandardDrawer>
     </>
   );
 });

--- a/apps/frontend/src/app/sso/providers/de.json
+++ b/apps/frontend/src/app/sso/providers/de.json
@@ -22,6 +22,16 @@
   "failedToDelete": "Fehler beim Löschen des SSO-Anbieters.",
   "oidcConfiguration": "OIDC-Konfiguration",
   "samlConfiguration": "SAML-Konfiguration",
+  "sections": {
+    "provider": "Anbieter",
+    "oidcEndpoints": "OIDC-Endpunkte",
+    "oidcCredentials": "Client-Zugangsdaten",
+    "oidcClaims": "Claim-Zuordnung",
+    "samlIdentityProvider": "Identity Provider",
+    "samlAttributes": "Attribut-Zuordnung",
+    "samlProvisioning": "Provisioning",
+    "samlSigning": "Service-Provider-Signierung"
+  },
   "issuer": "Aussteller",
   "entryPoint": "Entry Point",
   "authorizationURL": "Autorisierungs-URL",

--- a/apps/frontend/src/app/sso/providers/en.json
+++ b/apps/frontend/src/app/sso/providers/en.json
@@ -22,6 +22,16 @@
   "failedToDelete": "Failed to delete SSO provider.",
   "oidcConfiguration": "OIDC Configuration",
   "samlConfiguration": "SAML Configuration",
+  "sections": {
+    "provider": "Provider",
+    "oidcEndpoints": "OIDC endpoints",
+    "oidcCredentials": "Client credentials",
+    "oidcClaims": "Claim mapping",
+    "samlIdentityProvider": "Identity provider",
+    "samlAttributes": "Attribute mapping",
+    "samlProvisioning": "Provisioning",
+    "samlSigning": "Service provider signing"
+  },
   "issuer": "Issuer",
   "entryPoint": "Entry Point",
   "authorizationURL": "Authorization URL",

--- a/apps/frontend/src/components/standardDrawer.tsx
+++ b/apps/frontend/src/components/standardDrawer.tsx
@@ -18,7 +18,7 @@ interface Props {
   dialogProps?: Omit<DrawerDialogProps, 'children'>;
 }
 
-const DEFAULT_DIALOG_CLASSNAME = 'md:max-w-2xl md:mx-auto';
+const DEFAULT_DIALOG_CLASSNAME = 'md:max-w-2xl md:mx-auto bg-background';
 
 export function StandardDrawer(props: Props) {
   const { isOpen, onOpenChange, children, backdropProps, contentProps, dialogProps } = props;


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Refactors the SSO providers form to remove `Card` wrappers around editable inputs, applying the sectioned form layout established by the `EditMqttServerPage` refactor under the umbrella ticket ATT-294.

### Changes

- **OIDC modal** now groups fields into four sections:
  - *OIDC endpoints* (issuer, authorization, token, user-info URLs) with the auto-discovery dropdown moved inline with the section title
  - *Client credentials* (clientId, clientSecret)
  - *Claim mapping* (scopes, username/email claim paths)
  - *Permission mappings*
- **SAML modal** now groups fields into five sections:
  - *Identity provider* (entry point, issuer, certificate, audience)
  - *Attribute mapping* (email attribute keys)
  - *Provisioning* (provisioning secret)
  - *Permission mappings*
  - *Service provider signing* (cert, private key, sign/assertions/response/forceAuthn switches)
- **Setup instructions** section unwrapped from its `Card`. Read-only `TextField` inputs replaced with a `<dl>` + `<code>` visualization and icon-only copy buttons, so the section no longer mixes form controls with display-only content.
- Added `sections.*` translation keys to `en.json` / `de.json`.
- Removed now-unused imports: `Card`, `Separator`, `FileCode`, `Info`.

All `data-cy` selectors, validation, and copy-to-clipboard handlers preserved. End-to-end create + edit verified for OIDC in a real browser; SAML create flow verified for layout, signing toggles, and pending-setup state.

Linear issue: [ATT-309](https://linear.app/attraccess/issue/ATT-309/design-unwrap-card-from-sso-providers-form-att-294)

## Test plan

- [x] Typecheck (`nx typecheck frontend`)
- [x] Lint (`nx lint frontend`)
- [x] Browser create OIDC end-to-end (login → list → create modal → save → list shows new row)
- [x] Browser create SAML modal layout
- [x] Browser edit OIDC modal shows populated fields + setup URLs with copy buttons
- [x] Setup instructions section renders setup URLs as read-only code blocks (no inputs)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->