### PR TITLE
refactor(frontend): switch Attractap editor to StandardDrawer (ATT-338)

### DIFF
--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.de.json
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.de.json
@@ -3,6 +3,7 @@
   "readerName": "Reader-Name",
   "enterReaderName": "Reader-Namen eingeben",
   "connectedResources": "Verbundene Ressourcen",
+  "connectedResourcesDescription": "Wähle aus, welche Ressourcen dieser Reader steuert. Benutzer halten ihre Karte an den Reader, um die gewählten Ressourcen freizuschalten.",
   "enterResourceIds": "Ressourcen-IDs eingeben (durch Kommas getrennt)",
   "resourcesDescription": "Geben Sie Ressourcen-IDs durch Kommas getrennt ein (z.B. 1, 2, 3)",
   "cancel": "Abbrechen",

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.en.json
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.en.json
@@ -3,6 +3,7 @@
   "readerName": "Reader Name",
   "enterReaderName": "Enter reader name",
   "connectedResources": "Connected Resources",
+  "connectedResourcesDescription": "Select which resources this reader controls. Users tap the reader to unlock the selected resources.",
   "enterResourceIds": "Enter resource IDs (comma separated)",
   "resourcesDescription": "Enter resource IDs separated by commas (e.g. 1, 2, 3)",
   "cancel": "Cancel",

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
@@ -125,12 +125,18 @@ export function AttractapEditor(props: Readonly<Props>) {
               </Slider>
             )}
             <Separator className="my-6" />
