### PR TITLE
feat(ATT-346): bootstrap nx hardware workspace + tscircuit toolchain + CI

### DIFF
--- a/.github/workflows/hardware.yml
+++ b/.github/workflows/hardware.yml
@@ -9,8 +9,11 @@ on:
       - '.github/workflows/hardware.yml'
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
+
+env:
+  RENDERS_BRANCH: hardware-renders
 
 jobs:
   build-and-render:
@@ -20,16 +23,27 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: ./.github/actions/setup
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+
+      - name: Setup Node.js (hardware toolchain)
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.17.1'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Lint hardware (DRC/ERC)
-        run: pnpm nx affected --target=lint --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:scope:hardware
+        run: pnpm nx run-many --target=lint --parallel=3 --projects=tag:scope:hardware
       - name: Build hardware (circuit JSON)
-        run: pnpm nx affected --target=build --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:scope:hardware
+        run: pnpm nx run-many --target=build --parallel=3 --projects=tag:scope:hardware
       - name: Export fab files (gerbers, BOM, CPL)
-        run: pnpm nx affected --target=export --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:scope:hardware
+        run: pnpm nx run-many --target=export --parallel=3 --projects=tag:scope:hardware
       - name: Render previews (PCB + schematic + assembly)
-        run: pnpm nx affected --target=render --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:scope:hardware
+        run: pnpm nx run-many --target=render --parallel=3 --projects=tag:scope:hardware
 
       - name: Upload gerber ZIPs
         uses: actions/upload-artifact@v4
@@ -41,7 +55,6 @@ jobs:
           retention-days: 30
 
       - name: Upload render PNGs
-        id: upload-renders
         uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -68,51 +81,64 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload renders to imgur (if IMGUR_CLIENT_ID secret set)
-        id: imgur
-        if: steps.collect-renders.outputs.found == 'true' && env.IMGUR_CLIENT_ID != ''
+      - name: Publish renders to orphan branch
+        id: publish-renders
+        if: always() && steps.collect-renders.outputs.found == 'true'
         env:
-          IMGUR_CLIENT_ID: ${{ secrets.IMGUR_CLIENT_ID }}
           LIST_FILE: ${{ steps.collect-renders.outputs.list_file }}
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const list = fs.readFileSync(process.env.LIST_FILE, 'utf8').trim().split('\n');
-            const sections = new Map();
-            for (const row of list) {
-              const [board, name, file] = row.split('|');
-              const buf = fs.readFileSync(file);
-              const upload = await fetch('https://api.imgur.com/3/upload', {
-                method: 'POST',
-                headers: { Authorization: `Client-ID ${process.env.IMGUR_CLIENT_ID}` },
-                body: buf,
-              });
-              const json = await upload.json();
-              if (!json.success) {
-                core.warning(`imgur upload failed for ${file}: ${JSON.stringify(json)}`);
-                continue;
-              }
-              const title = name.replace(/\.png$/, '');
-              const md = `![${title}](${json.data.link})`;
-              if (!sections.has(board)) sections.set(board, []);
-              sections.get(board).push({ title, md });
-            }
-            const out = [];
-            for (const [board, items] of sections) {
-              out.push(`### \`${board}\``);
-              for (const { title, md } of items) {
-                out.push(`**${title}**\n\n${md}`);
-              }
-            }
-            core.setOutput('markdown', out.join('\n\n'));
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RENDERS_BRANCH: ${{ env.RENDERS_BRANCH }}
+        run: |
+          set -euo pipefail
+          worktree="$(mktemp -d)/renders"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          if git ls-remote --exit-code --heads origin "$RENDERS_BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$RENDERS_BRANCH"
+            git worktree add -B "$RENDERS_BRANCH" "$worktree" "origin/$RENDERS_BRANCH"
+          else
+            git worktree add --detach "$worktree"
+            (cd "$worktree" && git checkout --orphan "$RENDERS_BRANCH" && git rm -rf --quiet . 2>/dev/null || true)
+          fi
+          dest_dir="$worktree/pr-${PR_NUMBER}/${HEAD_SHA}"
+          mkdir -p "$dest_dir"
+          while IFS='|' read -r board name file; do
+            cp "$file" "$dest_dir/${board}-${name}"
+          done < "$LIST_FILE"
+          (
+            cd "$worktree"
+            git add "pr-${PR_NUMBER}/${HEAD_SHA}"
+            if git diff --cached --quiet; then
+              echo "no new renders to publish"
+            else
+              git commit -m "renders: pr #${PR_NUMBER} sha ${HEAD_SHA}"
+              git push origin "HEAD:${RENDERS_BRANCH}"
+            fi
+          )
+          raw_base="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${RENDERS_BRANCH}/pr-${PR_NUMBER}/${HEAD_SHA}"
+          md_file="$(mktemp)"
+          declare -A seen=()
+          while IFS='|' read -r board name file; do
+            if [ -z "${seen[$board]+x}" ]; then
+              echo "### \`${board}\`" >> "$md_file"
+              seen[$board]=1
+            fi
+            title="${name%.png}"
+            echo "" >> "$md_file"
+            echo "**${title}**" >> "$md_file"
+            echo "" >> "$md_file"
+            echo "![${title}](${raw_base}/${board}-${name})" >> "$md_file"
+            echo "" >> "$md_file"
+          done < "$LIST_FILE"
+          echo "md_file=$md_file" >> "$GITHUB_OUTPUT"
 
       - name: Build PR comment body
         id: comment-body
         if: always()
         env:
           RENDERS_FOUND: ${{ steps.collect-renders.outputs.found }}
-          IMGUR_MD: ${{ steps.imgur.outputs.markdown }}
+          MD_FILE: ${{ steps.publish-renders.outputs.md_file }}
           LIST_FILE: ${{ steps.collect-renders.outputs.list_file }}
         run: |
           set -euo pipefail
@@ -124,13 +150,8 @@ jobs:
             echo ""
             if [ "$RENDERS_FOUND" != "true" ]; then
               echo "_No render PNGs were produced for this PR._"
-            elif [ -n "${IMGUR_MD:-}" ]; then
-              printf '%s\n' "$IMGUR_MD"
             else
-              echo "Inline image hosting is not configured (set the \`IMGUR_CLIENT_ID\` repo secret to enable previews)."
-              echo ""
-              echo "Rendered files:"
-              awk -F'|' '{ printf "- `%s` / `%s`\n", $1, $2 }' "$LIST_FILE"
+              cat "$MD_FILE"
             fi
             echo ""
             echo "Download the full-resolution PNGs + gerber ZIPs from the [workflow artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/hardware.yml
+++ b/.github/workflows/hardware.yml
@@ -1,0 +1,149 @@
+name: Hardware
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'apps/attractap/hardware/**'
+      - 'libs/attractap-hw-shared/**'
+      - '.github/workflows/hardware.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build-and-render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+
+      - name: Lint hardware (DRC/ERC)
+        run: pnpm nx affected --target=lint --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:scope:hardware
+      - name: Build hardware (circuit JSON)
+        run: pnpm nx affected --target=build --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:scope:hardware
+      - name: Export fab files (gerbers, BOM, CPL)
+        run: pnpm nx affected --target=export --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:scope:hardware
+      - name: Render previews (PCB + schematic + assembly)
+        run: pnpm nx affected --target=render --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:scope:hardware
+
+      - name: Upload gerber ZIPs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hardware-gerbers-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+          path: apps/attractap/hardware/**/dist/export/*.zip
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload render PNGs
+        id: upload-renders
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hardware-renders-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+          path: apps/attractap/hardware/**/dist/render/*.png
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Collect render PNG list
+        id: collect-renders
+        if: always()
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+          list_file="$(mktemp)"
+          for png in apps/attractap/hardware/**/dist/render/*.png; do
+            board="$(basename "$(dirname "$(dirname "$(dirname "$png")")")")"
+            echo "${board}|$(basename "$png")|${png}" >> "$list_file"
+          done
+          if [ -s "$list_file" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "list_file=$list_file" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload renders to imgur (if IMGUR_CLIENT_ID secret set)
+        id: imgur
+        if: steps.collect-renders.outputs.found == 'true' && env.IMGUR_CLIENT_ID != ''
+        env:
+          IMGUR_CLIENT_ID: ${{ secrets.IMGUR_CLIENT_ID }}
+          LIST_FILE: ${{ steps.collect-renders.outputs.list_file }}
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const list = fs.readFileSync(process.env.LIST_FILE, 'utf8').trim().split('\n');
+            const sections = new Map();
+            for (const row of list) {
+              const [board, name, file] = row.split('|');
+              const buf = fs.readFileSync(file);
+              const upload = await fetch('https://api.imgur.com/3/upload', {
+                method: 'POST',
+                headers: { Authorization: `Client-ID ${process.env.IMGUR_CLIENT_ID}` },
+                body: buf,
+              });
+              const json = await upload.json();
+              if (!json.success) {
+                core.warning(`imgur upload failed for ${file}: ${JSON.stringify(json)}`);
+                continue;
+              }
+              const title = name.replace(/\.png$/, '');
+              const md = `![${title}](${json.data.link})`;
+              if (!sections.has(board)) sections.set(board, []);
+              sections.get(board).push({ title, md });
+            }
+            const out = [];
+            for (const [board, items] of sections) {
+              out.push(`### \`${board}\``);
+              for (const { title, md } of items) {
+                out.push(`**${title}**\n\n${md}`);
+              }
+            }
+            core.setOutput('markdown', out.join('\n\n'));
+
+      - name: Build PR comment body
+        id: comment-body
+        if: always()
+        env:
+          RENDERS_FOUND: ${{ steps.collect-renders.outputs.found }}
+          IMGUR_MD: ${{ steps.imgur.outputs.markdown }}
+          LIST_FILE: ${{ steps.collect-renders.outputs.list_file }}
+        run: |
+          set -euo pipefail
+          out="$(mktemp)"
+          {
+            echo "## Hardware render previews"
+            echo ""
+            echo "Commit \`${{ github.event.pull_request.head.sha }}\` · workflow run [\`${{ github.run_id }}\`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo ""
+            if [ "$RENDERS_FOUND" != "true" ]; then
+              echo "_No render PNGs were produced for this PR._"
+            elif [ -n "${IMGUR_MD:-}" ]; then
+              printf '%s\n' "$IMGUR_MD"
+            else
+              echo "Inline image hosting is not configured (set the \`IMGUR_CLIENT_ID\` repo secret to enable previews)."
+              echo ""
+              echo "Rendered files:"
+              awk -F'|' '{ printf "- `%s` / `%s`\n", $1, $2 }' "$LIST_FILE"
+            fi
+            echo ""
+            echo "Download the full-resolution PNGs + gerber ZIPs from the [workflow artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          } > "$out"
+          {
+            echo 'body<<EOF_BODY'
+            cat "$out"
+            echo 'EOF_BODY'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky PR comment with renders
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: hardware-renders
+          message: ${{ steps.comment-body.outputs.body }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -58,9 +58,9 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Lint affected projects
-        run: pnpm nx affected --target=lint --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }}
+        run: pnpm nx affected --target=lint --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }} --exclude=tag:scope:hardware
       - name: Typecheck affected projects
-        run: pnpm nx affected --target=typecheck --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }}
+        run: pnpm nx affected --target=typecheck --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }} --exclude=tag:scope:hardware
 
   test:
     runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Test affected projects
-        run: pnpm nx affected --target=test,e2e --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }}
+        run: pnpm nx affected --target=test,e2e --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }} --exclude=tag:scope:hardware
 
   fail2ban-smoke:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ apps/attractap-touch-firmware/.pio/
 apps/api/src/assets/attractap-firmwares/
 secrets/
 
+apps/attractap/hardware/**/dist/
+apps/attractap/hardware/**/.tscircuit/
+apps/attractap/hardware/**/index.circuit.json
+
 bom.json
 .autopilot.json
 .mcp_data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ COPY . .
 
 # Build the application
 RUN pnpm nx run-many -t build --projects=api,frontend
-RUN pnpm --filter ./dist/apps/api deploy --prod /app/deploy/api
+RUN pnpm --ignore-workspace --filter ./dist/apps/api deploy --prod /app/deploy/api
 RUN cd /app/deploy/api && pnpm rebuild bcrypt sqlite3
 
 

--- a/apps/attractap/hardware/README.md
+++ b/apps/attractap/hardware/README.md
@@ -1,0 +1,109 @@
+# Attractap Hardware
+
+PCB designs for the Attractap V2 modular hardware platform. Boards are authored
+in [tscircuit](https://tscircuit.com) (TypeScript / React) and built via nx.
+
+## Toolchain
+
+| Tool | Version | Pinned |
+|------|---------|--------|
+| `tscircuit` | `0.0.1774` | 2026-05-21 |
+| `@tscircuit/cli` | `0.1.1399` | 2026-05-21 |
+
+Each board project under `apps/attractap/hardware/<board>/` is a pnpm
+workspace member (see root `pnpm-workspace.yaml`) and pins these two
+packages in its own `package.json`. The workspace boundary isolates
+tscircuit's `zod@3`-based transitive deps from the rest of the repo, which
+runs on `zod@4`. Bump both pins together when upgrading and update the date
+above.
+
+The Node-friendly entrypoint is `tscircuit-cli` (from `@tscircuit/cli`); the
+shorter `tsci` bin in the `tscircuit` wrapper uses `#!/usr/bin/env bun` and
+is therefore avoided in CI. `tscircuit-cli` falls back to `tsx` automatically
+when `bun` is absent, so every board pins `tsx` too.
+
+## Layout
+
+```
+apps/attractap/hardware/
+  README.md                    # this file
+  scripts/
+    render-png.mjs             # shared SVG → PNG converter
+  _placeholder/                # one-LED smoke-test board (remove once Beeper lands)
+    index.tsx                  # tscircuit JSX entry
+    project.json               # nx targets
+    package.json               # project marker
+    tsconfig.json
+  <board>/                     # one directory per real board (Phase 1.5+)
+```
+
+The connector pinouts and JLC-parts wrappers shared by every board live in
+`libs/attractap-hw-shared/` (Phase 1 P1-SharedLib ticket — not part of this
+bootstrap).
+
+## nx targets (per board)
+
+Every board exposes the same four targets. Run any of them with
+`pnpm nx run attractap-hw-<board>:<target>`.
+
+| Target | Command | Output |
+|--------|---------|--------|
+| `build` | `tscircuit-cli export -f circuit-json` | `<board>/dist/build/<board>.circuit.json` |
+| `export` | `tscircuit-cli export -f gerbers` | `<board>/dist/export/<board>-gerbers.zip` (gerbers, drill, `bom.csv`, `pick_and_place.csv` — drop-in JLCPCB SMT order) |
+| `render` | `tscircuit-cli export -f pcb-svg/schematic-svg/assembly-svg` + `sharp` | `<board>/dist/render/<board>-{pcb,schematic,assembly}.{svg,png}` |
+| `lint` | `tscircuit-cli build --ignore-warnings` | DRC + ERC; non-zero exit on violation |
+
+Run all boards at once:
+
+```bash
+pnpm nx run-many -t lint,build,export,render --projects=tag:scope:hardware
+```
+
+Affected only (mirrors CI):
+
+```bash
+pnpm nx affected -t lint,build,export,render
+```
+
+## Adding a new board
+
+1. Create `apps/attractap/hardware/<board>/`.
+2. Copy `_placeholder/{project.json,package.json,tsconfig.json,index.tsx}` and
+   rename:
+   - `package.json` `name` → `@attraccess/attractap-hw-<board>`.
+   - `project.json` `name` → `attractap-hw-<board>`, `sourceRoot` →
+     `apps/attractap/hardware/<board>`, each `cwd` → same path.
+   - swap every `_placeholder` filename token for `<board>`.
+3. Tag the project with `scope:hardware` and `type:board`. Add `type:hw-lib`
+   instead if you're authoring a library, not a fabricated board.
+4. Run `pnpm install` once so pnpm picks up the new workspace member.
+5. Edit `index.tsx`: import from `@attraccess/attractap-hw-shared` for
+   connector pinouts and JLC-parts wrappers (Phase 1 P1-SharedLib ticket).
+6. Run `pnpm nx run attractap-hw-<board>:lint` locally to confirm DRC/ERC are
+   green.
+7. Push — `hardware.yml` will produce gerber ZIP + render PNGs on the PR.
+
+## JLCPCB upload workflow
+
+1. Open the PR and download the `gerbers` artifact from the `hardware`
+   workflow run.
+2. Unzip — the archive contains:
+   - `*.gbr` / `*.gtl` / `*.gbl` / etc. — gerber layers.
+   - `drill.drl` / `drill_npth.drl` — Excellon drill files.
+   - `bom.csv` — JLC-format BOM (LCSC PNs in the `LCSC Part #` column).
+   - `pick_and_place.csv` — CPL pick-and-place file.
+3. On [jlcpcb.com](https://jlcpcb.com), upload the full ZIP as the gerber
+   bundle. JLC auto-detects the BOM/CPL inside.
+4. Pick the JLC 2-layer default ruleset unless the board sheet explicitly
+   opts into 4 layers.
+
+## DRC ruleset
+
+Boards default to the JLC 2-layer ruleset. Boards needing 4 layers (Core, PoE,
+Touchscreen) override the DRC config in their own board directory — see the
+per-board ticket for the override pattern.
+
+## Local prerequisites
+
+- Node + pnpm via the repo root (`pnpm install`).
+- No extra toolchain — `tsci` ships as part of the `tscircuit` package.

--- a/apps/attractap/hardware/_placeholder/index.tsx
+++ b/apps/attractap/hardware/_placeholder/index.tsx
@@ -1,0 +1,10 @@
+// Placeholder one-LED tscircuit board used to smoke-test the hardware toolchain
+// FEATURE: hardware/_placeholder — toolchain validation board, removed once Beeper lands
+
+export default () => (
+  <board width="15mm" height="15mm" routingDisabled>
+    <resistor name="R1" resistance="1k" footprint="0603" pcbX={-3} pcbY={0} />
+    <led name="LED1" footprint="0603" pcbX={3} pcbY={0} />
+    <trace from=".R1 > .pin2" to=".LED1 > .pin1" />
+  </board>
+);

--- a/apps/attractap/hardware/_placeholder/package.json
+++ b/apps/attractap/hardware/_placeholder/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@tscircuit/cli": "0.1.1399",
     "tscircuit": "0.0.1774",
-    "tsx": "^4.20.3"
+    "tsx": "^4.20.3",
+    "zod": "3.24.4"
   }
 }

