### PR TITLE
refactor(frontend): unwrap Card from reset-password form (ATT-321)

### DIFF
--- a/apps/frontend/src/app/reset-password/resetPassword.tsx
+++ b/apps/frontend/src/app/reset-password/resetPassword.tsx
@@ -74,47 +74,43 @@ export function ResetPassword() {
   }
 
   return (
-    <Card data-cy="reset-password-form-card">
+    <div className="min-h-screen flex items-center justify-center px-4 py-8">
       <Form
         onSubmit={(e) => {
           e.preventDefault();
           onMainButtonPress();
         }}
+        className="max-w-md w-full gap-4"
         data-cy="reset-password-form"
       >
-        <Card.Header>{t('title')}</Card.Header>
-        <Card.Content>
-          <PasswordInput
-            label={t('inputs.password')}
-            value={password}
-            onChange={(setPassword)}
-            className="mb-4"
-            minLength={8}
-            required
-            data-cy="reset-password-password-input"
-            autoComplete="new-password"
-          />
-          <PasswordInput
-            label={t('inputs.confirmPassword')}
-            value={confirmPassword}
-            onChange={(setConfirmPassword)}
-            required
-            validate={() => {
-              if (password !== confirmPassword) {
-                return t('error.passwordsDoNotMatch.description');
-              }
-              return true;
-            }}
-            data-cy="reset-password-confirm-password-input"
-            autoComplete="new-password"
-          />
-        </Card.Content>
-        <Card.Footer>
-          <Button variant="primary" className="w-full" type="submit" data-cy="reset-password-submit-button">
-            {t('submit')}
-          </Button>
-        </Card.Footer>
+        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">{t('title')}</h3>
+        <PasswordInput
+          label={t('inputs.password')}
+          value={password}
+          onChange={setPassword}
+          minLength={8}
+          required
+          data-cy="reset-password-password-input"
+          autoComplete="new-password"
+        />
+        <PasswordInput
+          label={t('inputs.confirmPassword')}
+          value={confirmPassword}
+          onChange={setConfirmPassword}
+          required
+          validate={() => {
+            if (password !== confirmPassword) {
+              return t('error.passwordsDoNotMatch.description');
+            }
+            return true;
+          }}
+          data-cy="reset-password-confirm-password-input"
+          autoComplete="new-password"
+        />
+        <Button variant="primary" className="w-full mt-2" type="submit" data-cy="reset-password-submit-button">
+          {t('submit')}
+        </Button>
       </Form>
-    </Card>
+    </div>
   );
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Removes the `<Card>` wrapper around the reset-password `<Form>`. The form now uses a flat centred layout matching the `EditMqttServerPage` pattern: section heading + stacked `PasswordInput` controls + submit button. The success-state Card is preserved as a status card.

## Changes

- `apps/frontend/src/app/reset-password/resetPassword.tsx`
  - Replace `<Card>` + `Card.Header` / `Card.Content` / `Card.Footer` around the form with `<div class="min-h-screen flex items-center justify-center px-4 py-8">` + `<Form class="max-w-md w-full gap-4">`.
  - Use an `<h3>` section heading (`text-sm uppercase tracking-wide font-semibold text-default-700`) for the title.
  - Drop now-redundant `mb-4` on the first input (relies on `Form` gap).
  - Pass `setPassword` / `setConfirmPassword` directly to `onChange` (no extra parens).
  - Success state Card untouched.

## Acceptance criteria

- [x] No `<Card>` wrapping `PasswordInput` controls
- [x] Form still centred, reads as tight flat block
- [x] Success state remains a small Card

## Verification

- Lint + typecheck + build + test green via `pnpm nx lint frontend`.
- Browser verified at `/reset-password?token=demo&userId=1`:
  - Form renders without Card border, centred, max-width preserved.
  - Submit triggers mismatch validation (red outline on confirm field).

Linear: https://linear.app/attraccess/issue/ATT-321/design-unwrap-card-from-reset-password-form

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->