### PR TITLE
fix(frontend): keep Geräte-Einrichtung menu button on one line (ATT-368)

### DIFF
--- a/apps/frontend/src/app/attractap/AttractapList/index.tsx
+++ b/apps/frontend/src/app/attractap/AttractapList/index.tsx
@@ -114,7 +114,7 @@ export function AttractapList() {
               <WebSerialConsole>
                 {(onOpenSerialConsole) => (
                   <Dropdown>
-                    <DropdownTrigger className={buttonVariants({ variant: 'ghost' })}>
+                    <DropdownTrigger className={`${buttonVariants({ variant: 'ghost' })} whitespace-nowrap`}>
                       <MoreVertical className="w-4 h-4" />
                       {t('page.actions.menu')}
                     </DropdownTrigger>


### PR DESCRIPTION
## Summary
- Add `whitespace-nowrap` to the Attractap list `DropdownTrigger` so the German label "Geräte-Einrichtung" no longer wraps at the hyphen.
- Icon + label now render on a single line, as required by ATT-368.

## Why
`DropdownTrigger` inherits HeroUI button styling via `buttonVariants({ variant: 'ghost' })`, but that class set does not enforce `white-space: nowrap`. The browser broke the label at the hyphen at the page header's available width, producing a two-line button.

## Linear
- ATT-368 (parent: ATT-280 HeroUI v3 migration QA)

## Test plan
- [ ] Manual: open `/attractap`, confirm the "Geräte-Einrichtung" trigger renders on one line with the icon to the left.
- [ ] Manual: dropdown still opens and shows Serial Console / Hardware Setup items.
- [ ] Visual verification (screenshots) pending — agent could not boot dev server in this worktree (no installed node_modules).

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Prevent the Attractap Geräte-Einrichtung dropdown trigger label from wrapping onto two lines by enforcing no-wrap whitespace.