### PR TITLE
fix(frontend): populate email template editor on load (ATT-373)

### DIFF
--- a/apps/frontend/src/app/email-templates/edit/index.tsx
+++ b/apps/frontend/src/app/email-templates/edit/index.tsx
@@ -214,7 +214,7 @@ export function EditEmailTemplatePage() {
           <Editor
             theme={theme === 'dark' ? 'vs-dark' : 'vs-light'}
             defaultLanguage="mjml"
-            defaultValue={body}
+            value={body}
             onChange={(value) => setBody(value ?? '')}
             onMount={handleEditorMount}
           />


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes ATT-373 — email template editor pane was empty on load while the preview rendered correctly.

**Root cause:** Monaco's `defaultValue` is only honored on initial mount. Since the template body is fetched async, `body` was `''` at mount time. When `setBody(template.data.body)` later ran, Monaco ignored the prop change and the editor stayed empty.

**Fix:** Switch the Monaco editor to controlled mode by replacing `defaultValue={body}` with `value={body}` in `apps/frontend/src/app/email-templates/edit/index.tsx`. `onChange` already syncs back to state, so this is a one-line change.

## Linear issue

[ATT-373](https://linear.app/attraccess/issue/ATT-373/email-templates-editor-editor-pane-is-empty-on-load-initial-value-not)

## Test plan

- [x] `pnpm nx affected -t lint,typecheck,build` passes
- [x] Browser verified: editor body populates on load (inline view + expanded drawer); preview iframe still renders. Screenshots posted on the Linear issue.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Populate the email template editor content once the template body is loaded so the editor pane is no longer empty on initial load.