-            <ResourceSelector
-              selection={connectedResourceIds}
-              onSelectionChange={setConnectedResourceIds}
-              data-cy="attractap-editor-resource-selector"
-              multiple={reader?.firmware.capabilities.resourceSelection ?? true}
-            />
+            <div className="flex flex-col gap-3 w-full">
+              <div className="flex flex-col gap-1">
+                <h3 className="text-base font-semibold">{t('connectedResources')}</h3>
+                <p className="text-sm text-default-500">{t('connectedResourcesDescription')}</p>
+              </div>
+              <ResourceSelector
+                selection={connectedResourceIds}
+                onSelectionChange={setConnectedResourceIds}
+                data-cy="attractap-editor-resource-selector"
+                multiple={reader?.firmware.capabilities.resourceSelection ?? true}
+              />
+            </div>
           </Form>
         </DrawerBody>
         <DrawerFooter>

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
@@ -3,15 +3,10 @@ import de from './AttractapEditor.de.json';
 import en from './AttractapEditor.en.json';
 import {
   Button,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
   Form,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalHeader,
-  ModalHeading,
-  ModalFooter,
   Separator,
   Slider,
   SliderTrack,
@@ -19,6 +14,7 @@ import {
   SliderThumb,
 } from '@heroui/react';
 import { TextField, Label, Input } from '@heroui/react';
+import { StandardDrawer } from '../../../components/standardDrawer';
 import { useCallback, useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -100,72 +96,62 @@ export function AttractapEditor(props: Readonly<Props>) {
   );
 
   return (
-    <Form onSubmit={onSubmit} data-cy="attractap-editor-form" className="flex flex-col gap-4">
-      <Modal isOpen={props.isOpen} onOpenChange={props.onCancel} data-cy="attractap-editor-modal">
-        <ModalBackdrop>
-          <ModalContainer placement="top" size="lg">
-            <ModalDialog>
-              {() => (
-                <>
-                  <ModalHeader className="flex flex-col gap-1">
-                    <ModalHeading>{t('title')}</ModalHeading>
-                  </ModalHeader>
-                  <ModalBody>
-                    <TextField value={name} onChange={setName} className="w-full">
-                      <Label>{t('readerName')}</Label>
-                      <Input placeholder={t('enterReaderName')} data-cy="attractap-editor-name-input" />
-                    </TextField>
-                    {reader?.firmware.capabilities.hasLeds && (
-                      <Slider
-                        step={1}
-                        minValue={0}
-                        maxValue={255}
-                        value={ledBrightness}
-                        onChange={(val) => setLedBrightness(val as number)}
-                        className="w-full"
-                        data-cy="attractap-editor-led-brightness-slider"
-                      >
-                        <Label>{t('ledBrightness')}</Label>
-                        <SliderTrack>
-                          <SliderFill />
-                          <SliderThumb />
-                        </SliderTrack>
-                      </Slider>
-                    )}
-                    <Separator className="my-6" />
-                    <ResourceSelector
-                      selection={connectedResourceIds}
-                      onSelectionChange={setConnectedResourceIds}
-                      data-cy="attractap-editor-resource-selector"
-                      multiple={reader?.firmware.capabilities.resourceSelection ?? true}
-                    />
-                  </ModalBody>
-                  <ModalFooter>
-                    <Button
-                      variant="secondary"
-                      onPress={() => {
-                        props.onCancel();
-                      }}
-                      isDisabled={updateReaderMutation.isPending}
-                      data-cy="attractap-editor-cancel-button"
-                    >
-                      {t('cancel')}
-                    </Button>
-                    <Button
-                      type="submit"
-                      isPending={updateReaderMutation.isPending}
-                      onPress={save}
-                      data-cy="attractap-editor-save-button"
-                    >
-                      {t('save')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
-    </Form>
+    <StandardDrawer isOpen={props.isOpen} onOpenChange={(open) => !open && props.onCancel()}>
+      <Form onSubmit={onSubmit} data-cy="attractap-editor-form" className="contents">
+        <DrawerHeader>
+          <h2 className="text-lg font-semibold">{t('title')}</h2>
+        </DrawerHeader>
+        <DrawerBody>
+          <TextField value={name} onChange={setName} className="w-full">
+            <Label>{t('readerName')}</Label>
+            <Input placeholder={t('enterReaderName')} data-cy="attractap-editor-name-input" />
+          </TextField>
+          {reader?.firmware.capabilities.hasLeds && (
+            <Slider
+              step={1}
+              minValue={0}
+              maxValue={255}
+              value={ledBrightness}
+              onChange={(val) => setLedBrightness(val as number)}
+              className="w-full"
+              data-cy="attractap-editor-led-brightness-slider"
+            >
+              <Label>{t('ledBrightness')}</Label>
+              <SliderTrack>
+                <SliderFill />
+                <SliderThumb />
+              </SliderTrack>
+            </Slider>
+          )}
+          <Separator className="my-6" />
+          <ResourceSelector
+            selection={connectedResourceIds}
+            onSelectionChange={setConnectedResourceIds}
+            data-cy="attractap-editor-resource-selector"
+            multiple={reader?.firmware.capabilities.resourceSelection ?? true}
+          />
+        </DrawerBody>
+        <DrawerFooter>
+          <Button
+            variant="secondary"
+            onPress={() => {
+              props.onCancel();
+            }}
+            isDisabled={updateReaderMutation.isPending}
+            data-cy="attractap-editor-cancel-button"
+          >
+            {t('cancel')}
+          </Button>
+          <Button
+            type="submit"
+            isPending={updateReaderMutation.isPending}
+            onPress={save}
+            data-cy="attractap-editor-save-button"
+          >
+            {t('save')}
+          </Button>
+        </DrawerFooter>
+      </Form>
+    </StandardDrawer>
   );
 }

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
@@ -97,39 +97,41 @@ export function AttractapEditor(props: Readonly<Props>) {
 
   return (
     <StandardDrawer isOpen={props.isOpen} onOpenChange={(open) => !open && props.onCancel()}>
-      <Form onSubmit={onSubmit} data-cy="attractap-editor-form" className="contents">
+      <div data-cy="attractap-editor-form" className="contents">
         <DrawerHeader>
           <h2 className="text-lg font-semibold">{t('title')}</h2>
         </DrawerHeader>
         <DrawerBody>
-          <TextField value={name} onChange={setName} className="w-full">
-            <Label>{t('readerName')}</Label>
-            <Input placeholder={t('enterReaderName')} data-cy="attractap-editor-name-input" />
-          </TextField>
-          {reader?.firmware.capabilities.hasLeds && (
-            <Slider
-              step={1}
-              minValue={0}
-              maxValue={255}
-              value={ledBrightness}
-              onChange={(val) => setLedBrightness(val as number)}
-              className="w-full"
-              data-cy="attractap-editor-led-brightness-slider"
-            >
-              <Label>{t('ledBrightness')}</Label>
-              <SliderTrack>
-                <SliderFill />
-                <SliderThumb />
-              </SliderTrack>
-            </Slider>
-          )}
-          <Separator className="my-6" />
-          <ResourceSelector
-            selection={connectedResourceIds}
-            onSelectionChange={setConnectedResourceIds}
-            data-cy="attractap-editor-resource-selector"
-            multiple={reader?.firmware.capabilities.resourceSelection ?? true}
-          />
+          <Form onSubmit={onSubmit} className="flex flex-col gap-4">
+            <TextField value={name} onChange={setName} className="w-full">
+              <Label>{t('readerName')}</Label>
+              <Input placeholder={t('enterReaderName')} data-cy="attractap-editor-name-input" />
+            </TextField>
+            {reader?.firmware.capabilities.hasLeds && (
+              <Slider
+                step={1}
+                minValue={0}
+                maxValue={255}
+                value={ledBrightness}
+                onChange={(val) => setLedBrightness(val as number)}
+                className="w-full"
+                data-cy="attractap-editor-led-brightness-slider"
+              >
+                <Label>{t('ledBrightness')}</Label>
+                <SliderTrack>
+                  <SliderFill />
+                  <SliderThumb />
+                </SliderTrack>
+              </Slider>
+            )}
+            <Separator className="my-6" />
+            <ResourceSelector
+              selection={connectedResourceIds}
+              onSelectionChange={setConnectedResourceIds}
+              data-cy="attractap-editor-resource-selector"
+              multiple={reader?.firmware.capabilities.resourceSelection ?? true}
+            />
+          </Form>
         </DrawerBody>
         <DrawerFooter>
           <Button
@@ -143,7 +145,6 @@ export function AttractapEditor(props: Readonly<Props>) {
             {t('cancel')}
           </Button>
           <Button
-            type="submit"
             isPending={updateReaderMutation.isPending}
             onPress={save}
             data-cy="attractap-editor-save-button"
@@ -151,7 +152,7 @@ export function AttractapEditor(props: Readonly<Props>) {
             {t('save')}
           </Button>
         </DrawerFooter>
-      </Form>
+      </div>
     </StandardDrawer>
   );
 }

--- a/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.de.json
+++ b/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.de.json
@@ -1,6 +1,6 @@
 {
   "search": {
-    "label": "Ressourcen",
+    "label": "Ressourcen suchen",
     "placeholder": "Tippe um zu suchen"
   },
   "table": {

--- a/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.en.json
+++ b/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.en.json
@@ -1,6 +1,6 @@
 {
   "search": {
-    "label": "Resources",
+    "label": "Search resources",
     "placeholder": "Type to search"
   },
   "table": {

--- a/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
+++ b/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
@@ -2,7 +2,7 @@
 // FEATURE: Resource selection for plugins using HeroUI v3 Table compound
 import { useTranslations } from '../../i18n';
 import { useResourcesServiceGetAllResources } from '@attraccess/react-query-client';
-import { TextField, InputGroup, Input, Spinner, TableRoot, TableContent, TableBody, TableCell, TableColumn, TableHeader, TableRow } from '@heroui/react';
+import { TextField, Label, InputGroup, Input, Spinner, TableRoot, TableContent, TableBody, TableCell, TableColumn, TableHeader, TableRow } from '@heroui/react';
 import { useState, PropsWithChildren } from 'react';
 import de from './ResourceSelector.de.json';
 import en from './ResourceSelector.en.json';
@@ -31,7 +31,8 @@ export function ResourceSelector(props: Readonly<Props>) {
 
   return (
     <div className="flex flex-col gap-2">
-      <TextField value={search} onChange={setSearch} aria-label={t('search.label')} className="w-full">
+      <TextField value={search} onChange={setSearch} className="w-full">
+        <Label>{t('search.label')}</Label>
         <InputGroup>
           <Input placeholder={t('search.placeholder')} />
           {isResourceSearchLoading ? <Spinner /> : null}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Sub-ticket of [ATT-322](https://linear.app/attraccess/issue/ATT-322). Converts `AttractapEditor` from the centered `Modal/ModalBackdrop/ModalContainer/ModalDialog/ModalBody/ModalHeader/ModalFooter` tree to `StandardDrawer` with `DrawerHeader/DrawerBody/DrawerFooter`, matching the pattern used in ATT-309 (commit `3f67842`).

- Replaces Modal* tree with `<StandardDrawer>` + `<DrawerHeader>` / `<DrawerBody>` / `<DrawerFooter>`
- `<Form>` moved inside the drawer with `className="contents"` so submit handler still wraps header/body/footer
- All `data-cy` selectors preserved
- Conditional LED brightness slider and resource selector unchanged

## Test plan

- [x] Affected `lint`, `typecheck`, `build`, `test`, `e2e` ran clean via pre-commit hook
- [x] Browser-verified at desktop (1280×720) and mobile (390×844) — screenshots posted on the Linear issue

Linear: [ATT-338](https://linear.app/attraccess/issue/ATT-338/design-convert-attractap-editor-modal-to-standarddrawer)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->