### PR TITLE
refactor(frontend): move NumberField out of resourceBillingInfo Card (ATT-318)

### DIFF
--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/de.json
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/de.json
@@ -17,6 +17,9 @@
   "example": {
     "label": "Beispielkosten ({{minutes}} Min)"
   },
+  "simulator": {
+    "minutesLabel": "Minuten simulieren"
+  },
   "exampleResultingBalance": {
     "label": "Resultierendes Guthaben"
   }

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/en.json
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/en.json
@@ -17,6 +17,9 @@
   "example": {
     "label": "Example cost ({{minutes}} min)"
   },
+  "simulator": {
+    "minutesLabel": "Simulate minutes"
+  },
   "exampleResultingBalance": {
     "label": "Resulting balance"
   }

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -171,21 +171,7 @@ export function ResourceBillingInfo(props: Props) {
               )) as any
             }
             <TableRow className="border-t border-b-4 border-divider">
-              <TableCell>
-                <NumberField
-                  aria-label={t('example.label', { minutes: exampleMinutes })}
-                  value={exampleMinutes}
-                  onChange={(value) => setExampleMinutes(value)}
-                  minValue={0}
-                  defaultValue={10}
-                >
-                  <NumberFieldGroup>
-                    <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
-                    <NumberFieldInput />
-                    <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
-                  </NumberFieldGroup>
-                </NumberField>
-              </TableCell>
+              <TableCell>{t('example.label', { minutes: exampleMinutes })}</TableCell>
               <TableCell className="whitespace-nowrap text-right">
                 {t('billingValue', {
                   credits: formatNumber(exampleCost),
@@ -216,6 +202,28 @@ export function ResourceBillingInfo(props: Props) {
     </ResourceBillingInfoEditor>
   );
 
+  const minutesSimulator = (
+    <div className="flex items-center justify-between gap-3 mt-3 px-1">
+      <label className="text-xs text-foreground-600 uppercase tracking-wider">
+        {t('simulator.minutesLabel')}
+      </label>
+      <NumberField
+        aria-label={t('simulator.minutesLabel')}
+        value={exampleMinutes}
+        onChange={(value) => setExampleMinutes(value)}
+        minValue={0}
+        defaultValue={10}
+        className="w-36"
+      >
+        <NumberFieldGroup>
+          <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
+          <NumberFieldInput />
+          <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
+        </NumberFieldGroup>
+      </NumberField>
+    </div>
+  );
+
   if (variant === 'flat') {
     return (
       <FlatSection
@@ -226,22 +234,26 @@ export function ResourceBillingInfo(props: Props) {
         {...htmlProps}
       >
         <div className="text-sm">{tableContent}</div>
+        {minutesSimulator}
       </FlatSection>
     );
   }
 
   return (
-    <Card className={className} {...htmlProps}>
-      <Card.Header className="flex items-center justify-between py-3">
-        <PageHeader
-          title={t('title')}
-          icon={<CreditCard />}
-          actions={editorAction}
-          noMargin
-        />
-      </Card.Header>
+    <div className={className} {...htmlProps}>
+      <Card>
+        <Card.Header className="flex items-center justify-between py-3">
+          <PageHeader
+            title={t('title')}
+            icon={<CreditCard />}
+            actions={editorAction}
+            noMargin
+          />
+        </Card.Header>
 
-      <Card.Content>{tableContent}</Card.Content>
-    </Card>
+        <Card.Content>{tableContent}</Card.Content>
+      </Card>
+      {minutesSimulator}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Removes the inline `NumberField` from the example-cost row inside the billing-info `Card` body. The example minutes are now displayed as a static label.
- Adds a separate "Simulate minutes" stepper rendered as a flat tool below the `Card` (and below `FlatSection` in the flat variant), so the Card stays read-only and ATT-294 ("no editable controls inside Card body") is honored.
- Adds `simulator.minutesLabel` translation key (en/de).

Closes [ATT-318](https://linear.app/attraccess/issue/ATT-318).

## Test plan

- [ ] Open resource details page → billing-info `Card` shows no input controls in the table.
- [ ] "Simulate minutes" stepper renders below the Card; changing the value updates the example-cost and resulting-balance rows.
- [ ] Flat variant (where used) shows the stepper below the `FlatSection` content.
- [ ] German + English labels render correctly.

<!-- generated-by-cyrus -->