### PR TITLE
fix(frontend): open editor on email template row click (ATT-372)

### DIFF
--- a/apps/frontend/src/app/email-templates/EmailTemplatesPage.tsx
+++ b/apps/frontend/src/app/email-templates/EmailTemplatesPage.tsx
@@ -59,7 +59,7 @@ export function EmailTemplatesPage() {
             <TableRow
               key={item.key}
               id={item.key}
-              className="cursor-pointer hover:bg-primary-50 transition-bg duration-300"
+              className="cursor-pointer hover:bg-primary-50 transition-colors duration-300"
               onAction={() => openEditor(item.key)}
             >
               <TableCell>{item.type}</TableCell>

--- a/apps/frontend/src/app/email-templates/EmailTemplatesPage.tsx
+++ b/apps/frontend/src/app/email-templates/EmailTemplatesPage.tsx
@@ -2,16 +2,25 @@ import { useEmailTemplatesServiceEmailTemplateControllerFindAll } from '@attracc
 import { Table, TableContent, TableHeader, TableColumn, TableBody, TableRow, TableCell, Button } from '@heroui/react';
 import { Edit3, Mail } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { useNavigate } from 'react-router-dom';
 import { PageHeader } from '../../components/pageHeader'; // Assuming PageHeader exists
 import { EmptyState } from '../../components/emptyState';
 
 import en from './en.json';
 import de from './de.json';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export function EmailTemplatesPage() {
   const { t } = useTranslations({ en, de });
+  const navigate = useNavigate();
   const { data: emailTemplates } = useEmailTemplatesServiceEmailTemplateControllerFindAll();
+
+  const openEditor = useCallback(
+    (type: string) => {
+      navigate(`/email-templates/${type}`);
+    },
+    [navigate],
+  );
 
   const tableItems = useMemo(() => {
     return (emailTemplates ?? []).map((item) => ({
@@ -19,15 +28,17 @@ export function EmailTemplatesPage() {
       type: t(`templateTypes.${item.type}`),
       subject: item.subject,
       actions: (
-        <Button variant="ghost"
-
-
+        <Button
+          variant="ghost"
           isIconOnly
           aria-label={t('editButton')}
-        ><Edit3 size={18} /></Button>
+          onPress={() => openEditor(item.type)}
+        >
+          <Edit3 size={18} />
+        </Button>
       ),
     }));
-  }, [emailTemplates, t]);
+  }, [emailTemplates, t, openEditor]);
 
   return (
     <>
@@ -45,7 +56,12 @@ export function EmailTemplatesPage() {
           renderEmptyState={() => <EmptyState />}
         >
           {(item) => (
-            <TableRow key={item.key} id={item.key}>
+            <TableRow
+              key={item.key}
+              id={item.key}
+              className="cursor-pointer hover:bg-primary-50 transition-bg duration-300"
+              onAction={() => openEditor(item.key)}
+            >
               <TableCell>{item.type}</TableCell>
               <TableCell>{item.subject}</TableCell>
               <TableCell>{item.actions}</TableCell>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes [ATT-372](https://linear.app/attraccess/issue/ATT-372/email-templates-clicking-a-row-should-open-the-editor). On the email templates list, clicking a row did nothing. Now both the row and the inline edit button navigate to `/email-templates/:type`.

## Changes

- Add `onAction` to each `TableRow` so clicking a row opens the editor for that template type.
- Wire `onPress` on the inline edit `Button` (was previously a no-op).
- Add `cursor-pointer` / hover styling consistent with other clickable tables (`user-management`, `resourceGroupCard`).

## Test plan

- [x] Lint + typecheck pass (`nx lint frontend`)
- [x] Manual browser verification: row click opens editor (screenshots in Linear)
- [x] Manual browser verification: edit button opens editor (screenshot in Linear)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Ensure email template rows and edit actions navigate to the template editor page.

New Features:
- Enable navigation to the email template editor when clicking a row in the templates table.

Bug Fixes:
- Wire the inline edit button in the email templates table to open the corresponding template editor.

Enhancements:
- Add pointer cursor and hover styling to email template table rows to indicate clickability.