### PR TITLE
refactor(frontend): group CreateMqttServerPage into sections (ATT-320)

### DIFF
--- a/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
@@ -1,8 +1,8 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, Checkbox, Form, Input, Label, TextField } from "@heroui/react";
+import { Button, Checkbox, Form, Input, Label, TextField } from "@heroui/react";
 import { Select } from '../../../components/select';
 import { LabeledSwitch } from '../../../components/labeledSwitch';
-import { ArrowLeft } from 'lucide-react';
+import { PageHeader } from '../../../components/pageHeader';
 import { PasswordInput } from '../../../components/PasswordInput';
 import { useNavigate } from 'react-router-dom';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -255,25 +255,9 @@ export function CreateMqttServerPage(props?: Readonly<CreateMqttServerPageProps>
   }, [props, navigate]);
 
   return (
-    <Card data-cy="create-mqtt-server-page-card">
-      <Card.Header>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <Button variant="ghost"
-              isIconOnly
-              onPress={handleCancel}
-              aria-label={t('back')}
-              data-cy="create-mqtt-server-page-back-button"
-            >
-              <ArrowLeft size={20} />
-            </Button>
-            <h2>{t('addNewMqttServer')}</h2>
-          </div>
-        </div>
-      </Card.Header>
-      <div style={{ padding: '1rem' }}>
-        <CreateMqttServerForm {...props} onCancel={handleCancel} />
-      </div>
-    </Card>
+    <div className="max-w-7xl mx-auto px-4 py-8" data-cy="create-mqtt-server-page">
+      <PageHeader title={t('addNewMqttServer')} onBack={handleCancel} />
+      <CreateMqttServerForm {...props} onCancel={handleCancel} />
+    </div>
   );
 }

--- a/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
@@ -1,6 +1,7 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { Button, Card, Checkbox, Form, Input, Label, TextField } from "@heroui/react";
 import { Select } from '../../../components/select';
+import { LabeledSwitch } from '../../../components/labeledSwitch';
 import { ArrowLeft } from 'lucide-react';
 import { PasswordInput } from '../../../components/PasswordInput';
 import { useNavigate } from 'react-router-dom';
