### PR TITLE
fix(frontend): wrap MetricsSettingsForm button icon ternary in JSX braces (ATT-323)

### DIFF
--- a/apps/frontend/src/app/settings/forms/MetricsSettingsForm/index.tsx
+++ b/apps/frontend/src/app/settings/forms/MetricsSettingsForm/index.tsx
@@ -342,7 +342,7 @@ export function MetricsSettingsForm() {
 
       <div className="flex gap-2 flex-wrap">
         <Button variant="primary" onPress={handleGenerate} isPending={isGenerating}>
-          metricsSettings?.apiKeyConfigured ? <RefreshCwIcon size={16} /> : <KeyIcon size={16} />
+          {metricsSettings?.apiKeyConfigured ? <RefreshCwIcon size={16} /> : <KeyIcon size={16} />}
           {metricsSettings?.apiKeyConfigured ? t('rerollButton') : t('generateButton')}
         </Button>
 


### PR DESCRIPTION
## Summary
- Wrap the generate/regenerate icon ternary in `{}` so React evaluates it instead of rendering `metricsSettings?.apiKeyConfigured ?` and ` :` as literal button text.
- Introduced in 84c3f8b ("rebase fixup for MetricsSettingsForm + dep merge") during the v2→v3 migration: the `startContent` prop was unwrapped into Button children but the JSX expression braces were lost.

Targets `att-280-update-heorui-to-v3` (PR #759) — bug only exists on the v3 migration branch. `main` already uses `startContent={...}` and is unaffected.

Linear: [ATT-323](https://linear.app/attraccess/issue/ATT-323)

## Test plan
- [ ] Visual: open `/settings` on this branch, verify the Metriken card "Generate API Key" / "Regenerate API Key" button shows only the icon + label (no raw `metricsSettings?.apiKeyConfigured ?` text) in both en and de.
- [ ] Verify in both states: with and without an API key configured.

<!-- generated-by-cyrus -->