### PR TITLE
refactor(frontend): unwrap Cards from SumUp admin page (ATT-317)

### DIFF
--- a/apps/frontend/src/app/billing/administration/sumup/configuration/apiKey/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/apiKey/index.tsx
@@ -80,7 +80,7 @@ export function ApiKeyCard(props: Omit<ComponentPropsWithoutRef<'section'>, 'chi
     <section
       {...sectionProps}
       className={twMerge(
-        'w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0',
+        'w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0 @xl:pt-0 @xl:border-t-0 @xl:pl-6 @xl:border-l @xl:first:pl-0 @xl:first:border-l-0',
         className
       )}
     >

--- a/apps/frontend/src/app/billing/administration/sumup/configuration/apiKey/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/apiKey/index.tsx
@@ -7,17 +7,19 @@ import {
   useBillingServiceGetSumUpReadersKey,
   useBillingServiceSetSumUpApiKey,
 } from '@attraccess/react-query-client';
-import { Button, Card, CardProps, Chip, Form, Link, Spinner } from '@heroui/react';
+import { Button, Chip, Form, Link, Spinner } from '@heroui/react';
 import { PageHeader } from '../../../../../../components/pageHeader';
 import { PasswordInput } from '../../../../../../components/PasswordInput';
-import { useCallback, useRef, useState } from 'react';
+import { ComponentPropsWithoutRef, useCallback, useRef, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
 import { useToastMessage } from '../../../../../../components/toastProvider';
 import { useQueryClient } from '@tanstack/react-query';
 import { CheckIcon, WebhookIcon, XIcon } from 'lucide-react';
 import API_ERROR_TRANSLATIONS_DE from '../../../../../../global-translations/api-errors.de.json';
 import API_ERROR_TRANSLATIONS_EN from '../../../../../../global-translations/api-errors.en.json';
 
-export function ApiKeyCard(props: Omit<CardProps, 'children'>) {
+export function ApiKeyCard(props: Omit<ComponentPropsWithoutRef<'section'>, 'children'>) {
+  const { className, ...sectionProps } = props;
   const { t, tExists } = useTranslations({
     en: {
       ...en,
@@ -75,68 +77,72 @@ export function ApiKeyCard(props: Omit<CardProps, 'children'>) {
   }, [setSumUpApiKey, apiKey]);
 
   return (
-    <Card {...props}>
-      <Card.Header>
-        <PageHeader
-          icon={<WebhookIcon size={20} />}
-          title={t('title')}
-          subtitle={t('subtitle')}
-          noMargin
-          actions={
-            <Chip
-              color={isLoadingConfiguration ? 'default' : configuration?.enabled ? 'success' : 'warning'}
-              variant="soft"
-            >
-              <div className="flex items-center gap-2">
-                {isLoadingConfiguration ? (
-                  <Spinner />
-                ) : configuration?.enabled ? (
-                  <CheckIcon size={16} />
-                ) : (
-                  <XIcon size={16} />
-                )}
-                {isLoadingConfiguration
-                  ? t('status.loading.title')
-                  : configuration?.enabled
-                    ? t('status.enabled.title')
-                    : t('status.disabled.title')}
-              </div>
-            </Chip>
-          }
+    <section
+      {...sectionProps}
+      className={twMerge(
+        'w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0',
+        className
+      )}
+    >
+      <PageHeader
+        icon={<WebhookIcon size={20} />}
+        title={t('title')}
+        subtitle={t('subtitle')}
+        noMargin
+        actions={
+          <Chip
+            color={isLoadingConfiguration ? 'default' : configuration?.enabled ? 'success' : 'warning'}
+            variant="soft"
+          >
+            <div className="flex items-center gap-2">
+              {isLoadingConfiguration ? (
+                <Spinner />
+              ) : configuration?.enabled ? (
+                <CheckIcon size={16} />
+              ) : (
+                <XIcon size={16} />
+              )}
+              {isLoadingConfiguration
+                ? t('status.loading.title')
+                : configuration?.enabled
+                  ? t('status.enabled.title')
+                  : t('status.disabled.title')}
+            </div>
+          </Chip>
+        }
+      />
+
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmitApiKey();
+        }}
+        ref={apiKeyFormRef}
+        className="flex flex-col gap-2 w-full"
+      >
+        <PasswordInput
+          label={t('inputs.apiKey.label')}
+          description={t('inputs.apiKey.description')}
+          value={apiKey}
+          onChange={setApiKey}
+          autoComplete="off"
+          isRequired
         />
-      </Card.Header>
 
-      <Card.Content className="flex flex-col gap-2">
-        <Form
-          onSubmit={(e) => {
-            e.preventDefault();
-            onSubmitApiKey();
-          }}
-          ref={apiKeyFormRef}
-        >
-          <PasswordInput
-            label={t('inputs.apiKey.label')}
-            description={t('inputs.apiKey.description')}
-            value={apiKey}
-            onChange={(setApiKey)}
-            autoComplete="off"
-            isRequired
-          />
+        <small>
+          <Link href={sumUpApiKeyUrl} target="_blank" rel="noopener noreferrer">
+            {sumUpApiKeyUrl}
+          </Link>
+        </small>
 
-          <small>
-            <Link href={sumUpApiKeyUrl} target="_blank" rel="noopener noreferrer">
-              {sumUpApiKeyUrl}
-            </Link>
-          </small>
+        <input type="submit" hidden />
+      </Form>
 
-          <input type="submit" hidden />
-        </Form>
-      </Card.Content>
-      <Card.Footer>
+      <div className="flex justify-end">
         <Button variant="primary" onPress={onSubmitApiKey} isPending={isPendingSetSumUpApiKey}>
           {t('actions.save')}
         </Button>
-      </Card.Footer>
-    </Card>
+      </div>
+    </section>
   );
 }

--- a/apps/frontend/src/app/billing/administration/sumup/configuration/currency/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/currency/index.tsx
@@ -79,7 +79,7 @@ export function CurrencyCard(props: Omit<ComponentPropsWithoutRef<'section'>, 'c
     <section
       {...sectionProps}
       className={twMerge(
-        'w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0',
+        'w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0 @xl:pt-0 @xl:border-t-0 @xl:pl-6 @xl:border-l @xl:first:pl-0 @xl:first:border-l-0',
         className
       )}
     >

--- a/apps/frontend/src/app/billing/administration/sumup/configuration/currency/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/currency/index.tsx
@@ -7,9 +7,10 @@ import {
   useBillingServiceGetBillingConfigurationKey,
   useBillingServiceSetBillingConfiguration,
 } from '@attraccess/react-query-client';
-import { Button, Card, CardProps, Form } from '@heroui/react';
+import { Button, Form } from '@heroui/react';
 import { PageHeader } from '../../../../../../components/pageHeader';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { ComponentPropsWithoutRef, useCallback, useEffect, useRef, useState } from 'react';
+import { twMerge } from 'tailwind-merge';
 import { useToastMessage } from '../../../../../../components/toastProvider';
 import { useQueryClient } from '@tanstack/react-query';
 import { EuroIcon } from 'lucide-react';
@@ -17,7 +18,8 @@ import { Select } from '../../../../../../components/select';
 import API_ERROR_TRANSLATIONS_DE from '../../../../../../global-translations/api-errors.de.json';
 import API_ERROR_TRANSLATIONS_EN from '../../../../../../global-translations/api-errors.en.json';
 
-export function CurrencyCard(props: Omit<CardProps, 'children'>) {
+export function CurrencyCard(props: Omit<ComponentPropsWithoutRef<'section'>, 'children'>) {
+  const { className, ...sectionProps } = props;
   const { t, tExists } = useTranslations({
     en: {
       ...en,
@@ -74,38 +76,41 @@ export function CurrencyCard(props: Omit<CardProps, 'children'>) {
   }, [setConfiguration, currency]);
 
   return (
-    <Card {...props}>
-      <Card.Header>
-        <PageHeader icon={<EuroIcon size={20} />} title={t('title')} subtitle={t('subtitle')} noMargin />
-      </Card.Header>
-      <Card.Content>
-        <Form
-          onSubmit={(e) => {
-            e.preventDefault();
-            onSubmitConfiguration();
-          }}
-          ref={configFormRef}
-          className="flex flex-col gap-4"
-        >
-          <Select
-            items={Object.values(Currency).map((currency) => ({
-              key: currency,
-              label: currency,
-            }))}
-            label={t('inputs.currency.label')}
-            value={currency}
-            onChange={(key) => setCurrency(key as Currency)}
-          />
+    <section
+      {...sectionProps}
+      className={twMerge(
+        'w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0',
+        className
+      )}
+    >
+      <PageHeader icon={<EuroIcon size={20} />} title={t('title')} subtitle={t('subtitle')} noMargin />
 
-          <input type="submit" hidden />
-        </Form>
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmitConfiguration();
+        }}
+        ref={configFormRef}
+        className="flex flex-col gap-4 w-full"
+      >
+        <Select
+          items={Object.values(Currency).map((currency) => ({
+            key: currency,
+            label: currency,
+          }))}
+          label={t('inputs.currency.label')}
+          value={currency}
+          onChange={(key) => setCurrency(key as Currency)}
+        />
 
-        <Card.Footer>
-          <Button variant="primary" onPress={onSubmitConfiguration} isPending={isPendingSetConfiguration}>
-            {t('actions.save')}
-          </Button>
-        </Card.Footer>
-      </Card.Content>
-    </Card>
+        <input type="submit" hidden />
+      </Form>
+
+      <div className="flex justify-end">
+        <Button variant="primary" onPress={onSubmitConfiguration} isPending={isPendingSetConfiguration}>
+          {t('actions.save')}
+        </Button>
+      </div>
+    </section>
   );
 }

--- a/apps/frontend/src/app/billing/administration/sumup/configuration/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/index.tsx
@@ -5,9 +5,11 @@ import { cn } from '@heroui/react';
 
 export function SumUpConfigurationCard(props: Omit<HTMLAttributes<HTMLDivElement>, 'children'>) {
   return (
-    <div {...props} className={cn('flex flex-col gap-4', props.className)}>
-      <ApiKeyCard className="flex-grow" />
-      <CurrencyCard className="flex-grow" />
+    <div {...props} className={cn('@container w-full', props.className)}>
+      <div className="flex flex-col @xl:flex-row gap-4 @xl:gap-6 @xl:items-stretch">
+        <ApiKeyCard className="flex-1" />
+        <CurrencyCard className="flex-1" />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Removes `Card` wrappers around the API key (Zugangsdaten) and currency (Konfiguration) forms on `/billing/administration/sumup`.
- Replaces them with the flat sectioned pattern from `EditMqttServerPage` (parent ATT-294): `PageHeader`, bare inputs, save button as the section footer, and `border-t` separators between sections.

## Test plan

- [ ] `/billing/administration/sumup` renders the credentials and configuration sections as flat blocks separated by a divider line — no `Card` chrome.
- [ ] Saving the API key still triggers the success toast and invalidates the SumUp configuration/readers queries.
- [ ] Saving the currency still triggers the success toast and invalidates the billing configuration query.
- [ ] Status chip (Aktiviert/Deaktiviert/Loading) still renders in the API key section header.

Closes ATT-317.

<!-- generated-by-cyrus -->