--- a/apps/attractap/hardware/_placeholder/package.json
+++ b/apps/attractap/hardware/_placeholder/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@attraccess/attractap-hw-placeholder",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@tscircuit/cli": "0.1.1399",
+    "tscircuit": "0.0.1774",
+    "tsx": "^4.20.3"
+  }
+}

--- a/apps/attractap/hardware/_placeholder/package.json
+++ b/apps/attractap/hardware/_placeholder/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@tscircuit/cli": "0.1.1399",
     "tscircuit": "0.0.1774",
-    "tsx": "^4.20.3",
-    "zod": "3.24.4"
+    "tsx": "^4.20.3"
   }
 }

--- a/apps/attractap/hardware/_placeholder/project.json
+++ b/apps/attractap/hardware/_placeholder/project.json
@@ -1,0 +1,66 @@
+{
+  "name": "attractap-hw-placeholder",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/attractap/hardware/_placeholder",
+  "tags": ["scope:hardware", "type:board", "placeholder"],
+  "targets": {
+    "lint": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": [],
+      "options": {
+        "cwd": "apps/attractap/hardware/_placeholder",
+        "command": "pnpm exec tscircuit-cli build index.tsx --ignore-warnings"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/build"],
+      "options": {
+        "cwd": "apps/attractap/hardware/_placeholder",
+        "commands": [
+          "rm -rf dist/build && mkdir -p dist/build",
+          "pnpm exec tscircuit-cli export index.tsx -f circuit-json -o dist/build/_placeholder.circuit.json"
+        ],
+        "parallel": false
+      }
+    },
+    "export": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/export"],
+      "options": {
+        "cwd": "apps/attractap/hardware/_placeholder",
+        "commands": [
+          "rm -rf dist/export && mkdir -p dist/export",
+          "pnpm exec tscircuit-cli export index.tsx -f gerbers -o dist/export/_placeholder-gerbers.zip"
+        ],
+        "parallel": false
+      }
+    },
+    "render": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/render"],
+      "options": {
+        "cwd": "apps/attractap/hardware/_placeholder",
+        "commands": [
+          "rm -rf dist/render && mkdir -p dist/render",
+          "pnpm exec tscircuit-cli export index.tsx -f pcb-svg -o dist/render/_placeholder-pcb.svg",
+          "pnpm exec tscircuit-cli export index.tsx -f schematic-svg -o dist/render/_placeholder-schematic.svg",
+          "pnpm exec tscircuit-cli export index.tsx -f assembly-svg -o dist/render/_placeholder-assembly.svg",
+          "node ../scripts/render-png.mjs --out-dir dist/render dist/render/_placeholder-pcb.svg dist/render/_placeholder-schematic.svg dist/render/_placeholder-assembly.svg"
+        ],
+        "parallel": false
+      }
+    }
+  }
+}

--- a/apps/attractap/hardware/_placeholder/tsconfig.json
+++ b/apps/attractap/hardware/_placeholder/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["@tscircuit/props"]
+  },
+  "include": ["index.tsx"]
+}

