### PR TITLE
refactor(frontend): unwrap Card from BillingDashboardTopupCard (ATT-316)

### DIFF
--- a/apps/frontend/src/app/billing/dashboard/summary/de.json
+++ b/apps/frontend/src/app/billing/dashboard/summary/de.json
@@ -4,6 +4,7 @@
   "transactions": {
     "table": {
       "ariaLabel": "Transaktionen",
+      "empty": "Noch keine Transaktionen.",
       "columns": {
         "id": "ID",
         "dateTime": "Datum",

--- a/apps/frontend/src/app/billing/dashboard/summary/en.json
+++ b/apps/frontend/src/app/billing/dashboard/summary/en.json
@@ -4,6 +4,7 @@
   "transactions": {
     "table": {
       "ariaLabel": "Transactions",
+      "empty": "No transactions yet.",
       "columns": {
         "id": "ID",
         "dateTime": "Date",

--- a/apps/frontend/src/app/billing/dashboard/summary/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/index.tsx
@@ -1,6 +1,7 @@
 import { DateTimeDisplay, useNumberFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { Button, Chip, cn, Skeleton, Spinner, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
+import { EmptyState } from '../../../../components/emptyState';
 import de from './de.json';
 import en from './en.json';
 import { useAuth } from '../../../../hooks/useAuth';
@@ -165,7 +166,7 @@ export function SummaryCard(props: Props) {
             <TableColumn>{t('transactions.table.columns.amount')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.actions')}</TableColumn>
           </TableHeader>
-          <TableBody items={transactions?.data ?? []} renderEmptyState={() => t('transactions.table.empty')}>
+          <TableBody items={transactions?.data ?? []} renderEmptyState={() => <EmptyState message={t('transactions.table.empty') as string} />}>
             {(transaction) => (
               <TableRow key={transaction.id} id={transaction.id} className="wrap-none cursor-pointer">
                 <TableCell>{transaction.id}</TableCell>

--- a/apps/frontend/src/app/billing/dashboard/summary/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/index.tsx
@@ -1,5 +1,5 @@
 import { DateTimeDisplay, useNumberFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, CardProps, Chip, cn, Skeleton, Spinner, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import { Button, Chip, cn, Skeleton, Spinner, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import de from './de.json';
 import en from './en.json';
@@ -17,13 +17,14 @@ import { dbCurrencyToUserCurrency } from '@attraccess/shared';
 import { TransactionDetailsModal } from './transactionDetailsModal';
 
 interface Props {
+  className?: string;
   transactionsPerPage?: number;
   userId?: number;
   isDisabled?: boolean;
 }
 
-export function SummaryCard(props: Omit<CardProps, 'children'> & Props) {
-  const { transactionsPerPage = 5, userId: userIdFromProps, isDisabled, ...cardProps } = props;
+export function SummaryCard(props: Props) {
+  const { className, transactionsPerPage = 5, userId: userIdFromProps, isDisabled } = props;
   const { t } = useTranslations({ en, de });
 
   const { user: currentUser } = useAuth();
@@ -140,33 +141,27 @@ export function SummaryCard(props: Omit<CardProps, 'children'> & Props) {
   }
 
   return (
-    <Card {...cardProps}>
-      <Card.Header>
-        <PageHeader title={t('title')} noMargin icon={<CreditCardIcon />} />
-      </Card.Header>
-      <Card.Content>
-        <div className="mb-4">
-          {isLoadingBalance ? (
-            <Spinner />
-          ) : (
-            <p className="text-2xl font-bold">
-              {t('balance', {
-                balance: formatNumber(dbCurrencyToUserCurrency(balance?.value ?? 0, configuration.minorUnit)),
-                currency: configuration.currency,
-              })}
-            </p>
-          )}
-        </div>
+    <div className={cn('w-full flex flex-col gap-6', className)}>
+      <PageHeader title={t('title')} noMargin icon={<CreditCardIcon />} />
 
-        <Table>
-          <TableContent aria-label={t('transactions.table.ariaLabel')}>
+      {isLoadingBalance ? (
+        <Spinner />
+      ) : (
+        <p className="text-2xl font-bold">
+          {t('balance', {
+            balance: formatNumber(dbCurrencyToUserCurrency(balance?.value ?? 0, configuration.minorUnit)),
+            currency: configuration.currency,
+          })}
+        </p>
+      )}
+
+      <Table>
+        <TableContent aria-label={t('transactions.table.ariaLabel')}>
           <TableHeader>
             <TableColumn isRowHeader>{t('transactions.table.columns.id')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.dateTime')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.status')}</TableColumn>
-            <TableColumn className="w-full">
-              {t('transactions.table.columns.details')}
-            </TableColumn>
+            <TableColumn className="w-full">{t('transactions.table.columns.details')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.amount')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.actions')}</TableColumn>
           </TableHeader>
@@ -190,24 +185,30 @@ export function SummaryCard(props: Omit<CardProps, 'children'> & Props) {
                   {formatNumber(dbCurrencyToUserCurrency(transaction.amount, configuration.minorUnit))}
                 </TableCell>
                 <TableCell>
-                  <Button isIconOnly variant="ghost" onPress={() => { setOpenedTransactionId(transaction.id); setIsOpenDetails(true); }}>
+                  <Button
+                    isIconOnly
+                    variant="ghost"
+                    onPress={() => {
+                      setOpenedTransactionId(transaction.id);
+                      setIsOpenDetails(true);
+                    }}
+                  >
                     <ReceiptTextIcon />
                   </Button>
                 </TableCell>
               </TableRow>
             )}
           </TableBody>
-          </TableContent>
-        </Table>
+        </TableContent>
+      </Table>
 
-        {openedTransactionId && (
-          <TransactionDetailsModal
-            transactionId={openedTransactionId}
-            isOpen={isOpenDetails}
-            onClose={() => setIsOpenDetails(false)}
-          />
-        )}
-      </Card.Content>
-    </Card>
+      {openedTransactionId && (
+        <TransactionDetailsModal
+          transactionId={openedTransactionId}
+          isOpen={isOpenDetails}
+          onClose={() => setIsOpenDetails(false)}
+        />
+      )}
+    </div>
   );
 }

--- a/apps/frontend/src/app/billing/dashboard/summary/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/index.tsx
@@ -165,7 +165,7 @@ export function SummaryCard(props: Props) {
             <TableColumn>{t('transactions.table.columns.amount')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.actions')}</TableColumn>
           </TableHeader>
-          <TableBody items={transactions?.data ?? []}>
+          <TableBody items={transactions?.data ?? []} renderEmptyState={() => t('transactions.table.empty')}>
             {(transaction) => (
               <TableRow key={transaction.id} id={transaction.id} className="wrap-none cursor-pointer">
                 <TableCell>{transaction.id}</TableCell>

--- a/apps/frontend/src/app/billing/dashboard/topup/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/topup/index.tsx
@@ -1,7 +1,20 @@
 import { useNumberFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
-import { Alert, AlertContent, AlertTitle, Button, Card, CardProps, cn, Form, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, Spinner } from '@heroui/react';
+import {
+  Alert,
+  AlertContent,
+  AlertTitle,
+  Button,
+  cn,
+  Form,
+  NumberField,
+  NumberFieldDecrementButton,
+  NumberFieldGroup,
+  NumberFieldIncrementButton,
+  NumberFieldInput,
+  Spinner,
+} from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import { SumUpIcon } from '../../../../components/icons/sumup.icon';
 import {
@@ -23,15 +36,16 @@ import { dbCurrencyToUserCurrency, userCurrencyToDbCurrency } from '@attraccess/
 import API_ERROR_TRANSLATIONS_DE from '../../../../global-translations/api-errors.de.json';
 import API_ERROR_TRANSLATIONS_EN from '../../../../global-translations/api-errors.en.json';
 
-type Props = Omit<CardProps, 'children'> & {
+interface Props {
+  className?: string;
   title?: string;
   subtitle?: string;
   desiredAmount?: number;
   onProcessingComplete?: () => void;
-};
+}
 
 export function BillingDashboardTopupCard(props: Props) {
-  const { title, subtitle, desiredAmount, onProcessingComplete, ...cardProps } = props;
+  const { className, title, subtitle, desiredAmount, onProcessingComplete } = props;
   const { t, tExists } = useTranslations({
     en: {
       ...en,
@@ -117,33 +131,26 @@ export function BillingDashboardTopupCard(props: Props) {
 
   if (isLoadingSumUpConfiguration) {
     return (
-      <Card {...cardProps} className={cn('max-w-full', cardProps.className)}>
-        <Card.Header>
-          <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
-        </Card.Header>
-        <Card.Content className="flex justify-center py-8">
+      <div className={cn('w-full flex flex-col gap-6', className)}>
+        <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
+        <div className="flex justify-center py-8">
           <Spinner />
-        </Card.Content>
-      </Card>
+        </div>
+      </div>
     );
   }
 
   if (isSumUpConfigurationError || !sumUpConfiguration?.enabled) {
     return (
-      <Card {...cardProps} className={cn('max-w-full', cardProps.className)}>
-        <Card.Header>
-          <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
-        </Card.Header>
-        <Card.Content>
-          <Alert status={isSumUpConfigurationError ? 'danger' : 'warning'}
-          >
-            <AlertContent>
-              <AlertTitle>{t('unavailable.title')}</AlertTitle>
-            </AlertContent>
-            <p className="text-sm">{t('unavailable.description')}</p>
-          </Alert>
-        </Card.Content>
-      </Card>
+      <div className={cn('w-full flex flex-col gap-6', className)}>
+        <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
+        <Alert status={isSumUpConfigurationError ? 'danger' : 'warning'}>
+          <AlertContent>
+            <AlertTitle>{t('unavailable.title')}</AlertTitle>
+          </AlertContent>
+          <p className="text-sm">{t('unavailable.description')}</p>
+        </Alert>
+      </div>
     );
   }
 
@@ -160,61 +167,57 @@ export function BillingDashboardTopupCard(props: Props) {
   }
 
   return (
-    <Card {...cardProps} className={cn('max-w-full', props.className)}>
-      <Card.Header>
-        <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
-      </Card.Header>
+    <div className={cn('w-full flex flex-col gap-6', className)}>
+      <PageHeader title={title ?? t('title')} subtitle={subtitle ?? t('subtitle')} icon={<SumUpIcon />} noMargin />
 
-      <Card.Content>
-        <Form
-          onSubmit={(e) => {
-            e.preventDefault();
-            onSubmit();
-          }}
+      <Form
+        className="gap-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmit();
+        }}
+      >
+        {(readers ?? []).length > 1 && (
+          <Select
+            items={readers?.map((reader) => ({ key: reader.id, label: reader.name })) ?? []}
+            label={t('inputs.reader.label')}
+            value={readerId}
+            onChange={(key) => setReaderId(key as string)}
+          />
+        )}
+
+        <NumberField
+          aria-label={t('inputs.amount.label')}
+          value={amount}
+          onChange={(value) => setAmount(value)}
+          minValue={1}
         >
-          {(readers ?? []).length > 1 && (
-            <Select
-              items={readers?.map((reader) => ({ key: reader.id, label: reader.name })) ?? []}
-              label={t('inputs.reader.label')}
-              value={readerId}
-              onChange={(key) => setReaderId(key as string)}
-            />
-          )}
+          <NumberFieldGroup>
+            <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
+            <NumberFieldInput />
+            <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
+          </NumberFieldGroup>
+        </NumberField>
+        <input type="submit" hidden />
+      </Form>
 
-          <NumberField
-            aria-label={t('inputs.amount.label')}
-            value={amount}
-            onChange={(value) => setAmount(value)}
-            minValue={1}
-          >
-            <NumberFieldGroup>
-              <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
-              <NumberFieldInput />
-              <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
-            </NumberFieldGroup>
-          </NumberField>
-          <input type="submit" hidden />
-        </Form>
+      <Alert status="warning">
+        <AlertContent>
+          <AlertTitle>{t('topUpInstructions.title')}</AlertTitle>
+        </AlertContent>
+        <p className="max-w-[600px] text-sm whitespace-pre-wrap text-wrap">{t('topUpInstructions.description')}</p>
+      </Alert>
 
-        <div>
-          <Alert status="warning">
-            <AlertContent>
-              <AlertTitle>{t('topUpInstructions.title')}</AlertTitle>
-            </AlertContent>
-            <p className="max-w-[600px] text-sm whitespace-pre-wrap text-wrap">{t('topUpInstructions.description')}</p>
-          </Alert>
-        </div>
-      </Card.Content>
-
-      <Card.Footer>
-        <Button variant="primary"
+      <div className="flex justify-end">
+        <Button
+          variant="primary"
           onPress={onSubmit}
           isPending={isPendingTopUpWithSumUpReader}
           isDisabled={!readerId || amount === 0}
         >
           {t('actions.topUp', { amount: formatNumber(amount), currency: configuration?.currency })}
         </Button>
-      </Card.Footer>
-    </Card>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Removes the `Card` wrapper around the SumUp top-up form on the billing dashboard.
- Replaces it with the flat sectioned pattern used in `EditMqttServerPage` (parent ATT-294).
- All three render branches (loading, disabled, normal) now render as flat sections under `PageHeader`.

## Changes

- `apps/frontend/src/app/billing/dashboard/topup/index.tsx`:
  - Replaced `Omit<CardProps, 'children'>` props with a plain `Props` interface (`className`, `title`, `subtitle`, `desiredAmount`, `onProcessingComplete`).
  - Loading branch: `<Card>` + `Card.Header/Content` → `<div className="w-full flex flex-col gap-6">` with `PageHeader` + centered `Spinner`.
  - Error / disabled branch: same flat wrapper with `PageHeader` + `Alert`.
  - Normal branch: flat wrapper with `PageHeader`, `Form` (gap-4), warning `Alert`, and a right-aligned top-up `Button` (replaces `Card.Footer`).
  - Dropped unused `Card` / `CardProps` imports.

Linear: [ATT-316](https://linear.app/attraccess/issue/ATT-316/design-unwrap-card-from-billingdashboardtopupcard)

## Test plan

- [x] `nx affected --target=lint,typecheck,build,test` (ran via pre-commit hook) — all green, 76/76 frontend tests pass.
- [ ] Manual visual check of the three render states (loading, SumUp disabled, normal) on the billing dashboard — not performed in this session (auth required, browser automation unavailable).

<!-- generated-by-cyrus -->