### PR TITLE
fix(frontend): restore visible labels on usage-based billing editor (ATT-364)

### DIFF
--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/editor/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/editor/index.tsx
@@ -10,6 +10,7 @@ import {
   DrawerFooter,
   DrawerHeader,
   Form,
+  Label,
   NumberField,
   NumberFieldDecrementButton,
   NumberFieldGroup,
@@ -139,12 +140,12 @@ export function ResourceBillingInfoEditor(props: Props) {
         <DrawerBody>
           <Form onSubmit={onSubmit} className="flex flex-col gap-4">
             <NumberField
-              aria-label={t('inputs.creditsPerUsage.label', { currency: configuration.currency })}
               value={creditsPerUsage}
               minValue={0}
               onChange={(value) => setCreditsPerUsage(value)}
               defaultValue={0}
             >
+              <Label>{t('inputs.creditsPerUsage.label', { currency: configuration.currency })}</Label>
               <NumberFieldGroup>
                 <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
                 <NumberFieldInput />
@@ -152,12 +153,12 @@ export function ResourceBillingInfoEditor(props: Props) {
               </NumberFieldGroup>
             </NumberField>
             <NumberField
-              aria-label={t('inputs.creditsPerMinute.label', { currency: configuration.currency })}
               value={creditsPerMinute}
               minValue={0}
               onChange={(value) => setCreditsPerMinute(value)}
               defaultValue={0}
             >
+              <Label>{t('inputs.creditsPerMinute.label', { currency: configuration.currency })}</Label>
               <NumberFieldGroup>
                 <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
                 <NumberFieldInput />


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Restore visible labels on the usage-based pricing edit drawer.

In HeroUI v3 a `NumberField` only renders a visible label when a `<Label>` child is provided — `aria-label` alone leaves the input visually unlabeled. The drawer used `aria-label` for both inputs, so users saw two unlabeled spinners.

This change swaps `aria-label` for a `<Label>` slot child on both `NumberField`s, restoring the visible "EUR pro Nutzung" and "EUR pro Minute" labels while keeping the same translation keys.

## Implementation

- `apps/frontend/src/app/resources/details/resourceBillingInfo/editor/index.tsx`: import `Label`, drop `aria-label`, add `<Label>` child to each `NumberField`.

## Verification

Manual browser run on the affected drawer with a seeded admin + machine resource. Labels render above the inputs as expected (see Linear issue for screenshot).

Linear: [ATT-364](https://linear.app/attraccess/issue/ATT-364/usage-based-pricing-edit-drawer-has-no-labels-for-inputs)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Display translated visible labels for the usage-per-usage and usage-per-minute number fields instead of relying on aria-labels that are not rendered as labels in HeroUI v3.