@@ -80,81 +81,151 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
   const qosOptions = [0, 1, 2] as const;
 
   return (
-    <Form onSubmit={handleSubmit} data-cy="create-mqtt-server-form">
-      <TextField value={formValues.name} onChange={(v) => setFormValues((p) => ({ ...p, name: v }))}>
-        <Label>{t('nameLabel')}</Label>
-        <Input id="name" name="name" placeholder={t('namePlaceholder')} required data-cy="create-mqtt-server-form-name-input" />
-      </TextField>
+    <Form onSubmit={handleSubmit} className="gap-8" data-cy="create-mqtt-server-form">
+      <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+          {t('sections.connection')}
+        </h3>
+        <TextField
+          value={formValues.name}
+          onChange={(v) => setFormValues((p) => ({ ...p, name: v }))}
+          className="w-full"
+        >
+          <Label>{t('nameLabel')}</Label>
+          <Input
+            id="name"
+            name="name"
+            placeholder={t('namePlaceholder')}
+            required
+            data-cy="create-mqtt-server-form-name-input"
+          />
+        </TextField>
 
-      <TextField value={formValues.host} onChange={(v) => setFormValues((p) => ({ ...p, host: v }))}>
-        <Label>{t('hostLabel')}</Label>
-        <Input id="host" name="host" placeholder={t('hostPlaceholder')} required data-cy="create-mqtt-server-form-host-input" />
-      </TextField>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 w-full">
+          <TextField
+            value={formValues.host}
+            onChange={(v) => setFormValues((p) => ({ ...p, host: v }))}
+            className="md:col-span-2"
+          >
+            <Label>{t('hostLabel')}</Label>
+            <Input
+              id="host"
+              name="host"
+              placeholder={t('hostPlaceholder')}
+              required
+              data-cy="create-mqtt-server-form-host-input"
+            />
+          </TextField>
 
-      <TextField value={String(formValues.port ?? 1883)} onChange={(v) => setFormValues((p) => ({ ...p, port: parseInt(v, 10) }))}>
-        <Label>{t('portLabel')}</Label>
-        <Input id="port" name="port" type="number" placeholder={t('portPlaceholder')} required data-cy="create-mqtt-server-form-port-input" />
-      </TextField>
+          <TextField
+            value={String(formValues.port ?? 1883)}
+            onChange={(v) => setFormValues((p) => ({ ...p, port: parseInt(v, 10) }))}
+          >
+            <Label>{t('portLabel')}</Label>
+            <Input
+              id="port"
+              name="port"
+              type="number"
+              placeholder={t('portPlaceholder')}
+              required
+              data-cy="create-mqtt-server-form-port-input"
+            />
+          </TextField>
+        </div>
+      </section>
 
-      <TextField value={formValues.clientId} onChange={(v) => setFormValues((p) => ({ ...p, clientId: v }))}>
-        <Label>{t('clientIdLabel')}</Label>
-        <Input id="clientId" name="clientId" placeholder={t('clientIdPlaceholder')} data-cy="create-mqtt-server-form-client-id-input" />
-      </TextField>
+      <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+          {t('sections.authentication')}
+        </h3>
+        <TextField
+          value={formValues.clientId}
+          onChange={(v) => setFormValues((p) => ({ ...p, clientId: v }))}
+          className="w-full"
+        >
+          <Label>{t('clientIdLabel')}</Label>
+          <Input
+            id="clientId"
+            name="clientId"
+            placeholder={t('clientIdPlaceholder')}
+            data-cy="create-mqtt-server-form-client-id-input"
+          />
+        </TextField>
 
-      <TextField value={formValues.username} onChange={(v) => setFormValues((p) => ({ ...p, username: v }))}>
-        <Label>{t('usernameLabel')}</Label>
-        <Input id="username" name="username" placeholder={t('usernamePlaceholder')} data-cy="create-mqtt-server-form-username-input" />
-      </TextField>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
+          <TextField
+            value={formValues.username}
+            onChange={(v) => setFormValues((p) => ({ ...p, username: v }))}
+          >
+            <Label>{t('usernameLabel')}</Label>
+            <Input
+              id="username"
+              name="username"
+              placeholder={t('usernamePlaceholder')}
+              data-cy="create-mqtt-server-form-username-input"
+            />
+          </TextField>
 
-      <PasswordInput
-        label={t('passwordLabel')}
-        id="password"
-        name="password"
-        placeholder={t('passwordPlaceholder')}
-        value={formValues.password}
-        onChange={(v: string) => setFormValues((p) => ({ ...p, password: v }))}
-        className="w-full"
-        data-cy="create-mqtt-server-form-password-input"
-        autoComplete="off"
-      />
+          <PasswordInput
+            label={t('passwordLabel')}
+            id="password"
+            name="password"
+            placeholder={t('passwordPlaceholder')}
+            value={formValues.password}
+            onChange={(v: string) => setFormValues((p) => ({ ...p, password: v }))}
+            data-cy="create-mqtt-server-form-password-input"
+            autoComplete="off"
+          />
+        </div>
 
-      <Checkbox
-        id="useTls"
-        name="useTls"
-        isSelected={formValues.useTls}
-        onChange={(checked) => setFormValues((prev) => ({ ...prev, useTls: checked }))}
-        data-cy="create-mqtt-server-form-use-tls-checkbox"
-      >
-        {t('useTls')}
-      </Checkbox>
+        <Checkbox
+          id="useTls"
+          name="useTls"
+          isSelected={formValues.useTls}
+          onChange={(checked) => setFormValues((prev) => ({ ...prev, useTls: checked }))}
+          data-cy="create-mqtt-server-form-use-tls-checkbox"
+        >
+          {t('useTls')}
+        </Checkbox>
+      </section>
 
-      <Select
-        label={t('defaultPublishQosLabel')}
-        value={String(formValues.defaultPublishQos ?? 0)}
-        onChange={(key) => setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }))}
-        data-cy="create-mqtt-server-form-default-publish-qos-input"
-        items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
-      />
+      <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+          {t('sections.publishDefaults')}
+        </h3>
+        <Select
+          label={t('defaultPublishQosLabel')}
+          value={String(formValues.defaultPublishQos ?? 0)}
+          onChange={(key) => setFormValues((prev) => ({ ...prev, defaultPublishQos: Number(key) }))}
+          data-cy="create-mqtt-server-form-default-publish-qos-input"
+          items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
+        />
 
-      <Checkbox
-        id="defaultPublishRetain"
-        name="defaultPublishRetain"
-        isSelected={!!formValues.defaultPublishRetain}
-        onChange={(checked) => setFormValues((prev) => ({ ...prev, defaultPublishRetain: checked }))}
-        data-cy="create-mqtt-server-form-default-publish-retain-checkbox"
-      >
-        {t('defaultPublishRetainLabel')}
-      </Checkbox>
+        <LabeledSwitch
+          id="defaultPublishRetain"
+          name="defaultPublishRetain"
+          isSelected={!!formValues.defaultPublishRetain}
+          onChange={(checked) => setFormValues((prev) => ({ ...prev, defaultPublishRetain: checked }))}
+          data-cy="create-mqtt-server-form-default-publish-retain-checkbox"
+        >
+          {t('defaultPublishRetainLabel')}
+        </LabeledSwitch>
+      </section>
 
