### PR TITLE
refactor(frontend): convert Account settings Modal to StandardDrawer (ATT-340)

### DIFF
--- a/apps/frontend/src/app/account/index.tsx
+++ b/apps/frontend/src/app/account/index.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from '../../components/pageHeader';
-import { Button, Card, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, useOverlayState } from '@heroui/react';
+import { Button, Card, DrawerBody, DrawerFooter, DrawerHeader, useOverlayState } from '@heroui/react';
+import { StandardDrawer } from '../../components/standardDrawer';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
@@ -79,37 +80,27 @@ export default function AccountPage() {
         </Card>
       </div>
 
-      <Modal isOpen={isOpen} onOpenChange={setOpen}>
-        <ModalBackdrop>
-          <ModalContainer size="sm">
-            <ModalDialog>
-              {({ close }) => (
-                <>
-                  <ModalHeader>
-                    <ModalHeading>{t('deleteAccount.modal.title')}</ModalHeading>
-                  </ModalHeader>
-                  <ModalBody>
-                    <p className="text-sm text-default-500">{t('deleteAccount.modal.description')}</p>
-                  </ModalBody>
-                  <ModalFooter>
-                    <Button variant="ghost" onPress={close} isDisabled={isRequestingDelete}>
-                      {t('deleteAccount.actions.cancel')}
-                    </Button>
-                    <Button
-                      variant="danger"
-                      onPress={() => requestDelete()}
-                      isPending={isRequestingDelete}
-                      data-cy="delete-account-confirm-button"
-                    >
-                      {t('deleteAccount.actions.confirm')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerHeader>
+          <h2 className="text-lg font-semibold">{t('deleteAccount.modal.title')}</h2>
+        </DrawerHeader>
+        <DrawerBody>
+          <p className="text-sm text-default-500">{t('deleteAccount.modal.description')}</p>
+        </DrawerBody>
+        <DrawerFooter>
+          <Button variant="ghost" onPress={close} isDisabled={isRequestingDelete}>
+            {t('deleteAccount.actions.cancel')}
+          </Button>
+          <Button
+            variant="danger"
+            onPress={() => requestDelete()}
+            isPending={isRequestingDelete}
+            data-cy="delete-account-confirm-button"
+          >
+            {t('deleteAccount.actions.confirm')}
+          </Button>
+        </DrawerFooter>
+      </StandardDrawer>
     </div>
   );
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Sub-ticket of [ATT-322](https://linear.app/attraccess/issue/ATT-322). Replaces the delete-account `Modal` compound (`Modal/ModalBackdrop/ModalContainer/ModalDialog/ModalBody/ModalHeader/ModalFooter`) in `apps/frontend/src/app/account/index.tsx` with `StandardDrawer` + `DrawerHeader/DrawerBody/DrawerFooter`, matching the pattern used in sibling conversions (ATT-325 through ATT-338).

`close` now comes from the top-level `useOverlayState` destructure instead of the Modal render-prop, since `StandardDrawer` does not expose a render prop.

## Implementation notes

- Removed: `Modal`, `ModalBackdrop`, `ModalContainer`, `ModalDialog`, `ModalBody`, `ModalHeader`, `ModalFooter`, `ModalHeading` imports
- Added: `DrawerBody`, `DrawerFooter`, `DrawerHeader` from `@heroui/react`, `StandardDrawer` from `../../components/standardDrawer`
- Replaced `<ModalHeading>` with `<h2 className="text-lg font-semibold">` to match sibling pattern (e.g. ATT-332 TwoFactorPolicyModal)

## Test plan

- [x] `pnpm nx typecheck frontend` — passes
- [x] `pnpm nx lint frontend` — passes (via pre-commit hook)
- [x] `pnpm nx build frontend` — passes (via pre-commit hook)
- [x] `pnpm nx test frontend` — passes (via pre-commit hook)
- [x] Browser-verified on desktop (1280×820) — drawer renders as centered bottom sheet
- [x] Browser-verified on mobile (390×740) — drawer slides from bottom full-width

Linear: https://linear.app/attraccess/issue/ATT-340/design-convert-account-settings-modal-to-standarddrawer

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->