### PR TITLE
refactor(frontend): convert maintenance upsert + mark-done Modals to StandardDrawer (ATT-336)

### DIFF
--- a/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
@@ -4,15 +4,10 @@ import {
   AlertContent,
   AlertDescription,
   Button,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
   Form,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
   TextArea,
   useOverlayState,
 } from '@heroui/react';
@@ -25,6 +20,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
 import { AlertStatusIcon } from '../../../../../components/AlertStatusIcon';
+import { StandardDrawer } from '../../../../../components/standardDrawer';
 
 interface Props {
   resourceId: number;
@@ -79,53 +75,43 @@ export function MarkDoneModal(props: Props) {
   return (
     <>
       {children(open)}
-      <Modal isOpen={isOpen} onOpenChange={onOpenChangeHandler}>
-        <ModalBackdrop>
-          <ModalContainer size="md">
-            <ModalDialog>
-              {({ close }) => (
-                <>
-                  <ModalHeader>
-                    <ModalHeading>{t('actions.markDone.modal.title')}</ModalHeading>
-                  </ModalHeader>
-                  <ModalBody>
-                    <Form
-                      ref={formRef}
-                      onSubmit={(e) => {
-                        e.preventDefault();
-                        onSubmit();
-                      }}
-                    >
-                      <TextArea
-                        placeholder={t('actions.markDone.modal.notesPlaceholder')}
-                        value={notes}
-                        onChange={(e) => setNotes(e.target.value)}
-                      />
-                      {error ? (
-                        <Alert status="danger">
-                          <AlertStatusIcon status="danger" />
-                          <AlertContent>
-                            <AlertDescription>{(error as Error).message}</AlertDescription>
-                          </AlertContent>
-                        </Alert>
-                      ) : null}
-                      <button type="submit" hidden />
-                    </Form>
-                  </ModalBody>
-                  <ModalFooter>
-                    <Button variant="ghost" onPress={close}>
-                      {t('actions.markDone.modal.cancel')}
-                    </Button>
-                    <Button variant="primary" onPress={onSubmit} isPending={isPending}>
-                      {t('actions.markDone.modal.confirm')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+      <StandardDrawer isOpen={isOpen} onOpenChange={onOpenChangeHandler}>
+        <DrawerHeader>
+          <h2 className="text-lg font-semibold">{t('actions.markDone.modal.title')}</h2>
+        </DrawerHeader>
+        <DrawerBody>
+          <Form
+            ref={formRef}
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSubmit();
+            }}
+          >
+            <TextArea
+              placeholder={t('actions.markDone.modal.notesPlaceholder')}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
+            {error ? (
+              <Alert status="danger">
+                <AlertStatusIcon status="danger" />
+                <AlertContent>
+                  <AlertDescription>{(error as Error).message}</AlertDescription>
+                </AlertContent>
+              </Alert>
+            ) : null}
+            <button type="submit" hidden />
+          </Form>
+        </DrawerBody>
+        <DrawerFooter>
+          <Button variant="ghost" onPress={() => setOpen(false)}>
+            {t('actions.markDone.modal.cancel')}
+          </Button>
+          <Button variant="primary" onPress={onSubmit} isPending={isPending}>
+            {t('actions.markDone.modal.confirm')}
+          </Button>
+        </DrawerFooter>
+      </StandardDrawer>
     </>
   );
 }

--- a/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx
@@ -86,11 +86,14 @@ export function MarkDoneModal(props: Props) {
               e.preventDefault();
               onSubmit();
             }}
+            className="flex flex-col gap-4"
           >
             <TextArea
               placeholder={t('actions.markDone.modal.notesPlaceholder')}
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
+              rows={5}
+              className="w-full min-h-32 resize-y"
             />
             {error ? (
               <Alert status="danger">

--- a/apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx
@@ -140,7 +140,12 @@ export function ResourceMaintenanceUpsertModal(props: Props) {
                   {t('inputs.reason.displayedToUsers')}: <MaintenanceReasonDisplay reason={reason} />
                 </p>
               ) : null}
-              <TextArea value={reason} onChange={(e) => setReason(e.target.value)} />
+              <TextArea
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                rows={5}
+                className="w-full min-h-32 resize-y"
+              />
             </div>
 
             {error ? (

--- a/apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx
@@ -5,16 +5,10 @@ import {
   AlertTitle,
   Button,
   DatePicker,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
   Form,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
-  ModalIcon,
   TextArea,
   useOverlayState,
 } from '@heroui/react';
@@ -22,6 +16,7 @@ import de from './de.json';
 import en from './en.json';
 import { MaintenanceReasonDisplay } from '../../../../../components/MaintenanceReasonDisplay';
 import { LabeledSwitch } from '../../../../../components/labeledSwitch';
+import { StandardDrawer } from '../../../../../components/standardDrawer';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { parseAbsolute, type DateValue, type ZonedDateTime, toZoned } from '@internationalized/date';
 import { CalendarIcon } from 'lucide-react';
@@ -119,62 +114,54 @@ export function ResourceMaintenanceUpsertModal(props: Props) {
   return (
     <>
       {activator(open)}
-      <Modal isOpen={isOpen} onOpenChange={setOpen}>
-        <ModalBackdrop>
-          <ModalContainer size="md">
-            <ModalDialog>
-              {() => (
-                <>
-                  <ModalHeader>
-                    <ModalIcon><CalendarIcon /></ModalIcon>
-                    <ModalHeading>{t('title')}</ModalHeading>
-                  </ModalHeader>
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerHeader>
+          <div className="flex items-center gap-2">
+            <CalendarIcon className="w-5 h-5" />
+            <h2 className="text-lg font-semibold">{t('title')}</h2>
+          </div>
+        </DrawerHeader>
 
-                  <ModalBody>
-                    <Form onSubmit={onSubmit} ref={formRef} className="flex flex-col gap-4">
-                      <DatePicker value={startTime} isRequired hideTimeZone onChange={setStartTime} />
+        <DrawerBody>
+          <Form onSubmit={onSubmit} ref={formRef} className="flex flex-col gap-4">
+            <DatePicker value={startTime} isRequired hideTimeZone onChange={setStartTime} />
 
-                      <LabeledSwitch isSelected={hasEndDate} onChange={onHasEndDateChange}>
-                        {t('inputs.hasEndDate.label')}
-                      </LabeledSwitch>
-                      {hasEndDate && <DatePicker value={endTime} isRequired hideTimeZone onChange={setEndTime} />}
+            <LabeledSwitch isSelected={hasEndDate} onChange={onHasEndDateChange}>
+              {t('inputs.hasEndDate.label')}
+            </LabeledSwitch>
+            {hasEndDate && <DatePicker value={endTime} isRequired hideTimeZone onChange={setEndTime} />}
 
-                      <div>
-                        <label className="text-sm font-medium text-foreground mb-1 block">
-                          {t('inputs.reason.label')}
-                        </label>
-                        {reason ? (
-                          <p className="text-sm text-default-500 mb-2">
-                            {t('inputs.reason.displayedToUsers')}: <MaintenanceReasonDisplay reason={reason} />
-                          </p>
-                        ) : null}
-                        <TextArea value={reason} onChange={(e) => setReason(e.target.value)} />
-                      </div>
+            <div>
+              <label className="text-sm font-medium text-foreground mb-1 block">
+                {t('inputs.reason.label')}
+              </label>
+              {reason ? (
+                <p className="text-sm text-default-500 mb-2">
+                  {t('inputs.reason.displayedToUsers')}: <MaintenanceReasonDisplay reason={reason} />
+                </p>
+              ) : null}
+              <TextArea value={reason} onChange={(e) => setReason(e.target.value)} />
+            </div>
 
-                      {error ? (
-                        <Alert status="danger">
-                          <AlertContent>
-                            <AlertTitle>{t('alert.error.title')}</AlertTitle>
-                          </AlertContent>
-                          {(error as Error).message}
-                        </Alert>
-                      ) : null}
+            {error ? (
+              <Alert status="danger">
+                <AlertContent>
+                  <AlertTitle>{t('alert.error.title')}</AlertTitle>
+                </AlertContent>
+                {(error as Error).message}
+              </Alert>
+            ) : null}
 
-                      <button type="submit" hidden />
-                    </Form>
-                  </ModalBody>
+            <button type="submit" hidden />
+          </Form>
+        </DrawerBody>
 
-                  <ModalFooter>
-                    <Button variant="primary" onPress={onSubmit} type="submit" isPending={isCreating}>
-                      {t('actions.save')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+        <DrawerFooter>
+          <Button variant="primary" onPress={onSubmit} type="submit" isPending={isCreating}>
+            {t('actions.save')}
+          </Button>
+        </DrawerFooter>
+      </StandardDrawer>
     </>
   );
 }


### PR DESCRIPTION
## Summary
Sub-ticket of [ATT-322](https://linear.app/attraccess/issue/ATT-322). Both maintenance modals now use `StandardDrawer` instead of the legacy `Modal*` primitives, matching the pattern in `schedule-form-drawer.tsx` / `SSOProvidersList.tsx`.

- `apps/frontend/src/app/resources/details/maintenance-management/upsert/index.tsx` — `Modal*` → `StandardDrawer` + `DrawerHeader`/`DrawerBody`/`DrawerFooter`; calendar icon kept inline beside title; Save action in footer.
- `apps/frontend/src/app/resources/details/maintenance-management/mark-done/index.tsx` — same swap; Cancel close via `setOpen(false)` (was render-prop `close`); Mark-as-done action in footer.

Linear: [ATT-336](https://linear.app/attraccess/issue/ATT-336/design-convert-maintenance-upsert-mark-done-modals-to-standarddrawer)

## Test plan
- [x] `nx typecheck frontend` green
- [x] Browser-verified upsert drawer opens via `+` button in flat Maintenance section (screenshot in Linear)
- [x] Browser-verified mark-done drawer opens via checkmark on active maintenance row (screenshot in Linear)

<!-- generated-by-cyrus -->