-      <Select
-        label={t('defaultSubscribeQosLabel')}
-        value={String(formValues.defaultSubscribeQos ?? 0)}
-        onChange={(key) => setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }))}
-        data-cy="create-mqtt-server-form-default-subscribe-qos-input"
-        items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
-      />
+      <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+          {t('sections.subscribeDefaults')}
+        </h3>
+        <Select
+          label={t('defaultSubscribeQosLabel')}
+          value={String(formValues.defaultSubscribeQos ?? 0)}
+          onChange={(key) => setFormValues((prev) => ({ ...prev, defaultSubscribeQos: Number(key) }))}
+          data-cy="create-mqtt-server-form-default-subscribe-qos-input"
+          items={qosOptions.map((option) => ({ key: String(option), label: t(`qosOption.${option}`) }))}
+        />
+      </section>
 
-      <div className="flex justify-end space-x-3 mt-4">
+      <div className="flex justify-end space-x-3 mt-4 w-full">
         <Button variant="secondary" onPress={handleCancel} data-cy="create-mqtt-server-form-cancel-button">
           {t('cancel')}
         </Button>

--- a/apps/frontend/src/app/mqtt/servers/translations/create/de.json
+++ b/apps/frontend/src/app/mqtt/servers/translations/create/de.json
@@ -1,6 +1,12 @@
 {
   "addNewMqttServer": "Neuen MQTT-Server hinzufügen",
   "back": "Zurück",
+  "sections": {
+    "connection": "Verbindung",
+    "authentication": "Authentifizierung",
+    "publishDefaults": "Standards für Veröffentlichungen",
+    "subscribeDefaults": "Standards für Abonnements"
+  },
   "nameLabel": "Name",
   "namePlaceholder": "Mein MQTT-Server",
   "hostLabel": "Host",

--- a/apps/frontend/src/app/mqtt/servers/translations/create/de.json
+++ b/apps/frontend/src/app/mqtt/servers/translations/create/de.json
@@ -1,6 +1,5 @@
 {
   "addNewMqttServer": "Neuen MQTT-Server hinzufügen",
-  "back": "Zurück",
   "sections": {
     "connection": "Verbindung",
     "authentication": "Authentifizierung",

--- a/apps/frontend/src/app/mqtt/servers/translations/create/en.json
+++ b/apps/frontend/src/app/mqtt/servers/translations/create/en.json
@@ -1,6 +1,12 @@
 {
   "addNewMqttServer": "Add New MQTT Server",
   "back": "Back",
+  "sections": {
+    "connection": "Connection",
+    "authentication": "Authentication",
+    "publishDefaults": "Publish defaults",
+    "subscribeDefaults": "Subscribe defaults"
+  },
   "nameLabel": "Name",
   "namePlaceholder": "My MQTT Server",
   "hostLabel": "Host",

--- a/apps/frontend/src/app/mqtt/servers/translations/create/en.json
+++ b/apps/frontend/src/app/mqtt/servers/translations/create/en.json
@@ -1,6 +1,5 @@
 {
   "addNewMqttServer": "Add New MQTT Server",
-  "back": "Back",
   "sections": {
     "connection": "Connection",
     "authentication": "Authentication",


### PR DESCRIPTION
## Summary

- Group `CreateMqttServerPage` into 4 sections (Connection / Authentication / Publish defaults / Subscribe defaults), mirroring `EditMqttServerPage` markup landed in ATT-294.
- Host+Port laid out as `md:grid-cols-3` (host spans 2), Username+Password as `md:grid-cols-2`.
- Switch the publish-retain control from `Checkbox` to `LabeledSwitch` (parity with edit).
- Reuse `sections.*` translation keys (en/de) introduced in commit e498d22; added them to `translations/create/{en,de}.json`.

Closes ATT-320.

## Test plan
- [ ] Visual: open `/mqtt/servers/new`, confirm 4 section headings with top dividers, Host+Port row, Username+Password row, retain switch under TLS section.
- [ ] Visual: confirm parity with `/mqtt/servers/:id/edit`.
- [ ] DE/EN language toggle renders correct section labels.
- [x] `nx run frontend:lint,typecheck,test,build` green via pre-commit hook.

<!-- generated-by-cyrus -->