### PR TITLE
fix(frontend): remove stray gray squares in usage history table (ATT-363)

### DIFF
--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableHeaders.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableHeaders.tsx
@@ -27,7 +27,6 @@ export function generateHeaderColumns(
       <TableColumn key="project" id="project" className="hidden 2xl:table-cell">
         {t('headers.machine.project')}
       </TableColumn>,
-      <TableColumn key="icons" id="icons">{''}</TableColumn>,
     );
   } else if (resource.type === 'door') {
     headers.push(

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableRows.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableRows.tsx
@@ -39,20 +39,20 @@ export function generateRowCells(
         <DateTimeDisplay date={session.endTime} />
       </TableCell>,
       <TableCell key={`duration-${session.id}`} className="whitespace-nowrap">
-        <DurationDisplay
-          minutes={session.usageInMinutes >= 0 ? session.usageInMinutes : null}
-          alternativeText={
-            <Chip color="accent" variant="soft">
-              {t('rows.machine.inProgress')}
-            </Chip>
-          }
-        />
+        <div className="flex items-center gap-2">
+          <DurationDisplay
+            minutes={session.usageInMinutes >= 0 ? session.usageInMinutes : null}
+            alternativeText={
+              <Chip color="accent" variant="soft">
+                {t('rows.machine.inProgress')}
+              </Chip>
+            }
+          />
+          {hasNotes && <MessageSquareText className="w-4 h-4" />}
+        </div>
       </TableCell>,
       <TableCell key={`project-${session.id}`} className="hidden 2xl:table-cell">
         {projectCellRenderer ? projectCellRenderer(session) : session.project?.name}
-      </TableCell>,
-      <TableCell key={`icons-${session.id}`} className="flex items-center gap-2">
-        {hasNotes && <MessageSquareText />}
       </TableCell>,
     );
   } else if (resource.type === 'door') {

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableRows.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableRows.tsx
@@ -48,7 +48,9 @@ export function generateRowCells(
               </Chip>
             }
           />
-          {hasNotes && <MessageSquareText className="w-4 h-4" />}
+          {hasNotes && (
+            <MessageSquareText className="w-4 h-4" role="img" aria-label={t('rows.machine.hasNotes')} />
+          )}
         </div>
       </TableCell>,
       <TableCell key={`project-${session.id}`} className="hidden 2xl:table-cell">

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/translations/de.json
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/translations/de.json
@@ -28,6 +28,7 @@
     },
     "machine": {
       "inProgress": "In Benutzung",
+      "hasNotes": "Diese Sitzung hat Notizen",
       "project": {
         "unassigned": "Nicht zugewiesen",
         "updateSuccess": "Projekt aktualisiert",

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/translations/en.json
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/translations/en.json
@@ -28,6 +28,7 @@
     },
     "machine": {
       "inProgress": "In Use",
+      "hasNotes": "This session has notes",
       "project": {
         "unassigned": "Unassigned",
         "updateSuccess": "Project updated",


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Resolves [ATT-363](https://linear.app/attraccess/issue/ATT-363/resource-usage-history-table-shows-stray-gray-squares-at-row-end) — gray squares at the end of every row in the machine-type resource usage history table.

The `machine` row template defined an extra trailing `icons` TableColumn whose cell only rendered the notes indicator when notes existed. When a row had no notes the cell rendered empty, and HeroUI v3 paints empty `TableCell`s as visible blocks — producing the reported gray squares.

## Implementation

- Dropped the trailing `icons` TableColumn from `tableHeaders.tsx`.
- Inlined `MessageSquareText` into the existing `duration` cell so notes still surface alongside the duration value, without leaving an empty cell.

## Testing

- `pnpm nx affected --uncommitted --target=lint,typecheck` → clean (only a pre-existing unrelated warning).
- `pnpm nx affected --uncommitted --target=test --passWithNoTests` → 76 passed.
- Manual browser verification on the resource details page: history table now shows three clean columns with the notes icon appearing next to the duration only when notes exist.

| Before (parent issue screenshot 2) | After |
| - | - |
| Gray square at end of every row | Clean rows, notes icon inline beside duration |

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Fix layout of machine resource usage history table to remove stray gray cells while preserving notes visibility.

Bug Fixes:
- Eliminate empty trailing column in machine usage history rows that rendered as gray squares at the end of each row.

Enhancements:
- Display the notes icon inline next to the duration in machine usage history rows instead of in a separate icons column.