### PR TITLE
refactor(frontend): convert ResourceEditModal to StandardDrawer (ATT-325)

### DIFF
--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
@@ -1,15 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Button,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
   Form,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
   Tab,
   TabList,
   TabPanel,
@@ -31,6 +26,7 @@ import {
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToastMessage } from '../../../components/toastProvider';
+import { StandardDrawer } from '../../../components/standardDrawer';
 import { SharedDataTab } from './tabs/shared';
 import { MachineTab } from './tabs/machine';
 import { DoorTab } from './tabs/door';
@@ -165,7 +161,6 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
     setDeleteImage(file === null);
   }, []);
 
-  // Update form data when resource changes
   useEffect(() => {
     if (!isOpen) {
       return;
@@ -211,84 +206,76 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
   return (
     <>
       {props.children?.(open)}
-      <Modal isOpen={isOpen} onOpenChange={setOpen} data-cy="resource-edit-modal">
-        <ModalBackdrop>
-          <ModalContainer size="cover">
-            <ModalDialog>
-              {({ close }) => (
-                <>
-                  <ModalHeader>
-                    <ModalHeading>{t(`modalTitle.${props.resourceId ? 'update' : 'create'}`)}</ModalHeading>
-                  </ModalHeader>
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <div data-cy="resource-edit-modal" className="contents">
+          <DrawerHeader>
+            <h2 className="text-lg font-semibold">
+              {t(`modalTitle.${props.resourceId ? 'update' : 'create'}`)}
+            </h2>
+          </DrawerHeader>
 
-                  <ModalBody className="w-full space-y-4">
-                    <Form
-                      ref={formRef}
-                      onSubmit={(e) => {
-                        e.preventDefault();
-                        onSubmit();
-                      }}
-                      className="grid grid-cols-1 lg:grid-cols-2 gap-4 w-full"
-                    >
-                      <div className="flex flex-col gap-2 w-full">
-                        <SharedDataTab
-                          t={t}
-                          formData={formData}
-                          setField={setField}
-                          onImageSelected={onImageSelected}
-                          resource={resource}
-                        />
-                      </div>
+          <DrawerBody className="w-full space-y-4">
+            <Form
+              ref={formRef}
+              onSubmit={(e) => {
+                e.preventDefault();
+                onSubmit();
+              }}
+              className="flex flex-col gap-4 w-full"
+            >
+              <div className="flex flex-col gap-2 w-full">
+                <SharedDataTab
+                  t={t}
+                  formData={formData}
+                  setField={setField}
+                  onImageSelected={onImageSelected}
+                  resource={resource}
+                />
+              </div>
 
-                      <div className="flex flex-col gap-2 w-full">
-                        <Tabs selectedKey={formData.type}>
-                          <TabList>
-                            <Tab id="machine">{t('inputs.type.options.machine')}</Tab>
-                            <Tab id="door">{t('inputs.type.options.door')}</Tab>
-                          </TabList>
-                          <TabPanel id="machine">
-                            <MachineTab t={t} formData={formData} setField={setField} />
-                          </TabPanel>
-                          <TabPanel id="door">
-                            <DoorTab t={t} formData={formData} setField={setField} />
-                          </TabPanel>
-                        </Tabs>
-                      </div>
+              <div className="flex flex-col gap-2 w-full">
+                <Tabs selectedKey={formData.type}>
+                  <TabList>
+                    <Tab id="machine">{t('inputs.type.options.machine')}</Tab>
+                    <Tab id="door">{t('inputs.type.options.door')}</Tab>
+                  </TabList>
+                  <TabPanel id="machine">
+                    <MachineTab t={t} formData={formData} setField={setField} />
+                  </TabPanel>
+                  <TabPanel id="door">
+                    <DoorTab t={t} formData={formData} setField={setField} />
+                  </TabPanel>
+                </Tabs>
+              </div>
 
-                      <div className="lg:col-span-2">
-                        <ResourceMetadataEditor
-                          t={t}
-                          value={formData.metadata}
-                          onChange={(value) => setField('metadata', value)}
-                        />
-                      </div>
-                    </Form>
-                  </ModalBody>
+              <ResourceMetadataEditor
+                t={t}
+                value={formData.metadata}
+                onChange={(value) => setField('metadata', value)}
+              />
+            </Form>
+          </DrawerBody>
 
-                  <ModalFooter className="flex flex-col sm:flex-row gap-2 items-stretch sm:items-center w-full">
-                    <Button
-                      variant="outline"
-                      className="w-full sm:w-auto min-w-full sm:min-w-fit"
-                      onPress={close}
-                      data-cy="resource-edit-modal-cancel-button"
-                    >
-                      {t('buttons.cancel')}
-                    </Button>
-                    <Button
-                      variant="primary"
-                      className="w-full sm:w-auto min-w-full sm:min-w-fit"
-                      onPress={onSubmit}
-                      data-cy={`resource-edit-modal-${props.resourceId ? 'update' : 'create'}-button`}
-                    >
-                      {props.resourceId ? t('buttons.update') : t('buttons.create')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+          <DrawerFooter className="flex flex-col sm:flex-row gap-2 items-stretch sm:items-center w-full">
+            <Button
+              variant="outline"
+              className="w-full sm:w-auto min-w-full sm:min-w-fit"
+              onPress={close}
+              data-cy="resource-edit-modal-cancel-button"
+            >
+              {t('buttons.cancel')}
+            </Button>
+            <Button
+              variant="primary"
+              className="w-full sm:w-auto min-w-full sm:min-w-fit"
+              onPress={onSubmit}
+              data-cy={`resource-edit-modal-${props.resourceId ? 'update' : 'create'}-button`}
+            >
+              {props.resourceId ? t('buttons.update') : t('buttons.create')}
+            </Button>
+          </DrawerFooter>
+        </div>
+      </StandardDrawer>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Swap `Modal/ModalBackdrop/ModalContainer/ModalDialog/ModalBody/ModalHeader/ModalFooter` for `StandardDrawer` + `DrawerHeader/DrawerBody/DrawerFooter` in `apps/frontend/src/app/resources/editModal/resourceEditModal.tsx`.
- Collapse the 2-column grid to a single column to fit the narrower drawer width.
- `data-cy="resource-edit-modal"` preserved via a `contents` wrapper so existing selectors keep working; close action wired to `useOverlayState.close`.

Sub-ticket of ATT-322.

## Test plan
- [x] `npx nx typecheck frontend` (cache hit, green).
- [x] Manual: open create flow from `/resources` → drawer shows Name / Description / Image / Maschine|Tür tabs / Allow-takeover / Metadata. Submit creates resource.
- [x] Manual: open edit flow from resource details → drawer prefills, submit renames resource (verified in DB), drawer closes via `closeOnSuccess`.
- [x] Manual: cancel button closes drawer.

## Screenshots
| Create drawer | Edit drawer (top) | Edit drawer (scrolled) | Post-update |
| --- | --- | --- | --- |
| ![create](../../tmp/att-325-screenshots/01-create-drawer.png) | ![edit](../../tmp/att-325-screenshots/02-edit-drawer.png) | ![scrolled](../../tmp/att-325-screenshots/03-edit-drawer-scrolled.png) | ![updated](../../tmp/att-325-screenshots/05-updated-resource.png) |

Screenshots also attached to the Linear issue.

<!-- generated-by-cyrus -->