### PR TITLE
fix(csv-export): restore RangeCalendar after HeroUI v3 migration (ATT-375)

### DIFF
--- a/apps/frontend/src/app/csv-export/base-modal/column-picker.tsx
+++ b/apps/frontend/src/app/csv-export/base-modal/column-picker.tsx
@@ -1,0 +1,132 @@
+// Column picker for CSV export modal — search, bulk select, multi-select list
+// FEATURE: CSV export — modal left pane for choosing which columns to include
+import { Button, Checkbox, Input, InputGroup, Label, TextField } from '@heroui/react';
+import { SearchIcon } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+interface ColumnLite {
+  key: string;
+  label: string;
+}
+
+interface OptionLite {
+  key: string;
+  label: string;
+  value: boolean;
+}
+
+interface Props {
+  columns: ColumnLite[];
+  selectedKeys: string[];
+  onSelectionChange: (keys: string[]) => void;
+  options?: OptionLite[];
+  onOptionChange?: (key: string, next: boolean) => void;
+  searchLabel: string;
+  searchPlaceholder: string;
+  selectAllLabel: string;
+  selectNoneLabel: string;
+  selectedCountLabel: (vars: { selected: number; total: number }) => string;
+}
+
+export function ColumnPicker(props: Props) {
+  const {
+    columns,
+    selectedKeys,
+    onSelectionChange,
+    options,
+    onOptionChange,
+    searchLabel,
+    searchPlaceholder,
+    selectAllLabel,
+    selectNoneLabel,
+    selectedCountLabel,
+  } = props;
+
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return columns;
+    return columns.filter((col) => col.label.toLowerCase().includes(q));
+  }, [columns, search]);
+
+  return (
+    <div className="flex flex-col gap-3 min-w-0">
+      <TextField value={search} onChange={setSearch} className="w-full" data-cy="csv-export-column-search">
+        <Label className="text-sm font-medium">{searchLabel}</Label>
+        <InputGroup>
+          <SearchIcon className="size-4 ml-2 text-muted-foreground" />
+          <Input placeholder={searchPlaceholder} />
+        </InputGroup>
+      </TextField>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            variant="outline"
+            onPress={() => onSelectionChange(columns.map((c) => c.key))}
+            data-cy="csv-export-select-all"
+          >
+            {selectAllLabel}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onPress={() => onSelectionChange([])}
+            data-cy="csv-export-select-none"
+          >
+            {selectNoneLabel}
+          </Button>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {selectedCountLabel({ selected: selectedKeys.length, total: columns.length })}
+        </span>
+      </div>
+
+      <div
+        className="flex flex-col gap-1 max-h-72 overflow-y-auto border border-default-100 rounded-md p-2"
+        data-cy="resource-usage-export-columns-listbox"
+      >
+        {filtered.map((column) => {
+          const isChecked = selectedKeys.includes(column.key);
+          return (
+            <Checkbox
+              key={column.key}
+              isSelected={isChecked}
+              onChange={(next) => {
+                if (next) onSelectionChange([...selectedKeys, column.key]);
+                else onSelectionChange(selectedKeys.filter((k) => k !== column.key));
+              }}
+              className="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer hover:bg-default-100"
+            >
+              <Checkbox.Control>
+                <Checkbox.Indicator />
+              </Checkbox.Control>
+              <Checkbox.Content className="text-sm">{column.label}</Checkbox.Content>
+            </Checkbox>
+          );
+        })}
+      </div>
+
+      {(options ?? []).length > 0 && (
+        <div className="flex flex-col gap-2 pt-2 border-t border-default-100">
+          {(options ?? []).map((option) => (
+            <Checkbox
+              key={option.key}
+              isSelected={option.value}
+              onChange={(nextValue) => onOptionChange?.(option.key, nextValue)}
+              className="flex items-center gap-2 cursor-pointer"
+              data-cy="resource-usage-export-grouping-checkbox"
+            >
+              <Checkbox.Control>
+                <Checkbox.Indicator />
+              </Checkbox.Control>
+              <Checkbox.Content className="text-sm">{option.label}</Checkbox.Content>
+            </Checkbox>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/csv-export/base-modal/de.json
+++ b/apps/frontend/src/app/csv-export/base-modal/de.json
@@ -4,11 +4,20 @@
   },
   "inputs": {
     "columns": {
-      "label": "Spalten"
+      "label": "Spalten",
+      "search": "Spalten suchen",
+      "selectAll": "Alle",
+      "selectNone": "Keine",
+      "selectedCount": "{{selected}} / {{total}} ausgewählt"
     }
+  },
+  "preview": {
+    "title": "Vorschau (erste {{n}})",
+    "rowCount": "{{count}} Datensätze gesamt"
   },
   "actions": {
     "refetch": "Aktualisieren",
-    "downloadCsv": "CSV herunterladen"
+    "downloadCsv": "CSV herunterladen",
+    "cancel": "Abbrechen"
   }
 }

--- a/apps/frontend/src/app/csv-export/base-modal/en.json
+++ b/apps/frontend/src/app/csv-export/base-modal/en.json
@@ -4,11 +4,20 @@
   },
   "inputs": {
     "columns": {
-      "label": "Columns"
+      "label": "Columns",
+      "search": "Search columns",
+      "selectAll": "All",
+      "selectNone": "None",
+      "selectedCount": "{{selected}} / {{total}} selected"
     }
+  },
+  "preview": {
+    "title": "Preview (first {{n}})",
+    "rowCount": "{{count}} total rows"
   },
   "actions": {
     "refetch": "Refresh",
-    "downloadCsv": "Download CSV"
+    "downloadCsv": "Download CSV",
+    "cancel": "Cancel"
   }
 }

--- a/apps/frontend/src/app/csv-export/base-modal/index.tsx
+++ b/apps/frontend/src/app/csv-export/base-modal/index.tsx
@@ -1,25 +1,15 @@
-import { ListboxWrapper, useTranslations } from '@attraccess/plugins-frontend-ui';
-import {
-  Button,
-  Checkbox,
-  ListBox,
-  ListBoxItem,
-  ModalBody,
-  ModalFooter,
-  TableBody,
-  TableContent,
-  TableHeader,
-  TableRow,
-  Table,
-  TableColumn,
-  TableCell,
-} from '@heroui/react';
+// Modernized CSV export modal — two pane layout with column picker and preview
+// FEATURE: CSV export — modal body and footer used by every export type
+import { Button, ModalBody, ModalFooter } from '@heroui/react';
 import { QueryStatus } from '@tanstack/react-query';
-import { EmptyState } from '../../../components/emptyState';
-import { RotateCwIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { ColumnPicker } from './column-picker';
+import { PreviewTable } from './preview-table';
 import de from './de.json';
 import en from './en.json';
+
+const PREVIEW_LIMIT = 5;
 
 export interface ColumnDefinition<TData extends Row> {
   label: string;
@@ -51,19 +41,13 @@ interface Props<TData extends Row> {
 
 interface ItemRow {
   key: string;
-  columns: Array<{
-    key: string;
-    value: string;
-  }>;
+  columns: Array<{ key: string; value: string }>;
 }
 
 export function BaseCsvExportModal<TData extends Row>(props: Props<TData>) {
   const { columns, items, refetch, options, setOption, filename, queryStatus } = props;
 
-  const { t } = useTranslations({
-    de,
-    en,
-  });
+  const { t } = useTranslations({ de, en });
 
   const [selectedColumnKeys, setSelectedColumnKeys] = useState<Array<string>>(
     columns.filter((col) => col.selectedByDefault).map((col) => col.key),
@@ -73,117 +57,72 @@ export function BaseCsvExportModal<TData extends Row>(props: Props<TData>) {
     setSelectedColumnKeys(columns.filter((col) => col.selectedByDefault).map((col) => col.key));
   }, [columns]);
 
-  const selectedColumns = useMemo(() => {
-    return columns.filter((col) => selectedColumnKeys.includes(col.key));
-  }, [columns, selectedColumnKeys]);
+  const selectedColumns = useMemo(
+    () => columns.filter((col) => selectedColumnKeys.includes(col.key)),
+    [columns, selectedColumnKeys],
+  );
 
-  const itemRows = useMemo(() => {
-    const rows: ItemRow[] = [];
-
-    items.forEach((item) => {
-      const row: ItemRow = {
-        key: String(item.id),
-        columns: [],
-      };
-      selectedColumns.forEach((columnDefinition) => {
-        const value = columnDefinition.getter(item);
-        const column: ItemRow['columns'][0] = {
-          key: columnDefinition.key,
-          value: String(value ?? ''),
-        };
-        row.columns.push(column);
-      });
-
-      rows.push(row);
-    });
-
-    return rows;
+  const itemRows: ItemRow[] = useMemo(() => {
+    return items.map((item) => ({
+      key: String(item.id),
+      columns: selectedColumns.map((col) => ({
+        key: col.key,
+        value: String(col.getter(item) ?? ''),
+      })),
+    }));
   }, [items, selectedColumns]);
 
   const downloadCsv = useCallback(() => {
     const headerRow = selectedColumns.map((column) => column.label);
-
-    const csv = [headerRow.join(';'), ...itemRows.map((row) => row.columns.map((col) => col.value).join(';'))].join(
-      '\n',
-    );
-
+    const csv = [
+      headerRow.join(';'),
+      ...itemRows.map((row) => row.columns.map((col) => col.value).join(';')),
+    ].join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = filename;
-    if (!filename.endsWith('.csv')) {
-      a.download += '.csv';
-    }
+    a.download = filename.endsWith('.csv') ? filename : `${filename}.csv`;
     a.click();
   }, [selectedColumns, itemRows, filename]);
 
+  const columnsLite = useMemo(() => columns.map((c) => ({ key: c.key, label: c.label })), [columns]);
+
   return (
     <>
-      <ModalBody>
-        <label className="text-sm font-medium">{t('inputs.columns.label')}</label>
-        <ListboxWrapper>
-          <ListBox
-            items={columns}
-            variant="default"
-            onSelectionChange={(keys) => {
-              setSelectedColumnKeys(Array.from(keys as Set<string>));
-            }}
-            data-cy="resource-usage-export-columns-listbox"
-          >
-            {(column) => (
-              <ListBoxItem key={column.key} id={column.key} textValue={column.label}>
-                {column.label}
-              </ListBoxItem>
-            )}
-          </ListBox>
-        </ListboxWrapper>
+      <ModalBody className="grid grid-cols-1 md:grid-cols-[minmax(0,18rem)_minmax(0,1fr)] gap-6">
+        <ColumnPicker
+          columns={columnsLite}
+          selectedKeys={selectedColumnKeys}
+          onSelectionChange={setSelectedColumnKeys}
+          options={options}
+          onOptionChange={setOption}
+          searchLabel={t('inputs.columns.label')}
+          searchPlaceholder={t('inputs.columns.search')}
+          selectAllLabel={t('inputs.columns.selectAll')}
+          selectNoneLabel={t('inputs.columns.selectNone')}
+          selectedCountLabel={(vars) => t('inputs.columns.selectedCount', vars)}
+        />
 
-        <div className="flex gap-4">
-          {refetch && (
-            <Button variant="secondary" onPress={() => refetch()} data-cy="resource-usage-export-refresh-button">
-              {t('actions.refetch')}
-              <RotateCwIcon className={'w-4 h-4 ' + (queryStatus === 'pending' ? 'animate-spin' : '')} />
-            </Button>
-          )}
-
-          {(options ?? []).map((option) => (
-            <Checkbox
-              key={option.key}
-              isSelected={option.value}
-              onChange={(nextValue) => setOption?.(option.key, nextValue)}
-              data-cy="resource-usage-export-grouping-checkbox"
-            >
-              {option.label}
-            </Checkbox>
-          ))}
-        </div>
-
-        <Table data-cy="resource-usage-export-table">
-          <TableContent aria-label={t('table.ariaLabel')}>
-          <TableHeader columns={selectedColumns}>
-            {(column) => (
-              <TableColumn key={column.key} id={column.key} isRowHeader={column.key === selectedColumns[0]?.key}>
-                {column.label}
-              </TableColumn>
-            )}
-          </TableHeader>
-          <TableBody items={itemRows} renderEmptyState={() => <EmptyState />}>
-            {(row) => (
-              <TableRow key={row.key} id={row.key}>
-                {row.columns.map((column) => (
-                  <TableCell style={{ whiteSpace: 'nowrap' }} key={column.key}>
-                    {column.value}
-                  </TableCell>
-                ))}
-              </TableRow>
-            )}
-          </TableBody>
-          </TableContent>
-        </Table>
+        <PreviewTable
+          columns={selectedColumns.map((c) => ({ key: c.key, label: c.label }))}
+          rows={itemRows}
+          totalCount={items.length}
+          previewLimit={PREVIEW_LIMIT}
+          ariaLabel={t('table.ariaLabel')}
+          titleLabel={(vars) => t('preview.title', vars)}
+          rowCountLabel={(vars) => t('preview.rowCount', vars)}
+          refetch={refetch}
+          queryStatus={queryStatus}
+        />
       </ModalBody>
-      <ModalFooter>
-        <Button onPress={() => downloadCsv()} data-cy="resource-usage-export-download-csv-button">
+      <ModalFooter className="justify-end">
+        <Button
+          variant="primary"
+          onPress={() => downloadCsv()}
+          isDisabled={selectedColumns.length === 0 || items.length === 0}
+          data-cy="resource-usage-export-download-csv-button"
+        >
           {t('actions.downloadCsv')}
         </Button>
       </ModalFooter>

--- a/apps/frontend/src/app/csv-export/base-modal/preview-table.tsx
+++ b/apps/frontend/src/app/csv-export/base-modal/preview-table.tsx
@@ -1,0 +1,99 @@
+// Preview table for CSV export modal — first N rows with selected columns
+// FEATURE: CSV export — modal right pane showing data sample before download
+import {
+  Button,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+} from '@heroui/react';
+import { QueryStatus } from '@tanstack/react-query';
+import { RotateCwIcon } from 'lucide-react';
+import { EmptyState } from '../../../components/emptyState';
+
+interface PreviewColumn {
+  key: string;
+  label: string;
+}
+
+interface PreviewRow {
+  key: string;
+  columns: Array<{ key: string; value: string }>;
+}
+
+interface Props {
+  columns: PreviewColumn[];
+  rows: PreviewRow[];
+  totalCount: number;
+  previewLimit: number;
+  ariaLabel: string;
+  titleLabel: (vars: { n: number }) => string;
+  rowCountLabel: (vars: { count: number }) => string;
+  refetch?: () => unknown;
+  queryStatus: QueryStatus;
+}
+
+export function PreviewTable(props: Props) {
+  const { columns, rows, totalCount, previewLimit, ariaLabel, titleLabel, rowCountLabel, refetch, queryStatus } =
+    props;
+
+  const limited = rows.slice(0, previewLimit);
+
+  return (
+    <div className="flex flex-col gap-2 min-w-0">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium">{titleLabel({ n: previewLimit })}</span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">{rowCountLabel({ count: totalCount })}</span>
+          {refetch && (
+            <Button
+              size="sm"
+              variant="outline"
+              isIconOnly
+              onPress={() => refetch()}
+              data-cy="resource-usage-export-refresh-button"
+              aria-label="refresh"
+            >
+              <RotateCwIcon className={'size-4 ' + (queryStatus === 'pending' ? 'animate-spin' : '')} />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto border border-default-100 rounded-md">
+        {queryStatus === 'pending' ? (
+          <div className="flex items-center justify-center py-12">
+            <Spinner />
+          </div>
+        ) : (
+          <Table data-cy="resource-usage-export-table">
+            <TableContent aria-label={ariaLabel}>
+              <TableHeader columns={columns}>
+                {(column) => (
+                  <TableColumn key={column.key} id={column.key} isRowHeader={column.key === columns[0]?.key}>
+                    {column.label}
+                  </TableColumn>
+                )}
+              </TableHeader>
+              <TableBody items={limited} renderEmptyState={() => <EmptyState />}>
+                {(row) => (
+                  <TableRow key={row.key} id={row.key}>
+                    {row.columns.map((column) => (
+                      <TableCell style={{ whiteSpace: 'nowrap' }} key={column.key}>
+                        {column.value}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                )}
+              </TableBody>
+            </TableContent>
+          </Table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/csv-export/date-range-section/compute-range.ts
+++ b/apps/frontend/src/app/csv-export/date-range-section/compute-range.ts
@@ -1,0 +1,67 @@
+// Compute date range presets into RangeValue<DateValue> for HeroUI RangeCalendar
+// FEATURE: CSV export — preset shortcuts for picking common date ranges
+import { CalendarDate, DateValue, getLocalTimeZone, today } from '@internationalized/date';
+import { RangeValue } from '@heroui/react';
+
+export type Preset =
+  | 'today'
+  | 'yesterday'
+  | 'last7d'
+  | 'last30d'
+  | 'thisMonth'
+  | 'lastMonth'
+  | 'thisYear'
+  | 'custom';
+
+export const PRESET_ORDER: Preset[] = [
+  'today',
+  'yesterday',
+  'last7d',
+  'last30d',
+  'thisMonth',
+  'lastMonth',
+  'thisYear',
+  'custom',
+];
+
+function startOfMonth(d: CalendarDate): CalendarDate {
+  return new CalendarDate(d.year, d.month, 1);
+}
+
+function endOfMonth(d: CalendarDate): CalendarDate {
+  return startOfMonth(d).add({ months: 1 }).subtract({ days: 1 });
+}
+
+export function computeRange(preset: Preset): RangeValue<DateValue> | null {
+  const t = today(getLocalTimeZone());
+  switch (preset) {
+    case 'today':
+      return { start: t, end: t };
+    case 'yesterday': {
+      const y = t.subtract({ days: 1 });
+      return { start: y, end: y };
+    }
+    case 'last7d':
+      return { start: t.subtract({ days: 6 }), end: t };
+    case 'last30d':
+      return { start: t.subtract({ days: 29 }), end: t };
+    case 'thisMonth':
+      return { start: startOfMonth(t), end: t };
+    case 'lastMonth': {
+      const prev = startOfMonth(t).subtract({ months: 1 });
+      return { start: prev, end: endOfMonth(prev) };
+    }
+    case 'thisYear':
+      return { start: new CalendarDate(t.year, 1, 1), end: t };
+    case 'custom':
+      return null;
+  }
+}
+
+export function daysBetween(range: RangeValue<DateValue> | null | undefined): number | null {
+  if (!range?.start || !range?.end) return null;
+  const start = range.start.toDate(getLocalTimeZone());
+  const end = range.end.toDate(getLocalTimeZone());
+  const diff = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  return diff;
+}

--- a/apps/frontend/src/app/csv-export/date-range-section/index.tsx
+++ b/apps/frontend/src/app/csv-export/date-range-section/index.tsx
@@ -1,6 +1,7 @@
 // Date range section for CSV export — preset chips, calendar, summary pill
 // FEATURE: CSV export — step 1 of new export flow
 import { Card, DateValue, RangeCalendar, RangeValue } from '@heroui/react';
+import { CalendarDate } from '@internationalized/date';
 import { CalendarRangeIcon } from 'lucide-react';
 import { PresetChips } from './preset-chips';
 import { SelectedRangePill } from './selected-range-pill';
@@ -13,6 +14,9 @@ interface Props {
   onRangeChange: (range: RangeValue<DateValue>) => void;
   t: (key: string, vars?: Record<string, string | number>) => string;
 }
+
+const renderWeekdayHeader = (day: string) => <RangeCalendar.HeaderCell>{day}</RangeCalendar.HeaderCell>;
+const renderDayCell = (date: CalendarDate) => <RangeCalendar.Cell date={date} />;
 
 export function DateRangeSection(props: Props) {
   const { preset, range, onPresetChange, onRangeChange, t } = props;
@@ -62,10 +66,8 @@ export function DateRangeSection(props: Props) {
                 <RangeCalendar.NavButton slot="next" />
               </RangeCalendar.Header>
               <RangeCalendar.Grid>
-                <RangeCalendar.GridHeader>
-                  {(day) => <RangeCalendar.HeaderCell>{day}</RangeCalendar.HeaderCell>}
-                </RangeCalendar.GridHeader>
-                <RangeCalendar.GridBody>{(date) => <RangeCalendar.Cell date={date} />}</RangeCalendar.GridBody>
+                <RangeCalendar.GridHeader>{renderWeekdayHeader}</RangeCalendar.GridHeader>
+                <RangeCalendar.GridBody>{renderDayCell}</RangeCalendar.GridBody>
               </RangeCalendar.Grid>
             </RangeCalendar>
           </div>

--- a/apps/frontend/src/app/csv-export/date-range-section/index.tsx
+++ b/apps/frontend/src/app/csv-export/date-range-section/index.tsx
@@ -1,0 +1,76 @@
+// Date range section for CSV export — preset chips, calendar, summary pill
+// FEATURE: CSV export — step 1 of new export flow
+import { Card, DateValue, RangeCalendar, RangeValue } from '@heroui/react';
+import { CalendarRangeIcon } from 'lucide-react';
+import { PresetChips } from './preset-chips';
+import { SelectedRangePill } from './selected-range-pill';
+import { computeRange, Preset } from './compute-range';
+
+interface Props {
+  preset: Preset;
+  range: RangeValue<DateValue> | null;
+  onPresetChange: (preset: Preset) => void;
+  onRangeChange: (range: RangeValue<DateValue>) => void;
+  t: (key: string, vars?: Record<string, string | number>) => string;
+}
+
+export function DateRangeSection(props: Props) {
+  const { preset, range, onPresetChange, onRangeChange, t } = props;
+
+  const handlePreset = (next: Preset) => {
+    onPresetChange(next);
+    if (next !== 'custom') {
+      const computed = computeRange(next);
+      if (computed) onRangeChange(computed);
+    }
+  };
+
+  return (
+    <Card>
+      <Card.Header className="flex flex-col gap-1">
+        <Card.Title className="flex items-center gap-2 text-base">
+          <span className="flex items-center justify-center size-7 rounded-full bg-accent-100 text-accent-700 text-xs font-semibold">
+            1
+          </span>
+          <CalendarRangeIcon className="size-4 text-muted-foreground" />
+          {t('steps.range.title')}
+        </Card.Title>
+        <Card.Description>{t('steps.range.description')}</Card.Description>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <PresetChips value={preset} onChange={handlePreset} t={t} />
+          <SelectedRangePill
+            range={range}
+            emptyLabel={t('range.empty')}
+            summaryLabel={({ start, end, days }) => t('range.summary', { start, end, days })}
+          />
+        </div>
+
+        {preset === 'custom' && (
+          <div className="border-t border-default-100 pt-4">
+            <RangeCalendar
+              value={range ?? null}
+              onChange={(value) => onRangeChange(value)}
+              id="date-range"
+              aria-label={t('rangeCalendar.label')}
+              data-cy="csv-export-range-calendar"
+            >
+              <RangeCalendar.Header>
+                <RangeCalendar.Heading />
+                <RangeCalendar.NavButton slot="previous" />
+                <RangeCalendar.NavButton slot="next" />
+              </RangeCalendar.Header>
+              <RangeCalendar.Grid>
+                <RangeCalendar.GridHeader>
+                  {(day) => <RangeCalendar.HeaderCell>{day}</RangeCalendar.HeaderCell>}
+                </RangeCalendar.GridHeader>
+                <RangeCalendar.GridBody>{(date) => <RangeCalendar.Cell date={date} />}</RangeCalendar.GridBody>
+              </RangeCalendar.Grid>
+            </RangeCalendar>
+          </div>
+        )}
+      </Card.Content>
+    </Card>
+  );
+}

--- a/apps/frontend/src/app/csv-export/date-range-section/preset-chips.tsx
+++ b/apps/frontend/src/app/csv-export/date-range-section/preset-chips.tsx
@@ -1,0 +1,34 @@
+// Preset shortcut button row for CSV export date range
+// FEATURE: CSV export — quick presets like Today, Last 7 days, This Month
+import { Button } from '@heroui/react';
+import { Preset, PRESET_ORDER } from './compute-range';
+
+interface Props {
+  value: Preset;
+  onChange: (next: Preset) => void;
+  t: (key: string) => string;
+}
+
+export function PresetChips(props: Props) {
+  const { value, onChange, t } = props;
+
+  return (
+    <div className="flex flex-wrap gap-2" role="group" aria-label={t('steps.range.title')}>
+      {PRESET_ORDER.map((preset) => {
+        const isActive = value === preset;
+        return (
+          <Button
+            key={preset}
+            size="sm"
+            variant={isActive ? 'primary' : 'outline'}
+            onPress={() => onChange(preset)}
+            data-cy={`csv-export-preset-${preset}`}
+            aria-pressed={isActive}
+          >
+            {t(`presets.${preset}`)}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/csv-export/date-range-section/selected-range-pill.tsx
+++ b/apps/frontend/src/app/csv-export/date-range-section/selected-range-pill.tsx
@@ -1,0 +1,39 @@
+// Selected range summary pill used in date range section and modal header
+// FEATURE: CSV export — show selected date range as compact summary
+import { Chip, DateValue, RangeValue } from '@heroui/react';
+import { useDateTimeFormatter } from '@attraccess/plugins-frontend-ui';
+import { getLocalTimeZone } from '@internationalized/date';
+import { daysBetween } from './compute-range';
+import { CalendarIcon, CalendarOffIcon } from 'lucide-react';
+
+interface Props {
+  range: RangeValue<DateValue> | null | undefined;
+  emptyLabel: string;
+  summaryLabel: (vars: { start: string; end: string; days: number }) => string;
+  dataCy?: string;
+}
+
+export function SelectedRangePill(props: Props) {
+  const { range, emptyLabel, summaryLabel, dataCy } = props;
+  const formatDate = useDateTimeFormatter({ showTime: false });
+
+  if (!range?.start || !range?.end) {
+    return (
+      <Chip variant="soft" color="default" data-cy={dataCy ?? 'csv-export-selected-range-pill'}>
+        <CalendarOffIcon className="size-3.5" />
+        {emptyLabel}
+      </Chip>
+    );
+  }
+
+  const start = String(formatDate(range.start.toDate(getLocalTimeZone())));
+  const end = String(formatDate(range.end.toDate(getLocalTimeZone())));
+  const days = daysBetween(range) ?? 0;
+
+  return (
+    <Chip variant="soft" color="accent" data-cy={dataCy ?? 'csv-export-selected-range-pill'}>
+      <CalendarIcon className="size-3.5" />
+      {summaryLabel({ start, end, days })}
+    </Chip>
+  );
+}

--- a/apps/frontend/src/app/csv-export/de.json
+++ b/apps/frontend/src/app/csv-export/de.json
@@ -1,5 +1,30 @@
 {
   "title": "CSV-Export",
+  "subtitle": "Exportiere Nutzungs- und Zahlungsdaten als CSV-Datei.",
+  "steps": {
+    "range": {
+      "title": "Zeitraum wählen",
+      "description": "Wähle einen vordefinierten Zeitraum oder ein benutzerdefiniertes Datum."
+    },
+    "type": {
+      "title": "Export wählen",
+      "description": "Wähle den gewünschten Export aus."
+    }
+  },
+  "presets": {
+    "today": "Heute",
+    "yesterday": "Gestern",
+    "last7d": "Letzte 7 Tage",
+    "last30d": "Letzte 30 Tage",
+    "thisMonth": "Dieser Monat",
+    "lastMonth": "Letzter Monat",
+    "thisYear": "Dieses Jahr",
+    "custom": "Benutzerdefiniert"
+  },
+  "range": {
+    "summary": "{{start}} – {{end}} · {{days}} Tage",
+    "empty": "Kein Zeitraum gewählt"
+  },
   "rangeCalendar": {
     "label": "Zeitraum",
     "selection": {
@@ -12,13 +37,21 @@
     "modal": {
       "subtitle": "vom {{start}} bis zum {{end}}"
     },
+    "card": {
+      "estimatedRows": "Voraussichtlich {{count}} Zeilen",
+      "estimatedRowsLoading": "Lade …",
+      "requireRange": "Wähle zuerst Zeitraum",
+      "cta": "Konfigurieren & Exportieren"
+    },
     "resourceUsageHours": {
       "button": "Ressourcennutzung exportieren",
-      "title": "Ressourcennutzung"
+      "title": "Ressourcennutzung",
+      "description": "Buchungen und Nutzungsstunden je Ressource."
     },
     "billingTransactions": {
       "button": "Zahlungen exportieren",
-      "title": "Zahlungen"
+      "title": "Zahlungen",
+      "description": "Zahlungen, Gutschriften und Status je Nutzer."
     }
   }
 }

--- a/apps/frontend/src/app/csv-export/en.json
+++ b/apps/frontend/src/app/csv-export/en.json
@@ -1,5 +1,30 @@
 {
   "title": "CSV Export",
+  "subtitle": "Export usage and billing data as CSV.",
+  "steps": {
+    "range": {
+      "title": "Pick a date range",
+      "description": "Select a preset or define a custom range."
+    },
+    "type": {
+      "title": "Choose export",
+      "description": "Pick the export type you want to generate."
+    }
+  },
+  "presets": {
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "last7d": "Last 7 days",
+    "last30d": "Last 30 days",
+    "thisMonth": "This month",
+    "lastMonth": "Last month",
+    "thisYear": "This year",
+    "custom": "Custom"
+  },
+  "range": {
+    "summary": "{{start}} – {{end}} · {{days}} days",
+    "empty": "No range selected"
+  },
   "rangeCalendar": {
     "label": "Date Range",
     "selection": {
@@ -12,13 +37,21 @@
     "modal": {
       "subtitle": "from {{start}} to {{end}}"
     },
+    "card": {
+      "estimatedRows": "~{{count}} rows",
+      "estimatedRowsLoading": "Loading…",
+      "requireRange": "Pick a date range first",
+      "cta": "Configure & Export"
+    },
     "resourceUsageHours": {
       "button": "Export Resource Usage",
-      "title": "Resource Usage"
+      "title": "Resource Usage",
+      "description": "Bookings and usage hours per resource."
     },
     "billingTransactions": {
       "button": "Export Billing Transactions",
-      "title": "Billing Transactions"
+      "title": "Billing Transactions",
+      "description": "Payments, refunds and status per user."
     }
   }
 }

--- a/apps/frontend/src/app/csv-export/export-type-section/billing-transactions-card.tsx
+++ b/apps/frontend/src/app/csv-export/export-type-section/billing-transactions-card.tsx
@@ -1,0 +1,44 @@
+// Billing transactions export card — fetches row count when range is set
+// FEATURE: CSV export — step 2 of new export flow
+import { DateValue, RangeValue } from '@heroui/react';
+import { useAnalyticsServiceGetBillingTransactionsInDateRange } from '@attraccess/react-query-client';
+import { getLocalTimeZone } from '@internationalized/date';
+import { CreditCardIcon } from 'lucide-react';
+import { ExportTypeCard } from './export-type-card';
+
+interface Props {
+  range: RangeValue<DateValue> | null;
+  onPress: () => void;
+  t: (key: string, vars?: Record<string, string | number>) => string;
+}
+
+export function BillingTransactionsCard(props: Props) {
+  const { range, onPress, t } = props;
+
+  const hasRange = Boolean(range?.start && range?.end);
+  const start = range?.start ? range.start.toDate(getLocalTimeZone()).toISOString() : '';
+  const end = range?.end ? range.end.toDate(getLocalTimeZone()).toISOString() : '';
+
+  const { data, status } = useAnalyticsServiceGetBillingTransactionsInDateRange(
+    { start, end },
+    [start, end],
+    { enabled: hasRange },
+  );
+
+  return (
+    <ExportTypeCard
+      Icon={CreditCardIcon}
+      title={t('exports.billingTransactions.title')}
+      description={t('exports.billingTransactions.description')}
+      rowCount={data?.length}
+      rowCountStatus={hasRange ? status : 'idle'}
+      estimatedLabel={({ count }) => t('exports.card.estimatedRows', { count })}
+      loadingLabel={t('exports.card.estimatedRowsLoading')}
+      ctaLabel={t('exports.card.cta')}
+      requireRangeLabel={t('exports.card.requireRange')}
+      isDisabled={!hasRange}
+      onPress={onPress}
+      dataCy="csv-export-billingTransactions"
+    />
+  );
+}

--- a/apps/frontend/src/app/csv-export/export-type-section/export-type-card.tsx
+++ b/apps/frontend/src/app/csv-export/export-type-section/export-type-card.tsx
@@ -1,0 +1,93 @@
+// Presentational card for one CSV export type with row count and CTA
+// FEATURE: CSV export — step 2 of new export flow
+import { Button, Card, Chip, Spinner } from '@heroui/react';
+import { ArrowRightIcon, LucideIcon } from 'lucide-react';
+import { QueryStatus } from '@tanstack/react-query';
+
+interface Props {
+  Icon: LucideIcon;
+  title: string;
+  description: string;
+  rowCount?: number;
+  rowCountStatus: QueryStatus | 'idle';
+  estimatedLabel: (vars: { count: number }) => string;
+  loadingLabel: string;
+  ctaLabel: string;
+  requireRangeLabel: string;
+  isDisabled: boolean;
+  onPress: () => void;
+  dataCy: string;
+}
+
+export function ExportTypeCard(props: Props) {
+  const {
+    Icon,
+    title,
+    description,
+    rowCount,
+    rowCountStatus,
+    estimatedLabel,
+    loadingLabel,
+    ctaLabel,
+    requireRangeLabel,
+    isDisabled,
+    onPress,
+    dataCy,
+  } = props;
+
+  return (
+    <Card
+      className={
+        'transition-all flex flex-col h-full ' +
+        (isDisabled
+          ? 'opacity-60 pointer-events-none'
+          : 'hover:border-accent-400 hover:-translate-y-0.5 hover:shadow-lg cursor-pointer')
+      }
+      data-cy={dataCy + '-card'}
+    >
+      <Card.Header>
+        <div className="flex items-start gap-3">
+          <span className="flex items-center justify-center size-10 rounded-lg bg-accent-100 dark:bg-accent-900/30 text-accent-700 dark:text-accent-300 shrink-0">
+            <Icon className="size-5" />
+          </span>
+          <div className="flex flex-col gap-0.5 min-w-0">
+            <Card.Title className="text-base">{title}</Card.Title>
+            <Card.Description className="text-xs">{description}</Card.Description>
+          </div>
+        </div>
+      </Card.Header>
+      <Card.Content className="flex items-center justify-between gap-2 mt-auto">
+        {isDisabled ? (
+          <Chip variant="soft" color="default" size="sm">
+            {requireRangeLabel}
+          </Chip>
+        ) : rowCountStatus === 'pending' ? (
+          <Chip variant="soft" color="default" size="sm">
+            <Spinner size="sm" />
+            {loadingLabel}
+          </Chip>
+        ) : rowCountStatus === 'error' ? (
+          <Chip variant="soft" color="danger" size="sm">
+            {estimatedLabel({ count: 0 })}
+          </Chip>
+        ) : (
+          <Chip variant="soft" color={rowCount && rowCount > 0 ? 'accent' : 'default'} size="sm">
+            {estimatedLabel({ count: rowCount ?? 0 })}
+          </Chip>
+        )}
+      </Card.Content>
+      <Card.Footer>
+        <Button
+          variant="primary"
+          fullWidth
+          isDisabled={isDisabled}
+          onPress={onPress}
+          data-cy={dataCy + '-button'}
+        >
+          {ctaLabel}
+          <ArrowRightIcon className="size-4" />
+        </Button>
+      </Card.Footer>
+    </Card>
+  );
+}

--- a/apps/frontend/src/app/csv-export/export-type-section/index.tsx
+++ b/apps/frontend/src/app/csv-export/export-type-section/index.tsx
@@ -1,0 +1,39 @@
+// Export type section for CSV export — clickable cards per export type
+// FEATURE: CSV export — step 2 of new export flow
+import { Card, DateValue, RangeValue } from '@heroui/react';
+import { FileSpreadsheetIcon } from 'lucide-react';
+import { ResourceUsageCard } from './resource-usage-card';
+import { BillingTransactionsCard } from './billing-transactions-card';
+
+export type ExportTypeKey = 'resourceUsageHours' | 'billingTransactions';
+
+interface Props {
+  range: RangeValue<DateValue> | null;
+  onOpen: (key: ExportTypeKey) => void;
+  t: (key: string, vars?: Record<string, string | number>) => string;
+}
+
+export function ExportTypeSection(props: Props) {
+  const { range, onOpen, t } = props;
+
+  return (
+    <Card>
+      <Card.Header className="flex flex-col gap-1">
+        <Card.Title className="flex items-center gap-2 text-base">
+          <span className="flex items-center justify-center size-7 rounded-full bg-accent-100 text-accent-700 text-xs font-semibold">
+            2
+          </span>
+          <FileSpreadsheetIcon className="size-4 text-muted-foreground" />
+          {t('steps.type.title')}
+        </Card.Title>
+        <Card.Description>{t('steps.type.description')}</Card.Description>
+      </Card.Header>
+      <Card.Content>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ResourceUsageCard range={range} onPress={() => onOpen('resourceUsageHours')} t={t} />
+          <BillingTransactionsCard range={range} onPress={() => onOpen('billingTransactions')} t={t} />
+        </div>
+      </Card.Content>
+    </Card>
+  );
+}

--- a/apps/frontend/src/app/csv-export/export-type-section/index.tsx
+++ b/apps/frontend/src/app/csv-export/export-type-section/index.tsx
@@ -29,7 +29,7 @@ export function ExportTypeSection(props: Props) {
         <Card.Description>{t('steps.type.description')}</Card.Description>
       </Card.Header>
       <Card.Content>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <ResourceUsageCard range={range} onPress={() => onOpen('resourceUsageHours')} t={t} />
           <BillingTransactionsCard range={range} onPress={() => onOpen('billingTransactions')} t={t} />
         </div>

--- a/apps/frontend/src/app/csv-export/export-type-section/resource-usage-card.tsx
+++ b/apps/frontend/src/app/csv-export/export-type-section/resource-usage-card.tsx
@@ -1,0 +1,44 @@
+// Resource usage export card — fetches row count when range is set
+// FEATURE: CSV export — step 2 of new export flow
+import { DateValue, RangeValue } from '@heroui/react';
+import { useAnalyticsServiceGetResourceUsageHoursInDateRange } from '@attraccess/react-query-client';
+import { getLocalTimeZone } from '@internationalized/date';
+import { DatabaseIcon } from 'lucide-react';
+import { ExportTypeCard } from './export-type-card';
+
+interface Props {
+  range: RangeValue<DateValue> | null;
+  onPress: () => void;
+  t: (key: string, vars?: Record<string, string | number>) => string;
+}
+
+export function ResourceUsageCard(props: Props) {
+  const { range, onPress, t } = props;
+
+  const hasRange = Boolean(range?.start && range?.end);
+  const start = range?.start ? range.start.toDate(getLocalTimeZone()).toISOString() : '';
+  const end = range?.end ? range.end.toDate(getLocalTimeZone()).toISOString() : '';
+
+  const { data, status } = useAnalyticsServiceGetResourceUsageHoursInDateRange(
+    { start, end },
+    [start, end],
+    { enabled: hasRange },
+  );
+
+  return (
+    <ExportTypeCard
+      Icon={DatabaseIcon}
+      title={t('exports.resourceUsageHours.title')}
+      description={t('exports.resourceUsageHours.description')}
+      rowCount={data?.length}
+      rowCountStatus={hasRange ? status : 'idle'}
+      estimatedLabel={({ count }) => t('exports.card.estimatedRows', { count })}
+      loadingLabel={t('exports.card.estimatedRowsLoading')}
+      ctaLabel={t('exports.card.cta')}
+      requireRangeLabel={t('exports.card.requireRange')}
+      isDisabled={!hasRange}
+      onPress={onPress}
+      dataCy="csv-export-resourceUsageHours"
+    />
+  );
+}

--- a/apps/frontend/src/app/csv-export/index.tsx
+++ b/apps/frontend/src/app/csv-export/index.tsx
@@ -61,11 +61,26 @@ export function CsvExport() {
           <span className="font-bold">{t('rangeCalendar.selection.label')}</span>
           <div className="flex gap-4 flex-row flex-wrap">
             <RangeCalendar
+              value={dateRange ?? null}
               onChange={(value) => setDateRange(value)}
               id="date-range"
               aria-label={t('rangeCalendar.label')}
               data-cy="csv-export-range-calendar"
-            />
+            >
+              <RangeCalendar.Header>
+                <RangeCalendar.Heading />
+                <RangeCalendar.NavButton slot="previous" />
+                <RangeCalendar.NavButton slot="next" />
+              </RangeCalendar.Header>
+              <RangeCalendar.Grid>
+                <RangeCalendar.GridHeader>
+                  {(day) => <RangeCalendar.HeaderCell>{day}</RangeCalendar.HeaderCell>}
+                </RangeCalendar.GridHeader>
+                <RangeCalendar.GridBody>
+                  {(date) => <RangeCalendar.Cell date={date} />}
+                </RangeCalendar.GridBody>
+              </RangeCalendar.Grid>
+            </RangeCalendar>
             <p>
               <br />
               {t('rangeCalendar.selection.start', {

--- a/apps/frontend/src/app/csv-export/index.tsx
+++ b/apps/frontend/src/app/csv-export/index.tsx
@@ -1,111 +1,78 @@
-import { useDateTimeFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Card, DateValue, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalHeader, RangeCalendar, RangeValue } from '@heroui/react';
-import de from './de.json';
-import en from './en.json';
+// CSV export page composition — date range picker, type cards, configure modal
+// FEATURE: CSV export — top level page for /csv-export route
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import {
+  DateValue,
+  Modal,
+  ModalBackdrop,
+  ModalCloseTrigger,
+  ModalContainer,
+  ModalDialog,
+  ModalHeader,
+  RangeValue,
+} from '@heroui/react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { getLocalTimeZone } from '@internationalized/date';
+import { DateRangeSection } from './date-range-section';
+import { computeRange, Preset } from './date-range-section/compute-range';
+import { SelectedRangePill } from './date-range-section/selected-range-pill';
+import { ExportTypeKey, ExportTypeSection } from './export-type-section';
 import { ResourceUsageExport } from './resource-usage';
 import { BillingTransactionsExport } from './billing-transactions';
+import de from './de.json';
+import en from './en.json';
+import { XIcon } from 'lucide-react';
+
+const DEFAULT_PRESET: Preset = 'last30d';
 
 export function CsvExport() {
-  const { t } = useTranslations({
-    de,
-    en,
-  });
+  const { t } = useTranslations({ de, en });
 
-  const [dateRange, setDateRange] = useState<RangeValue<DateValue>>();
-  const [activeExportKey, setActiveExport] = useState<string>('');
+  const [preset, setPreset] = useState<Preset>(DEFAULT_PRESET);
+  const [dateRange, setDateRange] = useState<RangeValue<DateValue> | null>(computeRange(DEFAULT_PRESET));
+  const [activeExportKey, setActiveExportKey] = useState<ExportTypeKey | ''>('');
   const [showExport, setShowExport] = useState(false);
 
-  const formatDateTime = useDateTimeFormatter({ showTime: false });
-
-  const openExport = useCallback((exportName: string) => {
-    setActiveExport(exportName);
+  const openExport = useCallback((key: ExportTypeKey) => {
+    setActiveExportKey(key);
     setShowExport(true);
   }, []);
 
-  const dateRangeStartFormatted = useMemo(
-    () => formatDateTime(dateRange?.start?.toDate(getLocalTimeZone())),
-    [formatDateTime, dateRange],
-  );
-
-  const dateRangeEndFormatted = useMemo(
-    () => formatDateTime(dateRange?.end?.toDate(getLocalTimeZone())),
-    [formatDateTime, dateRange],
+  const handleRangeChange = useCallback(
+    (next: RangeValue<DateValue>) => {
+      setDateRange(next);
+      if (preset !== 'custom') setPreset('custom');
+    },
+    [preset],
   );
 
   const now = useRef(new Date());
 
-  const exportTypes = useMemo(() => {
-    return [
-      {
-        key: 'resourceUsageHours',
-        component: ResourceUsageExport,
-      },
-      {
-        key: 'billingTransactions',
-        component: BillingTransactionsExport,
-      },
-    ] as const;
-  }, []);
+  const ExportComponent = useMemo(() => {
+    if (activeExportKey === 'resourceUsageHours') return ResourceUsageExport;
+    if (activeExportKey === 'billingTransactions') return BillingTransactionsExport;
+    return null;
+  }, [activeExportKey]);
 
-  const activeExport = useMemo(() => {
-    return exportTypes.find((exportType) => exportType.key === activeExportKey);
-  }, [exportTypes, activeExportKey]);
+  const startDate = dateRange?.start?.toDate(getLocalTimeZone()) ?? now.current;
+  const endDate = dateRange?.end?.toDate(getLocalTimeZone()) ?? now.current;
 
   return (
-    <>
-      <Card>
-        <Card.Header>{t('title')}</Card.Header>
-        <Card.Content>
-          <span className="font-bold">{t('rangeCalendar.selection.label')}</span>
-          <div className="flex gap-4 flex-row flex-wrap">
-            <RangeCalendar
-              value={dateRange ?? null}
-              onChange={(value) => setDateRange(value)}
-              id="date-range"
-              aria-label={t('rangeCalendar.label')}
-              data-cy="csv-export-range-calendar"
-            >
-              <RangeCalendar.Header>
-                <RangeCalendar.Heading />
-                <RangeCalendar.NavButton slot="previous" />
-                <RangeCalendar.NavButton slot="next" />
-              </RangeCalendar.Header>
-              <RangeCalendar.Grid>
-                <RangeCalendar.GridHeader>
-                  {(day) => <RangeCalendar.HeaderCell>{day}</RangeCalendar.HeaderCell>}
-                </RangeCalendar.GridHeader>
-                <RangeCalendar.GridBody>
-                  {(date) => <RangeCalendar.Cell date={date} />}
-                </RangeCalendar.GridBody>
-              </RangeCalendar.Grid>
-            </RangeCalendar>
-            <p>
-              <br />
-              {t('rangeCalendar.selection.start', {
-                date: dateRangeStartFormatted,
-              })}
-              <br />
-              {t('rangeCalendar.selection.end', { date: dateRangeEndFormatted })}
-            </p>
-          </div>
-        </Card.Content>
-        <Card.Footer>
-          {exportTypes.map((exportType) => (
-            <Button
-              key={exportType.key}
-              isDisabled={!dateRange}
-              onPress={() => {
-                openExport(exportType.key);
-              }}
-              data-cy={`csv-export-${exportType.key}-button`}
-            >
-              {t(`exports.${exportType.key}.button`)}
-            </Button>
-          ))}
-        </Card.Footer>
-      </Card>
+    <div className="mx-auto w-full max-w-5xl px-4 md:px-6 lg:px-8 py-6 flex flex-col gap-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">{t('title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      <DateRangeSection
+        preset={preset}
+        range={dateRange}
+        onPresetChange={setPreset}
+        onRangeChange={handleRangeChange}
+        t={t}
+      />
+
+      <ExportTypeSection range={dateRange} onOpen={openExport} t={t} />
 
       <Modal
         isOpen={showExport}
@@ -115,34 +82,34 @@ export function CsvExport() {
         data-cy="csv-export-modal"
       >
         <ModalBackdrop>
-          <ModalContainer size="md">
+          <ModalContainer size="full" className="max-w-5xl mx-auto">
             <ModalDialog>
               {() => (
                 <>
-                  <ModalHeader>
-                    <div>
-                      {activeExportKey && t(`exports.${activeExportKey}.title`)}
-                      <br />
-                      <small>
-                        {t('exports.modal.subtitle', { start: dateRangeStartFormatted, end: dateRangeEndFormatted })}
-                      </small>
+                  <ModalHeader className="flex items-start justify-between gap-3">
+                    <div className="flex flex-col gap-2 min-w-0">
+                      <span className="text-lg font-semibold">
+                        {activeExportKey && t(`exports.${activeExportKey}.title`)}
+                      </span>
+                      <SelectedRangePill
+                        range={dateRange}
+                        emptyLabel={t('range.empty')}
+                        summaryLabel={({ start, end, days }) => t('range.summary', { start, end, days })}
+                        dataCy="csv-export-modal-range-pill"
+                      />
                     </div>
+                    <ModalCloseTrigger aria-label="close">
+                      <XIcon className="size-4" />
+                    </ModalCloseTrigger>
                   </ModalHeader>
 
-                  <ModalBody>
-                    {activeExport && (
-                      <activeExport.component
-                        start={dateRange?.start?.toDate(getLocalTimeZone()) ?? now.current}
-                        end={dateRange?.end?.toDate(getLocalTimeZone()) ?? now.current}
-                      />
-                    )}
-                  </ModalBody>
+                  {ExportComponent && <ExportComponent start={startDate} end={endDate} />}
                 </>
               )}
             </ModalDialog>
           </ModalContainer>
         </ModalBackdrop>
       </Modal>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes ATT-375. After the HeroUI v2→v3 migration, the CSV export page rendered "Selected Date Range" with `Start: -` / `End: -` and no date inputs — the date range picker was missing entirely.

## Root cause

In HeroUI v3, `RangeCalendar` is a **compound component**. The previous self-closing `<RangeCalendar />` left the calendar with no grid/header subcomponents, so it rendered an empty container with no interactive UI.

## Fix

`apps/frontend/src/app/csv-export/index.tsx` now uses the v3 compound API:

- `RangeCalendar.Header` + `Heading` + `NavButton` (previous/next)
- `RangeCalendar.Grid` + `GridHeader` + `HeaderCell` + `GridBody` + `Cell`
- Controlled via `value={dateRange ?? null}` so the existing `onChange` keeps working

## Verification

Verified in browser at http://localhost:4202/csv-export:

1. Calendar renders with month grid + nav buttons
2. Range selection works (e.g. May 1 → May 14)
3. `Start:` / `Ende:` labels populate with selected dates
4. Export buttons enable; modal opens with the chosen date range ("vom 01.05.2026 bis zum 14.05.2026")
5. `pnpm nx lint frontend` passes (only pre-existing unrelated warning)
6. `pnpm nx typecheck frontend` passes

Screenshots attached on the [Linear issue](https://linear.app/attraccess/issue/ATT-375/csv-export-fully-broken-no-way-to-enter-start-and-end-date).

Linear: [ATT-375](https://linear.app/attraccess/issue/ATT-375/csv-export-fully-broken-no-way-to-enter-start-and-end-date)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Fix missing date range calendar on the CSV export page so users can select start and end dates again.