### PR TITLE
refactor(frontend): convert NFC card activate/deactivate Modals to StandardDrawer (ATT-337)

### DIFF
--- a/apps/frontend/src/app/attractap/NfcCardList/activate/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/activate/index.tsx
@@ -1,15 +1,5 @@
-import {
-  Button,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
-  useOverlayState,
-} from '@heroui/react';
+import { Button, DrawerBody, DrawerFooter, DrawerHeader, useOverlayState } from '@heroui/react';
+import { StandardDrawer } from '../../../../components/standardDrawer';
 import de from './de.json';
 import en from './en.json';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -53,28 +43,22 @@ export function NfcCardActivateModal(props: Props) {
       {activator(() => {
         open();
       })}
-      <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="nfc-card-activate-modal">
-        <ModalBackdrop>
-          <ModalContainer size="sm">
-            <ModalDialog>
-              {({ close }) => (
-                <>
-                  <ModalHeader>
-                    <ModalHeading>{t('title')}</ModalHeading>
-                  </ModalHeader>
-                  <ModalBody>{t('description')}</ModalBody>
-                  <ModalFooter>
-                    <Button onPress={close}>{t('cancel')}</Button>
-                    <Button onPress={onActivate} isPending={isPending}>
-                      {t('activate')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <div data-cy="nfc-card-activate-modal" className="contents">
+          <DrawerHeader>
+            <h2 className="text-lg font-semibold">{t('title')}</h2>
+          </DrawerHeader>
+          <DrawerBody>{t('description')}</DrawerBody>
+          <DrawerFooter>
+            <Button variant="secondary" onPress={close}>
+              {t('cancel')}
+            </Button>
+            <Button variant="primary" onPress={onActivate} isPending={isPending}>
+              {t('activate')}
+            </Button>
+          </DrawerFooter>
+        </div>
+      </StandardDrawer>
     </>
   );
 }

--- a/apps/frontend/src/app/attractap/NfcCardList/deactivate/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/deactivate/index.tsx
@@ -1,15 +1,5 @@
-import {
-  Button,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
-  useOverlayState,
-} from '@heroui/react';
+import { Button, DrawerBody, DrawerFooter, DrawerHeader, useOverlayState } from '@heroui/react';
+import { StandardDrawer } from '../../../../components/standardDrawer';
 import de from './de.json';
 import en from './en.json';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -53,28 +43,22 @@ export function NfcCardDeactivateModal(props: Props) {
       {activator(() => {
         open();
       })}
-      <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="nfc-card-deactivate-modal">
-        <ModalBackdrop>
-          <ModalContainer size="sm">
-            <ModalDialog>
-              {({ close }) => (
-                <>
-                  <ModalHeader>
-                    <ModalHeading>{t('title')}</ModalHeading>
-                  </ModalHeader>
-                  <ModalBody>{t('description')}</ModalBody>
-                  <ModalFooter>
-                    <Button onPress={close}>{t('cancel')}</Button>
-                    <Button onPress={onDeactivate} isPending={isPending}>
-                      {t('deactivate')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <div data-cy="nfc-card-deactivate-modal" className="contents">
+          <DrawerHeader>
+            <h2 className="text-lg font-semibold">{t('title')}</h2>
+          </DrawerHeader>
+          <DrawerBody>{t('description')}</DrawerBody>
+          <DrawerFooter>
+            <Button variant="secondary" onPress={close}>
+              {t('cancel')}
+            </Button>
+            <Button variant="primary" onPress={onDeactivate} isPending={isPending}>
+              {t('deactivate')}
+            </Button>
+          </DrawerFooter>
+        </div>
+      </StandardDrawer>
     </>
   );
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
- Replace `Modal/ModalBackdrop/ModalContainer/ModalDialog/ModalBody/ModalHeader/ModalHeading` with `StandardDrawer` + `Drawer{Header,Body,Footer}` in `NfcCardActivateModal` and `NfcCardDeactivateModal`.
- Drop the render-prop `close` in favor of the outer `useOverlayState` close.
- Preserve `data-cy` via wrapping `<div className="contents">` (matches SSO drawer precedent at 3f67842).

Sub-ticket of [ATT-322](https://linear.app/attraccess/issue/ATT-322) — issue [ATT-337](https://linear.app/attraccess/issue/ATT-337/design-convert-nfc-card-activate-deactivate-modals-to-standarddrawer).

## Test plan
- [x] `nx typecheck frontend` passes
- [x] `eslint` clean on changed files
- [x] Browser-verified: login → `/attractap/nfc-cards` → click *Aktivieren* / *Deaktivieren* on a card → drawer slides up with header, description body, Abbrechen + action footer buttons (screenshots in Linear).

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->