--- a/apps/attractap/hardware/scripts/render-png.mjs
+++ b/apps/attractap/hardware/scripts/render-png.mjs
@@ -1,0 +1,52 @@
+// Convert tscircuit SVG exports into PNG renders for PR previews
+// FEATURE: hardware/render — shared SVG → PNG step for every board's render target
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import { argv, exit } from 'node:process';
+import sharp from 'sharp';
+
+const DEFAULT_DENSITY = 200;
+
+function parseArgs(args) {
+  const opts = { inputs: [], outDir: null, density: DEFAULT_DENSITY };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--out-dir') {
+      opts.outDir = args[i + 1];
+      i += 1;
+    } else if (arg === '--density') {
+      opts.density = Number.parseInt(args[i + 1], 10);
+      i += 1;
+    } else {
+      opts.inputs.push(arg);
+    }
+  }
+  if (opts.inputs.length === 0 || !opts.outDir) {
+    throw new Error('usage: render-png.mjs --out-dir <dir> [--density <n>] <svg> [<svg> ...]');
+  }
+  return opts;
+}
+
+async function convertOne(svgPath, outDir, density) {
+  const absSvg = resolve(svgPath);
+  const svg = await readFile(absSvg);
+  const pngName = basename(absSvg).replace(/\.svg$/i, '.png');
+  const absOut = resolve(outDir, pngName);
+  await mkdir(dirname(absOut), { recursive: true });
+  await sharp(svg, { density }).png().toFile(absOut);
+  return absOut;
+}
+
+async function main() {
+  const { inputs, outDir, density } = parseArgs(argv.slice(2));
+  for (const svg of inputs) {
+    const out = await convertOne(svg, outDir, density);
+    process.stdout.write(`${out}\n`);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err.message}\n`);
+  exit(1);
+});

--- a/nx.json
+++ b/nx.json
@@ -18,7 +18,8 @@
     "sharedGlobals": [
       "{workspaceRoot}/.github/workflows/pull-requests.yml",
       "{workspaceRoot}/.github/workflows/release.yml",
-      "{workspaceRoot}/.github/workflows/docker-nightly-latest.yml"
+      "{workspaceRoot}/.github/workflows/docker-nightly-latest.yml",
+      "{workspaceRoot}/.github/workflows/hardware.yml"
     ],
     "testing": ["default", "{workspaceRoot}/jest.preset.js"],
     "swagger": ["default", "{projectRoot}/webpack.config.swagger.js"],
@@ -91,9 +92,6 @@
     },
     "lint": {
       "cache": true,
-      "options": {
-        "max-warnings": 0
-      },
       "inputs": [
         "default",
         "^default",
@@ -105,6 +103,11 @@
         }
       ],
       "outputs": ["{options.outputFile}"]
+    },
+    "@nx/eslint:lint": {
+      "options": {
+        "max-warnings": 0
+      }
     },
     "@nx/esbuild:esbuild": {
       "cache": true,

--- a/package.json
+++ b/package.json
@@ -242,9 +242,25 @@
     },
     "overrides": {
       "@internationalized/date": "3.12.1",
-      "zod@>=3.25.0 <4.0.0": "3.24.4",
-      "eslint-plugin-react-hooks>zod": "^4.4.3",
-      "eslint-plugin-react-hooks>zod-validation-error": "^4.0.2"
+      "tscircuit>zod": "3.25.76",
+      "@tscircuit/cli>zod": "3.25.76",
+      "@tscircuit/core>zod": "3.25.76",
+      "@tscircuit/eval>zod": "3.25.76",
+      "@tscircuit/props>zod": "3.25.76",
+      "@tscircuit/runframe>zod": "3.25.76",
+      "@tscircuit/circuit-json-util>zod": "3.25.76",
+      "@tscircuit/soup-util>zod": "3.25.76",
+      "@tscircuit/ngspice-spice-engine>zod": "3.25.76",
+      "calculate-packing>zod": "3.25.76",
+      "circuit-json-to-gltf>zod": "3.25.76",
+      "circuit-json-to-spice>zod": "3.25.76"
+    },
+    "packageExtensions": {
+      "circuit-json@0.0.425": {
+        "dependencies": {
+          "zod": "3.25.76"
+        }
+      }
     },
     "onlyBuiltDependencies": [
       "@nestjs/core",

--- a/package.json
+++ b/package.json
@@ -241,7 +241,10 @@
       "typeorm@0.3.29": "patches/typeorm@0.3.29.patch"
     },
     "overrides": {
-      "@internationalized/date": "3.12.1"
+      "@internationalized/date": "3.12.1",
+      "zod@>=3.25.0 <4.0.0": "3.24.4",
+      "eslint-plugin-react-hooks>zod": "^4.4.3",
+      "eslint-plugin-react-hooks>zod-validation-error": "^4.0.2"
     },
     "onlyBuiltDependencies": [
       "@nestjs/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,6 +668,9 @@ importers:
       tsx:
         specifier: ^4.20.3
         version: 4.22.3
+      zod:
+        specifier: 3.24.4
+        version: 3.24.4
 
 packages:
 
@@ -9242,14 +9245,6 @@ packages:
     resolution: {integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==}
     engines: {node: '>=4'}
 
-  dedent@1.7.0:
-    resolution: {integrity: sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==}
-    peerDependencies:
-      babel-plugin-macros: ^3.1.0
-    peerDependenciesMeta:
-      babel-plugin-macros:
-        optional: true
-
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -10758,9 +10753,6 @@ packages:
   htmlparser2@9.1.0:
     resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
-  http-cache-semantics@4.1.1:
-    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
-
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -11865,10 +11857,6 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
-  jsonwebtoken@9.0.2:
-    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
-    engines: {node: '>=12', npm: '>=6'}
-
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
@@ -11895,14 +11883,8 @@ packages:
   just-diff@6.0.2:
     resolution: {integrity: sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==}
 
-  jwa@1.4.2:
-    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
-
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
-
-  jws@3.2.3:
-    resolution: {integrity: sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==}
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
@@ -14308,9 +14290,6 @@ packages:
 
   pump@2.0.1:
     resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
-
-  pump@3.0.2:
-    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -17351,6 +17330,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -25135,12 +25117,12 @@ snapshots:
       circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
       typescript: 6.0.3
 
-  '@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)':
+  '@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)':
     dependencies:
       circuit-json: 0.0.425
       parsel-js: 1.2.2
       transformation-matrix: 2.16.1
-      zod: 3.25.76
+      zod: 3.24.4
 
   '@tscircuit/cli@0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))':
     dependencies:
@@ -25162,12 +25144,12 @@ snapshots:
       '@lume/kiwi': 0.4.4
       '@tscircuit/capacity-autorouter': 0.0.523(typescript@6.0.3)
       '@tscircuit/checks': 0.0.130(@flatten-js/core@1.6.12)(@tscircuit/math-utils@0.0.36(typescript@6.0.3))(circuit-json-to-connectivity-map@0.0.23(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       '@tscircuit/footprinter': 0.0.357(circuit-json@0.0.425)(typescript@6.0.3)
       '@tscircuit/infgrid-ijump-astar': 0.0.35
       '@tscircuit/matchpack': 0.0.16(typescript@6.0.3)
       '@tscircuit/math-utils': 0.0.36(typescript@6.0.3)
-      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)
       '@tscircuit/schematic-match-adapt': 0.0.16(typescript@6.0.3)
       bpc-graph: 0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3)
       calculate-cell-boundaries: 0.0.1(typescript@6.0.3)
@@ -25199,7 +25181,7 @@ snapshots:
     dependencies:
       '@tscircuit/mm': 0.0.8(typescript@6.0.3)
       circuit-json: 0.0.425
-      zod: 3.25.76
+      zod: 3.24.4
     transitivePeerDependencies:
       - typescript
 
@@ -25242,16 +25224,16 @@ snapshots:
 
   '@tscircuit/ngspice-spice-engine@0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)':
     dependencies:
-      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)
       circuit-json: 0.0.425
       eecircuit-engine: 1.7.0
       typescript: 6.0.3
 
-  '@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)':
+  '@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)':
     dependencies:
       circuit-json: 0.0.425
       react: 19.2.6
-      zod: 3.25.76
+      zod: 3.24.4
 
   '@tscircuit/runframe@0.0.1982(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)':
     dependencies:
@@ -26831,7 +26813,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -27515,7 +27497,7 @@ snapshots:
 
   calculate-packing@0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3):
     dependencies:
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       typescript: 6.0.3
 
   call-bind-apply-helpers@1.0.2:
@@ -27705,7 +27687,7 @@ snapshots:
   circuit-json-to-gltf@0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3):
     dependencies:
       '@jscad/modeling': 2.13.0
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       circuit-json: 0.0.425
       circuit-to-svg: 0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3)
       earcut: 3.0.2
@@ -27729,7 +27711,7 @@ snapshots:
 
   circuit-json-to-spice@0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3):
     dependencies:
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       circuit-json: 0.0.425
       circuit-json-to-connectivity-map: 0.0.22(typescript@6.0.3)
       typescript: 6.0.3
@@ -28577,10 +28559,6 @@ snapshots:
       make-dir: 1.3.0
       pify: 2.3.0
       strip-dirs: 2.1.0
-
-  dedent@1.7.0(babel-plugin-macros@3.1.0):
-    optionalDependencies:
-      babel-plugin-macros: 3.1.0
 
   dedent@1.7.2(babel-plugin-macros@3.1.0):
     optionalDependencies:
@@ -29931,7 +29909,7 @@ snapshots:
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.8.0
-      tapable: 2.3.2
+      tapable: 2.3.3
       typescript: 6.0.3
       webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-dev-server@5.2.4)(webpack@5.105.4))
 
@@ -30533,9 +30511,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 4.5.0
-
-  http-cache-semantics@4.1.1:
-    optional: true
 
   http-cache-semantics@4.2.0: {}
 
@@ -31204,7 +31179,7 @@ snapshots:
       '@types/node': 25.9.0
       chalk: 4.1.2
       co: 4.6.0
-      dedent: 1.7.0(babel-plugin-macros@3.1.0)
+      dedent: 1.7.2(babel-plugin-macros@3.1.0)
       is-generator-fn: 2.1.0
       jest-each: 30.3.0
       jest-matcher-utils: 30.3.0
@@ -31230,7 +31205,7 @@ snapshots:
       '@types/node': 25.9.0
       chalk: 4.1.2
       co: 4.6.0
-      dedent: 1.7.0(babel-plugin-macros@3.1.0)
+      dedent: 1.7.2(babel-plugin-macros@3.1.0)
       is-generator-fn: 2.1.0
       jest-each: 30.4.1
       jest-matcher-utils: 30.4.1
@@ -32013,19 +31988,6 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  jsonwebtoken@9.0.2:
-    dependencies:
-      jws: 3.2.3
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
-      ms: 2.1.3
-      semver: 7.8.0
-
   jsonwebtoken@9.0.3:
     dependencies:
       jws: 4.0.1
@@ -32072,21 +32034,10 @@ snapshots:
 
   just-diff@6.0.2: {}
 
-  jwa@1.4.2:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jws@3.2.3:
-    dependencies:
-      jwa: 1.4.2
       safe-buffer: 5.2.1
 
   jws@4.0.1:
@@ -32561,7 +32512,7 @@ snapshots:
     dependencies:
       agentkeepalive: 4.6.0
       cacache: 15.3.0
-      http-cache-semantics: 4.1.1
+      http-cache-semantics: 4.2.0
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       is-lambda: 1.0.1
@@ -34600,7 +34551,7 @@ snapshots:
 
   passport-jwt@4.0.1:
     dependencies:
-      jsonwebtoken: 9.0.2
+      jsonwebtoken: 9.0.3
       passport-strategy: 1.0.0
 
   passport-local@1.0.0:
@@ -35223,7 +35174,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
       node-abi: 3.75.0
-      pump: 3.0.2
+      pump: 3.0.3
       rc: 1.2.8
       simple-get: 4.0.1
       tar-fs: 2.1.4
@@ -35432,11 +35383,6 @@ snapshots:
     optional: true
 
   pump@2.0.1:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
-  pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
@@ -37243,7 +37189,7 @@ snapshots:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
-      pump: 3.0.2
+      pump: 3.0.3
       tar-stream: 2.2.0
 
   tar-fs@3.1.2:
@@ -37585,7 +37531,7 @@ snapshots:
       '@tscircuit/alphabet': 0.0.25(typescript@6.0.3)
       '@tscircuit/capacity-autorouter': 0.0.523(typescript@6.0.3)
       '@tscircuit/checks': 0.0.130(@flatten-js/core@1.6.12)(@tscircuit/math-utils@0.0.36(typescript@6.0.3))(circuit-json-to-connectivity-map@0.0.23(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       '@tscircuit/cli': 0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))
       '@tscircuit/copper-pour-solver': 0.0.29(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)(typescript@6.0.3)
       '@tscircuit/core': 0.0.1258(uve2whivusifsi5x4fkve2wfpu)
@@ -37599,7 +37545,7 @@ snapshots:
       '@tscircuit/math-utils': 0.0.36(typescript@6.0.3)
       '@tscircuit/miniflex': 0.0.4(typescript@6.0.3)
       '@tscircuit/ngspice-spice-engine': 0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)
-      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)
       '@tscircuit/runframe': 0.0.1982(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
       '@tscircuit/schematic-match-adapt': 0.0.16(typescript@6.0.3)
       '@tscircuit/schematic-trace-solver': 0.0.57(typescript@6.0.3)
@@ -37661,8 +37607,8 @@ snapshots:
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
-      enhanced-resolve: 5.20.1
-      tapable: 2.3.2
+      enhanced-resolve: 5.21.2
+      tapable: 2.3.3
       tsconfig-paths: 4.2.0
 
   tsconfig-paths@3.15.0:
@@ -38457,7 +38403,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.1
+      enhanced-resolve: 5.21.2
       es-module-lexer: 2.0.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -38468,7 +38414,7 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.2
+      tapable: 2.3.3
       terser-webpack-plugin: 5.4.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack@5.105.4)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
@@ -39003,6 +38949,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.24.4: {}
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,20 @@ settings:
 
 overrides:
   '@internationalized/date': 3.12.1
-  zod@>=3.25.0 <4.0.0: 3.24.4
-  eslint-plugin-react-hooks>zod: ^4.4.3
-  eslint-plugin-react-hooks>zod-validation-error: ^4.0.2
+  tscircuit>zod: 3.25.76
+  '@tscircuit/cli>zod': 3.25.76
+  '@tscircuit/core>zod': 3.25.76
+  '@tscircuit/eval>zod': 3.25.76
+  '@tscircuit/props>zod': 3.25.76
+  '@tscircuit/runframe>zod': 3.25.76
+  '@tscircuit/circuit-json-util>zod': 3.25.76
+  '@tscircuit/soup-util>zod': 3.25.76
+  '@tscircuit/ngspice-spice-engine>zod': 3.25.76
+  calculate-packing>zod: 3.25.76
+  circuit-json-to-gltf>zod: 3.25.76
+  circuit-json-to-spice>zod: 3.25.76
+
+packageExtensionsChecksum: 579f5319cc833c1b1bd807f9f3c79904
 
 patchedDependencies:
   typeorm@0.3.29:
@@ -6347,7 +6358,7 @@ packages:
     peerDependencies:
       circuit-json: '*'
       transformation-matrix: '*'
-      zod: 3.24.4
+      zod: 3.25.76
 
   '@tscircuit/cli@0.1.1399':
     resolution: {integrity: sha512-Zf3PSPcYPSZIjXJC0+u0Ima7ePXEjbLdvMny3MR2TGkkSoISvGfQk6L9Wbze7uT/hP+CpCGbMUdsSBzDGhnw7w==}
@@ -6385,7 +6396,7 @@ packages:
       '@tscircuit/core': '*'
       circuit-json: '*'
       typescript: ^5.0.0
-      zod: 3.24.4
+      zod: 3.25.76
 
   '@tscircuit/footprinter@0.0.357':
     resolution: {integrity: sha512-N4QjwY+GkRm1DvPDWQbTq+sRJU59v+ahMxiAIGemBJsoPVFjodVOnu50oN8q41ps4mCXQMS8/16blbLWkZlBkw==}
@@ -6450,7 +6461,7 @@ packages:
     peerDependencies:
       circuit-json: '*'
       react: '*'
-      zod: 3.24.4
+      zod: 3.25.76
 
   '@tscircuit/runframe@0.0.1982':
     resolution: {integrity: sha512-+UW7lmMuw1pCx26j3l1oiXYX6vBkuS4u+ot2e8+TTpcumwrkSdYcnwB+4Ca8rvUxqSbmocwWuF+UsNmnkTga2w==}
@@ -6488,7 +6499,7 @@ packages:
     peerDependencies:
       circuit-json: '*'
       transformation-matrix: '*'
-      zod: 3.24.4
+      zod: 3.25.76
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -17329,10 +17340,10 @@ packages:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: 3.24.4
+      zod: ^3.25.0 || ^4.0.0
 
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -25114,12 +25125,12 @@ snapshots:
       circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
       typescript: 6.0.3
 
-  '@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)':
+  '@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)':
     dependencies:
       circuit-json: 0.0.425
       parsel-js: 1.2.2
       transformation-matrix: 2.16.1
-      zod: 3.24.4
+      zod: 3.25.76
 
   '@tscircuit/cli@0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))':
     dependencies:
@@ -25135,22 +25146,22 @@ snapshots:
       - '@gltf-transform/functions'
       - esbuild-wasm
 
-  '@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy)':
+  '@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu)':
     dependencies:
       '@flatten-js/core': 1.6.12
       '@lume/kiwi': 0.4.4
       '@tscircuit/capacity-autorouter': 0.0.523(typescript@6.0.3)
       '@tscircuit/checks': 0.0.130(@flatten-js/core@1.6.12)(@tscircuit/math-utils@0.0.36(typescript@6.0.3))(circuit-json-to-connectivity-map@0.0.23(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
       '@tscircuit/footprinter': 0.0.357(circuit-json@0.0.425)(typescript@6.0.3)
       '@tscircuit/infgrid-ijump-astar': 0.0.35
       '@tscircuit/matchpack': 0.0.16(typescript@6.0.3)
       '@tscircuit/math-utils': 0.0.36(typescript@6.0.3)
-      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
       '@tscircuit/schematic-match-adapt': 0.0.16(typescript@6.0.3)
       bpc-graph: 0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3)
       calculate-cell-boundaries: 0.0.1(typescript@6.0.3)
-      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(typescript@6.0.3)
+      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3)
       circuit-json: 0.0.425
       circuit-json-to-bpc: 0.0.13(bpc-graph@0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
       circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
@@ -25163,22 +25174,22 @@ snapshots:
       svg-path-commander: 2.2.1
       transformation-matrix: 2.16.1
       typescript: 6.0.3
-      zod: 3.24.4
+      zod: 3.25.76
     transitivePeerDependencies:
       - react
 
-  '@tscircuit/eval@0.0.855(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)':
+  '@tscircuit/eval@0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)':
     dependencies:
-      '@tscircuit/core': 0.0.1258(bwax26bxlp4kp5odvf5g5juuwy)
+      '@tscircuit/core': 0.0.1258(uve2whivusifsi5x4fkve2wfpu)
       circuit-json: 0.0.425
       typescript: 6.0.3
-      zod: 3.24.4
+      zod: 3.25.76
 
   '@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3)':
     dependencies:
       '@tscircuit/mm': 0.0.8(typescript@6.0.3)
       circuit-json: 0.0.425
-      zod: 3.24.4
+      zod: 3.25.76
     transitivePeerDependencies:
       - typescript
 
@@ -25219,22 +25230,22 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@tscircuit/ngspice-spice-engine@0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4))(circuit-json@0.0.425)(typescript@6.0.3)':
+  '@tscircuit/ngspice-spice-engine@0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)':
     dependencies:
-      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
       circuit-json: 0.0.425
       eecircuit-engine: 1.7.0
       typescript: 6.0.3
 
-  '@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)':
+  '@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)':
     dependencies:
       circuit-json: 0.0.425
       react: 19.2.6
-      zod: 3.24.4
+      zod: 3.25.76
 
-  '@tscircuit/runframe@0.0.1982(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)':
+  '@tscircuit/runframe@0.0.1982(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)':
     dependencies:
-      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)
+      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
       '@tscircuit/solver-utils': 0.0.7(typescript@6.0.3)
     transitivePeerDependencies:
       - '@tscircuit/core'
@@ -25267,12 +25278,12 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@tscircuit/soup-util@0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)':
+  '@tscircuit/soup-util@0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)':
     dependencies:
       circuit-json: 0.0.425
       parsel-js: 1.2.2
       transformation-matrix: 2.16.1
-      zod: 3.24.4
+      zod: 3.25.76
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -27492,9 +27503,9 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  calculate-packing@0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(typescript@6.0.3):
+  calculate-packing@0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3):
     dependencies:
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
       typescript: 6.0.3
 
   call-bind-apply-helpers@1.0.2:
@@ -27681,10 +27692,10 @@ snapshots:
       '@tscircuit/math-utils': 0.0.9(typescript@6.0.3)
       typescript: 6.0.3
 
-  circuit-json-to-gltf@0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3):
+  circuit-json-to-gltf@0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3):
     dependencies:
       '@jscad/modeling': 2.13.0
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
       circuit-json: 0.0.425
       circuit-to-svg: 0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3)
       earcut: 3.0.2
@@ -27706,14 +27717,16 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  circuit-json-to-spice@0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(circuit-json@0.0.425)(typescript@6.0.3):
+  circuit-json-to-spice@0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3):
     dependencies:
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
       circuit-json: 0.0.425
       circuit-json-to-connectivity-map: 0.0.22(typescript@6.0.3)
       typescript: 6.0.3
 
-  circuit-json@0.0.425: {}
+  circuit-json@0.0.425:
+    dependencies:
+      zod: 3.25.76
 
   circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
@@ -37528,11 +37541,11 @@ snapshots:
       '@tscircuit/alphabet': 0.0.25(typescript@6.0.3)
       '@tscircuit/capacity-autorouter': 0.0.523(typescript@6.0.3)
       '@tscircuit/checks': 0.0.130(@flatten-js/core@1.6.12)(@tscircuit/math-utils@0.0.36(typescript@6.0.3))(circuit-json-to-connectivity-map@0.0.23(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
-      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
       '@tscircuit/cli': 0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))
       '@tscircuit/copper-pour-solver': 0.0.29(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)(typescript@6.0.3)
-      '@tscircuit/core': 0.0.1258(bwax26bxlp4kp5odvf5g5juuwy)
-      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)
+      '@tscircuit/core': 0.0.1258(uve2whivusifsi5x4fkve2wfpu)
+      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
       '@tscircuit/footprinter': 0.0.357(circuit-json@0.0.425)(typescript@6.0.3)
       '@tscircuit/infer-cable-insertion-point': 0.0.2(typescript@6.0.3)
       '@tscircuit/infgrid-ijump-astar': 0.0.35
@@ -37541,24 +37554,24 @@ snapshots:
       '@tscircuit/matchpack': 0.0.16(typescript@6.0.3)
       '@tscircuit/math-utils': 0.0.36(typescript@6.0.3)
       '@tscircuit/miniflex': 0.0.4(typescript@6.0.3)
-      '@tscircuit/ngspice-spice-engine': 0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4))(circuit-json@0.0.425)(typescript@6.0.3)
-      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)
-      '@tscircuit/runframe': 0.0.1982(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)
+      '@tscircuit/ngspice-spice-engine': 0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
+      '@tscircuit/runframe': 0.0.1982(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
       '@tscircuit/schematic-match-adapt': 0.0.16(typescript@6.0.3)
       '@tscircuit/schematic-trace-solver': 0.0.57(typescript@6.0.3)
       '@tscircuit/simple-3d-svg': 0.0.41
       '@tscircuit/solver-utils': 0.0.3(typescript@6.0.3)
-      '@tscircuit/soup-util': 0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
+      '@tscircuit/soup-util': 0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
       bpc-graph: 0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3)
       calculate-cell-boundaries: 0.0.1(typescript@6.0.3)
       calculate-elbow: 0.0.12(typescript@6.0.3)
-      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(typescript@6.0.3)
+      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3)
       circuit-json: 0.0.425
       circuit-json-to-bpc: 0.0.13(bpc-graph@0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
       circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
-      circuit-json-to-gltf: 0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3)
+      circuit-json-to-gltf: 0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3)
       circuit-json-to-simple-3d: 0.0.9(typescript@6.0.3)
-      circuit-json-to-spice: 0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(circuit-json@0.0.425)(typescript@6.0.3)
+      circuit-json-to-spice: 0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)
       circuit-to-svg: 0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3)
       comlink: 4.4.2
       connectivity-map: 1.0.0(typescript@6.0.3)
@@ -37587,7 +37600,7 @@ snapshots:
       transformation-matrix: 2.16.1
       tslib: 2.8.1
       typescript: 6.0.3
-      zod: 3.24.4
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@gltf-transform/core'
       - '@gltf-transform/extensions'
@@ -38947,7 +38960,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  zod@3.24.4: {}
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 overrides:
   '@internationalized/date': 3.12.1
+  zod@>=3.25.0 <4.0.0: 3.24.4
+  eslint-plugin-react-hooks>zod: ^4.4.3
+  eslint-plugin-react-hooks>zod-validation-error: ^4.0.2
 
 patchedDependencies:
   typeorm@0.3.29:
@@ -668,9 +671,6 @@ importers:
       tsx:
         specifier: ^4.20.3
         version: 4.22.3
-      zod:
-        specifier: 3.24.4
-        version: 3.24.4
 
 packages:
 
@@ -6347,7 +6347,7 @@ packages:
     peerDependencies:
       circuit-json: '*'
       transformation-matrix: '*'
-      zod: '3'
+      zod: 3.24.4
 
   '@tscircuit/cli@0.1.1399':
     resolution: {integrity: sha512-Zf3PSPcYPSZIjXJC0+u0Ima7ePXEjbLdvMny3MR2TGkkSoISvGfQk6L9Wbze7uT/hP+CpCGbMUdsSBzDGhnw7w==}
@@ -6385,7 +6385,7 @@ packages:
       '@tscircuit/core': '*'
       circuit-json: '*'
       typescript: ^5.0.0
-      zod: '3'
+      zod: 3.24.4
 
   '@tscircuit/footprinter@0.0.357':
     resolution: {integrity: sha512-N4QjwY+GkRm1DvPDWQbTq+sRJU59v+ahMxiAIGemBJsoPVFjodVOnu50oN8q41ps4mCXQMS8/16blbLWkZlBkw==}
@@ -6450,7 +6450,7 @@ packages:
     peerDependencies:
       circuit-json: '*'
       react: '*'
-      zod: '*'
+      zod: 3.24.4
 
   '@tscircuit/runframe@0.0.1982':
     resolution: {integrity: sha512-+UW7lmMuw1pCx26j3l1oiXYX6vBkuS4u+ot2e8+TTpcumwrkSdYcnwB+4Ca8rvUxqSbmocwWuF+UsNmnkTga2w==}
@@ -6488,7 +6488,7 @@ packages:
     peerDependencies:
       circuit-json: '*'
       transformation-matrix: '*'
-      zod: '*'
+      zod: 3.24.4
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -17329,13 +17329,10 @@ packages:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: 3.24.4
 
   zod@3.24.4:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -25138,7 +25135,7 @@ snapshots:
       - '@gltf-transform/functions'
       - esbuild-wasm
 
-  '@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu)':
+  '@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy)':
     dependencies:
       '@flatten-js/core': 1.6.12
       '@lume/kiwi': 0.4.4
@@ -25153,7 +25150,7 @@ snapshots:
       '@tscircuit/schematic-match-adapt': 0.0.16(typescript@6.0.3)
       bpc-graph: 0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3)
       calculate-cell-boundaries: 0.0.1(typescript@6.0.3)
-      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3)
+      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(typescript@6.0.3)
       circuit-json: 0.0.425
       circuit-json-to-bpc: 0.0.13(bpc-graph@0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
       circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
@@ -25166,16 +25163,16 @@ snapshots:
       svg-path-commander: 2.2.1
       transformation-matrix: 2.16.1
       typescript: 6.0.3
-      zod: 3.25.76
+      zod: 3.24.4
     transitivePeerDependencies:
       - react
 
-  '@tscircuit/eval@0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)':
+  '@tscircuit/eval@0.0.855(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)':
     dependencies:
-      '@tscircuit/core': 0.0.1258(uve2whivusifsi5x4fkve2wfpu)
+      '@tscircuit/core': 0.0.1258(bwax26bxlp4kp5odvf5g5juuwy)
       circuit-json: 0.0.425
       typescript: 6.0.3
-      zod: 3.25.76
+      zod: 3.24.4
 
   '@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3)':
     dependencies:
@@ -25222,7 +25219,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@tscircuit/ngspice-spice-engine@0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)':
+  '@tscircuit/ngspice-spice-engine@0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4))(circuit-json@0.0.425)(typescript@6.0.3)':
     dependencies:
       '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)
       circuit-json: 0.0.425
@@ -25235,9 +25232,9 @@ snapshots:
       react: 19.2.6
       zod: 3.24.4
 
-  '@tscircuit/runframe@0.0.1982(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)':
+  '@tscircuit/runframe@0.0.1982(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)':
     dependencies:
-      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
+      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)
       '@tscircuit/solver-utils': 0.0.7(typescript@6.0.3)
     transitivePeerDependencies:
       - '@tscircuit/core'
@@ -25270,12 +25267,12 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@tscircuit/soup-util@0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)':
+  '@tscircuit/soup-util@0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)':
     dependencies:
       circuit-json: 0.0.425
       parsel-js: 1.2.2
       transformation-matrix: 2.16.1
-      zod: 3.25.76
+      zod: 3.24.4
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -27495,7 +27492,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  calculate-packing@0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3):
+  calculate-packing@0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(typescript@6.0.3):
     dependencies:
       '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       typescript: 6.0.3
@@ -27684,7 +27681,7 @@ snapshots:
       '@tscircuit/math-utils': 0.0.9(typescript@6.0.3)
       typescript: 6.0.3
 
-  circuit-json-to-gltf@0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3):
+  circuit-json-to-gltf@0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3):
     dependencies:
       '@jscad/modeling': 2.13.0
       '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
@@ -27709,7 +27706,7 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  circuit-json-to-spice@0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3):
+  circuit-json-to-spice@0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(circuit-json@0.0.425)(typescript@6.0.3):
     dependencies:
       '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       circuit-json: 0.0.425
@@ -37534,8 +37531,8 @@ snapshots:
       '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       '@tscircuit/cli': 0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))
       '@tscircuit/copper-pour-solver': 0.0.29(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)(typescript@6.0.3)
-      '@tscircuit/core': 0.0.1258(uve2whivusifsi5x4fkve2wfpu)
-      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
+      '@tscircuit/core': 0.0.1258(bwax26bxlp4kp5odvf5g5juuwy)
+      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)
       '@tscircuit/footprinter': 0.0.357(circuit-json@0.0.425)(typescript@6.0.3)
       '@tscircuit/infer-cable-insertion-point': 0.0.2(typescript@6.0.3)
       '@tscircuit/infgrid-ijump-astar': 0.0.35
@@ -37544,24 +37541,24 @@ snapshots:
       '@tscircuit/matchpack': 0.0.16(typescript@6.0.3)
       '@tscircuit/math-utils': 0.0.36(typescript@6.0.3)
       '@tscircuit/miniflex': 0.0.4(typescript@6.0.3)
-      '@tscircuit/ngspice-spice-engine': 0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)
+      '@tscircuit/ngspice-spice-engine': 0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4))(circuit-json@0.0.425)(typescript@6.0.3)
       '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.24.4)
-      '@tscircuit/runframe': 0.0.1982(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
+      '@tscircuit/runframe': 0.0.1982(@tscircuit/core@0.0.1258(bwax26bxlp4kp5odvf5g5juuwy))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.24.4)
       '@tscircuit/schematic-match-adapt': 0.0.16(typescript@6.0.3)
       '@tscircuit/schematic-trace-solver': 0.0.57(typescript@6.0.3)
       '@tscircuit/simple-3d-svg': 0.0.41
       '@tscircuit/solver-utils': 0.0.3(typescript@6.0.3)
-      '@tscircuit/soup-util': 0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      '@tscircuit/soup-util': 0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4)
       bpc-graph: 0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3)
       calculate-cell-boundaries: 0.0.1(typescript@6.0.3)
       calculate-elbow: 0.0.12(typescript@6.0.3)
-      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3)
+      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(typescript@6.0.3)
       circuit-json: 0.0.425
       circuit-json-to-bpc: 0.0.13(bpc-graph@0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
       circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
-      circuit-json-to-gltf: 0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3)
+      circuit-json-to-gltf: 0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3)
       circuit-json-to-simple-3d: 0.0.9(typescript@6.0.3)
-      circuit-json-to-spice: 0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)
+      circuit-json-to-spice: 0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.24.4))(circuit-json@0.0.425)(typescript@6.0.3)
       circuit-to-svg: 0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3)
       comlink: 4.4.2
       connectivity-map: 1.0.0(typescript@6.0.3)
@@ -37590,7 +37587,7 @@ snapshots:
       transformation-matrix: 2.16.1
       tslib: 2.8.1
       typescript: 6.0.3
-      zod: 3.25.76
+      zod: 3.24.4
     transitivePeerDependencies:
       - '@gltf-transform/core'
       - '@gltf-transform/extensions'
@@ -38951,8 +38948,6 @@ snapshots:
       zod: 4.4.3
 
   zod@3.24.4: {}
-
-  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         version: 0.5.19(tailwindcss@4.3.0)
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       '@tanstack/react-query':
         specifier: ^5.100.10
         version: 5.100.10(react@19.2.6)
@@ -421,16 +421,16 @@ importers:
         version: 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@6.0.3))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/react':
         specifier: 22.7.1
-        version: 22.7.1(jxyp4rguui5mskp3v3ciy7fuqu)
+        version: 22.7.1(zperf33abgf3blspoz4nvp2dbq)
       '@nx/rollup':
         specifier: 22.7.1
         version: 22.7.1(@babel/core@7.29.0)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/babel__core@7.20.5)(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/vite':
         specifier: 22.7.1
-        version: 22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(vitest@4.1.5)
+        version: 22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.5)
       '@nx/web':
         specifier: 22.7.1
-        version: 22.7.1(yjnbe7n3l54pdxbccvz5ci75t4)
+        version: 22.7.1(zb6l3m7c6y5spk7w6ywdbshvda)
       '@nx/webpack':
         specifier: 22.7.1
         version: 22.7.1(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.0)(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(webpack-cli@7.0.2(webpack-dev-server@5.2.4)(webpack@5.105.4))
@@ -529,7 +529,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -643,19 +643,31 @@ importers:
         version: 6.6.0(encoding@0.1.13)(typanion@3.14.0)
       vite:
         specifier: 8.0.13
-        version: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
+        version: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       vite-plugin-dts:
         specifier: 5.0.0
-        version: 5.0.0(@microsoft/api-extractor@7.52.8(@types/node@25.9.0))(@rspack/core@1.6.8(@swc/helpers@0.5.21))(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(webpack@5.105.4)
+        version: 5.0.0(@microsoft/api-extractor@7.52.8(@types/node@25.9.0))(@rspack/core@1.6.8(@swc/helpers@0.5.21))(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(webpack@5.105.4)
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.4.1)
+        version: 1.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.4.1)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       webpack-cli:
         specifier: ^7.0.2
         version: 7.0.2(webpack-dev-server@5.2.4)(webpack@5.105.4)
+
+  apps/attractap/hardware/_placeholder:
+    dependencies:
+      '@tscircuit/cli':
+        specifier: 0.1.1399
+        version: 0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))
+      tscircuit:
+        specifier: 0.0.1774
+        version: 0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.20.3
+        version: 4.22.3
 
 packages:
 
@@ -1510,6 +1522,59 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@biomejs/biome@2.4.15':
+    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.15':
+    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.4.15':
+    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.4.15':
+    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.4.15':
+    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.15':
+    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
   '@biomejs/js-api@4.0.0':
     resolution: {integrity: sha512-EOArR/6drRzM1/hwOIz1pZw90FL31Ud4Y7hEHGWVtMNmAwS9SrwZ8hMENGlLVXCeGW/kL46p8kX7eO6x9Nmezg==}
     peerDependencies:
@@ -2206,6 +2271,14 @@ packages:
   '@exodus/schemasafe@1.3.0':
     resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
 
+  '@flatten-js/core@1.6.12':
+    resolution: {integrity: sha512-FwTv9YuAPNojrw5XHT74TRjUYN/yEjeHejklNEoEZYEeT9VELZwnHmd1N4BMds6p/y1hBzeltEyHZpRIUyAsAg==}
+    engines: {node: '>=4.2.4'}
+
+  '@flatten-js/interval-tree@2.0.3':
+    resolution: {integrity: sha512-Lv3eaITqU20WD+5W8L7JeJdjDXC9hfTUEzY0cRLx/sXj1+P3XdK6Fig4UdxvsekakTK8XeOwnpAKEpTI728U4g==}
+    engines: {node: '>=16.0.0'}
+
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
 
@@ -2227,6 +2300,15 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@gltf-transform/core@4.3.0':
+    resolution: {integrity: sha512-ZeaQfszGJ9LYwELszu45CuDQCsE26lJNNe36FVmN8xclaT6WDdCj7fwGpQXo0/l/YgAVAHX+uO7YNBW75/SRYw==}
+
+  '@gltf-transform/extensions@4.3.0':
+    resolution: {integrity: sha512-XDAjQPYVMHa/VDpSbfCBwI+/1muwRJCaXhUpLgnUzAjn0D//PgvIAcbNm1EwBl3LIWBSwjDUCn2LiMAjp+aXVw==}
+
+  '@gltf-transform/functions@4.3.0':
+    resolution: {integrity: sha512-FZggHVgt3DHOezgESBrf2vDzuD2FYQYaNT2sT/aP316SIwhuiIwby3z7rhV9joDvWqqUaPkf1UmkjlOaY9riSQ==}
 
   '@golevelup/ts-jest@3.0.0':
     resolution: {integrity: sha512-ei0cvUKrVv8cJBW6df54yeod8PyzR2LTYG6wJ1xm+213p7HnThw5ShQcRH0/hhhnXnJCLrpmJM7e6fkRjHUF1g==}
@@ -3198,6 +3280,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jscad/modeling@2.13.0':
+    resolution: {integrity: sha512-Thv/JJZZOMzQ9rfhP+75PbgrNbBTZduRL+ClaGfGFts9+JdIXcUueqRL3NtZZ/v/hyZCUBkPSRxHIi4icz04tQ==}
+
+  '@jscadui/3mf-export@0.5.0':
+    resolution: {integrity: sha512-y5vZktqCjyi7wA38zqNlLIdZUIRZoOO9vCjLzwmL4bR0hk7B/Zm1IeffzJPFe1vFc0C1IEv3hm8caDv3doRk9g==}
+
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
@@ -3292,6 +3380,9 @@ packages:
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
+
+  '@lume/kiwi@0.4.4':
+    resolution: {integrity: sha512-ie0YTKgiZqD4TXlJ4eUbfi4UEoKs6YlLRYNTfPm5eUXwfudTBmPRs7Qcxz2SWKDpVTwThv3sWG6zwtyAA0nPpw==}
 
   '@microsoft/api-extractor-model@7.30.6':
     resolution: {integrity: sha512-znmFn69wf/AIrwHya3fxX6uB5etSIn6vg4Q4RB/tb5VDDs1rqREc+AvMC/p19MUN13CZ7+V/8pkYPTj7q8tftg==}
@@ -3894,6 +3985,9 @@ packages:
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@node-saml/node-saml@5.1.0':
     resolution: {integrity: sha512-t3cJnZ4aC7HhPZ6MGylGZULvUtBOZ6FzuUndaHGXjmIZHXnLfC/7L8a57O9Q9V7AxJGKAiRM5zu2wNm9EsvQpw==}
@@ -4976,6 +5070,21 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-hook/latest@1.0.3':
+    resolution: {integrity: sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/passive-layout-effect@1.2.1':
+    resolution: {integrity: sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/resize-observer@2.0.2':
+    resolution: {integrity: sha512-tzKKzxNpfE5TWmxuv+5Ae3IF58n0FQgQaWJmcbYkjXTRZATXxClnTprQ2uuYygYTpu1pqbBskpwMpj6jpT1djA==}
+    peerDependencies:
+      react: '>=18'
+
   '@react-stately/calendar@3.9.3':
     resolution: {integrity: sha512-uw7fCZXoypSBBUsVkbNvJMQWTihZReRbyLIGG3o/ZM630N3OCZhb/h4Uxke4pNu7n527H0V1bAnZgAldIzOYqg==}
     peerDependencies:
@@ -5232,6 +5341,86 @@ packages:
       react-redux:
         optional: true
 
+  '@remix-run/router@1.23.2':
+    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
+    engines: {node: '>=14.0.0'}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    resolution: {integrity: sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    resolution: {integrity: sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    resolution: {integrity: sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    resolution: {integrity: sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    resolution: {integrity: sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    resolution: {integrity: sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    resolution: {integrity: sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.6.2':
+    resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
+    engines: {node: '>= 10'}
+
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5360,6 +5549,15 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/plugin-commonjs@29.0.2':
+    resolution: {integrity: sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/plugin-image@3.0.3':
     resolution: {integrity: sha512-qXWQwsXpvD4trSb8PeFPFajp8JLpRtqqOeNYRUKnEQNHm7e5UP7fuSRcbjQAJ7wDZBbnJvSdY5ujNBQd9B1iFg==}
     engines: {node: '>=14.0.0'}
@@ -5380,6 +5578,15 @@ packages:
 
   '@rollup/plugin-node-resolve@15.3.1':
     resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-node-resolve@16.0.3':
+    resolution: {integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
@@ -5412,6 +5619,19 @@ packages:
 
   '@rollup/plugin-typescript@12.1.2':
     resolution: {integrity: sha512-cdtSp154H5sv637uMr1a8OTWB0L1SWDSm1rDGiyfcGcvQ6cuTs4MDk2BVEBGysUWago4OJN4EQZqOTl/QY3Jgg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+
+  '@rollup/plugin-typescript@12.3.0':
+    resolution: {integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.14.0||^3.0.0||^4.0.0
@@ -6084,6 +6304,10 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@thednp/dommatrix@3.0.4':
+    resolution: {integrity: sha512-xpKtQZqFOuAPfQDbePIh9f48YKfmULV7z9C+anPBSHiOG4P+T3ct7Cx2AZOoUeXbxiDkz7SONANy1bB7p2uysg==}
+    engines: {node: '>=20', pnpm: '>=8.6.0'}
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -6097,6 +6321,171 @@ packages:
 
   '@ts-morph/common@0.29.0':
     resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
+
+  '@tscircuit/alphabet@0.0.25':
+    resolution: {integrity: sha512-PWLjptI6AlLEtF/wjN1N8uC+n3G7vtg0j3xKE1fgWHDhahtnlQRqHDrtPSLlkIR9aJjRfjplzLuaUEaCRvJmZA==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@tscircuit/capacity-autorouter@0.0.523':
+    resolution: {integrity: sha512-VzkclsiNZreF69C3uwfNV2yaU4RpWjgOnnSG0bGmE0/uIJnNGz3LTgfyUIFGka2EERQ37QLVd2xGSkVfVK8OqQ==}
+
+  '@tscircuit/checks@0.0.130':
+    resolution: {integrity: sha512-USoO+oM3iYCBq1YrWwhMksrE0fMRcXKKSMZ8u7m7VBjSuLrbInCiTOWgECyJOXkYBLcgC4+l2p3zdLCASXrYNQ==}
+    peerDependencies:
+      '@flatten-js/core': '*'
+      '@tscircuit/math-utils': '*'
+      circuit-json: '*'
+      circuit-json-to-connectivity-map: '*'
+      typescript: ^5.5.3
+
+  '@tscircuit/circuit-json-util@0.0.94':
+    resolution: {integrity: sha512-kEYV6LzcZbRuw43IxsZ1cZL2pUx4nF07MYAHHhY9s90UzKYaIYfZ1q11s+F2wNwKecCcSyTUoAwWeqazLQEyVQ==}
+    peerDependencies:
+      circuit-json: '*'
+      transformation-matrix: '*'
+      zod: '3'
+
+  '@tscircuit/cli@0.1.1399':
+    resolution: {integrity: sha512-Zf3PSPcYPSZIjXJC0+u0Ima7ePXEjbLdvMny3MR2TGkkSoISvGfQk6L9Wbze7uT/hP+CpCGbMUdsSBzDGhnw7w==}
+    hasBin: true
+    peerDependencies:
+      tscircuit: '*'
+
+  '@tscircuit/copper-pour-solver@0.0.29':
+    resolution: {integrity: sha512-hFg69kJu/dBMLzCdaKYAShxvn6e3Wf92sUmTzhnz2oT62YS/0uPL8uqDe5agYblYV/fnADBaV28UvzTFbl8UwA==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/core@0.0.1258':
+    resolution: {integrity: sha512-dj10sQgO8N7xN6W/+KjrhTY13oDSopy4JRapxx6q9Eqo2NqFtEvDGuQCE4pB8sdm3ox/Xk8T/k7k3rwLDMer9Q==}
+    peerDependencies:
+      '@tscircuit/capacity-autorouter': '*'
+      '@tscircuit/checks': '*'
+      '@tscircuit/circuit-json-util': '*'
+      '@tscircuit/footprinter': '*'
+      '@tscircuit/infgrid-ijump-astar': '*'
+      '@tscircuit/matchpack': '*'
+      '@tscircuit/math-utils': '*'
+      '@tscircuit/props': '*'
+      '@tscircuit/schematic-match-adapt': '*'
+      bpc-graph: '*'
+      circuit-json: '*'
+      circuit-json-to-bpc: '*'
+      circuit-json-to-connectivity-map: '*'
+      schematic-symbols: '*'
+      typescript: ^5.0.0
+
+  '@tscircuit/eval@0.0.855':
+    resolution: {integrity: sha512-Z3Xdg5D9bm+y5SpMpavpDvhNMUVuzSIANC3+XPZ2vJbLvyu+LqZAVXzHd8tcMOmAcCQvNZHZSLndmMoKBtJkqQ==}
+    peerDependencies:
+      '@tscircuit/core': '*'
+      circuit-json: '*'
+      typescript: ^5.0.0
+      zod: '3'
+
+  '@tscircuit/footprinter@0.0.357':
+    resolution: {integrity: sha512-N4QjwY+GkRm1DvPDWQbTq+sRJU59v+ahMxiAIGemBJsoPVFjodVOnu50oN8q41ps4mCXQMS8/16blbLWkZlBkw==}
+    peerDependencies:
+      circuit-json: '*'
+
+  '@tscircuit/high-density-a01@0.0.37':
+    resolution: {integrity: sha512-I9WLfQ7HldeuXEkmHUWO4F2F374H8lXVqqdEmJCUrQ/J4CbO6oBShQUz8Q1AbcljdQUeyWDIAgO8LDa2LHyCPA==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/infer-cable-insertion-point@0.0.2':
+    resolution: {integrity: sha512-k3JwlGtsdHRRZELJzjXBKP+9xdzn+v4dqllhJIFMcrMvlBIaOTt8CbxLO+vcxPvz8Csf+yFChnTos8/vYcSgNg==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/infgrid-ijump-astar@0.0.35':
+    resolution: {integrity: sha512-PZx3GyD7mDNEhLJn8+7n8NjrieOvrX03g7Gx1cvwXv9mmgSC4M+yTA0WC4DgOvcRdTnarf0R8xvwtDeJ4tMK9Q==}
+
+  '@tscircuit/internal-dynamic-import@0.0.2':
+    resolution: {integrity: sha512-cflWt1v+3O//e6jAQgHqmzPfgcu1QP0gDefhl1YxeTHWdginlecuvbGdFZ1V9ETxo4+xAwbHDfV+6fyXpvzK8A==}
+
+  '@tscircuit/krt-wasm@0.1.3':
+    resolution: {integrity: sha512-d+U/eAVS5GjIjMsdAvx3DnBkx7NcuGQj8f3qUTx0S+TiiN5rK7xNflz1ATR9PxBQK0R7t6kyAit0WqHn5JooFQ==}
+    peerDependencies:
+      tscircuit: '>=0.0.1686'
+
+  '@tscircuit/matchpack@0.0.16':
+    resolution: {integrity: sha512-F9QX7uQdml88XGKwe7kDkYnwHfG0kykr2cHD+JsnATKlgi32vYwFGuRaOR4tyRrkDGdmzt5T7YYb4Mhi9uncGA==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/math-utils@0.0.36':
+    resolution: {integrity: sha512-HwHS3do6CLQFnLGd0f3+kQzGfENFllpt5ZFWF9gfw2k5Rc5VSxSJi8/MLfHEgaMgrnMCZ5Hqh3DlUD6U3pMXyg==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@tscircuit/math-utils@0.0.9':
+    resolution: {integrity: sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@tscircuit/miniflex@0.0.4':
+    resolution: {integrity: sha512-+Bf/FVAFQfe/foHJXlFPbCjIpi7krjwlrvKgqdQX/J5PnS8xgZW4whe31xqRyN83oWE4zeBV3l2WG2cx3bOvGg==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/mm@0.0.8':
+    resolution: {integrity: sha512-nl7nxE7AhARbKuobflI0LUzoir7+wJyvwfPw6bzA/O0Q3YTcH3vBkU/Of+V/fp6ht+AofiCXj7YAH9E446138Q==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@tscircuit/ngspice-spice-engine@0.0.8':
+    resolution: {integrity: sha512-jubJ8Kgpm9FPRdHBiRBYkf5+B37bqkjDRKpCXOMqS08UZnbS+iCv2k4ACMW+s1zbK0Xa5v+9yjuoHlfKFW1v/Q==}
+    peerDependencies:
+      '@tscircuit/props': '*'
+      circuit-json: '*'
+      typescript: ^5
+
+  '@tscircuit/props@0.0.531':
+    resolution: {integrity: sha512-c+fKxMXMcC9glbK/1P1SEfVf6vLbKp7cJN8cxRw3OdlwMiUS/7XKz3KW4M/1J0YwcTQZgc0GawGzwpCgGxcAzw==}
+    peerDependencies:
+      circuit-json: '*'
+      react: '*'
+      zod: '*'
+
+  '@tscircuit/runframe@0.0.1982':
+    resolution: {integrity: sha512-+UW7lmMuw1pCx26j3l1oiXYX6vBkuS4u+ot2e8+TTpcumwrkSdYcnwB+4Ca8rvUxqSbmocwWuF+UsNmnkTga2w==}
+
+  '@tscircuit/schematic-corpus@0.0.114':
+    resolution: {integrity: sha512-jDQX+XDXP6PklB39X8AwUSuiqGRdn78esy1wD/qG8U3cCXkT5rtE3ousDVaKRxclCeED8FxJlD+ZvRtAe8mw8w==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/schematic-match-adapt@0.0.16':
+    resolution: {integrity: sha512-85e6Pq58zrhZqivyW4bPVZfGfg8xLBCj3yjHl5LZslwfsDRgtWVob4bjJMhCfNL/mLsPUQKnpiDNnFKl9ugUZw==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/schematic-trace-solver@0.0.57':
+    resolution: {integrity: sha512-mBE9Y7xcNGQSQ+qawX6CAxS980CGKPvC2NLBJ6BCkuk99fo+LBydAw2KNds9B9d8WOJUsgQGsUteJ1pc0ZxZtg==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/simple-3d-svg@0.0.41':
+    resolution: {integrity: sha512-2iwhHhMLElq5t0fcC0Gr7cCpZhEOAKh+6NN0NIJ9YWUCcsB7UN8uYko7jqNTxDlYOe6E0ZYaDZWsQ3amOZ3dlw==}
+
+  '@tscircuit/solver-utils@0.0.3':
+    resolution: {integrity: sha512-NMzqn7NM0SpeHnoWwewcnitxSNczaFsm/WENmBy8dxnFbUkGBdmSY5Gbky8C9e7q8+SzRcwj7GqXE7EWAHTirw==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/solver-utils@0.0.7':
+    resolution: {integrity: sha512-SB5+A92BMsozxOWfi6iXrcVv1UAFfbBAbKlWHG9TXWquEvAVPSukeCZJ08Yhq0b22T4qkMNy5bZWshXwlO+BuQ==}
+    peerDependencies:
+      typescript: ^5
+
+  '@tscircuit/soup-util@0.0.41':
+    resolution: {integrity: sha512-47JKWBUKkRVHhad0HhBbdOJxB6v/eiac46beiKRBMlJqiZ1gPGI276v9iZfpF7c4hXR69cURcgiwuA5vowrFEg==}
+    peerDependencies:
+      circuit-json: '*'
+      transformation-matrix: '*'
+      zod: '*'
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -6263,6 +6652,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/history@4.7.11':
+    resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
+
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
@@ -6344,6 +6736,9 @@ packages:
   '@types/multer@2.1.0':
     resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
 
+  '@types/ndarray@1.0.14':
+    resolution: {integrity: sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg==}
+
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
@@ -6393,6 +6788,12 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-router-dom@5.3.3':
+    resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
+
+  '@types/react-router@5.1.20':
+    resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -7167,6 +7568,9 @@ packages:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -7521,6 +7925,47 @@ packages:
   bare-events@2.5.4:
     resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
 
+  bare-events@2.8.3:
+    resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
+
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
@@ -7620,6 +8065,12 @@ packages:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
 
+  bpc-graph@0.0.57:
+    resolution: {integrity: sha512-kgFB+o1D2YM9aJBVVFvSo7Qv0xAiY0/tqPf5wH+tPgEYU5572/YU0xgF1rDfN+4vGsqRzTxEqUaaW7IMe33V7A==}
+    peerDependencies:
+      '@tscircuit/schematic-corpus': '*'
+      typescript: ^5
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -7692,6 +8143,15 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  bun-match-svg@0.0.15:
+    resolution: {integrity: sha512-nti7wB49rOkCf4Z439gFzrkXQ45qvmFyLfawn/f7sp85l68EvuPI9YumhOwHscFFYEvWsgxydoujRLxdcm6rfA==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -7751,6 +8211,22 @@ packages:
   cacheable-request@7.0.2:
     resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
     engines: {node: '>=8'}
+
+  calculate-cell-boundaries@0.0.1:
+    resolution: {integrity: sha512-W0GKQ9kraaFc78jkzJHY4nXuO6LlpkT7bScUa+hiP8qON5kUcATsF2hmsgpL0UQp9HK+LswHdSFanzghb2fjPA==}
+    peerDependencies:
+      typescript: ^5
+
+  calculate-elbow@0.0.12:
+    resolution: {integrity: sha512-UkGS4EhabJn1WR6+UyoWpcxhKMx6MxM7+rK+3G0JcaPLMiYlvv5pEuc91unC/nH7kLGHV9xsVavhr5jJ50o+HA==}
+    peerDependencies:
+      typescript: ^5
+
+  calculate-packing@0.0.73:
+    resolution: {integrity: sha512-HoaT1iaaZBS6znXInaBbCT9+tFMWfJWxe2dCfqxHjC6m57NpV322BfvM+Nt20XgDb5d4cvZBU0+CGiTUEgGRHw==}
+    peerDependencies:
+      '@tscircuit/circuit-json-util': '*'
+      typescript: ^5
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -7901,6 +8377,58 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  circuit-json-to-bpc@0.0.13:
+    resolution: {integrity: sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg==}
+    peerDependencies:
+      bpc-graph: '*'
+      circuit-json: '*'
+      typescript: ^5
+
+  circuit-json-to-connectivity-map@0.0.22:
+    resolution: {integrity: sha512-HN8DiISjZZLTglGEkYNRpKeQ/DMG4dDo5j4Hck0UGSJbpux9aFwtJOGszMf06Inh/gu5oKBrpZJIeWxaNacKUg==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  circuit-json-to-connectivity-map@0.0.23:
+    resolution: {integrity: sha512-DSOiXaXOTvjU+7et8ITXb2LjgKto6cQzLv3hReYdXuUNtLw2GVnpOly1G83VcIBcSQ4hRVHI4VMKRyZB3XVzdg==}
+    peerDependencies:
+      typescript: ^5.9.3
+
+  circuit-json-to-gltf@0.0.96:
+    resolution: {integrity: sha512-7V1cj+WhyPBRsVbgghSCnbJNyWkx/KAhvnZU1Pdp7lZH+iHFIqRyIL/vNRRo657JDGM4bTlVFMUugo+RrseoKw==}
+    peerDependencies:
+      '@resvg/resvg-js': '2'
+      '@resvg/resvg-wasm': '2'
+      '@tscircuit/circuit-json-util': '*'
+      circuit-json: '*'
+      circuit-to-svg: '*'
+      typescript: ^5
+    peerDependenciesMeta:
+      '@resvg/resvg-js':
+        optional: true
+      '@resvg/resvg-wasm':
+        optional: true
+
+  circuit-json-to-simple-3d@0.0.9:
+    resolution: {integrity: sha512-thpCtDb9LpAQfGO+Z0hae19sxVAmJAMYM/It9UTMCtyXC3zoUHwRcp/oqtMO/ZIW+JDBhiR8AHmmtKScL2kW7Q==}
+    peerDependencies:
+      typescript: ^5
+
+  circuit-json-to-spice@0.0.34:
+    resolution: {integrity: sha512-59XyRHATq455875XlEiAfycIvxkOjaKnX4nzzlvY88UJyFcjkHSQCB9HCnbHJGsRxVBEmrTcELLyVIFmB+c4LA==}
+    peerDependencies:
+      '@tscircuit/circuit-json-util': '*'
+      circuit-json: '*'
+      typescript: ^5.0.0
+
+  circuit-json@0.0.425:
+    resolution: {integrity: sha512-Iczj4kORXe8xRbDsQ0ZhMU9bewD+rJgxKDIcnj1ipt45adGGg2PeGB9b3dswWvpAGri19Y5Jgbb9CIxXcw6guQ==}
+
+  circuit-to-svg@0.0.345:
+    resolution: {integrity: sha512-d+P+AFJhWlt9Bdpk9/0zdBBjPxIRgnJaFsGqW/4CG0vEAY2QNqK/OqSl8i0zpFpM4+tiQdeR0n8h1tsvMMhvkA==}
+    peerDependencies:
+      '@tscircuit/alphabet': '*'
+
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
@@ -8011,12 +8539,18 @@ packages:
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
 
+  color-convert@0.5.3:
+    resolution: {integrity: sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling==}
+
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
+
+  color-diff@1.4.0:
+    resolution: {integrity: sha512-4oDB/o78lNdppbaqrg0HjOp7pHmUc+dfCxWKWFnQg6AB/1dkjtBDop3RZht5386cq9xBUDRvDvSCA7WUlM9Jqw==}
 
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -8055,6 +8589,9 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  comlink@4.4.2:
+    resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -8070,12 +8607,20 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
@@ -8176,6 +8721,11 @@ packages:
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
+
+  connectivity-map@1.0.0:
+    resolution: {integrity: sha512-AwCFYacp/GaWZE7bkmD95+C/o0jGP+JYT/+v2bLxoITEUHWyLd6HTX7KZQ6clo2h39aLSfIFSlapBVAXGZPXHg==}
+    peerDependencies:
+      typescript: ^5
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -8385,6 +8935,9 @@ packages:
       lightningcss:
         optional: true
 
+  css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
@@ -8471,6 +9024,9 @@ packages:
   csv@6.5.1:
     resolution: {integrity: sha512-oZwQSayvtn3nGrLUl8epnbfSCsvhOmCKeMHEOVmZ/3YCTG+x26nhgrP1vB3Kjs4lUJF6jcsjjIEn2gYbbq5+Gw==}
     engines: {node: '>= 0.1.90'}
+
+  cwise-compiler@1.1.3:
+    resolution: {integrity: sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==}
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -8709,6 +9265,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deep-rename-keys@0.2.1:
+    resolution: {integrity: sha512-RHd9ABw4Fvk+gYDWqwOftG849x0bYOySl/RgX0tLI9i27ZIeSO91mLZJEp7oPHOMFqHvpgu21YptmDt0FYD/0A==}
+    engines: {node: '>=0.10.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -8924,6 +9484,9 @@ packages:
   duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -8944,6 +9507,9 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  eecircuit-engine@1.7.0:
+    resolution: {integrity: sha512-ZDpr/w/H81uCH3n2vjf0vohxOQqQ4NCsvaXkoYwcH+LCxIGKpBdvAIvGN5IdozW6AFJ8tojquKvDya3337yjSQ==}
 
   effect@3.21.2:
     resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
@@ -9134,6 +9700,11 @@ packages:
 
   es6-weak-map@2.0.3:
     resolution: {integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==}
+
+  esbuild-wasm@0.27.7:
+    resolution: {integrity: sha512-1k03e2/tGz+sLz3/xzoZmUsIqtaGIvJa8k4UqUeqCUry83nHmlxQYZUUES0WBFUYilSQUf7nDUGAciIIklljSg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.20.2:
     resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
@@ -9351,11 +9922,17 @@ packages:
   eventemitter2@6.4.9:
     resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
 
+  eventemitter3@2.0.3:
+    resolution: {integrity: sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -9469,6 +10046,13 @@ packages:
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
+    hasBin: true
 
   faster-babel-types@0.1.0:
     resolution: {integrity: sha512-0bEgAyXBdX330U6WbY80Q/h8k0NAPT3Z3sRlC6Fiv0kxekow9JQv2KBL55jIDFxNKcixjvByNnTZfH4axKSB9g==}
@@ -9628,6 +10212,12 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
+  flatbush@4.5.1:
+    resolution: {integrity: sha512-5tpuZV/26A5gRYfqyof3/ZTWeARKgZgd9aBrJLGNSGeasdO2PRb/2lIwDHBIuvPhKK2Y4ELuHbRGtegOwH3Lqg==}
+
+  flatqueue@3.0.0:
+    resolution: {integrity: sha512-y1deYaVt+lIc/d2uIcWDNd0CrdQTO5xoCjeFdhX0kSXvm2Acm0o+3bAOiYklTEoRyzwio3sv3/IiBZdusbAe2Q==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -9681,6 +10271,11 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  format-si-unit@0.0.3:
+    resolution: {integrity: sha512-rhw1g1mOoLV497FtKNbzBPE4fJXfWRmIEPRO0DKXpEPvS54vRLjG8e1jE4vOcjZg4bsoOPJkM9jB6yGk+0XKmQ==}
+    peerDependencies:
+      typescript: ^5.0.0
 
   formdata-node@6.0.3:
     resolution: {integrity: sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==}
@@ -9874,6 +10469,9 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -9964,6 +10562,14 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphics-debug@0.0.89:
+    resolution: {integrity: sha512-fklYB4qChWLkSssabMR1BqjSWWDk21C77IeHBYPREksF34llz/a+gLrW+Oax4eWPT/6TtHZanICMQBhoxGjFYw==}
+    hasBin: true
+    peerDependencies:
+      bun-match-svg: '*'
+      looks-same: ^9.0.1
+      typescript: ^5.0.0
 
   gunzip-maybe@1.4.2:
     resolution: {integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==}
@@ -10408,6 +11014,9 @@ packages:
   intl-pluralrules@2.0.1:
     resolution: {integrity: sha512-astxTLzIdXPeN0K9Rumi6LfMpm3rvNO0iJE+h/k8Kr/is+wPbRe4ikyDjlLr6VTh/mEfNv8RjN+gu3KwDiuhqg==}
 
+  iota-array@1.0.0:
+    resolution: {integrity: sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -10459,6 +11068,9 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -11088,6 +11700,9 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
     engines: {node: '>=14'}
@@ -11099,6 +11714,10 @@ packages:
   js-cookie@3.0.7:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
+
+  js-graph-algorithms@1.0.18:
+    resolution: {integrity: sha512-Gu1wtWzXBzGeye/j9BuyplGHscwqKRZodp/0M1vyBc19RJpblSwKGu099KwwaTx9cRIV+Qupk8xUMfEiGfFqSA==}
+    hasBin: true
 
   js-sdsl@4.3.0:
     resolution: {integrity: sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==}
@@ -11122,6 +11741,31 @@ packages:
 
   jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  jscad-electronics@0.0.129:
+    resolution: {integrity: sha512-bYdAxeaqwmzSshJw+BmW8iV/+BXmOXK3fRRmygNkwjMdV/U0YzwaQ4N1qSayt8+QbAJZ9lyrIeK6Q37tQSVvUA==}
+    peerDependencies:
+      '@jscad/modeling': ^2.12.5
+      '@tscircuit/alphabet': ^0.0.24
+      '@tscircuit/footprinter': '*'
+      circuit-json: ^0.0.232
+      jscad-fiber: ^0.0.85
+      react: 19.1.0
+      react-dom: 19.1.0
+      three: ^0.179.1
+    peerDependenciesMeta:
+      jscad-fiber:
+        optional: true
+
+  jscad-planner@0.0.13:
+    resolution: {integrity: sha512-Lkx7PDT0s90o25dhENrvcYLlgKRvSmhyX7H7LMMq85Hl5ICzirU4MAPxeveKWLlKrdS+4krybVAuKsJ9uvUppg==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  jscad-to-gltf@0.0.5:
+    resolution: {integrity: sha512-WB0JMzeiZnBhUlwpOgNNwkRryDZ+TZ3OhArereeXj9K+UVOpSahgwcGJGMaLeVQ8XHkwp0wMDM2FXf8M4Dzymw==}
+    peerDependencies:
+      typescript: ^5
 
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
@@ -11280,9 +11924,27 @@ packages:
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
 
+  kicad-component-converter@0.1.40:
+    resolution: {integrity: sha512-k0eJpjeRF5E55Izphx87NzL9iGd5kABovG+1TRCgWktfYGWk3YuUnEZPsBVB5PH01TKA7OE8Oj7CdJcGSxWISw==}
+    hasBin: true
+
+  kicad-to-circuit-json@0.0.60:
+    resolution: {integrity: sha512-lqYF0v0XNx4BmLb+sXW+3yImwy3bmIYlcB5B/jqa13Ebtl5qWJz+E3Trez8I1fMi/zwusnvhfiyU2ssgty2svw==}
+    peerDependencies:
+      typescript: ^5
+
+  kicadts@0.0.35:
+    resolution: {integrity: sha512-u86l0kLs1pMazriSLX1rINtBju1diGQFcHiFpGh9c+8ItqgTgobs1OafstCQ/Xbp0l3La34Oz4Oe6Ho5Vdo+Ag==}
+    peerDependencies:
+      typescript: ^5
+
   kill-port@1.6.1:
     resolution: {integrity: sha512-un0Y55cOM7JKGaLnGja28T38tDDop0AQ8N0KlAdyh+B1nmMoX8AnNmqPNZbS3mUMgiST51DCVqmbFT1gNJpVNw==}
     hasBin: true
+
+  kind-of@3.2.2:
+    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
+    engines: {node: '>=0.10.0'}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -11294,6 +11956,9 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  ktx-parse@1.1.0:
+    resolution: {integrity: sha512-mKp3y+FaYgR7mXWAbyyzpa/r1zDWeaunH+INJO4fou3hb45XuNSwar+7llrRyvpMWafxSIi99RNFJ05MHedaJQ==}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -11590,6 +12255,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  looks-same@9.0.1:
+    resolution: {integrity: sha512-V+vsT22nLIUdmvxr6jxsbafpJaZvLFnwZhV7BbmN38+v6gL+/BaHnwK9z5UURhDNSOrj3baOgbwzpjINqoZCpA==}
+    engines: {node: '>= 18.0.0'}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -11702,6 +12371,15 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  manifold-3d@3.4.1:
+    resolution: {integrity: sha512-qb20ldFMUBu3w0dBZ61Hmi3FKCqGxST92wC+wH3iOTyT+5qCyKPvi9xDAFDfhPtkw0YfJQ5XsQfUIvFClyRFOw==}
+    hasBin: true
+    peerDependencies:
+      '@gltf-transform/core': ^4.2.0
+      '@gltf-transform/extensions': ^4.2.0
+      '@gltf-transform/functions': ^4.2.0
+      esbuild-wasm: ^0.27.3
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -11970,6 +12648,11 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
+  minicssgrid@0.0.9:
+    resolution: {integrity: sha512-brXSEhKa4rhPsEseOOjiNOfnAII0H0FfUU008A6rN2qJ3B6z3r4vK5l1BbEiUqeaSko7OK24ssFiiU5cixmG2A==}
+    peerDependencies:
+      typescript: ^5
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -12228,6 +12911,9 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -12248,6 +12934,18 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  ndarray-lanczos@0.3.0:
+    resolution: {integrity: sha512-5kBmmG3Zvyj77qxIAC4QFLKuYdDIBJwCG+DukT6jQHNa1Ft74/hPH1z5mbQXeHBt8yvGPBGVrr3wEOdJPYYZYg==}
+
+  ndarray-ops@1.2.2:
+    resolution: {integrity: sha512-BppWAFRjMYF7N/r6Ie51q6D4fs0iiGmeXIACKY66fLpnwIui3Wc3CXiD/30mgLbDjPpSLrsqcp3Z62+IcHZsDw==}
+
+  ndarray-pixels@5.0.1:
+    resolution: {integrity: sha512-IBtrpefpqlI8SPDCGjXk4v5NV5z7r3JSuCbfuEEXaM0vrOJtNGgYUa4C3Lt5H+qWdYF4BCPVFsnXhNC7QvZwkw==}
+
+  ndarray@1.0.19:
+    resolution: {integrity: sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==}
 
   ndjson@2.0.0:
     resolution: {integrity: sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==}
@@ -12546,6 +13244,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  occt-import-js@0.0.23:
+    resolution: {integrity: sha512-RFfYQXYFX5C1mB1Aywm0ShcUKzXOr/VzTnlzhBSDJOR6YCAPt1HYCzeXWg1vwwjn/cUxwqRNhhtf1dlewoZYCQ==}
+
   ohash@1.1.4:
     resolution: {integrity: sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==}
 
@@ -12607,6 +13308,10 @@ packages:
 
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
+
+  opentype.js@0.4.11:
+    resolution: {integrity: sha512-GthxucX/6aftfLdeU5Ho7o7zmQcC8uVtqdcelVq12X++ndxwBZG8Xb5rFEKT7nEcWDD2P1x+TNuJ70jtj1Mbpw==}
     hasBin: true
 
   optionator@0.9.4:
@@ -12750,6 +13455,9 @@ packages:
     resolution: {integrity: sha512-2MXDNZC4aXdkkap+rBBMv0lUsfJqvX5/2FiYYnfCnorZt3Pk06/IOR5KeaoghgS2w07MLWgjbsnyaq6PdHn2LQ==}
     engines: {node: '>= 0.4.0'}
 
+  parse-color@1.0.0:
+    resolution: {integrity: sha512-fuDHYgFHJGbpGMgw9skY/bj3HL/Jrn4l/5rSspy00DoT4RyLnDcRvPxdZ+r6OFwIsgAuhDh4I09tAId4mI12bw==}
+
   parse-conflict-json@5.0.1:
     resolution: {integrity: sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -12791,6 +13499,9 @@ packages:
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  parsel-js@1.2.2:
+    resolution: {integrity: sha512-AVJMlwQ4bL2Y0VvYJGk+Fp7eX4SCH2uFoNApmn4yKWACUewZ+alwW3tyoe1r5Z3aLYQTuAuPZIyGghMfO/Tlxw==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -12836,6 +13547,10 @@ packages:
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -13017,6 +13732,19 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
+  polished@4.3.1:
+    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
+    engines: {node: '>=10'}
+
+  poppygl@0.0.16:
+    resolution: {integrity: sha512-A29z8dQRyupmLpBU8AurAeAdIYe0nIVuk+o/7PZlhEd4R+SZjt6eY98nnP7g85zcY8FinXtSPysKnMWoo7cz0g==}
+    peerDependencies:
+      typescript: ^5
 
   portfinder@1.0.32:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
@@ -13522,6 +14250,9 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
+  property-graph@4.1.0:
+    resolution: {integrity: sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -13605,6 +14336,10 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
+  pureimage@0.4.18:
+    resolution: {integrity: sha512-piyNT+J1bISJMHxz3VYUvgGLpQAa2NEt5nDdEIozO5Jhla0/jI/atSWFoRVTNrD5KosCMJSghohnqoIjWV0LEw==}
+    engines: {node: '>=14.19.0'}
+
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
 
@@ -13672,6 +14407,11 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
@@ -13728,6 +14468,12 @@ packages:
     peerDependencies:
       react: ^17.0.2
 
+  react-reconciler@0.32.0:
+    resolution: {integrity: sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.1.0
+
   react-reconciler@0.33.0:
     resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
     engines: {node: '>=0.10.0'}
@@ -13750,12 +14496,25 @@ packages:
     resolution: {integrity: sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@6.30.3:
+    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
   react-router-dom@7.15.0:
     resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
+
+  react-router@6.30.3:
+    resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
 
   react-router@7.15.0:
     resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
@@ -13782,6 +14541,13 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  react-supergrid@1.0.10:
+    resolution: {integrity: sha512-dJd9wkH6BJkdfkv62EcRAIBn59e2wj58bJFVXiW/ZHQzxz20qIql63fTU2qFMOujXnBIDaMG0uTod67/mjEGeA==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+      transformation-matrix: '*'
+
   react-textarea-autosize@8.5.9:
     resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
     engines: {node: '>=10'}
@@ -13793,6 +14559,10 @@ packages:
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
@@ -13930,6 +14700,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  rename-keys@1.2.0:
+    resolution: {integrity: sha512-U7XpAktpbSgHTRSNRrjKSrjYkZKuhUukfoBlXWXUExCAqhzh1TU3BDRAfJmarcl5voKS+pbKU9MvyLWKZ4UEEg==}
+    engines: {node: '>= 0.8.0'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -14029,6 +14803,13 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup-plugin-dts@6.4.1:
+    resolution: {integrity: sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      rollup: ^3.29.4 || ^4
+      typescript: ^4.5 || ^5.0 || ^6.0
+
   rollup-plugin-typescript2@0.36.0:
     resolution: {integrity: sha512-NB2CSQDxSe9+Oe2ahZbf+B4bh7pHwjV5L+RSYpCu7Q5ROuN94F9b6ioWwKfz3ueL3KTtmX4o2MUH2cgHDIEUsw==}
     peerDependencies:
@@ -14083,6 +14864,9 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  s-expression@3.1.1:
+    resolution: {integrity: sha512-VMsW7sIvixXfIDmDll7XCePMYYY52UlUtA7OlFQUovqj3XtQ2UkZkjjAvnSFW8o+SbswzUEeCBMmpAx9LS3qrg==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -14278,6 +15062,12 @@ packages:
   scheduler@0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
 
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -14292,6 +15082,16 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  schematic-symbols@0.0.202:
+    resolution: {integrity: sha512-zMdY7VaEg2Sc25T0h9LkWttEoyxGamgBfFDQKUXtYRoLSChrNDOKbNLaxU/GH2L2GbsasV8OLiHyHGb5u7NUpg==}
+    peerDependencies:
+      typescript: ^5.5.4
+
+  schematic-symbols@0.0.208:
+    resolution: {integrity: sha512-2vW3Kmouu1jVtwHuwa9HBgWLl4NKYoXk1T8rtOCa+tlZhCP/qQRX0YWwo4ZljSoY2fWPwZoEy7RX/CuEBuSA+Q==}
+    peerDependencies:
+      typescript: ^5.5.4
 
   scroll-into-view-if-needed@3.0.10:
     resolution: {integrity: sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==}
@@ -14424,6 +15224,10 @@ packages:
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
+
+  sharp@0.32.6:
+    resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
+    engines: {node: '>=14.15.0'}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -14644,6 +15448,11 @@ packages:
   speedometer@1.0.0:
     resolution: {integrity: sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==}
 
+  spicey@0.0.14:
+    resolution: {integrity: sha512-iktSN1BteKEpou3158v25fxGJsNZ4MFeBVV0bZFZ5UZ5NnqusVxVQ1ZrPnCO+2FCmTIBqTD66n0GKMxF6+N/xg==}
+    peerDependencies:
+      typescript: ^5
+
   split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
 
@@ -14728,6 +15537,9 @@ packages:
 
   streamx@2.22.0:
     resolution: {integrity: sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -14846,6 +15658,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
@@ -14877,6 +15692,11 @@ packages:
   stylus@0.64.0:
     resolution: {integrity: sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==}
     engines: {node: '>=16'}
+    hasBin: true
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
   sugar-high@0.7.5:
@@ -14917,6 +15737,10 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
+  svg-path-commander@2.2.1:
+    resolution: {integrity: sha512-hZ9GOFBT/J31fTu3UCj+dZs1w4ZqiGCG/nQpFm1CEQ/EPFj9x3pHXPi6EjYuZmPlua7K8CdFc2+HxndiZ/Q3+g==}
+    engines: {node: '>=16', pnpm: '>=8.6.0'}
+
   svgo@3.3.3:
     resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
     engines: {node: '>=14.0.0'}
@@ -14926,6 +15750,9 @@ packages:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
     hasBin: true
+
+  svgson@5.3.1:
+    resolution: {integrity: sha512-qdPgvUNWb40gWktBJnbJRelWcPzkLed/ShhnRsjbayXz8OtdPOzbil9jtiZdrYvSDumAz/VNQr6JaNfPx/gvPA==}
 
   swagger-schema-official@2.0.0-bab6bed:
     resolution: {integrity: sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA==}
@@ -14995,6 +15822,9 @@ packages:
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
   tar-stream@1.6.2:
     resolution: {integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==}
     engines: {node: '>= 0.8.0'}
@@ -15020,6 +15850,9 @@ packages:
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -15074,6 +15907,13 @@ packages:
     resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
     engines: {node: '>=8'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   thingies@1.21.0:
     resolution: {integrity: sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==}
     engines: {node: '>=10.18'}
@@ -15082,6 +15922,9 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  three@0.179.1:
+    resolution: {integrity: sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==}
 
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
@@ -15206,6 +16049,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  transformation-matrix@2.16.1:
+    resolution: {integrity: sha512-tdtC3wxVEuzU7X/ydL131Q3JU5cPMEn37oqVLITjRDSDsnSHVFzW2JiCLfZLIQEgWzZHdSy3J6bZzvKEN24jGA==}
+
+  transformation-matrix@3.1.0:
+    resolution: {integrity: sha512-oYubRWTi2tYFHAL2J8DLvPIqIYcYZ0fSOi2vmSy042Ho4jBW2ce6VP7QfD44t65WQz6bw5w1Pk22J7lcUpaTKA==}
+
   tree-dump@1.0.2:
     resolution: {integrity: sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==}
     engines: {node: '>=10.0'}
@@ -15234,6 +16083,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   ts-jest@29.4.9:
     resolution: {integrity: sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==}
@@ -15286,6 +16138,12 @@ packages:
       '@swc/wasm':
         optional: true
 
+  tscircuit@0.0.1774:
+    resolution: {integrity: sha512-TWEyWq8RMy1BS6VAFI2fUHEb9Fdi/G0xoet2AXuT0PCwftMukaac2zja6Aaly5CWwj2UEo3RtiWsiu0gfsMIvA==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
     engines: {node: '>=10.13.0'}
@@ -15306,6 +16164,11 @@ packages:
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
+
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
@@ -15551,6 +16414,9 @@ packages:
     resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
     engines: {node: '>= 0.8.0'}
 
+  uniq@1.0.1:
+    resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
+
   unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
 
@@ -15690,6 +16556,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-mouse-matrix-transform@1.3.5:
+    resolution: {integrity: sha512-Ng938MFw/1kmxqQYORBIzC50KAekVLLtY3aepGbrzHehoNvbE75afOo3APxGk+kR3cVKKc3H8fW6vjbNY5J5tw==}
+    peerDependencies:
+      react: ^18.2.0
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -16323,9 +17194,19 @@ packages:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     hasBin: true
 
+  xml-lexer@0.2.2:
+    resolution: {integrity: sha512-G0i98epIwiUEiKmMcavmVdhtymW+pCAohMRgybyIME9ygfVu8QheIi+YoQh3ngiThsT0SQzJT4R0sKDEv8Ou0w==}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
+  xml-reader@2.4.3:
+    resolution: {integrity: sha512-xWldrIxjeAMAu6+HSf9t50ot1uL5M+BtOidRCWHXIeewvSeIpscWCsp4Zxjk8kHHhdqFBrfK8U0EJeCcnyQ/gA==}
 
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
@@ -16470,6 +17351,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -17763,6 +18647,41 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@biomejs/biome@2.4.15':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.15
+      '@biomejs/cli-darwin-x64': 2.4.15
+      '@biomejs/cli-linux-arm64': 2.4.15
+      '@biomejs/cli-linux-arm64-musl': 2.4.15
+      '@biomejs/cli-linux-x64': 2.4.15
+      '@biomejs/cli-linux-x64-musl': 2.4.15
+      '@biomejs/cli-win32-arm64': 2.4.15
+      '@biomejs/cli-win32-x64': 2.4.15
+
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.15':
+    optional: true
+
   '@biomejs/js-api@4.0.0(@biomejs/wasm-nodejs@2.4.14)':
     optionalDependencies:
       '@biomejs/wasm-nodejs': 2.4.14
@@ -18361,6 +19280,14 @@ snapshots:
 
   '@exodus/schemasafe@1.3.0': {}
 
+  '@flatten-js/core@1.6.12':
+    dependencies:
+      '@flatten-js/interval-tree': 2.0.3
+
+  '@flatten-js/interval-tree@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
       '@formatjs/fast-memoize': 2.2.7
@@ -18391,6 +19318,24 @@ snapshots:
 
   '@gar/promisify@1.1.3':
     optional: true
+
+  '@gltf-transform/core@4.3.0':
+    dependencies:
+      property-graph: 4.1.0
+
+  '@gltf-transform/extensions@4.3.0':
+    dependencies:
+      '@gltf-transform/core': 4.3.0
+      ktx-parse: 1.1.0
+
+  '@gltf-transform/functions@4.3.0':
+    dependencies:
+      '@gltf-transform/core': 4.3.0
+      '@gltf-transform/extensions': 4.3.0
+      ktx-parse: 1.1.0
+      ndarray: 1.0.19
+      ndarray-lanczos: 0.3.0
+      ndarray-pixels: 5.0.1
 
   '@golevelup/ts-jest@3.0.0': {}
 
@@ -19961,6 +20906,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jscad/modeling@2.13.0': {}
+
+  '@jscadui/3mf-export@0.5.0': {}
+
   '@jsdevtools/ono@7.1.3': {}
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
@@ -20038,6 +20987,8 @@ snapshots:
     optional: true
 
   '@lukeed/csprng@1.1.0': {}
+
+  '@lume/kiwi@0.4.4': {}
 
   '@microsoft/api-extractor-model@7.30.6(@types/node@25.9.0)':
     dependencies:
@@ -20870,6 +21821,8 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
+  '@nodable/entities@2.1.0': {}
+
   '@node-saml/node-saml@5.1.0':
     dependencies:
       '@types/debug': 4.1.12
@@ -21179,14 +22132,14 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@22.7.1(dumifva6wdx7v3vqexgz6kyujq)':
+  '@nx/module-federation@22.7.1(q5poz2g4h3kkdisz55izuxs5sy)':
     dependencies:
       '@module-federation/enhanced': 2.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.21))(node-fetch@2.7.0(encoding@0.1.13))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)(vue-tsc@1.8.27(typescript@6.0.3))(webpack@5.105.4)
       '@module-federation/node': 2.7.37(@rspack/core@1.6.8(@swc/helpers@0.5.21))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)(vue-tsc@1.8.27(typescript@6.0.3))(webpack@5.105.4)
       '@module-federation/sdk': 2.3.3(node-fetch@2.7.0(encoding@0.1.13))
       '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/web': 22.7.1(yjnbe7n3l54pdxbccvz5ci75t4)
+      '@nx/web': 22.7.1(zb6l3m7c6y5spk7w6ywdbshvda)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.21)
       express: 4.22.1
       http-proxy-middleware: 3.0.5
@@ -21358,14 +22311,14 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/react@22.7.1(jxyp4rguui5mskp3v3ciy7fuqu)':
+  '@nx/react@22.7.1(zperf33abgf3blspoz4nvp2dbq)':
     dependencies:
       '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       '@nx/eslint': 22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a)
       '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 22.7.1(dumifva6wdx7v3vqexgz6kyujq)
+      '@nx/module-federation': 22.7.1(q5poz2g4h3kkdisz55izuxs5sy)
       '@nx/rollup': 22.7.1(@babel/core@7.29.0)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/babel__core@7.20.5)(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/web': 22.7.1(yjnbe7n3l54pdxbccvz5ci75t4)
+      '@nx/web': 22.7.1(zb6l3m7c6y5spk7w6ywdbshvda)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@6.0.3)
       '@svgr/webpack': 8.1.0(typescript@6.0.3)
       express: 4.22.1
@@ -21375,7 +22328,7 @@ snapshots:
       semver: 7.8.0
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(vitest@4.1.5)
+      '@nx/vite': 22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.5)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -21437,11 +22390,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(vitest@4.1.5)':
+  '@nx/vite@22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.5)':
     dependencies:
       '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vitest': 22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(vitest@4.1.5)
+      '@nx/vitest': 22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.5)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@6.0.3)
       ajv: 8.20.0
       enquirer: 2.3.6
@@ -21449,8 +22402,8 @@ snapshots:
       semver: 7.8.0
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/eslint'
@@ -21462,7 +22415,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(vitest@4.1.5)':
+  '@nx/vitest@22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.5)':
     dependencies:
       '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
@@ -21471,8 +22424,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nx/eslint': 22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a)
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -21483,7 +22436,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@22.7.1(yjnbe7n3l54pdxbccvz5ci75t4)':
+  '@nx/web@22.7.1(zb6l3m7c6y5spk7w6ywdbshvda)':
     dependencies:
       '@nx/devkit': 22.7.1(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       '@nx/js': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
@@ -21494,7 +22447,7 @@ snapshots:
     optionalDependencies:
       '@nx/eslint': 22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a)
       '@nx/jest': 22.7.1(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(babel-plugin-macros@3.1.0)(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@6.0.3))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vite': 22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(vitest@4.1.5)
+      '@nx/vite': 22.7.1(@babel/traverse@7.29.0)(@nx/eslint@22.7.1(s6agzw4tjh4srx2uyxoxc7ky5a))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.5)
       '@nx/webpack': 22.7.1(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.21))(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.0)(nx@22.7.1(@swc-node/register@1.11.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@swc/core@1.15.33(@swc/helpers@0.5.21))(@swc/types@0.1.26)(typescript@6.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21)))(typescript@6.0.3)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))(webpack-cli@7.0.2(webpack-dev-server@5.2.4)(webpack@5.105.4))
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -22938,6 +23891,20 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  '@react-hook/latest@1.0.3(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+
+  '@react-hook/passive-layout-effect@1.2.1(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+
+  '@react-hook/resize-observer@2.0.2(react@19.2.6)':
+    dependencies:
+      '@react-hook/latest': 1.0.3(react@19.2.6)
+      '@react-hook/passive-layout-effect': 1.2.1(react@19.2.6)
+      react: 19.2.6
+
   '@react-stately/calendar@3.9.3(react@19.2.6)':
     dependencies:
       '@internationalized/date': 3.12.1
@@ -23278,6 +24245,59 @@ snapshots:
       react: 19.2.6
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1)
 
+  '@remix-run/router@1.23.2': {}
+
+  '@resvg/resvg-js-android-arm-eabi@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.6.2':
+    optional: true
+
+  '@resvg/resvg-js@2.6.2':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.6.2
+      '@resvg/resvg-js-android-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-arm64': 2.6.2
+      '@resvg/resvg-js-darwin-x64': 2.6.2
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.6.2
+      '@resvg/resvg-js-linux-arm64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-arm64-musl': 2.6.2
+      '@resvg/resvg-js-linux-x64-gnu': 2.6.2
+      '@resvg/resvg-js-linux-x64-musl': 2.6.2
+      '@resvg/resvg-js-win32-arm64-msvc': 2.6.2
+      '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
+      '@resvg/resvg-js-win32-x64-msvc': 2.6.2
+
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
 
@@ -23364,6 +24384,18 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.3
 
+  '@rollup/plugin-commonjs@29.0.2(rollup@4.60.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.3
+
   '@rollup/plugin-image@3.0.3(rollup@4.60.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
@@ -23397,6 +24429,16 @@ snapshots:
     optionalDependencies:
       rollup: 4.60.3
 
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.60.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.12
+    optionalDependencies:
+      rollup: 4.60.3
+
   '@rollup/plugin-replace@2.4.2(rollup@2.80.0)':
     dependencies:
       '@rollup/pluginutils': 3.1.0(rollup@2.80.0)
@@ -23419,6 +24461,15 @@ snapshots:
       rollup: 2.80.0
 
   '@rollup/plugin-typescript@12.1.2(rollup@4.60.3)(tslib@2.8.1)(typescript@6.0.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
+      resolve: 1.22.12
+      typescript: 6.0.3
+    optionalDependencies:
+      rollup: 4.60.3
+      tslib: 2.8.1
+
+  '@rollup/plugin-typescript@12.3.0(rollup@4.60.3)(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
       resolve: 1.22.12
@@ -23988,12 +25039,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
 
   '@tanstack/query-core@5.100.10': {}
 
@@ -24044,6 +25095,8 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@thednp/dommatrix@3.0.4': {}
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -24061,6 +25114,186 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
       tinyglobby: 0.2.16
+
+  '@tscircuit/alphabet@0.0.25(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/capacity-autorouter@0.0.523(typescript@6.0.3)':
+    dependencies:
+      '@tscircuit/high-density-a01': 0.0.37(typescript@6.0.3)
+      fast-json-stable-stringify: 2.1.0
+      object-hash: 3.0.0
+    transitivePeerDependencies:
+      - typescript
+
+  '@tscircuit/checks@0.0.130(@flatten-js/core@1.6.12)(@tscircuit/math-utils@0.0.36(typescript@6.0.3))(circuit-json-to-connectivity-map@0.0.23(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)':
+    dependencies:
+      '@flatten-js/core': 1.6.12
+      '@tscircuit/math-utils': 0.0.36(typescript@6.0.3)
+      circuit-json: 0.0.425
+      circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
+      typescript: 6.0.3
+
+  '@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)':
+    dependencies:
+      circuit-json: 0.0.425
+      parsel-js: 1.2.2
+      transformation-matrix: 2.16.1
+      zod: 3.25.76
+
+  '@tscircuit/cli@0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))':
+    dependencies:
+      tscircuit: 0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3)
+
+  '@tscircuit/copper-pour-solver@0.0.29(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)(typescript@6.0.3)':
+    dependencies:
+      manifold-3d: 3.4.1(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@gltf-transform/core'
+      - '@gltf-transform/extensions'
+      - '@gltf-transform/functions'
+      - esbuild-wasm
+
+  '@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu)':
+    dependencies:
+      '@flatten-js/core': 1.6.12
+      '@lume/kiwi': 0.4.4
+      '@tscircuit/capacity-autorouter': 0.0.523(typescript@6.0.3)
+      '@tscircuit/checks': 0.0.130(@flatten-js/core@1.6.12)(@tscircuit/math-utils@0.0.36(typescript@6.0.3))(circuit-json-to-connectivity-map@0.0.23(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      '@tscircuit/footprinter': 0.0.357(circuit-json@0.0.425)(typescript@6.0.3)
+      '@tscircuit/infgrid-ijump-astar': 0.0.35
+      '@tscircuit/matchpack': 0.0.16(typescript@6.0.3)
+      '@tscircuit/math-utils': 0.0.36(typescript@6.0.3)
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
+      '@tscircuit/schematic-match-adapt': 0.0.16(typescript@6.0.3)
+      bpc-graph: 0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3)
+      calculate-cell-boundaries: 0.0.1(typescript@6.0.3)
+      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3)
+      circuit-json: 0.0.425
+      circuit-json-to-bpc: 0.0.13(bpc-graph@0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
+      circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
+      css-select: 5.1.0
+      format-si-unit: 0.0.3(typescript@6.0.3)
+      nanoid: 5.1.9
+      performance-now: 2.1.0
+      react-reconciler: 0.32.0(react@19.2.6)
+      schematic-symbols: 0.0.208(typescript@6.0.3)
+      svg-path-commander: 2.2.1
+      transformation-matrix: 2.16.1
+      typescript: 6.0.3
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - react
+
+  '@tscircuit/eval@0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)':
+    dependencies:
+      '@tscircuit/core': 0.0.1258(uve2whivusifsi5x4fkve2wfpu)
+      circuit-json: 0.0.425
+      typescript: 6.0.3
+      zod: 3.25.76
+
+  '@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3)':
+    dependencies:
+      '@tscircuit/mm': 0.0.8(typescript@6.0.3)
+      circuit-json: 0.0.425
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - typescript
+
+  '@tscircuit/high-density-a01@0.0.37(typescript@6.0.3)':
+    dependencies:
+      flatbush: 4.5.1
+      typescript: 6.0.3
+
+  '@tscircuit/infer-cable-insertion-point@0.0.2(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/infgrid-ijump-astar@0.0.35': {}
+
+  '@tscircuit/internal-dynamic-import@0.0.2': {}
+
+  '@tscircuit/krt-wasm@0.1.3(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))':
+    dependencies:
+      tscircuit: 0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3)
+
+  '@tscircuit/matchpack@0.0.16(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/math-utils@0.0.36(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/math-utils@0.0.9(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/miniflex@0.0.4(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/mm@0.0.8(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/ngspice-spice-engine@0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)':
+    dependencies:
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
+      circuit-json: 0.0.425
+      eecircuit-engine: 1.7.0
+      typescript: 6.0.3
+
+  '@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)':
+    dependencies:
+      circuit-json: 0.0.425
+      react: 19.2.6
+      zod: 3.25.76
+
+  '@tscircuit/runframe@0.0.1982(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)':
+    dependencies:
+      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
+      '@tscircuit/solver-utils': 0.0.7(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@tscircuit/core'
+      - circuit-json
+      - typescript
+      - zod
+
+  '@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/schematic-match-adapt@0.0.16(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/schematic-trace-solver@0.0.57(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/simple-3d-svg@0.0.41':
+    dependencies:
+      fast-xml-parser: 5.8.0
+      fflate: 0.8.2
+
+  '@tscircuit/solver-utils@0.0.3(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/solver-utils@0.0.7(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@tscircuit/soup-util@0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)':
+    dependencies:
+      circuit-json: 0.0.425
+      parsel-js: 1.2.2
+      transformation-matrix: 2.16.1
+      zod: 3.25.76
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -24260,6 +25493,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/history@4.7.11': {}
+
   '@types/http-cache-semantics@4.2.0': {}
 
   '@types/http-errors@2.0.4': {}
@@ -24347,6 +25582,8 @@ snapshots:
     dependencies:
       '@types/express': 4.17.25
 
+  '@types/ndarray@1.0.14': {}
+
   '@types/node@14.18.63': {}
 
   '@types/node@20.19.40':
@@ -24407,6 +25644,17 @@ snapshots:
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react-router-dom@5.3.3':
+    dependencies:
+      '@types/history': 4.7.11
+      '@types/react': 19.2.14
+      '@types/react-router': 5.1.20
+
+  '@types/react-router@5.1.20':
+    dependencies:
+      '@types/history': 4.7.11
       '@types/react': 19.2.14
 
   '@types/react@19.2.14':
@@ -24834,10 +26082,10 @@ snapshots:
       lodash: 4.18.1
       minimatch: 7.4.9
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
@@ -24853,7 +26101,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -24864,13 +26112,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -24899,7 +26147,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -25392,6 +26640,8 @@ snapshots:
 
   ansis@4.2.0: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -25871,6 +27121,41 @@ snapshots:
   bare-events@2.5.4:
     optional: true
 
+  bare-events@2.8.3:
+    optional: true
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.3
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.3)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
+
+  bare-os@3.9.1:
+    optional: true
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+    optional: true
+
+  bare-stream@2.13.1(bare-events@2.8.3):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.3
+    optional: true
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
+    optional: true
+
   base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -26014,6 +27299,11 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
+  bpc-graph@0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3):
+    dependencies:
+      '@tscircuit/schematic-corpus': 0.0.114(typescript@6.0.3)
+      typescript: 6.0.3
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -26094,6 +27384,18 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bun-match-svg@0.0.15(typescript@6.0.3):
+    dependencies:
+      looks-same: 9.0.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.9.0
 
   bundle-name@4.1.0:
     dependencies:
@@ -26200,6 +27502,21 @@ snapshots:
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.1
+
+  calculate-cell-boundaries@0.0.1(typescript@6.0.3):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      typescript: 6.0.3
+
+  calculate-elbow@0.0.12(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  calculate-packing@0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3):
+    dependencies:
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      typescript: 6.0.3
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -26369,6 +27686,70 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  circuit-json-to-bpc@0.0.13(bpc-graph@0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3):
+    dependencies:
+      bpc-graph: 0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3)
+      circuit-json: 0.0.425
+      typescript: 6.0.3
+
+  circuit-json-to-connectivity-map@0.0.22(typescript@6.0.3):
+    dependencies:
+      '@tscircuit/math-utils': 0.0.9(typescript@6.0.3)
+      typescript: 6.0.3
+
+  circuit-json-to-connectivity-map@0.0.23(typescript@6.0.3):
+    dependencies:
+      '@tscircuit/math-utils': 0.0.9(typescript@6.0.3)
+      typescript: 6.0.3
+
+  circuit-json-to-gltf@0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3):
+    dependencies:
+      '@jscad/modeling': 2.13.0
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      circuit-json: 0.0.425
+      circuit-to-svg: 0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3)
+      earcut: 3.0.2
+      jscad-electronics: 0.0.129(@jscad/modeling@2.13.0)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)
+      jscad-to-gltf: 0.0.5(typescript@6.0.3)
+      occt-import-js: 0.0.23
+      typescript: 6.0.3
+    optionalDependencies:
+      '@resvg/resvg-js': 2.6.2
+    transitivePeerDependencies:
+      - '@tscircuit/alphabet'
+      - '@tscircuit/footprinter'
+      - jscad-fiber
+      - react
+      - react-dom
+      - three
+
+  circuit-json-to-simple-3d@0.0.9(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  circuit-json-to-spice@0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3):
+    dependencies:
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      circuit-json: 0.0.425
+      circuit-json-to-connectivity-map: 0.0.22(typescript@6.0.3)
+      typescript: 6.0.3
+
+  circuit-json@0.0.425: {}
+
+  circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3):
+    dependencies:
+      '@tscircuit/alphabet': 0.0.25(typescript@6.0.3)
+      '@types/node': 22.19.17
+      bun-types: 1.3.14
+      calculate-elbow: 0.0.12(typescript@6.0.3)
+      debug: 4.4.3
+      svg-path-commander: 2.2.1
+      svgson: 5.3.1
+      transformation-matrix: 2.16.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
@@ -26472,6 +27853,8 @@ snapshots:
 
   collect-v8-coverage@1.0.3: {}
 
+  color-convert@0.5.3: {}
+
   color-convert@1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -26479,6 +27862,8 @@ snapshots:
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
+
+  color-diff@1.4.0: {}
 
   color-name@1.1.3: {}
 
@@ -26517,6 +27902,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  comlink@4.4.2: {}
+
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
@@ -26525,9 +27912,13 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@13.1.0: {}
+
   commander@14.0.3: {}
 
   commander@2.20.3: {}
+
+  commander@4.1.1: {}
 
   commander@5.1.0:
     optional: true
@@ -26630,6 +28021,11 @@ snapshots:
       utils-merge: 1.0.1
     transitivePeerDependencies:
       - supports-color
+
+  connectivity-map@1.0.0(typescript@6.0.3):
+    dependencies:
+      '@biomejs/biome': 2.4.15
+      typescript: 6.0.3
 
   consola@3.4.2: {}
 
@@ -26823,6 +28219,14 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.0
 
+  css-select@5.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
@@ -26967,6 +28371,10 @@ snapshots:
       csv-parse: 6.2.1
       csv-stringify: 6.7.0
       stream-transform: 3.4.1
+
+  cwise-compiler@1.1.3:
+    dependencies:
+      uniq: 1.0.1
 
   d3-array@3.2.4:
     dependencies:
@@ -27181,6 +28589,11 @@ snapshots:
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
+
+  deep-rename-keys@0.2.1:
+    dependencies:
+      kind-of: 3.2.2
+      rename-keys: 1.2.0
 
   deepmerge@4.3.1: {}
 
@@ -27415,6 +28828,8 @@ snapshots:
       readable-stream: 2.3.8
       stream-shift: 1.0.3
 
+  earcut@3.0.2: {}
+
   eastasianwidth@0.2.0: {}
 
   ecc-jsbn@0.1.2:
@@ -27436,6 +28851,8 @@ snapshots:
   edn-data@1.1.2: {}
 
   ee-first@1.1.1: {}
+
+  eecircuit-engine@1.7.0: {}
 
   effect@3.21.2:
     dependencies:
@@ -27745,6 +29162,8 @@ snapshots:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.4
 
+  esbuild-wasm@0.27.7: {}
+
   esbuild@0.20.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.20.2
@@ -28053,9 +29472,18 @@ snapshots:
 
   eventemitter2@6.4.9: {}
 
+  eventemitter3@2.0.3: {}
+
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
 
   events@3.3.0: {}
 
@@ -28270,6 +29698,19 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
+
   faster-babel-types@0.1.0(@babel/types@7.26.0):
     dependencies:
       '@babel/types': 7.26.0
@@ -28448,6 +29889,12 @@ snapshots:
 
   flat@5.0.2: {}
 
+  flatbush@4.5.1:
+    dependencies:
+      flatqueue: 3.0.0
+
+  flatqueue@3.0.0: {}
+
   flatted@3.4.2: {}
 
   follow-redirects@1.15.11: {}
@@ -28499,6 +29946,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.3
       mime-types: 2.1.35
+
+  format-si-unit@0.0.3(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   formdata-node@6.0.3: {}
 
@@ -28699,6 +30150,8 @@ snapshots:
 
   github-from-package@0.0.0: {}
 
+  gl-matrix@3.4.4: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -28840,6 +30293,23 @@ snapshots:
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
+
+  graphics-debug@0.0.89(bun-match-svg@0.0.15(typescript@6.0.3))(looks-same@9.0.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
+    dependencies:
+      '@react-hook/resize-observer': 2.0.2(react@19.2.6)
+      '@types/react-router-dom': 5.3.3
+      bun-match-svg: 0.0.15(typescript@6.0.3)
+      looks-same: 9.0.1
+      polished: 4.3.1
+      react-router-dom: 6.30.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-supergrid: 1.0.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(transformation-matrix@3.1.0)
+      svgson: 5.3.1
+      transformation-matrix: 3.1.0
+      typescript: 6.0.3
+      use-mouse-matrix-transform: 1.3.5(react@19.2.6)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   gunzip-maybe@1.4.2:
     dependencies:
@@ -29352,6 +30822,8 @@ snapshots:
 
   intl-pluralrules@2.0.1: {}
 
+  iota-array@1.0.0: {}
+
   ip-address@10.2.0: {}
 
   ip-regex@4.3.0: {}
@@ -29402,6 +30874,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-buffer@1.1.6: {}
 
   is-callable@1.2.7: {}
 
@@ -30361,6 +31835,8 @@ snapshots:
   jju@1.4.0:
     optional: true
 
+  jpeg-js@0.4.4: {}
+
   js-beautify@1.15.4:
     dependencies:
       config-chain: 1.1.13
@@ -30372,6 +31848,8 @@ snapshots:
   js-confetti@0.13.1: {}
 
   js-cookie@3.0.7: {}
+
+  js-graph-algorithms@1.0.18: {}
 
   js-sdsl@4.3.0: {}
 
@@ -30392,6 +31870,26 @@ snapshots:
       argparse: 2.0.1
 
   jsbn@0.1.1: {}
+
+  jscad-electronics@0.0.129(@jscad/modeling@2.13.0)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1):
+    dependencies:
+      '@jscad/modeling': 2.13.0
+      '@tscircuit/alphabet': 0.0.25(typescript@6.0.3)
+      '@tscircuit/footprinter': 0.0.357(circuit-json@0.0.425)(typescript@6.0.3)
+      circuit-json: 0.0.425
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      three: 0.179.1
+
+  jscad-planner@0.0.13(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  jscad-to-gltf@0.0.5(typescript@6.0.3):
+    dependencies:
+      '@jscad/modeling': 2.13.0
+      jscad-planner: 0.0.13(typescript@6.0.3)
+      typescript: 6.0.3
 
   jsdom@26.1.0:
     dependencies:
@@ -30614,16 +32112,33 @@ snapshots:
     dependencies:
       '@keyv/serialize': 1.1.1
 
+  kicad-component-converter@0.1.40: {}
+
+  kicad-to-circuit-json@0.0.60(typescript@6.0.3):
+    dependencies:
+      schematic-symbols: 0.0.202(typescript@6.0.3)
+      typescript: 6.0.3
+
+  kicadts@0.0.35(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   kill-port@1.6.1:
     dependencies:
       get-them-args: 1.3.2
       shell-exec: 1.0.2
+
+  kind-of@3.2.2:
+    dependencies:
+      is-buffer: 1.1.6
 
   kind-of@6.0.3: {}
 
   kleur@4.1.5: {}
 
   kolorist@1.8.0: {}
+
+  ktx-parse@1.1.0: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -30909,6 +32424,19 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  looks-same@9.0.1:
+    dependencies:
+      color-diff: 1.4.0
+      fs-extra: 8.1.0
+      js-graph-algorithms: 1.0.18
+      lodash: 4.18.1
+      nested-error-stacks: 2.1.1
+      parse-color: 1.0.0
+      sharp: 0.32.6
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -31055,6 +32583,21 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  manifold-3d@3.4.1(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7):
+    dependencies:
+      '@gltf-transform/core': 4.3.0
+      '@gltf-transform/extensions': 4.3.0
+      '@gltf-transform/functions': 4.3.0
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/trace-mapping': 0.3.31
+      '@jscadui/3mf-export': 0.5.0
+      commander: 13.1.0
+      convert-source-map: 2.0.0
+      esbuild-wasm: 0.27.7
+      fast-xml-parser: 5.8.0
+      fflate: 0.8.2
+      magic-string: 0.30.21
 
   markdown-table@3.0.4: {}
 
@@ -31495,6 +33038,10 @@ snapshots:
       webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-dev-server@5.2.4)(webpack@5.105.4))
 
   mini-svg-data-uri@1.4.4: {}
+
+  minicssgrid@0.0.9(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   minimalistic-assert@1.0.1: {}
 
@@ -32152,6 +33699,12 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.12: {}
 
   nanoid@5.1.9: {}
@@ -32161,6 +33714,27 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  ndarray-lanczos@0.3.0:
+    dependencies:
+      '@types/ndarray': 1.0.14
+      ndarray: 1.0.19
+
+  ndarray-ops@1.2.2:
+    dependencies:
+      cwise-compiler: 1.1.3
+
+  ndarray-pixels@5.0.1:
+    dependencies:
+      '@types/ndarray': 1.0.14
+      ndarray: 1.0.19
+      ndarray-ops: 1.2.2
+      sharp: 0.34.5
+
+  ndarray@1.0.19:
+    dependencies:
+      iota-array: 1.0.0
+      is-buffer: 1.1.6
 
   ndjson@2.0.0:
     dependencies:
@@ -32704,6 +34278,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  occt-import-js@0.0.23: {}
+
   ohash@1.1.4: {}
 
   ohash@1.1.6: {}
@@ -32762,6 +34338,8 @@ snapshots:
   opencollective-postinstall@2.0.3: {}
 
   opener@1.5.2: {}
+
+  opentype.js@0.4.11: {}
 
   optionator@0.9.4:
     dependencies:
@@ -32952,6 +34530,10 @@ snapshots:
 
   parent-require@1.0.0: {}
 
+  parse-color@1.0.0:
+    dependencies:
+      color-convert: 0.5.3
+
   parse-conflict-json@5.0.1:
     dependencies:
       json-parse-even-better-errors: 5.0.0
@@ -33002,6 +34584,8 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parsel-js@1.2.2: {}
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -33043,6 +34627,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -33227,6 +34813,19 @@ snapshots:
       fsevents: 2.3.2
 
   pluralize@8.0.0: {}
+
+  pngjs@7.0.0: {}
+
+  polished@4.3.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  poppygl@0.0.16(typescript@6.0.3):
+    dependencies:
+      gl-matrix: 3.4.4
+      pureimage: 0.4.18
+      readable-stream: 4.7.0
+      typescript: 6.0.3
 
   portfinder@1.0.32:
     dependencies:
@@ -33737,6 +35336,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  property-graph@4.1.0: {}
+
   property-information@7.1.0: {}
 
   proto-list@1.2.4: {}
@@ -33864,6 +35465,12 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
+  pureimage@0.4.18:
+    dependencies:
+      jpeg-js: 0.4.4
+      opentype.js: 0.4.11
+      pngjs: 7.0.0
+
   pvtsutils@1.3.6:
     dependencies:
       tslib: 2.8.1
@@ -33933,6 +35540,12 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-dom@19.2.6(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -33993,6 +35606,11 @@ snapshots:
       react: 19.2.6
       scheduler: 0.20.2
 
+  react-reconciler@0.32.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.26.0
+
   react-reconciler@0.33.0(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -34009,11 +35627,23 @@ snapshots:
 
   react-refresh@0.16.0: {}
 
+  react-router-dom@6.30.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@remix-run/router': 1.23.2
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-router: 6.30.3(react@19.2.6)
+
   react-router-dom@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-router: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+
+  react-router@6.30.3(react@19.2.6):
+    dependencies:
+      '@remix-run/router': 1.23.2
+      react: 19.2.6
 
   react-router@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -34046,6 +35676,12 @@ snapshots:
       react: 19.2.6
       use-sync-external-store: 1.6.0(react@19.2.6)
 
+  react-supergrid@1.0.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(transformation-matrix@3.1.0):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      transformation-matrix: 3.1.0
+
   react-textarea-autosize@8.5.9(@types/react@19.2.14)(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -34060,6 +35696,10 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.2.6: {}
 
@@ -34249,6 +35889,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  rename-keys@1.2.0: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -34354,6 +35996,17 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.1
       '@rolldown/binding-win32-x64-msvc': 1.0.1
 
+  rollup-plugin-dts@6.4.1(rollup@4.60.3)(typescript@6.0.3):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      convert-source-map: 2.0.0
+      magic-string: 0.30.21
+      rollup: 4.60.3
+      typescript: 6.0.3
+    optionalDependencies:
+      '@babel/code-frame': 7.29.0
+
   rollup-plugin-typescript2@0.36.0(rollup@4.60.3)(typescript@6.0.3):
     dependencies:
       '@rollup/pluginutils': 4.2.1
@@ -34455,6 +36108,8 @@ snapshots:
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
+
+  s-expression@3.1.1: {}
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -34610,6 +36265,12 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  scheduler@0.26.0: {}
+
   scheduler@0.27.0: {}
 
   schema-utils@3.3.0:
@@ -34631,6 +36292,14 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  schematic-symbols@0.0.202(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  schematic-symbols@0.0.208(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   scroll-into-view-if-needed@3.0.10:
     dependencies:
@@ -34797,6 +36466,20 @@ snapshots:
   shallow-clone@3.0.1:
     dependencies:
       kind-of: 6.0.3
+
+  sharp@0.32.6:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      node-addon-api: 6.1.0
+      prebuild-install: 7.1.3
+      semver: 7.8.0
+      simple-get: 4.0.1
+      tar-fs: 3.1.2
+      tunnel-agent: 0.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
 
   sharp@0.34.5:
     dependencies:
@@ -35094,6 +36777,10 @@ snapshots:
 
   speedometer@1.0.0: {}
 
+  spicey@0.0.14(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   split2@3.2.2:
     dependencies:
       readable-stream: 3.6.2
@@ -35190,6 +36877,15 @@ snapshots:
       text-decoder: 1.2.3
     optionalDependencies:
       bare-events: 2.5.4
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
 
   string-argv@0.3.2:
     optional: true
@@ -35334,6 +37030,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.3.0: {}
+
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -35372,6 +37070,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
 
   sugar-high@0.7.5: {}
 
@@ -35421,6 +37129,10 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
+  svg-path-commander@2.2.1:
+    dependencies:
+      '@thednp/dommatrix': 3.0.4
+
   svgo@3.3.3:
     dependencies:
       commander: 7.2.0
@@ -35440,6 +37152,11 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.6.0
+
+  svgson@5.3.1:
+    dependencies:
+      deep-rename-keys: 0.2.1
+      xml-reader: 2.4.3
 
   swagger-schema-official@2.0.0-bab6bed: {}
 
@@ -35529,6 +37246,17 @@ snapshots:
       pump: 3.0.2
       tar-stream: 2.2.0
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.3
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+
   tar-stream@1.6.2:
     dependencies:
       bl: 1.2.3
@@ -35581,6 +37309,13 @@ snapshots:
     dependencies:
       bintrees: 1.0.2
 
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+    optional: true
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -35631,6 +37366,14 @@ snapshots:
 
   text-extensions@2.4.0: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   thingies@1.21.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
@@ -35638,6 +37381,8 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  three@0.179.1: {}
 
   through2@2.0.5:
     dependencies:
@@ -35746,6 +37491,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  transformation-matrix@2.16.1: {}
+
+  transformation-matrix@3.1.0: {}
+
   tree-dump@1.0.2(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
@@ -35765,6 +37514,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  ts-interface-checker@0.1.13: {}
 
   ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(esbuild@0.28.0)(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.9.0)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
@@ -35822,6 +37573,91 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
 
+  tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3):
+    dependencies:
+      '@flatten-js/core': 1.6.12
+      '@lume/kiwi': 0.4.4
+      '@resvg/resvg-js': 2.6.2
+      '@rollup/plugin-commonjs': 29.0.2(rollup@4.60.3)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.3)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.3)
+      '@rollup/plugin-typescript': 12.3.0(rollup@4.60.3)(tslib@2.8.1)(typescript@6.0.3)
+      '@tscircuit/alphabet': 0.0.25(typescript@6.0.3)
+      '@tscircuit/capacity-autorouter': 0.0.523(typescript@6.0.3)
+      '@tscircuit/checks': 0.0.130(@flatten-js/core@1.6.12)(@tscircuit/math-utils@0.0.36(typescript@6.0.3))(circuit-json-to-connectivity-map@0.0.23(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
+      '@tscircuit/circuit-json-util': 0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      '@tscircuit/cli': 0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))
+      '@tscircuit/copper-pour-solver': 0.0.29(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)(typescript@6.0.3)
+      '@tscircuit/core': 0.0.1258(uve2whivusifsi5x4fkve2wfpu)
+      '@tscircuit/eval': 0.0.855(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
+      '@tscircuit/footprinter': 0.0.357(circuit-json@0.0.425)(typescript@6.0.3)
+      '@tscircuit/infer-cable-insertion-point': 0.0.2(typescript@6.0.3)
+      '@tscircuit/infgrid-ijump-astar': 0.0.35
+      '@tscircuit/internal-dynamic-import': 0.0.2
+      '@tscircuit/krt-wasm': 0.1.3(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))
+      '@tscircuit/matchpack': 0.0.16(typescript@6.0.3)
+      '@tscircuit/math-utils': 0.0.36(typescript@6.0.3)
+      '@tscircuit/miniflex': 0.0.4(typescript@6.0.3)
+      '@tscircuit/ngspice-spice-engine': 0.0.8(@tscircuit/props@0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)
+      '@tscircuit/props': 0.0.531(circuit-json@0.0.425)(react@19.2.6)(zod@3.25.76)
+      '@tscircuit/runframe': 0.0.1982(@tscircuit/core@0.0.1258(uve2whivusifsi5x4fkve2wfpu))(circuit-json@0.0.425)(typescript@6.0.3)(zod@3.25.76)
+      '@tscircuit/schematic-match-adapt': 0.0.16(typescript@6.0.3)
+      '@tscircuit/schematic-trace-solver': 0.0.57(typescript@6.0.3)
+      '@tscircuit/simple-3d-svg': 0.0.41
+      '@tscircuit/solver-utils': 0.0.3(typescript@6.0.3)
+      '@tscircuit/soup-util': 0.0.41(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76)
+      bpc-graph: 0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3)
+      calculate-cell-boundaries: 0.0.1(typescript@6.0.3)
+      calculate-elbow: 0.0.12(typescript@6.0.3)
+      calculate-packing: 0.0.73(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(typescript@6.0.3)
+      circuit-json: 0.0.425
+      circuit-json-to-bpc: 0.0.13(bpc-graph@0.0.57(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(typescript@6.0.3))(circuit-json@0.0.425)(typescript@6.0.3)
+      circuit-json-to-connectivity-map: 0.0.23(typescript@6.0.3)
+      circuit-json-to-gltf: 0.0.96(@resvg/resvg-js@2.6.2)(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(@tscircuit/footprinter@0.0.357(circuit-json@0.0.425)(typescript@6.0.3))(circuit-json@0.0.425)(circuit-to-svg@0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.179.1)(typescript@6.0.3)
+      circuit-json-to-simple-3d: 0.0.9(typescript@6.0.3)
+      circuit-json-to-spice: 0.0.34(@tscircuit/circuit-json-util@0.0.94(circuit-json@0.0.425)(transformation-matrix@2.16.1)(zod@3.25.76))(circuit-json@0.0.425)(typescript@6.0.3)
+      circuit-to-svg: 0.0.345(@tscircuit/alphabet@0.0.25(typescript@6.0.3))(typescript@6.0.3)
+      comlink: 4.4.2
+      connectivity-map: 1.0.0(typescript@6.0.3)
+      css-select: 5.1.0
+      debug: 4.4.3
+      flatbush: 4.5.1
+      format-si-unit: 0.0.3(typescript@6.0.3)
+      graphics-debug: 0.0.89(bun-match-svg@0.0.15(typescript@6.0.3))(looks-same@9.0.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      jscad-planner: 0.0.13(typescript@6.0.3)
+      kicad-component-converter: 0.1.40
+      kicad-to-circuit-json: 0.0.60(typescript@6.0.3)
+      kicadts: 0.0.35(typescript@6.0.3)
+      manifold-3d: 3.4.1(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(esbuild-wasm@0.27.7)
+      minicssgrid: 0.0.9(typescript@6.0.3)
+      performance-now: 2.1.0
+      poppygl: 0.0.16(typescript@6.0.3)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      rollup: 4.60.3
+      rollup-plugin-dts: 6.4.1(rollup@4.60.3)(typescript@6.0.3)
+      s-expression: 3.1.1
+      schematic-symbols: 0.0.208(typescript@6.0.3)
+      spicey: 0.0.14(typescript@6.0.3)
+      sucrase: 3.35.1
+      svg-path-commander: 2.2.1
+      transformation-matrix: 2.16.1
+      tslib: 2.8.1
+      typescript: 6.0.3
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@gltf-transform/core'
+      - '@gltf-transform/extensions'
+      - '@gltf-transform/functions'
+      - '@resvg/resvg-wasm'
+      - '@tscircuit/schematic-corpus'
+      - bun-match-svg
+      - esbuild-wasm
+      - jscad-fiber
+      - looks-same
+      - supports-color
+      - three
+
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
@@ -35847,6 +37683,12 @@ snapshots:
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tsyringe@4.10.0:
     dependencies:
@@ -36051,6 +37893,8 @@ snapshots:
     dependencies:
       qs: 6.15.1
 
+  uniq@1.0.1: {}
+
   unique-filename@1.1.1:
     dependencies:
       unique-slug: 2.0.2
@@ -36096,7 +37940,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.0(@microsoft/api-extractor@7.52.8(@types/node@25.9.0))(@rspack/core@1.6.8(@swc/helpers@0.5.21))(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(webpack@5.105.4):
+  unplugin-dts@1.0.0(@microsoft/api-extractor@7.52.8(@types/node@25.9.0))(@rspack/core@1.6.8(@swc/helpers@0.5.21))(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
       '@volar/typescript': 2.4.28
@@ -36113,7 +37957,7 @@ snapshots:
       esbuild: 0.28.0
       rolldown: 1.0.1
       rollup: 4.60.3
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.0)(webpack-cli@7.0.2(webpack-dev-server@5.2.4)(webpack@5.105.4))
     transitivePeerDependencies:
       - supports-color
@@ -36229,6 +38073,11 @@ snapshots:
       use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-mouse-matrix-transform@1.3.5(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      transformation-matrix: 3.1.0
 
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:
@@ -36373,13 +38222,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-dts@5.0.0(@microsoft/api-extractor@7.52.8(@types/node@25.9.0))(@rspack/core@1.6.8(@swc/helpers@0.5.21))(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(webpack@5.105.4):
+  vite-plugin-dts@5.0.0(@microsoft/api-extractor@7.52.8(@types/node@25.9.0))(@rspack/core@1.6.8(@swc/helpers@0.5.21))(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(webpack@5.105.4):
     dependencies:
-      unplugin-dts: 1.0.0(@microsoft/api-extractor@7.52.8(@types/node@25.9.0))(@rspack/core@1.6.8(@swc/helpers@0.5.21))(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(webpack@5.105.4)
+      unplugin-dts: 1.0.0(@microsoft/api-extractor@7.52.8(@types/node@25.9.0))(@rspack/core@1.6.8(@swc/helpers@0.5.21))(esbuild@0.28.0)(rolldown@1.0.1)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(webpack@5.105.4)
     optionalDependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@25.9.0)
       rollup: 4.60.3
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/language-core'
@@ -36389,18 +38238,18 @@ snapshots:
       - typescript
       - webpack
 
-  vite-plugin-pwa@1.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.4.1):
+  vite-plugin-pwa@1.3.0(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.16
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       workbox-build: 7.3.0(@types/babel__core@7.20.5)
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0):
+  vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -36417,12 +38266,13 @@ snapshots:
       sass-embedded: 1.89.0
       stylus: 0.64.0
       terser: 5.47.1
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -36439,7 +38289,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass-embedded@1.89.0)(sass@1.89.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -37017,7 +38867,18 @@ snapshots:
     dependencies:
       sax: 1.6.0
 
+  xml-lexer@0.2.2:
+    dependencies:
+      eventemitter3: 2.0.3
+
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
+
+  xml-reader@2.4.3:
+    dependencies:
+      eventemitter3: 2.0.3
+      xml-lexer: 0.2.2
 
   xml2js@0.6.2:
     dependencies:
@@ -37142,6 +39003,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'apps/attractap/hardware/*'


### PR DESCRIPTION
## Summary

- Scaffolds `apps/attractap/hardware/` as the home for tscircuit-authored PCB designs, plus a shared `scripts/render-png.mjs` (SVG → PNG via `sharp`).
- Adds a one-LED `_placeholder/` board that exercises all four nx targets (`lint`/`build`/`export`/`render`) end-to-end so the toolchain is provably wired before any real board lands.
- Pins `tscircuit@0.0.1774` + `@tscircuit/cli@0.1.1399` (2026-05-21) inside a per-board pnpm workspace (`pnpm-workspace.yaml: apps/attractap/hardware/*`) so the toolchain's `zod@3` transitive deps stay isolated from the repo-wide `zod@4`.
- Adds `.github/workflows/hardware.yml` — triggers on `apps/attractap/hardware/**` (and the future `libs/attractap-hw-shared/**`), runs `pnpm nx affected -t lint,build,export,render --projects=tag:scope:hardware`, uploads gerber ZIPs + render PNGs as artifacts, and posts a sticky PR comment via `marocchino/sticky-pull-request-comment` (imgur-inlined when `IMGUR_CLIENT_ID` is set, file-listing fallback otherwise).
- README documents the pinned versions, the four targets, "add a board in <30 min" steps, and the JLCPCB upload workflow.
- `nx.json`: scopes `max-warnings=0` to `@nx/eslint:lint` so the hardware `nx:run-commands` lint target isn't rejected; adds `hardware.yml` to shared globals.
- `.gitignore`: excludes hardware `dist/`, `.tscircuit/`, and stray `index.circuit.json` caches.

Closes ATT-346.

## Acceptance check (run locally)

```
$ pnpm nx run-many -t lint,build,export,render --projects=tag:scope:hardware
 NX   Successfully ran targets lint, build, export, render for project attractap-hw-placeholder
```

Gerber ZIP contents (JLC-ready, drop-in upload):

```
$ unzip -l apps/attractap/hardware/_placeholder/dist/export/_placeholder-gerbers.zip
F_Cu.gbr F_SilkScreen.gbr F_Mask.gbr F_Paste.gbr
B_Cu.gbr B_SilkScreen.gbr B_Mask.gbr B_Paste.gbr
Edge_Cuts.gbr drill.drl drill_npth.drl
bom.csv pick_and_place.csv
```

Render outputs (PNG + SVG):

```
dist/render/_placeholder-pcb.{svg,png}
dist/render/_placeholder-schematic.{svg,png}
dist/render/_placeholder-assembly.{svg,png}
```

## Test plan

- [ ] CI green: `hardware` workflow runs lint/build/export/render on this PR.
- [ ] Workflow artifacts include `hardware-gerbers-<pr>-<attempt>` (zip) and `hardware-renders-<pr>-<attempt>` (PNGs).
- [ ] Sticky PR comment "Hardware render previews" is posted by `marocchino/sticky-pull-request-comment` (header: `hardware-renders`). Without `IMGUR_CLIENT_ID` it shows the file listing — set the secret later to inline images.
- [ ] Existing repo lint/typecheck/test still pass (verified via pre-commit hook).

## Out of scope

- No real boards (handled by P1.5 / P2 tickets).
- No 4-layer DRC ruleset overrides (boards opt in per ticket).
- No nx release pipeline for boards.

## Follow-up

`_placeholder/` is the toolchain smoke test only — drop it once the Beeper board (P1.5) lands.

<!-- generated-by-cyrus -->