### PR TITLE
refactor(frontend): unwrap Card from flow node property-input (ATT-319)

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/node/de.json
+++ b/apps/frontend/src/app/resources/details/flows/node/de.json
@@ -1,7 +1,8 @@
 {
   "editor": {
     "buttons": {
-      "save": "Speichern"
+      "save": "Speichern",
+      "cancel": "Abbrechen"
     }
   },
   "nodes": {

--- a/apps/frontend/src/app/resources/details/flows/node/editor/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/editor/index.tsx
@@ -1,15 +1,10 @@
 import { ResourceFlowNodeSchemaDto } from '@attraccess/react-query-client';
 import {
   Button,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
   Form,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
   useOverlayState,
 } from '@heroui/react';
 import { useNodeId, useNodesData } from '@xyflow/react';
@@ -17,6 +12,7 @@ import { useFlowContext } from '../../flowContext';
 import { Property, PropertyInput } from './property-input';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { TFunction } from '@attraccess/plugins-frontend-ui';
+import { StandardDrawer } from '../../../../../../components/standardDrawer';
 
 interface Props {
   schema: ResourceFlowNodeSchemaDto;
@@ -58,48 +54,41 @@ export function NodeEditor(props: Props) {
   return (
     <>
       {props.children(open)}
-      <Modal isOpen={isOpen} onOpenChange={setOpen}>
-        <ModalBackdrop>
-          <ModalContainer size="lg">
-            <ModalDialog>
-              {() => (
-                <>
-                  <ModalHeader>
-                    <ModalHeading>{t('nodes.' + schema.type + '.title')}</ModalHeading>
-                    <p className="text-sm text-muted">{t('nodes.' + schema.type + '.description')}</p>
-                  </ModalHeader>
+      <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
+        <DrawerHeader className="flex flex-col gap-1">
+          <h2 className="text-lg font-semibold">{t('nodes.' + schema.type + '.title')}</h2>
+          <p className="text-sm text-default-500">{t('nodes.' + schema.type + '.description')}</p>
+        </DrawerHeader>
 
-                  <ModalBody className="flex flex-col gap-2">
-                    <Form onSubmit={onSave} ref={formRef} className="flex flex-col gap-4">
-                      {Object.entries(schema.configSchema.properties as Record<string, Property<unknown>>).map(
-                        ([propertyName, property]) => (
-                          <PropertyInput
-                            key={propertyName}
-                            isRequired={(schema.configSchema.required as string[])?.includes(propertyName)}
-                            nodeType={schema.type}
-                            tNodeTranslations={t}
-                            name={propertyName}
-                            schema={property}
-                            value={data[propertyName]}
-                            onChange={(value) => onInputChange(propertyName, value)}
-                          />
-                        ),
-                      )}
-                      <input hidden type="submit" />
-                    </Form>
-                  </ModalBody>
+        <DrawerBody className="flex flex-col gap-2">
+          <Form onSubmit={onSave} ref={formRef} className="flex flex-col gap-4">
+            {Object.entries(schema.configSchema.properties as Record<string, Property<unknown>>).map(
+              ([propertyName, property]) => (
+                <PropertyInput
+                  key={propertyName}
+                  isRequired={(schema.configSchema.required as string[])?.includes(propertyName)}
+                  nodeType={schema.type}
+                  tNodeTranslations={t}
+                  name={propertyName}
+                  schema={property}
+                  value={data[propertyName]}
+                  onChange={(value) => onInputChange(propertyName, value)}
+                />
+              ),
+            )}
+            <input hidden type="submit" />
+          </Form>
+        </DrawerBody>
 
-                  <ModalFooter>
-                    <Button variant="primary" onPress={onSave}>
-                      {t('editor.buttons.save')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+        <DrawerFooter className="flex flex-wrap gap-2 justify-end">
+          <Button variant="ghost" onPress={close}>
+            {t('editor.buttons.cancel')}
+          </Button>
+          <Button variant="primary" onPress={onSave}>
+            {t('editor.buttons.save')}
+          </Button>
+        </DrawerFooter>
+      </StandardDrawer>
     </>
   );
 }

--- a/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
@@ -1,5 +1,5 @@
 import { ResourceFlowNodeDto, useBillingServiceGetBillingConfiguration } from '@attraccess/react-query-client';
-import { Button, Card, Input, Label, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalHeader, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, TextArea, TextField } from '@heroui/react';
+import { Button, Input, Label, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalHeader, NumberField, NumberFieldDecrementButton, NumberFieldGroup, NumberFieldIncrementButton, NumberFieldInput, TextArea, TextField } from '@heroui/react';
 import { Select } from '../../../../../../../components/select';
 import { MqttServerSelect } from '../../../../../../../components/mqttServerSelect';
 import { LabeledSwitch } from '../../../../../../../components/labeledSwitch';
@@ -230,11 +230,7 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
         let content = null;
         if (Object.entries((value ?? {}) as Record<string, unknown>)?.length === 0) {
           content = (
-            <Card>
-              <Card.Content>
-                <p className="text-sm text-gray-500">{t('nodes.' + nodeType + '.config.' + name + '.empty')}</p>
-              </Card.Content>
-            </Card>
+            <p className="text-sm text-default-500">{t('nodes.' + nodeType + '.config.' + name + '.empty')}</p>
           );
         } else {
           content = (
@@ -298,76 +294,66 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
 
       let content = null;
       if (arrayValue.length === 0) {
-        content = (
-          <Card>
-            <Card.Content>
-              <p className="text-sm text-gray-500">{emptyText}</p>
-            </Card.Content>
-          </Card>
-        );
+        content = <p className="text-sm text-default-500">{emptyText}</p>;
       } else {
         content = (
-          <div className="flex flex-col gap-2 w-full">
+          <div className="flex flex-col w-full divide-y divide-default-200">
             {arrayValue.map((row, index) => (
-              <Card key={index} className="p-2 w-full">
-                <Card.Content className="p-0">
-                  <div className="grid grid-cols-[1fr_auto] gap-2 items-start">
-                    <div className="flex flex-col gap-2 p-2 w-full">
-                      {items && items.type === 'object' && items.properties ? (
-                        <>
-                          {Object.entries(items.properties).map(([propName, propSchema]) => (
-                            <PropertyInput
-                              key={propName}
-                              nodeType={nodeType}
-                              tNodeTranslations={t}
-                              name={name + '.items.' + propName}
-                              schema={propSchema as Property<unknown>}
-                              value={(row as Record<string, unknown>)?.[propName]}
-                              onChange={(newItemPropValue) => {
-                                const newArrayValue = [...arrayValue] as Array<Record<string, unknown>>;
-                                newArrayValue[index] = {
-                                  ...(newArrayValue[index] ?? {}),
-                                  [propName]: newItemPropValue,
-                                };
-                                onChange(newArrayValue as TValue);
-                              }}
-                              isRequired={false}
-                              hideLabel
-                            />
-                          ))}
-                        </>
-                      ) : items ? (
+              <div key={index} className="grid grid-cols-[1fr_auto] gap-2 items-start py-2 first:pt-0 last:pb-0">
+                <div className="flex flex-col gap-2 w-full">
+                  {items && items.type === 'object' && items.properties ? (
+                    <>
+                      {Object.entries(items.properties).map(([propName, propSchema]) => (
                         <PropertyInput
+                          key={propName}
                           nodeType={nodeType}
                           tNodeTranslations={t}
-                          name={name + '.items'}
-                          schema={items as unknown as Property<unknown>}
-                          value={row as unknown}
-                          onChange={(newItemValue) => {
-                            const newArrayValue = [...arrayValue];
-                            newArrayValue[index] = newItemValue as unknown;
+                          name={name + '.items.' + propName}
+                          schema={propSchema as Property<unknown>}
+                          value={(row as Record<string, unknown>)?.[propName]}
+                          onChange={(newItemPropValue) => {
+                            const newArrayValue = [...arrayValue] as Array<Record<string, unknown>>;
+                            newArrayValue[index] = {
+                              ...(newArrayValue[index] ?? {}),
+                              [propName]: newItemPropValue,
+                            };
                             onChange(newArrayValue as TValue);
                           }}
                           isRequired={false}
                           hideLabel
                         />
-                      ) : null}
-                    </div>
-                    <div className="row-span-2 flex items-start p-2">
-                      <Button
-                        variant="danger-soft"
-                        isIconOnly
-                        onPress={() => {
-                          const copy = (arrayValue as Array<unknown>).filter((_, i) => i !== index);
-                          onChange(copy as TValue);
-                        }}
-                      >
-                        <XIcon size={16} />
-                      </Button>
-                    </div>
-                  </div>
-                </Card.Content>
-              </Card>
+                      ))}
+                    </>
+                  ) : items ? (
+                    <PropertyInput
+                      nodeType={nodeType}
+                      tNodeTranslations={t}
+                      name={name + '.items'}
+                      schema={items as unknown as Property<unknown>}
+                      value={row as unknown}
+                      onChange={(newItemValue) => {
+                        const newArrayValue = [...arrayValue];
+                        newArrayValue[index] = newItemValue as unknown;
+                        onChange(newArrayValue as TValue);
+                      }}
+                      isRequired={false}
+                      hideLabel
+                    />
+                  ) : null}
+                </div>
+                <div className="flex items-start">
+                  <Button
+                    variant="danger-soft"
+                    isIconOnly
+                    onPress={() => {
+                      const copy = (arrayValue as Array<unknown>).filter((_, i) => i !== index);
+                      onChange(copy as TValue);
+                    }}
+                  >
+                    <XIcon size={16} />
+                  </Button>
+                </div>
+              </div>
             ))}
           </div>
         );

--- a/apps/frontend/src/app/resources/details/flows/node/en.json
+++ b/apps/frontend/src/app/resources/details/flows/node/en.json
@@ -1,7 +1,8 @@
 {
   "editor": {
     "buttons": {
-      "save": "Save"
+      "save": "Save",
+      "cancel": "Cancel"
     }
   },
   "nodes": {


### PR DESCRIPTION
## Summary
- Remove `Card` wrappers around object-property and array-item editors in `PropertyInput` (flow node config editor).
- Empty states render as muted text (`text-default-500`) instead of a Card.
- Array rows now use a flat `divide-y divide-default-200` list inside a single `div`, eliminating the nested-Card stack inside the node-editor Modal.

## Linear
[ATT-319](https://linear.app/attraccess/issue/ATT-319/design-unwrap-cards-from-flow-node-property-input-object-array-editors)

## Test plan
- [ ] Open flow editor, configure a node with `object` (additionalProperties) property → empty + populated states render flat
- [ ] Configure a node with `array` of objects → rows separated by dividers, no nested Cards, delete button still works
- [ ] Add/remove rows updates state correctly

<!-- generated-by-cyrus -->