### PR TITLE
fix(frontend): add i18n key for delete-account-confirmation template

### DIFF
--- a/apps/frontend/src/app/email-templates/de.json
+++ b/apps/frontend/src/app/email-templates/de.json
@@ -16,6 +16,7 @@
     "password-changed": "Passwort geändert",
     "resource-usage-billing-transaction-summary": "Ressourcen-Nutzung Kostenübersicht",
     "user-invitation": "Benutzereinladung",
-    "project-invitation": "Projekteinladung"
+    "project-invitation": "Projekteinladung",
+    "delete-account-confirmation": "Kontolöschung Bestätigung"
   }
 }

--- a/apps/frontend/src/app/email-templates/en.json
+++ b/apps/frontend/src/app/email-templates/en.json
@@ -16,6 +16,7 @@
     "password-changed": "Password Changed",
     "resource-usage-billing-transaction-summary": "Resource Usage Billing Transaction Summary",
     "user-invitation": "User Invitation",
-    "project-invitation": "Project Invitation"
+    "project-invitation": "Project Invitation",
+    "delete-account-confirmation": "Delete Account Confirmation"
   }
 }


### PR DESCRIPTION
## Summary
- Adds missing `templateTypes.delete-account-confirmation` to `apps/frontend/src/app/email-templates/en.json` and `de.json`.
- Resolves the `!!! templateTypes.delete-account-confirmation !!!` marker on `/email-templates`.

Closes ATT-324 (Linear), refs #871.

## Notes
- Backend enum (`EmailTemplateType`) also defines `resource-health-changed`, which has no translation either. Out of scope for ATT-324, but may show the same marker if seeded — flagging for follow-up.

## Test plan
- [ ] `pnpm install` + node 24, run `pnpm serve --only=frontend`, log in as admin, open `/email-templates`.
- [ ] Confirm bottom row shows "Delete Account Confirmation" (en) / "Kontolöschung Bestätigung" (de).
- [ ] Confirm no `!!! ... !!!` markers on the page.

<!-- generated-by-cyrus -->