### PR TITLE
fix(frontend): placeholder icon for resources without image (ATT-362)

### DIFF
--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
@@ -153,7 +153,8 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
                       height={48}
                       width={48}
                       src={filenameToUrl(resource.imageFilename)}
-                      alt={resource.name}
+                      alt=""
+                      aria-hidden="true"
                       className="object-contain"
                       style={{ height: 48, width: 48 }}
                     />
@@ -161,7 +162,7 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
                     <div
                       className="flex items-center justify-center text-default-400"
                       style={{ height: 48, width: 48 }}
-                      aria-label={resource.name}
+                      aria-hidden="true"
                     >
                       <ShapesIcon className="w-6 h-6" />
                     </div>

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { filenameToUrl } from '../../../api';
 import { StatusChip } from './statusChip';
-import { ChevronRightIcon } from 'lucide-react';
+import { ChevronRightIcon, ShapesIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useAuth } from '../../../hooks/useAuth';
 import { useDebounce } from '../../../hooks/useDebounce';
@@ -148,14 +148,24 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
             {(resource) => (
               <TableRow key={resource.id} id={resource.id} className="cursor-pointer hover:bg-primary-50 transition-bg duration-300" onAction={() => navigate(`/resources/${resource.id}`)}>
                 <TableCell>
-                  <img
-                    height={48}
-                    width={48}
-                    src={filenameToUrl(resource.imageFilename)}
-                    alt={resource.name}
-                    className="object-contain"
-                    style={{ height: 48, width: 48 }}
-                  />
+                  {resource.imageFilename ? (
+                    <img
+                      height={48}
+                      width={48}
+                      src={filenameToUrl(resource.imageFilename)}
+                      alt={resource.name}
+                      className="object-contain"
+                      style={{ height: 48, width: 48 }}
+                    />
+                  ) : (
+                    <div
+                      className="flex items-center justify-center text-default-400"
+                      style={{ height: 48, width: 48 }}
+                      aria-label={resource.name}
+                    >
+                      <ShapesIcon className="w-6 h-6" />
+                    </div>
+                  )}
                 </TableCell>
                 <TableCell>{resource.name}</TableCell>
                 <TableCell className="text-right">


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

- Resource list "Bild" column rendered a broken-image icon for resources without a picture.
- Now renders a neutral `ShapesIcon` placeholder in a 48x48 cell when `resource.imageFilename` is null/empty, matching the fallback already used in `resourceDetails.tsx`.

## Implementation

`apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx`:
- Imported `ShapesIcon` from `lucide-react`.
- Wrapped the existing `<img>` in a conditional on `resource.imageFilename`; renders the icon in a `text-default-400` 48x48 container when no image is set.

## Verification

- Started dev API + frontend, seeded `devadmin`, created a `machine` resource via the API with no image.
- Logged into the frontend and confirmed both rows in the "Nicht gruppiert" group render the placeholder icon in the "Bild" column (no broken-image glyph).

![resources list with placeholder](https://public.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/7b9a0080-eaf4-4827-9dc3-07d22753b9a8/51d43c04-b94e-474b-b068-7a9ff0656f14)

## Test plan

- [x] `pnpm nx typecheck frontend`
- [x] `pnpm nx lint frontend`
- [x] `pnpm nx test frontend` (76 tests pass)
- [x] Manual browser verification on `/resources` with a no-image resource

Linear: [ATT-362](https://linear.app/attraccess/issue/ATT-362/resource-thumbnail-renders-as-broken-image-when-resource-has-no)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Render a neutral placeholder icon for resources without images in the resource overview list to avoid broken image thumbnails.

Bug Fixes:
- Prevent broken-image thumbnails in the resource overview when a resource has no associated image.

Enhancements:
- Align the resource overview thumbnail behavior with the existing placeholder logic used in resource details for missing images.