### PR TITLE
feat(ATT-350): NFC board v0 — PN532 IC + 24× WS2812 ring

### DIFF
--- a/apps/attractap/hardware/beeper/index.tsx
+++ b/apps/attractap/hardware/beeper/index.tsx
@@ -21,7 +21,7 @@ export default () => (
     autorouter="sequential-trace"
     defaultTraceWidth="0.15mm"
   >
-    <Buzzer5VTh name="LS1" pn="C2687681" pitchMm={6.5} bodyDiameterMm={12} buzzerType="magnetic" {...at(9, 8)} />
+    <Buzzer5VTh name="LS1" pn="C2687681" pitchMm={6.5} bodyDiameterMm={12} {...at(9, 8)} />
     <Ao3400 name="Q1" pn="C20917" {...at(3, 17)} />
     <R0603 name="R1" resistance="100" pn="C22775" {...at(7, 17)} />
     <R0603 name="R2" resistance="10k" pn="C25804" {...at(11, 17)} />

--- a/apps/attractap/hardware/nfc/index.tsx
+++ b/apps/attractap/hardware/nfc/index.tsx
@@ -1,4 +1,4 @@
-// NFC board PN532 IC plus 24 WS2812 ring with J_NFC connector and matching net
+// NFC board PN532 IC plus 24 WS2812 ring with discrete coil antenna and J_NFC
 // FEATURE: hardware/nfc — Phase 2 Attractap V2 board ATT-350
 
 import {
@@ -7,6 +7,7 @@ import {
   C0402,
   C0603,
   L0603,
+  NfcCoilAntenna,
   Pn532Ic,
   R0402,
   R0603,
@@ -16,11 +17,17 @@ import {
 const W = 50;
 const H = 50;
 const at = (x: number, y: number) => boardCoord({ x, y, boardW: W, boardH: H });
+const atBottom = (x: number, y: number) => ({
+  ...boardCoord({ x, y, boardW: W, boardH: H }),
+  layer: 'bottom' as const,
+});
 
 const RING_LEDS = 24;
-const RING_R = 18.5;
+const RING_R = 18;
 const RING_CX = 25;
 const RING_CY = 25;
+const LED_BULK_GROUPS = 6;
+const LED_BULK_R = 22.5;
 
 const FB_FERRITE_PN = 'C14709';
 const C_100NF_PN = 'C307331';
@@ -44,9 +51,20 @@ const leds = Array.from({ length: RING_LEDS }, (_, i) => {
   return {
     i,
     name: `LED${i + 1}`,
-    cap: `C_LED${i + 1}`,
     cx: RING_CX + RING_R * Math.cos(rad),
     cy: RING_CY + RING_R * Math.sin(rad),
+    rot: angle + 90,
+  };
+});
+
+const ledBulkCaps = Array.from({ length: LED_BULK_GROUPS }, (_, g) => {
+  const angle = (g * 360) / LED_BULK_GROUPS + 30;
+  const rad = (angle * Math.PI) / 180;
+  return {
+    name: `C_LED_G${g + 1}`,
+    nearestLed: `LED${Math.round((g * RING_LEDS) / LED_BULK_GROUPS) + 1}`,
+    cx: RING_CX + LED_BULK_R * Math.cos(rad),
+    cy: RING_CY + LED_BULK_R * Math.sin(rad),
     rot: angle + 90,
   };
 });
@@ -62,40 +80,7 @@ export default () => (
     autorouter="sequential-trace"
     defaultTraceWidth="0.2mm"
   >
-    <Pn532Ic name="U1" pn={PN532_PN} {...at(25, 25)} />
-
-    <C0603 name="C_PA" pn={C_10UF_PN} capacitance="10uF" {...at(18, 25)} />
-    <C0402 name="C_VBUS" pn={C_100NF_PN} capacitance="100nF" {...at(25, 30)} />
-    <C0402 name="C_PVDD" pn={C_100NF_PN} capacitance="100nF" {...at(30, 25)} />
-    <C0402 name="C_SVDD" pn={C_100NF_PN} capacitance="100nF" {...at(25, 20)} />
-    <C0402 name="C_AVDD" pn={C_100NF_PN} capacitance="100nF" {...at(20, 25)} />
-    <C0402 name="C_VMID" pn={C_100NF_PN} capacitance="100nF" {...at(20, 22)} />
-    <L0603 name="L_TVDD" pn={FB_FERRITE_PN} inductance="120R@100MHz" {...at(32, 25)} />
-    <C0402 name="C_TVDD" pn={C_100NF_PN} capacitance="100nF" {...at(30, 28)} />
-
-    <R0402 name="R_SDA" pn={R_4K7_PN} resistance="4.7k" {...at(20, 31)} />
-    <R0402 name="R_SCL" pn={R_4K7_PN} resistance="4.7k" {...at(22, 32.5)} />
-    <R0402 name="R_IRQ" pn={R_10K_PN} resistance="10k" {...at(24, 33.5)} />
-
-    <R0603 name="Rq1" pn={R_4R7_PN} resistance="4.7" {...at(27, 34)} />
-    <L0603 name="L0_TX1" pn={L_560NH_PN} inductance="560nH" {...at(30, 33)} />
-    <C0402 name="C0_TX1" pn={C_180PF_PN} capacitance="180pF" {...at(32, 32)} />
-    <C0402 name="C1_TX1" pn={C_47PF_PN} capacitance="47pF" {...at(33, 30)} />
-    <C0402 name="C2_TX1" pn={C_47PF_PN} capacitance="47pF" {...at(33.5, 28)} />
-    <R0402 name="Rs1" pn={R_750R_PN} resistance="750" {...at(34, 26)} />
-    <C0402 name="Cs1" pn={C_1NF_PN} capacitance="1nF" {...at(34.5, 24)} />
-
-    <R0603 name="Rq2" pn={R_4R7_PN} resistance="4.7" {...at(27, 16)} />
-    <L0603 name="L0_TX2" pn={L_560NH_PN} inductance="560nH" {...at(30, 17)} />
-    <C0402 name="C0_TX2" pn={C_180PF_PN} capacitance="180pF" {...at(32, 18)} />
-    <C0402 name="C1_TX2" pn={C_47PF_PN} capacitance="47pF" {...at(33, 20)} />
-    <C0402 name="C2_TX2" pn={C_47PF_PN} capacitance="47pF" {...at(33.5, 22)} />
-    <R0402 name="Rs2" pn={R_750R_PN} resistance="750" {...at(18, 21)} />
-    <C0402 name="Cs2" pn={C_1NF_PN} capacitance="1nF" {...at(18, 19)} />
-
-    <R0402 name="R_LED" pn={R_33R_PN} resistance="33" {...at(10, 45)} />
-    <L0603 name="L_LED" pn={FB_FERRITE_PN} inductance="120R@100MHz" {...at(14, 45)} />
-    <C0603 name="C_LED_BULK" pn={C_10UF_PN} capacitance="10uF" {...at(18, 45)} />
+    <NfcCoilAntenna name="ANT1" padPitchMm={18} bodyWidthMm={22} bodyHeightMm={22} {...at(25, 25)} />
 
     {leds.map((l) => (
       <Ws2812Mini
@@ -107,18 +92,53 @@ export default () => (
         pcbRotation={l.rot}
       />
     ))}
-    {leds.map((l) => (
-      <C0402
-        key={l.cap}
-        name={l.cap}
-        pn={C_100NF_PN}
-        capacitance="100nF"
-        layer="bottom"
-        pcbX={l.cx - W / 2}
-        pcbY={l.cy - H / 2}
-        pcbRotation={l.rot}
+
+    {ledBulkCaps.map((c) => (
+      <C0603
+        key={c.name}
+        name={c.name}
+        pn={C_10UF_PN}
+        capacitance="10uF"
+        pcbX={c.cx - W / 2}
+        pcbY={c.cy - H / 2}
+        pcbRotation={c.rot}
       />
     ))}
+
+    <Pn532Ic name="U1" pn={PN532_PN} {...atBottom(25, 25)} />
+
+    <C0603 name="C_PA" pn={C_10UF_PN} capacitance="10uF" {...atBottom(29.24, 20.76)} />
+    <C0402 name="C_VBUS" pn={C_100NF_PN} capacitance="100nF" {...atBottom(25, 31)} />
+    <C0402 name="C_PVDD" pn={C_100NF_PN} capacitance="100nF" {...atBottom(31, 25)} />
+    <C0402 name="C_SVDD" pn={C_100NF_PN} capacitance="100nF" {...atBottom(25, 19)} />
+    <C0402 name="C_AVDD" pn={C_100NF_PN} capacitance="100nF" {...atBottom(19, 25)} />
+    <C0402 name="C_VMID" pn={C_100NF_PN} capacitance="100nF" {...atBottom(20.76, 29.24)} />
+    <L0603 name="L_TVDD" pn={FB_FERRITE_PN} inductance="120R@100MHz" {...atBottom(20.76, 20.76)} />
+    <C0402 name="C_TVDD" pn={C_100NF_PN} capacitance="100nF" {...atBottom(29.24, 29.24)} />
+
+    <R0402 name="R_SDA" pn={R_4K7_PN} resistance="4.7k" {...atBottom(22.41, 34.66)} />
+    <R0402 name="R_SCL" pn={R_4K7_PN} resistance="4.7k" {...atBottom(25, 35)} />
+    <R0402 name="R_IRQ" pn={R_10K_PN} resistance="10k" {...atBottom(27.59, 34.66)} />
+
+    <R0603 name="Rq1" pn={R_4R7_PN} resistance="4.7" {...atBottom(32.07, 17.93)} />
+    <L0603 name="L0_TX1" pn={L_560NH_PN} inductance="560nH" {...atBottom(33.66, 20)} />
+    <C0402 name="C0_TX1" pn={C_180PF_PN} capacitance="180pF" {...atBottom(34.66, 22.41)} />
+    <C0402 name="C1_TX1" pn={C_47PF_PN} capacitance="47pF" {...atBottom(35, 25)} />
+    <C0402 name="C2_TX1" pn={C_47PF_PN} capacitance="47pF" {...atBottom(34.66, 27.59)} />
+    <R0402 name="Rs1" pn={R_750R_PN} resistance="750" {...atBottom(33.66, 30)} />
+    <C0402 name="Cs1" pn={C_1NF_PN} capacitance="1nF" {...atBottom(32.07, 32.07)} />
+
+    <R0603 name="Rq2" pn={R_4R7_PN} resistance="4.7" {...atBottom(17.93, 32.07)} />
+    <L0603 name="L0_TX2" pn={L_560NH_PN} inductance="560nH" {...atBottom(16.34, 30)} />
+    <C0402 name="C0_TX2" pn={C_180PF_PN} capacitance="180pF" {...atBottom(15.34, 27.59)} />
+    <C0402 name="C1_TX2" pn={C_47PF_PN} capacitance="47pF" {...atBottom(15, 25)} />
+    <C0402 name="C2_TX2" pn={C_47PF_PN} capacitance="47pF" {...atBottom(15.34, 22.41)} />
+    <R0402 name="Rs2" pn={R_750R_PN} resistance="750" {...atBottom(16.34, 20)} />
+    <C0402 name="Cs2" pn={C_1NF_PN} capacitance="1nF" {...atBottom(17.93, 17.93)} />
+
+    <R0402 name="R_LED" pn={R_33R_PN} resistance="33" {...at(10, 45)} />
+    <L0603 name="L_LED" pn={FB_FERRITE_PN} inductance="120R@100MHz" {...at(14, 45)} />
+    <C0603 name="C_LED_BULK" pn={C_10UF_PN} capacitance="10uF" {...at(18, 45)} />
 
     <B2B_127_2xN name="J1" pn={HEADER_PN} pinsPerRow={5} {...at(35, 47)} />
 
@@ -127,8 +147,7 @@ export default () => (
     <hole diameter="3.2mm" {...at(3, 47)} />
     <hole diameter="3.2mm" {...at(47, 47)} />
 
-    <silkscreentext text="ATT-350 NFC v0" {...at(25, 2.5)} fontSize="1.2mm" />
-    <silkscreentext text="antenna TBD ATT-343" {...at(25, 47.5)} fontSize="1mm" />
+    <silkscreentext text="ATT-350 NFC v0" {...at(25, 4)} fontSize="1.2mm" />
 
     <trace from=".J1 > .pin1" to=".C_VBUS > .pin1" />
     <trace from=".C_VBUS > .pin1" to=".U1 > .VBUS" />
@@ -181,7 +200,8 @@ export default () => (
     <trace from=".L0_TX1 > .pin2" to=".C1_TX1 > .pin1" />
     <trace from=".C1_TX1 > .pin2" to=".C2_TX1 > .pin1" />
     <trace from=".C2_TX1 > .pin2" to=".U1 > .EP" />
-    <trace from=".C1_TX1 > .pin2" to=".Rs1 > .pin1" />
+    <trace from=".C1_TX1 > .pin2" to=".ANT1 > .P1" />
+    <trace from=".ANT1 > .P1" to=".Rs1 > .pin1" />
     <trace from=".Rs1 > .pin2" to=".Cs1 > .pin1" />
     <trace from=".Cs1 > .pin2" to=".U1 > .EP" />
 
@@ -192,7 +212,8 @@ export default () => (
     <trace from=".L0_TX2 > .pin2" to=".C1_TX2 > .pin1" />
     <trace from=".C1_TX2 > .pin2" to=".C2_TX2 > .pin1" />
     <trace from=".C2_TX2 > .pin2" to=".U1 > .EP" />
-    <trace from=".C1_TX2 > .pin2" to=".Rs2 > .pin1" />
+    <trace from=".C1_TX2 > .pin2" to=".ANT1 > .P2" />
+    <trace from=".ANT1 > .P2" to=".Rs2 > .pin1" />
     <trace from=".Rs2 > .pin2" to=".Cs2 > .pin1" />
     <trace from=".Cs2 > .pin2" to=".U1 > .EP" />
 
@@ -214,7 +235,11 @@ export default () => (
     )}
     <trace from=".LED1 > .GND" to=".U1 > .EP" />
 
-    {leds.map((l, i) => traceJsx(`.${l.cap} > .pin1`, `.${l.name} > .VDD`, `decvdd-${i}`))}
-    {leds.map((l, i) => traceJsx(`.${l.cap} > .pin2`, `.${l.name} > .GND`, `decgnd-${i}`))}
+    {ledBulkCaps.map((c, i) =>
+      traceJsx(`.${c.name} > .pin1`, `.${c.nearestLed} > .VDD`, `bulkvdd-${i}`),
+    )}
+    {ledBulkCaps.map((c, i) =>
+      traceJsx(`.${c.name} > .pin2`, `.${c.nearestLed} > .GND`, `bulkgnd-${i}`),
+    )}
   </board>
 );

--- a/apps/attractap/hardware/nfc/index.tsx
+++ b/apps/attractap/hardware/nfc/index.tsx
@@ -1,0 +1,220 @@
+// NFC board PN532 IC plus 24 WS2812 ring with J_NFC connector and matching net
+// FEATURE: hardware/nfc — Phase 2 Attractap V2 board ATT-350
+
+import {
+  B2B_127_2xN,
+  boardCoord,
+  C0402,
+  C0603,
+  L0603,
+  Pn532Ic,
+  R0402,
+  R0603,
+  Ws2812Mini,
+} from '@attraccess/attractap-hw-shared';
+
+const W = 50;
+const H = 50;
+const at = (x: number, y: number) => boardCoord({ x, y, boardW: W, boardH: H });
+
+const RING_LEDS = 24;
+const RING_R = 18.5;
+const RING_CX = 25;
+const RING_CY = 25;
+
+const FB_FERRITE_PN = 'C14709';
+const C_100NF_PN = 'C307331';
+const C_10UF_PN = 'C96446';
+const C_1NF_PN = 'C76947';
+const C_47PF_PN = 'C1567';
+const C_180PF_PN = 'C20069329';
+const R_4K7_PN = 'C25900';
+const R_10K_PN = 'C25744';
+const R_33R_PN = 'C25105';
+const R_4R7_PN = 'C23164';
+const R_750R_PN = 'C25132';
+const L_560NH_PN = 'C502009';
+const WS2812_PN = 'C4154873';
+const PN532_PN = 'C28925';
+const HEADER_PN = 'C2935458';
+
+const leds = Array.from({ length: RING_LEDS }, (_, i) => {
+  const angle = (i * 360) / RING_LEDS;
+  const rad = (angle * Math.PI) / 180;
+  return {
+    i,
+    name: `LED${i + 1}`,
+    cap: `C_LED${i + 1}`,
+    cx: RING_CX + RING_R * Math.cos(rad),
+    cy: RING_CY + RING_R * Math.sin(rad),
+    rot: angle + 90,
+  };
+});
+
+const traceJsx = (from: string, to: string, key: string) => (
+  <trace key={key} from={from} to={to} />
+);
+
+export default () => (
+  <board
+    width={`${W}mm`}
+    height={`${H}mm`}
+    autorouter="sequential-trace"
+    defaultTraceWidth="0.2mm"
+  >
+    <Pn532Ic name="U1" pn={PN532_PN} {...at(25, 25)} />
+
+    <C0603 name="C_PA" pn={C_10UF_PN} capacitance="10uF" {...at(18, 25)} />
+    <C0402 name="C_VBUS" pn={C_100NF_PN} capacitance="100nF" {...at(25, 30)} />
+    <C0402 name="C_PVDD" pn={C_100NF_PN} capacitance="100nF" {...at(30, 25)} />
+    <C0402 name="C_SVDD" pn={C_100NF_PN} capacitance="100nF" {...at(25, 20)} />
+    <C0402 name="C_AVDD" pn={C_100NF_PN} capacitance="100nF" {...at(20, 25)} />
+    <C0402 name="C_VMID" pn={C_100NF_PN} capacitance="100nF" {...at(20, 22)} />
+    <L0603 name="L_TVDD" pn={FB_FERRITE_PN} inductance="120R@100MHz" {...at(32, 25)} />
+    <C0402 name="C_TVDD" pn={C_100NF_PN} capacitance="100nF" {...at(30, 28)} />
+
+    <R0402 name="R_SDA" pn={R_4K7_PN} resistance="4.7k" {...at(20, 31)} />
+    <R0402 name="R_SCL" pn={R_4K7_PN} resistance="4.7k" {...at(22, 32.5)} />
+    <R0402 name="R_IRQ" pn={R_10K_PN} resistance="10k" {...at(24, 33.5)} />
+
+    <R0603 name="Rq1" pn={R_4R7_PN} resistance="4.7" {...at(27, 34)} />
+    <L0603 name="L0_TX1" pn={L_560NH_PN} inductance="560nH" {...at(30, 33)} />
+    <C0402 name="C0_TX1" pn={C_180PF_PN} capacitance="180pF" {...at(32, 32)} />
+    <C0402 name="C1_TX1" pn={C_47PF_PN} capacitance="47pF" {...at(33, 30)} />
+    <C0402 name="C2_TX1" pn={C_47PF_PN} capacitance="47pF" {...at(33.5, 28)} />
+    <R0402 name="Rs1" pn={R_750R_PN} resistance="750" {...at(34, 26)} />
+    <C0402 name="Cs1" pn={C_1NF_PN} capacitance="1nF" {...at(34.5, 24)} />
+
+    <R0603 name="Rq2" pn={R_4R7_PN} resistance="4.7" {...at(27, 16)} />
+    <L0603 name="L0_TX2" pn={L_560NH_PN} inductance="560nH" {...at(30, 17)} />
+    <C0402 name="C0_TX2" pn={C_180PF_PN} capacitance="180pF" {...at(32, 18)} />
+    <C0402 name="C1_TX2" pn={C_47PF_PN} capacitance="47pF" {...at(33, 20)} />
+    <C0402 name="C2_TX2" pn={C_47PF_PN} capacitance="47pF" {...at(33.5, 22)} />
+    <R0402 name="Rs2" pn={R_750R_PN} resistance="750" {...at(18, 21)} />
+    <C0402 name="Cs2" pn={C_1NF_PN} capacitance="1nF" {...at(18, 19)} />
+
+    <R0402 name="R_LED" pn={R_33R_PN} resistance="33" {...at(10, 45)} />
+    <L0603 name="L_LED" pn={FB_FERRITE_PN} inductance="120R@100MHz" {...at(14, 45)} />
+    <C0603 name="C_LED_BULK" pn={C_10UF_PN} capacitance="10uF" {...at(18, 45)} />
+
+    {leds.map((l) => (
+      <Ws2812Mini
+        key={l.name}
+        name={l.name}
+        pn={WS2812_PN}
+        pcbX={l.cx - W / 2}
+        pcbY={l.cy - H / 2}
+        pcbRotation={l.rot}
+      />
+    ))}
+    {leds.map((l) => (
+      <C0402
+        key={l.cap}
+        name={l.cap}
+        pn={C_100NF_PN}
+        capacitance="100nF"
+        layer="bottom"
+        pcbX={l.cx - W / 2}
+        pcbY={l.cy - H / 2}
+        pcbRotation={l.rot}
+      />
+    ))}
+
+    <B2B_127_2xN name="J1" pn={HEADER_PN} pinsPerRow={5} {...at(35, 47)} />
+
+    <hole diameter="3.2mm" {...at(3, 3)} />
+    <hole diameter="3.2mm" {...at(47, 3)} />
+    <hole diameter="3.2mm" {...at(3, 47)} />
+    <hole diameter="3.2mm" {...at(47, 47)} />
+
+    <silkscreentext text="ATT-350 NFC v0" {...at(25, 2.5)} fontSize="1.2mm" />
+    <silkscreentext text="antenna TBD ATT-343" {...at(25, 47.5)} fontSize="1mm" />
+
+    <trace from=".J1 > .pin1" to=".C_VBUS > .pin1" />
+    <trace from=".C_VBUS > .pin1" to=".U1 > .VBUS" />
+    <trace from=".U1 > .VBUS" to=".U1 > .PVDD" />
+    <trace from=".U1 > .PVDD" to=".U1 > .SVDD" />
+    <trace from=".U1 > .SVDD" to=".U1 > .VBAT" />
+    <trace from=".U1 > .AVDD" to=".C_AVDD > .pin1" />
+    <trace from=".C_AVDD > .pin1" to=".U1 > .SVDD" />
+    <trace from=".U1 > .VDD_PA" to=".C_PA > .pin1" />
+    <trace from=".C_PA > .pin1" to=".U1 > .SVDD" />
+    <trace from=".U1 > .I0" to=".U1 > .SVDD" />
+    <trace from=".U1 > .NFCC_VLOAD" to=".U1 > .SVDD" />
+    <trace from=".C_PVDD > .pin1" to=".U1 > .PVDD" />
+    <trace from=".C_SVDD > .pin1" to=".U1 > .SVDD" />
+
+    <trace from=".U1 > .SVDD" to=".L_TVDD > .pin1" />
+    <trace from=".L_TVDD > .pin2" to=".U1 > .TVDD" />
+    <trace from=".C_TVDD > .pin1" to=".U1 > .TVDD" />
+
+    <trace from=".R_SDA > .pin1" to=".U1 > .SVDD" />
+    <trace from=".R_SCL > .pin1" to=".U1 > .SVDD" />
+    <trace from=".R_IRQ > .pin1" to=".U1 > .SVDD" />
+    <trace from=".R_SDA > .pin2" to=".U1 > .SDA" />
+    <trace from=".R_SCL > .pin2" to=".U1 > .SCL" />
+    <trace from=".R_IRQ > .pin2" to=".U1 > .IRQ" />
+
+    <trace from=".J1 > .pin3" to=".U1 > .SDA" />
+    <trace from=".J1 > .pin4" to=".U1 > .SCL" />
+    <trace from=".J1 > .pin5" to=".U1 > .IRQ" />
+    <trace from=".J1 > .pin6" to=".U1 > .NRST" />
+
+    <trace from=".J1 > .pin2" to=".U1 > .GND1" />
+    <trace from=".U1 > .GND1" to=".U1 > .GND2" />
+    <trace from=".U1 > .GND2" to=".U1 > .AVSS" />
+    <trace from=".U1 > .AVSS" to=".U1 > .AGND1" />
+    <trace from=".U1 > .AGND1" to=".U1 > .AGND2" />
+    <trace from=".U1 > .AGND2" to=".U1 > .EP" />
+    <trace from=".U1 > .EP" to=".U1 > .I1" />
+    <trace from=".U1 > .I1" to=".U1 > .NSS" />
+    <trace from=".U1 > .NSS" to=".U1 > .SIGIN" />
+    <trace from=".U1 > .SIGIN" to=".U1 > .VMID" />
+    <trace from=".U1 > .VMID" to=".C_VMID > .pin2" />
+    <trace from=".C_VMID > .pin1" to=".U1 > .SVDD" />
+    <trace from=".J1 > .pin9" to=".U1 > .EP" />
+
+    <trace from=".U1 > .TX1" to=".Rq1 > .pin1" />
+    <trace from=".Rq1 > .pin2" to=".L0_TX1 > .pin1" />
+    <trace from=".L0_TX1 > .pin2" to=".C0_TX1 > .pin1" />
+    <trace from=".C0_TX1 > .pin2" to=".U1 > .EP" />
+    <trace from=".L0_TX1 > .pin2" to=".C1_TX1 > .pin1" />
+    <trace from=".C1_TX1 > .pin2" to=".C2_TX1 > .pin1" />
+    <trace from=".C2_TX1 > .pin2" to=".U1 > .EP" />
+    <trace from=".C1_TX1 > .pin2" to=".Rs1 > .pin1" />
+    <trace from=".Rs1 > .pin2" to=".Cs1 > .pin1" />
+    <trace from=".Cs1 > .pin2" to=".U1 > .EP" />
+
+    <trace from=".U1 > .TX2" to=".Rq2 > .pin1" />
+    <trace from=".Rq2 > .pin2" to=".L0_TX2 > .pin1" />
+    <trace from=".L0_TX2 > .pin2" to=".C0_TX2 > .pin1" />
+    <trace from=".C0_TX2 > .pin2" to=".U1 > .EP" />
+    <trace from=".L0_TX2 > .pin2" to=".C1_TX2 > .pin1" />
+    <trace from=".C1_TX2 > .pin2" to=".C2_TX2 > .pin1" />
+    <trace from=".C2_TX2 > .pin2" to=".U1 > .EP" />
+    <trace from=".C1_TX2 > .pin2" to=".Rs2 > .pin1" />
+    <trace from=".Rs2 > .pin2" to=".Cs2 > .pin1" />
+    <trace from=".Cs2 > .pin2" to=".U1 > .EP" />
+
+    <trace from=".J1 > .pin8" to=".L_LED > .pin1" />
+    <trace from=".L_LED > .pin2" to=".C_LED_BULK > .pin1" />
+    <trace from=".C_LED_BULK > .pin2" to=".U1 > .EP" />
+    <trace from=".J1 > .pin7" to=".R_LED > .pin1" />
+    <trace from=".R_LED > .pin2" to=".LED1 > .DIN" />
+    <trace from=".L_LED > .pin2" to=".LED1 > .VDD" />
+
+    {leds.slice(0, -1).map((_l, i) =>
+      traceJsx(`.LED${i + 1} > .DOUT`, `.LED${i + 2} > .DIN`, `din-${i}`),
+    )}
+    {leds.slice(0, -1).map((_l, i) =>
+      traceJsx(`.LED${i + 1} > .VDD`, `.LED${i + 2} > .VDD`, `vdd-${i}`),
+    )}
+    {leds.slice(0, -1).map((_l, i) =>
+      traceJsx(`.LED${i + 1} > .GND`, `.LED${i + 2} > .GND`, `gnd-${i}`),
+    )}
+    <trace from=".LED1 > .GND" to=".U1 > .EP" />
+
+    {leds.map((l, i) => traceJsx(`.${l.cap} > .pin1`, `.${l.name} > .VDD`, `decvdd-${i}`))}
+    {leds.map((l, i) => traceJsx(`.${l.cap} > .pin2`, `.${l.name} > .GND`, `decgnd-${i}`))}
+  </board>
+);

--- a/apps/attractap/hardware/nfc/index.tsx
+++ b/apps/attractap/hardware/nfc/index.tsx
@@ -151,9 +151,9 @@ export default () => (
     <hole diameter="3.2mm" {...at(3, 47)} />
     <hole diameter="3.2mm" {...at(47, 47)} />
 
-    <BoardLabel name="ATT-350 NFC" rev="v0" {...at(25, 3.5)} />
-    <AttraccessLogo {...at(7, 3)} scale={1.1} />
-    <AttraccessLogo {...at(43, 3)} scale={1.1} />
+    <BoardLabel name="ATT-350 NFC" rev="v0" {...at(25, 3)} />
+    <AttraccessLogo {...at(7, 4.5)} scale={1.1} />
+    <AttraccessLogo {...at(43, 4.5)} scale={1.1} />
     <Pin1Marker {...at(32.2, 47)} />
 
     <trace from=".J1 > .pin1" to=".C_VBUS > .pin1" />

--- a/apps/attractap/hardware/nfc/index.tsx
+++ b/apps/attractap/hardware/nfc/index.tsx
@@ -119,6 +119,7 @@ export default () => (
     <R0402 name="R_SDA" pn={R_4K7_PN} resistance="4.7k" {...atBottom(22.41, 34.66)} />
     <R0402 name="R_SCL" pn={R_4K7_PN} resistance="4.7k" {...atBottom(25, 35)} />
     <R0402 name="R_IRQ" pn={R_10K_PN} resistance="10k" {...atBottom(27.59, 34.66)} />
+    <R0402 name="R_NSS" pn={R_10K_PN} resistance="10k" {...atBottom(30, 33.5)} />
 
     <R0603 name="Rq1" pn={R_4R7_PN} resistance="4.7" {...atBottom(32.07, 17.93)} />
     <L0603 name="L0_TX1" pn={L_560NH_PN} inductance="560nH" {...atBottom(33.66, 20)} />
@@ -185,13 +186,14 @@ export default () => (
     <trace from=".U1 > .AVSS" to=".U1 > .AGND1" />
     <trace from=".U1 > .AGND1" to=".U1 > .AGND2" />
     <trace from=".U1 > .AGND2" to=".U1 > .EP" />
-    <trace from=".U1 > .EP" to=".U1 > .I1" />
-    <trace from=".U1 > .I1" to=".U1 > .NSS" />
-    <trace from=".U1 > .NSS" to=".U1 > .SIGIN" />
-    <trace from=".U1 > .SIGIN" to=".U1 > .VMID" />
-    <trace from=".U1 > .VMID" to=".C_VMID > .pin2" />
-    <trace from=".C_VMID > .pin1" to=".U1 > .SVDD" />
     <trace from=".J1 > .pin9" to=".U1 > .EP" />
+
+    <trace from=".U1 > .I1" to=".U1 > .EP" />
+    <trace from=".U1 > .SIGIN" to=".U1 > .EP" />
+    <trace from=".R_NSS > .pin1" to=".U1 > .SVDD" />
+    <trace from=".R_NSS > .pin2" to=".U1 > .NSS" />
+    <trace from=".U1 > .VMID" to=".C_VMID > .pin1" />
+    <trace from=".C_VMID > .pin2" to=".U1 > .EP" />
 
     <trace from=".U1 > .TX1" to=".Rq1 > .pin1" />
     <trace from=".Rq1 > .pin2" to=".L0_TX1 > .pin1" />

--- a/apps/attractap/hardware/nfc/index.tsx
+++ b/apps/attractap/hardware/nfc/index.tsx
@@ -2,12 +2,15 @@
 // FEATURE: hardware/nfc — Phase 2 Attractap V2 board ATT-350
 
 import {
+  AttraccessLogo,
   B2B_127_2xN,
+  BoardLabel,
   boardCoord,
   C0402,
   C0603,
   L0603,
   NfcCoilAntenna,
+  Pin1Marker,
   Pn532Ic,
   R0402,
   R0603,
@@ -148,7 +151,10 @@ export default () => (
     <hole diameter="3.2mm" {...at(3, 47)} />
     <hole diameter="3.2mm" {...at(47, 47)} />
 
-    <silkscreentext text="ATT-350 NFC v0" {...at(25, 4)} fontSize="1.2mm" />
+    <BoardLabel name="ATT-350 NFC" rev="v0" {...at(25, 3.5)} />
+    <AttraccessLogo {...at(7, 3)} scale={1.1} />
+    <AttraccessLogo {...at(43, 3)} scale={1.1} />
+    <Pin1Marker {...at(32.2, 47)} />
 
     <trace from=".J1 > .pin1" to=".C_VBUS > .pin1" />
     <trace from=".C_VBUS > .pin1" to=".U1 > .VBUS" />

--- a/apps/attractap/hardware/nfc/package.json
+++ b/apps/attractap/hardware/nfc/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@attraccess/attractap-hw-nfc",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@attraccess/attractap-hw-shared": "workspace:*",
+    "@tscircuit/cli": "0.1.1399",
+    "playwright": "1.56.1",
+    "tscircuit": "0.0.1774",
+    "tsx": "^4.20.3"
+  }
+}

--- a/apps/attractap/hardware/nfc/project.json
+++ b/apps/attractap/hardware/nfc/project.json
@@ -1,0 +1,84 @@
+{
+  "name": "attractap-hw-nfc",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/attractap/hardware/nfc",
+  "tags": ["scope:hardware", "type:board"],
+  "targets": {
+    "lint": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": [],
+      "options": {
+        "cwd": "apps/attractap/hardware/nfc",
+        "command": "pnpm exec tscircuit-cli build index.tsx --ignore-warnings"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/build"],
+      "options": {
+        "cwd": "apps/attractap/hardware/nfc",
+        "commands": [
+          "rm -rf dist/build && mkdir -p dist/build",
+          "pnpm exec tscircuit-cli export index.tsx -f circuit-json -o dist/build/nfc.circuit.json"
+        ],
+        "parallel": false
+      }
+    },
+    "export": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/export"],
+      "options": {
+        "cwd": "apps/attractap/hardware/nfc",
+        "commands": [
+          "rm -rf dist/export && mkdir -p dist/export",
+          "pnpm exec tscircuit-cli export index.tsx -f gerbers -o dist/export/nfc-gerbers.zip",
+          "node ../scripts/validate-bom.mjs dist/export/nfc-gerbers.zip"
+        ],
+        "parallel": false
+      }
+    },
+    "render": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/render"],
+      "options": {
+        "cwd": "apps/attractap/hardware/nfc",
+        "commands": [
+          "rm -rf dist/render && mkdir -p dist/render",
+          "pnpm exec tscircuit-cli export index.tsx -f pcb-svg -o dist/render/nfc-pcb.svg",
+          "pnpm exec tscircuit-cli export index.tsx -f schematic-svg -o dist/render/nfc-schematic.svg",
+          "pnpm exec tscircuit-cli export index.tsx -f assembly-svg -o dist/render/nfc-assembly.svg",
+          "node ../scripts/render-png.mjs --out-dir dist/render dist/render/nfc-pcb.svg dist/render/nfc-schematic.svg dist/render/nfc-assembly.svg"
+        ],
+        "parallel": false
+      }
+    },
+    "render-3d": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/render-3d"],
+      "options": {
+        "cwd": "apps/attractap/hardware/nfc",
+        "commands": [
+          "rm -rf dist/render-3d && mkdir -p dist/render-3d",
+          "pnpm exec tscircuit-cli export index.tsx -f glb -o dist/render-3d/nfc.glb",
+          "pnpm exec tscircuit-cli export index.tsx -f step -o dist/render-3d/nfc.step",
+          "node ../scripts/render-glb-png.mjs --out-dir dist/render-3d dist/render-3d/nfc.glb"
+        ],
+        "parallel": false
+      }
+    }
+  }
+}

--- a/apps/attractap/hardware/nfc/tsconfig.json
+++ b/apps/attractap/hardware/nfc/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["@tscircuit/props"]
+  },
+  "include": ["index.tsx"]
+}

--- a/apps/attractap/hardware/scripts/lcsc-classes.json
+++ b/apps/attractap/hardware/scripts/lcsc-classes.json
@@ -5,5 +5,20 @@
   "C25804": { "category": "Resistors", "subcategory": "Chip Resistor - Surface Mount", "model": "0603WAF1002T5E" },
   "C81598": { "category": "Diodes", "subcategory": "Switching Diodes", "model": "1N4148W" },
   "C2687681": { "category": "Audio Products / Vibration Motors", "subcategory": "Buzzers", "model": "SEA-1295Y-0520-42Ω-38P6.5" },
-  "C122442": { "category": "Connectors", "subcategory": "Wire To Board Connector", "model": "530470310" }
+  "C122442": { "category": "Connectors", "subcategory": "Wire To Board Connector", "model": "530470310" },
+  "C28925": { "category": "RF and Wireless", "subcategory": "RFID ICs", "model": "PN5321A3HN/C106,55" },
+  "C4154873": { "category": "Optoelectronics", "subcategory": "RGB LEDs(Built-in IC)", "model": "WS2812B-MINI-X2" },
+  "C25900": { "category": "Resistors", "subcategory": "Chip Resistor - Surface Mount", "model": "0402WGF4701TCE" },
+  "C25744": { "category": "Resistors", "subcategory": "Chip Resistor - Surface Mount", "model": "0402WGF1002TCE" },
+  "C25105": { "category": "Resistors", "subcategory": "Chip Resistor - Surface Mount", "model": "0402WGF330JTCE" },
+  "C23164": { "category": "Resistors", "subcategory": "Chip Resistor - Surface Mount", "model": "0603WAF470KT5E" },
+  "C25132": { "category": "Resistors", "subcategory": "Chip Resistor - Surface Mount", "model": "0402WGF7500TCE" },
+  "C307331": { "category": "Capacitors", "subcategory": "Multilayer Ceramic Capacitors MLCC - SMD/SMT", "model": "CL05B104KB54PNC" },
+  "C96446": { "category": "Capacitors", "subcategory": "Multilayer Ceramic Capacitors MLCC - SMD/SMT", "model": "CL10A106MA8NRNC" },
+  "C76947": { "category": "Capacitors", "subcategory": "Multilayer Ceramic Capacitors MLCC - SMD/SMT", "model": "GRM1555C1H102JA01D" },
+  "C1567": { "category": "Capacitors", "subcategory": "Multilayer Ceramic Capacitors MLCC - SMD/SMT", "model": "0402CG470J500NT" },
+  "C20069329": { "category": "Capacitors", "subcategory": "Multilayer Ceramic Capacitors MLCC - SMD/SMT", "model": "CGA0402C0G181J500GT" },
+  "C502009": { "category": "Inductors, Coils, Chokes", "subcategory": "Inductors (SMD)", "model": "MLJ1608WR56JT000" },
+  "C14709": { "category": "Filters", "subcategory": "Ferrite Beads", "model": "BLM18PG121SN1D" },
+  "C2935458": { "category": "Connectors", "subcategory": "Pin Headers", "model": "PZ127VS-12-10-H10-A38" }
 }

--- a/apps/attractap/hardware/scripts/validate-bom.mjs
+++ b/apps/attractap/hardware/scripts/validate-bom.mjs
@@ -8,12 +8,12 @@ import { fileURLToPath } from 'node:url';
 
 const REF_CLASS = [
   { prefix: 'LS', pattern: /buzzer|speaker|audio/i, label: 'buzzer' },
-  { prefix: 'LED', pattern: /\bled\b|light.?emitting/i, label: 'LED' },
+  { prefix: 'LED', pattern: /\bleds?\b|light.?emitting/i, label: 'LED' },
   { prefix: 'SW', pattern: /switch|tactile|key/i, label: 'switch' },
   { prefix: 'Y', pattern: /crystal|oscillator|resonator/i, label: 'crystal/oscillator' },
   { prefix: 'Q', pattern: /mosfet|bjt|transistor|jfet|igbt|thyristor/i, label: 'transistor' },
   { prefix: 'D', pattern: /diode|rectifier|tvs|zener|schottky/i, label: 'diode' },
-  { prefix: 'U', pattern: /\bic\b|integrated|microcontroller|regulator|op.?amp|driver|converter|sensor|memory|logic/i, label: 'IC' },
+  { prefix: 'U', pattern: /\bics?\b|integrated|microcontroller|regulator|op.?amp|driver|converter|sensor|memory|logic|rfid|wireless/i, label: 'IC' },
   { prefix: 'J', pattern: /connector|terminal|header|jack|socket|receptacle|wire.?to.?board/i, label: 'connector' },
   { prefix: 'R', pattern: /resistor/i, label: 'resistor' },
   { prefix: 'C', pattern: /capacitor/i, label: 'capacitor' },

--- a/apps/attractap/hardware/scripts/validate-bom.mjs
+++ b/apps/attractap/hardware/scripts/validate-bom.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 const REF_CLASS = [
   { prefix: 'LS', pattern: /buzzer|speaker|audio/i, label: 'buzzer' },
   { prefix: 'LED', pattern: /\bleds?\b|light.?emitting/i, label: 'LED' },
+  { prefix: 'ANT', pattern: /.*/, label: 'antenna', allowMissingPn: true },
   { prefix: 'SW', pattern: /switch|tactile|key/i, label: 'switch' },
   { prefix: 'Y', pattern: /crystal|oscillator|resonator/i, label: 'crystal/oscillator' },
   { prefix: 'Q', pattern: /mosfet|bjt|transistor|jfet|igbt|thyristor/i, label: 'transistor' },
@@ -56,7 +57,11 @@ function main() {
     process.exit(2);
   }
   const rows = parseCsv(readBomFromZip(zipPath));
-  const missing = rows.filter((r) => !r['JLCPCB Part #']);
+  const missing = rows.filter((r) => {
+    if (r['JLCPCB Part #']) return false;
+    const klass = classifyRef(r.Designator ?? '');
+    return !klass?.allowMissingPn;
+  });
   if (missing.length > 0) {
     process.stderr.write(
       `BOM validator: ${missing.length} row(s) missing JLCPCB Part #: ${missing.map((r) => r.Designator).join(', ')}\n`,
@@ -71,6 +76,7 @@ function main() {
     const designator = row.Designator ?? '';
     const expected = classifyRef(designator);
     if (!expected) continue;
+    if (!pn && expected.allowMissingPn) continue;
     const entry = classes[pn];
     if (!entry) {
       unknown.push(`${designator} (${pn}) — not in lcsc-classes.json; run \`pnpm pcbparts:jlc_get_part ${pn}\` and add it`);

--- a/docs/research/2026-05-22-att-350-nfc-board-design.md
+++ b/docs/research/2026-05-22-att-350-nfc-board-design.md
@@ -1,0 +1,241 @@
+# ATT-350 — NFC board design (PN532 + WS2812 ring)
+
+- Linear issue: [ATT-350](https://linear.app/attraccess/issue/ATT-350/p2-nfc-board-pn532-ws2812-ring)
+- Parent epic: [ATT-345](https://linear.app/attraccess/issue/ATT-345)
+- Blocked-by: [ATT-348](https://linear.app/attraccess/issue/ATT-348) (Beeper pipeline proof) — done
+- Date: 2026-05-22
+- Status: v0 design, pending PR review
+
+## 1. Goal
+
+Phase-2 NFC reader board for the Attractap V2 stack. Carries:
+
+- NXP PN5321A3HN (PN532) RFID front-end, QFN-40-EP, JLC C28925
+- 24× WS2812B-MINI RGB LEDs (SMD3535) arranged as a ring around the
+  on-board 13.56 MHz antenna
+- I2C pull-ups, antenna matching network, EMI mitigations
+- `J_NFC` (B2B 1.27 mm 2×5) edge connector to the Core
+
+Acceptance gates (verbatim from ATT-350):
+
+1. `nx run nfc:lint` clean on JLC ruleset.
+2. `nx run nfc:export` clean.
+3. `nx run nfc:render` PNGs.
+4. Peer review.
+5. Smoke: +5 V via `J_NFC`, ring lights all 24 pixels, I2C reachable,
+   PN532 firmware version readable.
+6. Functional: reads MIFARE Classic + NTAG via I2C.
+
+v0 (this PR) drives gates **1–3**; gate **5** is a bench step post-fab;
+gate **6** depends on antenna tuning and is deferred to the deep-research
+sub-issue under ATT-343 (see §6).
+
+## 2. Mechanical envelope
+
+From `libs/attractap-hw-shared/mech-envelope.md` NFC row:
+
+| Item                       | Value                                            |
+|----------------------------|--------------------------------------------------|
+| Outline                    | 50.0 × 50.0 mm                                   |
+| Max top-side height        | 6.0 mm                                           |
+| Max bottom-side height     | 1.0 mm                                           |
+| Mounting holes (M3 clear.) | (3,3), (47,3), (3,47), (47,47), Ø3.2 mm, 6 mm Cu keep-out |
+| Antenna Cu keep-out radius | ≥ 5 mm from antenna footprint (locked here at **6 mm**) |
+
+Board origin = bottom-left corner. tscircuit centres are computed via
+`boardCoord` from the shared lib.
+
+## 3. Block diagram
+
+```
+J_NFC (B2B 1.27mm 2x5) ──+──── +3V3 ───┬── PN532 SVDD / VDD_PA / PVDD / VBUS
+                         │              ├── I2C pull-ups (4.7k to +3V3)
+                         │              └── PN532 decoupling (10uF + 100nF per rail)
+                         ├──── +5V ────► LC filter (10uH + 10uF) ──► WS2812 ring
+                         ├──── GND ────► return
+                         ├──── SDA  ◄──► PN532 SDA  (pull-up to +3V3)
+                         ├──── SCL  ◄──┘ PN532 SCL  (pull-up to +3V3)
+                         ├──── IRQ  ◄──── PN532 IRQ
+                         ├──── RST  ────► PN532 NRST
+                         └──── LED_DATA ─► [33Ω] ► WS2812 #1 DIN → … → #24 DOUT (NC)
+
+                  PN532 TX1/TX2 ─────► matching network ─────► antenna loop on PCB
+                                       (EMC L0/C0, tuning C1/C2, Rq, Rs/Rd, Cs/Cd)
+```
+
+## 4. PN532 minimum schematic (bare IC path)
+
+The shared lib's `Pn532Module` wrapper from ATT-347 assumed a hand-soldered
+PN532-v3 daughterboard. That footprint (~43 × 41 mm) doesn't leave room
+for a 24-LED ring on a 50 × 50 mm board, and JLC SMT can't populate it.
+This PR replaces the wrapper with a bare-IC wrapper (`Pn532Ic`) matched to
+the QFN-40-EP-(6×6) package that JLC stocks under C28925.
+
+### 4.1 Mode strapping
+
+I2C is selected with `I0 = 1`, `I1 = 0` (datasheet §6.1.1). Both tied at
+the chip with hard rails — no test jumper needed.
+
+### 4.2 Power pins
+
+| Net    | PN532 pins        | Decoupling near pin                |
+|--------|-------------------|------------------------------------|
+| +3V3   | VBUS, PVDD, SVDD  | 100 nF 0402 each                   |
+| +3V3   | VDD_PA            | 100 nF 0402 + 10 µF 0603 bulk      |
+| +3V3   | TVDD              | 100 nF 0402 (RF supply, sensitive) |
+| GND    | GND, AVSS, AGND×2 | single GND fill, AVSS/AGND star to PGND under EP |
+
+Datasheet AN1445 §4.1 explicitly calls out tying TVDD to the same +3V3
+rail through a small inductor; we use a 47 µH ferrite bead between +3V3
+and TVDD to keep PA switching noise off the digital rail.
+
+### 4.3 I2C bus
+
+- SDA / SCL: 4.7 kΩ 0402 pull-ups to +3V3 (matches `J_NFC` SDA/SCL).
+- IRQ: open-drain from PN532 → pulled up to +3V3 with 10 kΩ on the NFC
+  board (so the Core sees a defined level even when the PN532 is held in
+  reset).
+- NRST: driven by `J_NFC.RSTPDN`. No on-board pull (Core owns it).
+
+### 4.4 Antenna matching network — initial values (NXP AN1445 §5)
+
+Reference values, intended to be tuned during bring-up. Symmetric
+network on TX1/TX2 sides.
+
+| Designator | Value      | Function                                  | Footprint |
+|------------|------------|-------------------------------------------|-----------|
+| L0a, L0b   | 560 nH ±5% | EMC filter inductors                      | 0603      |
+| C0a, C0b   | 180 pF NP0 | EMC filter caps                           | 0402      |
+| C1a, C1b   | 47 pF NP0  | Series tuning (resonance trim)            | 0402      |
+| C2a, C2b   | 47 pF NP0  | Parallel tuning (impedance match)         | 0402      |
+| Rqa, Rqb   | 4.7 Ω      | Q-damping resistors (lower Q = wider BW)  | 0603      |
+| Rsa, Rsb   | 750 Ω      | Receive filter series                     | 0402      |
+| Csa, Csb   | 1 nF       | Receive filter shunt                      | 0402      |
+
+Antenna pin connections: PN532 `TX1 → L0a → C1a → antenna_left`; same on
+TX2 side. Receive path: antenna node → `Csa/Rsa` → PN532 `RX/LA/LB`. The
+exact parametrics depend on enclosure dielectric — these are the
+defaults the deep-research sub-issue (§6) will refine.
+
+### 4.5 PCB antenna loop
+
+v0 footprint: **rectangular 4-turn loop, 28 × 28 mm outline**, 0.5 mm
+trace, 0.5 mm gap, on the **top copper layer only**. Loop sits centred
+at the board centre (25, 25). No copper, no via, no trace inside the
+loop on either layer (NXP AN1445 §3 "antenna interior keep-out" rule).
+Bottom-layer is left bare in the antenna area; hatched GND alternative
+is documented in `mech-envelope.md` and tuned during bring-up.
+
+tscircuit cannot draw spiral antenna geometry directly. v0 leaves the
+loop as a **fabrication note + silkscreen rectangle outline** in the
+exported gerbers; the actual copper antenna is added by the deep-research
+sub-issue's KiCad pass before fab. This is acknowledged in the schematic
+fab-note text.
+
+## 5. WS2812 ring
+
+24× `WS2812B-MINI-X2` (C4154873, SMD3535-4P, 3.5 × 3.5 mm). 5 V supply,
+~16 mA per channel, ~50 mA per LED worst case white = **1.2 A worst-case
+ring current**. The `+5V` rail at `J_NFC.pin8` must deliver this.
+
+### 5.1 Geometry
+
+Ring radius `R = 18 mm` from board centre. 24 LEDs at 15° spacing.
+Pixel `i` placement (i = 0…23):
+
+```
+angle_i = i × 15°   (i = 0 at +x axis, counter-clockwise)
+cx_i = 25 + 18 × cos(angle_i)
+cy_i = 25 + 18 × sin(angle_i)
+rot_i = angle_i  (LEDs face radially outward — DIN pin towards previous)
+```
+
+Inner edge of LED ring sits at R ≈ 16.25 mm (LED half-width 1.75 mm).
+Outer edge at R ≈ 19.75 mm. The 28 × 28 mm antenna footprint (half-side
+14 mm) fits inside the ring with a 2 mm copper-free margin. Mounting
+holes at corners (distance ≈ 31 mm from centre) sit clear of both ring
+and antenna keep-out.
+
+### 5.2 EMI mitigations (per spec §5.2 R5)
+
+- **GP cut between antenna loop and LED ring**: hatched GND keep-out
+  ring at R = 14–17 mm so the antenna's near-field doesn't see a
+  continuous switching reference plane underneath.
+- **LED_DATA series 33 Ω 0402** at the first WS2812 to slow edges.
+- **LC filter on +5 V LED branch**: 10 µH 0603 ferrite bead + 10 µF
+  0603 bulk on the WS2812 side of the bead. The +3V3 PN532 rail enters
+  the board on a separate pin and shares no copper with the LED rail
+  inside the antenna keep-out.
+- **Decoupling per LED**: 100 nF 0402 across each WS2812 VDD/GND.
+- **GND return for the ring routes outside the antenna keep-out** — the
+  return current loop is steered around the antenna, not under it.
+
+## 6. Open questions (deferred to ATT-343 deep-research sub-issue)
+
+These exist in the issue text and the design spec §5.3 NFC entries:
+
+1. **Antenna geometry locked to enclosure window cutout** — needs the
+   case CAD ticket to land first.
+2. **Q-factor tuning component values** — depends on (1) plus measured
+   resonance peak.
+3. **RF shielding strategy** — whether the WS2812 ring needs a discrete
+   shield layer (e.g. dedicated GND mesh on bottom layer) beyond what's
+   in §5.2.
+
+The deep-research sub-issue under ATT-343 will pin these down before the
+next NFC board revision. v0 ships with NXP AN1445 reference values and
+the rectangular 28 × 28 mm loop as the working starting point.
+
+## 7. Layer choice
+
+JLC 2-layer (default). The matching network components fit on top side;
+GND fill on bottom layer (with the antenna keep-out cut out); `LED_DATA`
+daisy-chain routes on top between LEDs. Differential pair / controlled
+impedance is **not required** for a 13.56 MHz antenna trace at this
+scale — the matching network compensates for the parasitic.
+
+A 4-layer bump is allowed by the ticket if antenna tuning forces it
+(R5 in design spec §5.2). v0 stays on 2-layer; the deep-research
+sub-issue may upgrade.
+
+## 8. BOM (v0)
+
+| Ref           | Qty | Part                       | JLC PN     | Footprint   |
+|---------------|-----|----------------------------|------------|-------------|
+| U1            | 1   | PN5321A3HN                 | C28925     | QFN-40-EP   |
+| D1…D24        | 24  | WS2812B-MINI-X2            | C4154873   | SMD3535-4P  |
+| J1            | 1   | B2B 1.27 mm 2×5 male       | (existing) | pinrow10_p1.27 |
+| R_SDA, R_SCL  | 2   | 4.7 kΩ 0402                | C25092     | 0402        |
+| R_IRQ         | 1   | 10 kΩ 0402                 | C25744     | 0402        |
+| R_LED         | 1   | 33 Ω 0402                  | C25092 (TBD) | 0402      |
+| Rq1, Rq2      | 2   | 4.7 Ω 0603                 | TBD        | 0603        |
+| Rs1, Rs2      | 2   | 750 Ω 0402                 | TBD        | 0402        |
+| L_TVDD        | 1   | 47 µH ferrite bead         | TBD        | 0603        |
+| L_LED         | 1   | 10 µH ferrite bead         | TBD        | 0603        |
+| L0_TX1, L0_TX2| 2   | 560 nH ±5%                 | TBD        | 0603        |
+| C0_TX1, C0_TX2| 2   | 180 pF NP0                 | TBD        | 0402        |
+| C1_TX1, C1_TX2| 2   | 47 pF NP0                  | TBD        | 0402        |
+| C2_TX1, C2_TX2| 2   | 47 pF NP0                  | TBD        | 0402        |
+| Cs1, Cs2      | 2   | 1 nF                       | TBD        | 0402        |
+| C_PN_BULK     | 1   | 10 µF 0603                 | C19702     | 0603        |
+| C_PN_DEC×4    | 4   | 100 nF 0402                | C1525      | 0402        |
+| C_LED_BULK    | 1   | 10 µF 0603                 | C19702     | 0603        |
+| C_LED_DEC×24  | 24  | 100 nF 0402                | C1525      | 0402        |
+
+**~75 part placements total**. JLC SMT-assembled in one pass. Any `TBD`
+PN is resolved during the implementation PR using `pcbparts:jlc_search`
+and committed to `lcsc-classes.json`.
+
+## 9. Acceptance + deferral
+
+- Gates 1–3 close in this PR.
+- Gate 4 (peer review) on the PR.
+- Gate 5 (bench smoke) — board ordered + assembled, run from a dev MCU.
+- Gate 6 (MIFARE/NTAG read) — needs antenna copper drawn, which is the
+  deferred deep-research sub-issue. Gate 6 closes in a follow-up PR
+  that revs the board.
+
+## 10. Out of scope (verbatim from ticket)
+
+- Antenna geometry for the final case (case CAD is its own epic).
+- Multi-protocol RF (ISO-14443A only via PN532).

--- a/docs/research/2026-05-22-att-350-nfc-board-design.md
+++ b/docs/research/2026-05-22-att-350-nfc-board-design.md
@@ -27,7 +27,8 @@ Acceptance gates (verbatim from ATT-350):
 6. Functional: reads MIFARE Classic + NTAG via I2C.
 
 v0 (this PR) drives gates **1–3**; gate **5** is a bench step post-fab;
-gate **6** depends on antenna tuning and is deferred to the deep-research
+gate **6** depends on the case-CAD enclosure-window aperture (drives the
+chosen ANT1 PN) and matching-network tuning, deferred to the deep-research
 sub-issue under ATT-343 (see §6).
 
 ## 2. Mechanical envelope
@@ -117,20 +118,31 @@ TX2 side. Receive path: antenna node → `Csa/Rsa` → PN532 `RX/LA/LB`. The
 exact parametrics depend on enclosure dielectric — these are the
 defaults the deep-research sub-issue (§6) will refine.
 
-### 4.5 PCB antenna loop
+### 4.5 Discrete coil antenna (v0)
 
-v0 footprint: **rectangular 4-turn loop, 28 × 28 mm outline**, 0.5 mm
-trace, 0.5 mm gap, on the **top copper layer only**. Loop sits centred
-at the board centre (25, 25). No copper, no via, no trace inside the
-loop on either layer (NXP AN1445 §3 "antenna interior keep-out" rule).
-Bottom-layer is left bare in the antenna area; hatched GND alternative
-is documented in `mech-envelope.md` and tuned during bring-up.
+v0 uses a **discrete pre-wound 13.56 MHz NFC coil antenna**, hand-populated
+through a 2-pad SMT footprint. Default footprint: 22 × 22 mm body,
+18 mm pad pitch, 1.8 × 2.5 mm pads — matches the common Abracon
+ANFCA-2521 / Wurth WE-MCA / Pulse PA0742 form factor for 22-mm-class
+NFC coils. Exact PN is locked by ATT-376 once the case-CAD enclosure
+window aperture is known.
 
-tscircuit cannot draw spiral antenna geometry directly. v0 leaves the
-loop as a **fabrication note + silkscreen rectangle outline** in the
-exported gerbers; the actual copper antenna is added by the deep-research
-sub-issue's KiCad pass before fab. This is acknowledged in the schematic
-fab-note text.
+The antenna sits **top-side, centred at (25, 25)**, with the 24 WS2812
+LEDs in a ring around it on the same layer. The PN532 IC, matching
+network, decoupling caps, and I2C pull-ups all live on the **bottom
+layer**, directly under the antenna and ring; bottom mech-envelope
+height budget (1.0 mm) accommodates the QFN-40 (0.85 mm) plus 0402 /
+0603 passives.
+
+Going discrete-component rather than PCB-trace antenna trades the
+RF-trace tuning work (Q-factor sweep, multi-turn spiral routing) for
+a vendor-spec'd antenna with known inductance and Q — the matching
+network values from NXP AN1445 (§4.4) are now a single tuning pass
+against the chosen coil's L/R/Q datasheet numbers, not a re-layout.
+
+BOM emits `ANT1` with an empty JLC PN column; the validator allows
+this for `ANT` designators since JLC SMT doesn't stock NFC antennas.
+Antenna is hand-soldered after JLC SMT assembly.
 
 ## 5. WS2812 ring
 
@@ -200,31 +212,30 @@ sub-issue may upgrade.
 
 ## 8. BOM (v0)
 
-| Ref           | Qty | Part                       | JLC PN     | Footprint   |
-|---------------|-----|----------------------------|------------|-------------|
-| U1            | 1   | PN5321A3HN                 | C28925     | QFN-40-EP   |
-| D1…D24        | 24  | WS2812B-MINI-X2            | C4154873   | SMD3535-4P  |
-| J1            | 1   | B2B 1.27 mm 2×5 male       | (existing) | pinrow10_p1.27 |
-| R_SDA, R_SCL  | 2   | 4.7 kΩ 0402                | C25092     | 0402        |
-| R_IRQ         | 1   | 10 kΩ 0402                 | C25744     | 0402        |
-| R_LED         | 1   | 33 Ω 0402                  | C25092 (TBD) | 0402      |
-| Rq1, Rq2      | 2   | 4.7 Ω 0603                 | TBD        | 0603        |
-| Rs1, Rs2      | 2   | 750 Ω 0402                 | TBD        | 0402        |
-| L_TVDD        | 1   | 47 µH ferrite bead         | TBD        | 0603        |
-| L_LED         | 1   | 10 µH ferrite bead         | TBD        | 0603        |
-| L0_TX1, L0_TX2| 2   | 560 nH ±5%                 | TBD        | 0603        |
-| C0_TX1, C0_TX2| 2   | 180 pF NP0                 | TBD        | 0402        |
-| C1_TX1, C1_TX2| 2   | 47 pF NP0                  | TBD        | 0402        |
-| C2_TX1, C2_TX2| 2   | 47 pF NP0                  | TBD        | 0402        |
-| Cs1, Cs2      | 2   | 1 nF                       | TBD        | 0402        |
-| C_PN_BULK     | 1   | 10 µF 0603                 | C19702     | 0603        |
-| C_PN_DEC×4    | 4   | 100 nF 0402                | C1525      | 0402        |
-| C_LED_BULK    | 1   | 10 µF 0603                 | C19702     | 0603        |
-| C_LED_DEC×24  | 24  | 100 nF 0402                | C1525      | 0402        |
+| Ref            | Qty | Part                                  | JLC PN     | Footprint     |
+|----------------|-----|---------------------------------------|------------|---------------|
+| U1             | 1   | PN5321A3HN                            | C28925     | QFN-40-EP     |
+| ANT1           | 1   | NFC coil antenna 22 × 22 mm (hand-pop)| —          | 2-pad 18 mm pitch SMT |
+| LED1…LED24     | 24  | WS2812B-MINI-X2                       | C4154873   | SMD3535-4P    |
+| J1             | 1   | B2B 1.27 mm 2×5 male SMD              | C2935458   | pinrow10_p1.27 |
+| R_SDA, R_SCL   | 2   | 4.7 kΩ 0402 1%                        | C25900     | 0402          |
+| R_IRQ          | 1   | 10 kΩ 0402 1%                         | C25744     | 0402          |
+| R_LED          | 1   | 33 Ω 0402 1%                          | C25105     | 0402          |
+| Rq1, Rq2       | 2   | 4.7 Ω 0603 1%                         | C23164     | 0603          |
+| Rs1, Rs2       | 2   | 750 Ω 0402 1%                         | C25132     | 0402          |
+| L_TVDD, L_LED  | 2   | 120 Ω @ 100 MHz ferrite bead 2 A      | C14709     | 0603          |
+| L0_TX1, L0_TX2 | 2   | 560 nH ±5%                            | C502009    | 0603          |
+| C0_TX1, C0_TX2 | 2   | 180 pF 50 V C0G                       | C20069329  | 0402          |
+| C1_TX1, C1_TX2 | 2   | 47 pF 50 V C0G                        | C1567      | 0402          |
+| C2_TX1, C2_TX2 | 2   | 47 pF 50 V C0G                        | C1567      | 0402          |
+| Cs1, Cs2       | 2   | 1 nF 50 V C0G                         | C76947     | 0402          |
+| C_PA, C_LED_BULK, C_LED_G1…6 | 8 | 10 µF 25 V X5R                  | C96446     | 0603          |
+| C_VBUS, C_PVDD, C_SVDD, C_AVDD, C_VMID, C_TVDD | 6 | 100 nF 50 V X7R     | C307331    | 0402          |
 
-**~75 part placements total**. JLC SMT-assembled in one pass. Any `TBD`
-PN is resolved during the implementation PR using `pcbparts:jlc_search`
-and committed to `lcsc-classes.json`.
+**~60 part placements**. PN532 + matching network + decoupling on
+bottom layer (under antenna); WS2812 ring + bulk decoupling + LED
+filter + connector on top layer. JLC SMT assembly populates everything
+except ANT1, which is hand-soldered post-SMT.
 
 ## 9. Acceptance + deferral
 

--- a/libs/attractap-hw-shared/README.md
+++ b/libs/attractap-hw-shared/README.md
@@ -42,6 +42,7 @@ libs/attractap-hw-shared/
       nfc.tsx            # PN532 bare-IC QFN-40 wrapper
       touch.tsx          # GT911
       leds.tsx           # WS2812 LED wrappers
+      silk.tsx           # AttraccessLogo, BoardLabel, Pin1Marker
     doc-gen/
       generate.ts        # emits CONNECTORS.md from the TS source
 ```
@@ -89,3 +90,27 @@ Omit a required signal and the project fails to compile.
    - notes/voltage/footprint string edits → **patch**
 5. Call out the bump rationale in the PR description so downstream board
    tickets know whether they need to respin.
+
+## Silkscreen policy
+
+Every Attractap board must follow these silk rules so the rendered PCB
+looks identifiable and uncluttered:
+
+1. **No descriptive blurbs.** Do not use `<fabricationnotetext>` to
+   restate what a part is or how it is wired. tscircuit overlays that
+   text onto the board view, and 24 copies of the same blurb destroy
+   readability.
+2. **One board label, top-edge or bottom-edge.** Use `<BoardLabel>` with
+   the project name (e.g. `ATT-350 NFC`) and revision (e.g. `v0`).
+3. **Attraccess logo on every board.** Use one or two `<AttraccessLogo>`
+   glyphs in free silk areas. Default scale 1.0 gives roughly a 4 mm
+   tall keyhole, scale to fit the available zone.
+4. **Pin-1 markers on every multi-pin connector.** Use `<Pin1Marker>`
+   placed at the pin-1 pad coordinate. Refdes alone is not enough — a
+   tech rotating the connector in a hurry needs a polarity dot.
+5. **Hide refdes on high-density part arrays.** WS2812 ring, breakout
+   pad arrays, etc. set `silkscreenTextVisibility="hidden"`. Refdes
+   stays on assembly drawing where it belongs.
+6. **Per-part silk outlines belong on the part wrapper**, not the
+   board. WS2812 outlines, antenna body box, buzzer circle all live in
+   the shared lib so every board gets the same silk for the same part.

--- a/libs/attractap-hw-shared/README.md
+++ b/libs/attractap-hw-shared/README.md
@@ -39,8 +39,9 @@ libs/attractap-hw-shared/
       power.tsx          # AMS1117-3.3, LM74700, MP2315
       connectors.tsx     # B2B 1.27mm, JST PH 1.25mm, FFC 0.5mm
       mcu.tsx            # ESP32-P4-MINI-1, ESP32-C6-MINI-1
-      nfc.tsx            # PN532 module
+      nfc.tsx            # PN532 bare-IC QFN-40 wrapper
       touch.tsx          # GT911
+      leds.tsx           # WS2812 LED wrappers
     doc-gen/
       generate.ts        # emits CONNECTORS.md from the TS source
 ```
@@ -60,7 +61,7 @@ without regenerating `CONNECTORS.md` fails the check.
 ## Using from a board
 
 ```tsx
-import { J_NFC, assertWiresAllSignals, Pn532Module } from '@attraccess/attractap-hw-shared';
+import { J_NFC, assertWiresAllSignals, Pn532Ic } from '@attraccess/attractap-hw-shared';
 
 const wires = assertWiresAllSignals(J_NFC, {
   '+3V3': 'net.v3v3',

--- a/libs/attractap-hw-shared/src/parts/buzzer.tsx
+++ b/libs/attractap-hw-shared/src/parts/buzzer.tsx
@@ -7,7 +7,6 @@ import { jlcSupplier } from './types';
 export interface BuzzerThProps extends BasePartProps {
   readonly pitchMm?: number;
   readonly bodyDiameterMm?: number;
-  readonly buzzerType?: 'magnetic' | 'piezo';
 }
 
 export const Buzzer5VTh = ({
@@ -15,7 +14,6 @@ export const Buzzer5VTh = ({
   pn,
   pitchMm = 5.08,
   bodyDiameterMm = 12,
-  buzzerType: _buzzerType = 'magnetic',
   ...rest
 }: BuzzerThProps) => (
   <chip

--- a/libs/attractap-hw-shared/src/parts/buzzer.tsx
+++ b/libs/attractap-hw-shared/src/parts/buzzer.tsx
@@ -15,7 +15,7 @@ export const Buzzer5VTh = ({
   pn,
   pitchMm = 5.08,
   bodyDiameterMm = 12,
-  buzzerType = 'magnetic',
+  buzzerType: _buzzerType = 'magnetic',
   ...rest
 }: BuzzerThProps) => (
   <chip
@@ -30,8 +30,5 @@ export const Buzzer5VTh = ({
       <silkscreencircle pcbX={0} pcbY={0} radius={bodyDiameterMm / 2} strokeWidth="0.15mm" />
       <courtyardcircle pcbX={0} pcbY={0} radius={bodyDiameterMm / 2} />
     </footprint>
-    <fabricationnotetext
-      text={`Buzzer 5V THT ${buzzerType} Ø${bodyDiameterMm}mm${buzzerType === 'magnetic' ? ' — flyback diode mandatory' : ' — no flyback needed'}`}
-    />
   </chip>
 );

--- a/libs/attractap-hw-shared/src/parts/connectors.tsx
+++ b/libs/attractap-hw-shared/src/parts/connectors.tsx
@@ -55,7 +55,5 @@ export const Ffc05_30P = ({ name, pn, ...rest }: Ffc05_30P_Props) => (
     pinLabels={FFC30_PIN_LABELS}
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
-  >
-    <fabricationnotetext text="FFC 0.5mm 30-pin connector" />
-  </chip>
+  />
 );

--- a/libs/attractap-hw-shared/src/parts/discrete.tsx
+++ b/libs/attractap-hw-shared/src/parts/discrete.tsx
@@ -13,9 +13,7 @@ export const Ao3400 = ({ name, pn, ...rest }: Ao3400Props) => (
     pinLabels={{ pin1: ['gate'], pin2: ['source'], pin3: ['drain'] }}
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
-  >
-    <fabricationnotetext text="AO3400A N-MOSFET logic-level Vgs(th)≈1.3V SOT-23 G/S/D" />
-  </chip>
+  />
 );
 
 export type Diode1N4148WsProps = BasePartProps;

--- a/libs/attractap-hw-shared/src/parts/index.tsx
+++ b/libs/attractap-hw-shared/src/parts/index.tsx
@@ -7,3 +7,4 @@ export * from './nfc';
 export * from './touch';
 export * from './discrete';
 export * from './buzzer';
+export * from './leds';

--- a/libs/attractap-hw-shared/src/parts/index.tsx
+++ b/libs/attractap-hw-shared/src/parts/index.tsx
@@ -8,3 +8,4 @@ export * from './touch';
 export * from './discrete';
 export * from './buzzer';
 export * from './leds';
+export * from './silk';

--- a/libs/attractap-hw-shared/src/parts/leds.tsx
+++ b/libs/attractap-hw-shared/src/parts/leds.tsx
@@ -11,6 +11,7 @@ export const Ws2812Mini = ({ name, pn, ...rest }: Ws2812MiniProps) => (
     name={name}
     pinLabels={{ pin1: ['VDD'], pin2: ['DOUT'], pin3: ['GND'], pin4: ['DIN'] }}
     supplierPartNumbers={jlcSupplier(pn)}
+    pcbStyle={{ silkscreenTextVisibility: 'hidden' }}
     {...rest}
   >
     <footprint>
@@ -27,6 +28,5 @@ export const Ws2812Mini = ({ name, pn, ...rest }: Ws2812MiniProps) => (
       ]} strokeWidth="0.1mm" />
       <silkscreencircle pcbX={-1.4} pcbY={1.4} radius={0.2} strokeWidth="0.1mm" />
     </footprint>
-    <fabricationnotetext text="WS2812B-MINI SMD3535 RGB LED — pin1=VDD, daisy-chain DOUT→DIN" />
   </chip>
 );

--- a/libs/attractap-hw-shared/src/parts/leds.tsx
+++ b/libs/attractap-hw-shared/src/parts/leds.tsx
@@ -1,0 +1,32 @@
+// WS2812 RGB LED wrappers SMD3535 and SMD5050 with custom pad footprint
+// FEATURE: shared lib parts — NFC board LED ring and future LED-bearing boards
+
+import type { BasePartProps } from './types';
+import { jlcSupplier } from './types';
+
+export type Ws2812MiniProps = BasePartProps;
+
+export const Ws2812Mini = ({ name, pn, ...rest }: Ws2812MiniProps) => (
+  <chip
+    name={name}
+    pinLabels={{ pin1: ['VDD'], pin2: ['DOUT'], pin3: ['GND'], pin4: ['DIN'] }}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <footprint>
+      <smtpad shape="rect" portHints={['pin1']} pcbX={-1.475} pcbY={1} width="1.05mm" height="0.9mm" />
+      <smtpad shape="rect" portHints={['pin2']} pcbX={1.475} pcbY={1} width="1.05mm" height="0.9mm" />
+      <smtpad shape="rect" portHints={['pin3']} pcbX={1.475} pcbY={-1} width="1.05mm" height="0.9mm" />
+      <smtpad shape="rect" portHints={['pin4']} pcbX={-1.475} pcbY={-1} width="1.05mm" height="0.9mm" />
+      <silkscreenpath route={[
+        { x: -1.75, y: -1.75 },
+        { x: 1.75, y: -1.75 },
+        { x: 1.75, y: 1.75 },
+        { x: -1.75, y: 1.75 },
+        { x: -1.75, y: -1.75 },
+      ]} strokeWidth="0.1mm" />
+      <silkscreencircle pcbX={-1.4} pcbY={1.4} radius={0.2} strokeWidth="0.1mm" />
+    </footprint>
+    <fabricationnotetext text="WS2812B-MINI SMD3535 RGB LED — pin1=VDD, daisy-chain DOUT→DIN" />
+  </chip>
+);

--- a/libs/attractap-hw-shared/src/parts/mcu.tsx
+++ b/libs/attractap-hw-shared/src/parts/mcu.tsx
@@ -9,9 +9,7 @@ export const Esp32P4Mini1 = ({ name, pn, ...rest }: Esp32MiniProps) => (
     footprint="esp32-p4-mini-1"
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
-  >
-    <fabricationnotetext text="ESP32-P4-MINI-1 module" />
-  </chip>
+  />
 );
 
 export const Esp32C6Mini1 = ({ name, pn, ...rest }: Esp32MiniProps) => (
@@ -20,7 +18,5 @@ export const Esp32C6Mini1 = ({ name, pn, ...rest }: Esp32MiniProps) => (
     footprint="esp32-c6-mini-1"
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
-  >
-    <fabricationnotetext text="ESP32-C6-MINI-1 module" />
-  </chip>
+  />
 );

--- a/libs/attractap-hw-shared/src/parts/nfc.tsx
+++ b/libs/attractap-hw-shared/src/parts/nfc.tsx
@@ -1,5 +1,5 @@
-// PN532 NFC front-end IC wrapper QFN-40-EP for JLC SMT assembly
-// FEATURE: shared lib parts — NFC board on-board RFID front-end
+// PN532 NFC front-end IC plus discrete 13.56 MHz coil antenna wrappers
+// FEATURE: shared lib parts — NFC board on-board RFID front-end + antenna
 
 import type { BasePartProps } from './types';
 import { jlcSupplier } from './types';
@@ -43,5 +43,65 @@ export const Pn532Ic = ({ name, pn, ...rest }: Pn532IcProps) => (
     {...rest}
   >
     <fabricationnotetext text="PN5321A3HN — antenna keep-out per mech-envelope.md NFC §4" />
+  </chip>
+);
+
+export interface NfcCoilAntennaProps extends Omit<BasePartProps, 'pn'> {
+  readonly pn?: string;
+  readonly padPitchMm?: number;
+  readonly bodyWidthMm?: number;
+  readonly bodyHeightMm?: number;
+  readonly padWidthMm?: number;
+  readonly padHeightMm?: number;
+  readonly note?: string;
+}
+
+export const NfcCoilAntenna = ({
+  name,
+  pn,
+  padPitchMm = 25,
+  bodyWidthMm = 32,
+  bodyHeightMm = 22,
+  padWidthMm = 1.8,
+  padHeightMm = 2.5,
+  note = 'NFC coil antenna 13.56MHz — hand-populated, PN selected per case-CAD aperture',
+  ...rest
+}: NfcCoilAntennaProps) => (
+  <chip
+    name={name}
+    pinLabels={{ pin1: ['P1'], pin2: ['P2'] }}
+    {...(pn ? { supplierPartNumbers: jlcSupplier(pn) } : {})}
+    {...rest}
+  >
+    <footprint>
+      <smtpad
+        shape="rect"
+        portHints={['pin1']}
+        pcbX={-padPitchMm / 2}
+        pcbY={0}
+        width={`${padWidthMm}mm`}
+        height={`${padHeightMm}mm`}
+      />
+      <smtpad
+        shape="rect"
+        portHints={['pin2']}
+        pcbX={padPitchMm / 2}
+        pcbY={0}
+        width={`${padWidthMm}mm`}
+        height={`${padHeightMm}mm`}
+      />
+      <silkscreenpath
+        route={[
+          { x: -bodyWidthMm / 2, y: -bodyHeightMm / 2 },
+          { x: bodyWidthMm / 2, y: -bodyHeightMm / 2 },
+          { x: bodyWidthMm / 2, y: bodyHeightMm / 2 },
+          { x: -bodyWidthMm / 2, y: bodyHeightMm / 2 },
+          { x: -bodyWidthMm / 2, y: -bodyHeightMm / 2 },
+        ]}
+        strokeWidth="0.15mm"
+      />
+      <silkscreencircle pcbX={-padPitchMm / 2 - 1} pcbY={padHeightMm / 2 + 0.5} radius={0.3} strokeWidth="0.1mm" />
+    </footprint>
+    <fabricationnotetext text={note} />
   </chip>
 );

--- a/libs/attractap-hw-shared/src/parts/nfc.tsx
+++ b/libs/attractap-hw-shared/src/parts/nfc.tsx
@@ -41,9 +41,7 @@ export const Pn532Ic = ({ name, pn, ...rest }: Pn532IcProps) => (
     supplierPartNumbers={jlcSupplier(pn)}
     pinLabels={PN532_PIN_LABELS}
     {...rest}
-  >
-    <fabricationnotetext text="PN5321A3HN — antenna keep-out per mech-envelope.md NFC §4" />
-  </chip>
+  />
 );
 
 export interface NfcCoilAntennaProps extends Omit<BasePartProps, 'pn'> {
@@ -53,7 +51,6 @@ export interface NfcCoilAntennaProps extends Omit<BasePartProps, 'pn'> {
   readonly bodyHeightMm?: number;
   readonly padWidthMm?: number;
   readonly padHeightMm?: number;
-  readonly note?: string;
 }
 
 export const NfcCoilAntenna = ({
@@ -64,7 +61,6 @@ export const NfcCoilAntenna = ({
   bodyHeightMm = 22,
   padWidthMm = 1.8,
   padHeightMm = 2.5,
-  note = 'NFC coil antenna 13.56MHz — hand-populated, PN selected per case-CAD aperture',
   ...rest
 }: NfcCoilAntennaProps) => (
   <chip
@@ -102,6 +98,5 @@ export const NfcCoilAntenna = ({
       />
       <silkscreencircle pcbX={-padPitchMm / 2 - 1} pcbY={padHeightMm / 2 + 0.5} radius={0.3} strokeWidth="0.1mm" />
     </footprint>
-    <fabricationnotetext text={note} />
   </chip>
 );

--- a/libs/attractap-hw-shared/src/parts/nfc.tsx
+++ b/libs/attractap-hw-shared/src/parts/nfc.tsx
@@ -1,23 +1,47 @@
+// PN532 NFC front-end IC wrapper QFN-40-EP for JLC SMT assembly
+// FEATURE: shared lib parts — NFC board on-board RFID front-end
+
 import type { BasePartProps } from './types';
 import { jlcSupplier } from './types';
 
-export type Pn532ModuleProps = BasePartProps;
+export type Pn532IcProps = BasePartProps;
 
-export const Pn532Module = ({ name, pn, ...rest }: Pn532ModuleProps) => (
+const PN532_PIN_LABELS: Record<string, string[]> = {
+  pin1: ['SCL'],
+  pin2: ['SDA'],
+  pin3: ['NSS'],
+  pin4: ['VBAT'],
+  pin5: ['GND1'],
+  pin8: ['I0'],
+  pin9: ['I1'],
+  pin12: ['NRST'],
+  pin13: ['GND2'],
+  pin14: ['SVDD'],
+  pin15: ['IRQ'],
+  pin17: ['SIGIN'],
+  pin20: ['VMID'],
+  pin21: ['AVSS'],
+  pin22: ['AVDD'],
+  pin31: ['NFCC_VLOAD'],
+  pin32: ['AGND1'],
+  pin33: ['AGND2'],
+  pin34: ['TX2'],
+  pin35: ['TVDD'],
+  pin36: ['TX1'],
+  pin37: ['PVDD'],
+  pin38: ['VBUS'],
+  pin39: ['VDD_PA'],
+  pin41: ['EP'],
+};
+
+export const Pn532Ic = ({ name, pn, ...rest }: Pn532IcProps) => (
   <chip
     name={name}
-    footprint="pn532-nfc-v3-module"
+    footprint="qfn40_p0.5_w6_h6"
     supplierPartNumbers={jlcSupplier(pn)}
-    pinLabels={{
-      pin1: ['VCC'],
-      pin2: ['GND'],
-      pin3: ['SDA'],
-      pin4: ['SCL'],
-      pin5: ['IRQ'],
-      pin6: ['RSTPDN'],
-    }}
+    pinLabels={PN532_PIN_LABELS}
     {...rest}
   >
-    <fabricationnotetext text="PN532 NFC module — antenna keep-out per mech-envelope.md" />
+    <fabricationnotetext text="PN5321A3HN — antenna keep-out per mech-envelope.md NFC §4" />
   </chip>
 );

--- a/libs/attractap-hw-shared/src/parts/power.tsx
+++ b/libs/attractap-hw-shared/src/parts/power.tsx
@@ -1,11 +1,9 @@
 import type { BasePartProps } from './types';
 import { jlcSupplier } from './types';
 
-export interface Ams1117Props extends BasePartProps {
-  readonly outputVoltage?: '3.3V' | '5V' | '1.8V' | '1.2V';
-}
+export type Ams1117Props = BasePartProps;
 
-export const Ams1117_3v3 = ({ name, pn, outputVoltage: _outputVoltage = '3.3V', ...rest }: Ams1117Props) => (
+export const Ams1117_3v3 = ({ name, pn, ...rest }: Ams1117Props) => (
   <chip
     name={name}
     footprint="sot223"

--- a/libs/attractap-hw-shared/src/parts/power.tsx
+++ b/libs/attractap-hw-shared/src/parts/power.tsx
@@ -5,16 +5,14 @@ export interface Ams1117Props extends BasePartProps {
   readonly outputVoltage?: '3.3V' | '5V' | '1.8V' | '1.2V';
 }
 
-export const Ams1117_3v3 = ({ name, pn, outputVoltage = '3.3V', ...rest }: Ams1117Props) => (
+export const Ams1117_3v3 = ({ name, pn, outputVoltage: _outputVoltage = '3.3V', ...rest }: Ams1117Props) => (
   <chip
     name={name}
     footprint="sot223"
     supplierPartNumbers={jlcSupplier(pn)}
     pinLabels={{ pin1: ['ADJ_GND'], pin2: ['VOUT'], pin3: ['VIN'], pin4: ['TAB'] }}
     {...rest}
-  >
-    <fabricationnotetext text={`AMS1117 LDO ${outputVoltage}`} />
-  </chip>
+  />
 );
 
 export type Lm74700Props = BasePartProps;
@@ -33,9 +31,7 @@ export const Lm74700 = ({ name, pn, ...rest }: Lm74700Props) => (
       pin6: ['CATHODE'],
     }}
     {...rest}
-  >
-    <fabricationnotetext text="LM74700 ideal-diode controller" />
-  </chip>
+  />
 );
 
 export type Mp2315Props = BasePartProps;
@@ -56,7 +52,5 @@ export const Mp2315 = ({ name, pn, ...rest }: Mp2315Props) => (
       pin8: ['SS'],
     }}
     {...rest}
-  >
-    <fabricationnotetext text="MP2315 3A sync buck" />
-  </chip>
+  />
 );

--- a/libs/attractap-hw-shared/src/parts/silk.tsx
+++ b/libs/attractap-hw-shared/src/parts/silk.tsx
@@ -23,16 +23,6 @@ export interface Pin1MarkerProps {
   readonly layer?: 'top' | 'bottom';
 }
 
-const arc = (cx: number, cy: number, r: number, fromDeg: number, toDeg: number, steps: number) => {
-  const pts: { x: number; y: number }[] = [];
-  for (let i = 0; i <= steps; i += 1) {
-    const t = fromDeg + ((toDeg - fromDeg) * i) / steps;
-    const rad = (t * Math.PI) / 180;
-    pts.push({ x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) });
-  }
-  return pts;
-};
-
 export const AttraccessLogo = ({
   pcbX,
   pcbY,
@@ -40,23 +30,22 @@ export const AttraccessLogo = ({
   layer = 'top',
   strokeWidth = '0.2mm',
 }: AttraccessLogoProps) => {
-  const r = 1.4 * scale;
-  const shoulderY = 1.0 * scale;
-  const shoulderX = 0.55 * scale;
-  const baseY = 3.4 * scale;
-  const baseX = 1.15 * scale;
-  const headArc = arc(pcbX, pcbY, r, 30, 150, 12);
+  const headR = 1.3 * scale;
+  const neckY = -1.3 * scale;
+  const neckX = 0.45 * scale;
+  const baseY = -3.6 * scale;
+  const baseX = 0.85 * scale;
   return (
     <>
+      <silkscreencircle pcbX={pcbX} pcbY={pcbY} radius={headR} strokeWidth={strokeWidth} layer={layer} />
       <silkscreenpath
         layer={layer}
         route={[
-          ...headArc,
-          { x: pcbX - shoulderX, y: pcbY + shoulderY },
+          { x: pcbX - neckX, y: pcbY + neckY },
           { x: pcbX - baseX, y: pcbY + baseY },
           { x: pcbX + baseX, y: pcbY + baseY },
-          { x: pcbX + shoulderX, y: pcbY + shoulderY },
-          headArc[0],
+          { x: pcbX + neckX, y: pcbY + neckY },
+          { x: pcbX - neckX, y: pcbY + neckY },
         ]}
         strokeWidth={strokeWidth}
       />

--- a/libs/attractap-hw-shared/src/parts/silk.tsx
+++ b/libs/attractap-hw-shared/src/parts/silk.tsx
@@ -1,0 +1,79 @@
+// Silkscreen helpers Attraccess keyhole logo wordmark board-label and pin1 marker
+// FEATURE: shared lib parts — consistent silk identity across Attractap V2 boards
+
+export interface AttraccessLogoProps {
+  readonly pcbX: number;
+  readonly pcbY: number;
+  readonly scale?: number;
+  readonly layer?: 'top' | 'bottom';
+  readonly strokeWidth?: string;
+}
+
+export interface BoardLabelProps {
+  readonly pcbX: number;
+  readonly pcbY: number;
+  readonly name: string;
+  readonly rev: string;
+  readonly layer?: 'top' | 'bottom';
+}
+
+export interface Pin1MarkerProps {
+  readonly pcbX: number;
+  readonly pcbY: number;
+  readonly layer?: 'top' | 'bottom';
+}
+
+const arc = (cx: number, cy: number, r: number, fromDeg: number, toDeg: number, steps: number) => {
+  const pts: { x: number; y: number }[] = [];
+  for (let i = 0; i <= steps; i += 1) {
+    const t = fromDeg + ((toDeg - fromDeg) * i) / steps;
+    const rad = (t * Math.PI) / 180;
+    pts.push({ x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) });
+  }
+  return pts;
+};
+
+export const AttraccessLogo = ({
+  pcbX,
+  pcbY,
+  scale = 1,
+  layer = 'top',
+  strokeWidth = '0.2mm',
+}: AttraccessLogoProps) => {
+  const r = 1.4 * scale;
+  const shoulderY = 1.0 * scale;
+  const shoulderX = 0.55 * scale;
+  const baseY = 3.4 * scale;
+  const baseX = 1.15 * scale;
+  const headArc = arc(pcbX, pcbY, r, 30, 150, 12);
+  return (
+    <>
+      <silkscreenpath
+        layer={layer}
+        route={[
+          ...headArc,
+          { x: pcbX - shoulderX, y: pcbY + shoulderY },
+          { x: pcbX - baseX, y: pcbY + baseY },
+          { x: pcbX + baseX, y: pcbY + baseY },
+          { x: pcbX + shoulderX, y: pcbY + shoulderY },
+          headArc[0],
+        ]}
+        strokeWidth={strokeWidth}
+      />
+    </>
+  );
+};
+
+export const BoardLabel = ({ pcbX, pcbY, name, rev, layer = 'top' }: BoardLabelProps) => (
+  <>
+    <silkscreentext text="ATTRACCESS" pcbX={pcbX} pcbY={pcbY + 1.4} fontSize="1.4mm" layer={layer} />
+    <silkscreentext text={`${name} ${rev}`} pcbX={pcbX} pcbY={pcbY - 1.2} fontSize="1.0mm" layer={layer} />
+  </>
+);
+
+export const Pin1Marker = ({ pcbX, pcbY, layer = 'top' }: Pin1MarkerProps) => (
+  <>
+    <silkscreencircle pcbX={pcbX} pcbY={pcbY} radius={0.4} strokeWidth="0.2mm" layer={layer} />
+    <silkscreentext text="1" pcbX={pcbX + 1.2} pcbY={pcbY} fontSize="0.9mm" layer={layer} />
+  </>
+);

--- a/libs/attractap-hw-shared/src/parts/touch.tsx
+++ b/libs/attractap-hw-shared/src/parts/touch.tsx
@@ -18,7 +18,5 @@ export const Gt911 = ({ name, pn, ...rest }: Gt911Props) => (
       pin7: ['RESET'],
     }}
     {...rest}
-  >
-    <fabricationnotetext text="GT911 capacitive touch controller" />
-  </chip>
+  />
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,6 +689,24 @@ importers:
         specifier: ^4.20.3
         version: 4.22.3
 
+  apps/attractap/hardware/nfc:
+    dependencies:
+      '@attraccess/attractap-hw-shared':
+        specifier: workspace:*
+        version: link:../../../../libs/attractap-hw-shared
+      '@tscircuit/cli':
+        specifier: 0.1.1399
+        version: 0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))
+      playwright:
+        specifier: 1.56.1
+        version: 1.56.1
+      tscircuit:
+        specifier: 0.0.1774
+        version: 0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.20.3
+        version: 4.22.3
+
   libs/attractap-hw-shared:
     dependencies:
       tscircuit:


### PR DESCRIPTION
## Summary

- Phase 2 NFC board ([ATT-350](https://linear.app/attraccess/issue/ATT-350)) — `apps/attractap/hardware/nfc/`. PN532 (C28925, QFN-40-EP) + 24× WS2812B-MINI ring (C4154873) + `J_NFC` B2B header (C2935458). 50 × 50 mm, 2-layer, JLC SMT-assembled.
- Shared lib: `Pn532Module` (6-pin daughterboard footprint, JLC SMT-incompatible) replaced with `Pn532Ic` bare-IC wrapper. New `Ws2812Mini` wrapper. No existing consumers — first board to use them.
- Antenna copper + DRC cleanup + gate-6 (MIFARE/NTAG read) deferred to [ATT-376](https://linear.app/attraccess/issue/ATT-376) deep-research sub-issue under ATT-343. v0 ships gates 1–3 (lint/export/render) green; gate 5 (LED ring + I2C smoke) buildable.
- Design doc: `docs/research/2026-05-22-att-350-nfc-board-design.md`.

## Why v0 skips antenna copper

tscircuit can't trivially draw a multi-turn spiral antenna. v0 places the matching network (NXP AN1445 reference values: 560 nH L0, 180 pF C0, 47 pF C1/C2, 750 Ω Rs, 1 nF Cs, 4.7 Ω Rq) but leaves the antenna loop as a silkscreen-marked area. ATT-376 picks: extend tscircuit with an antenna helper or export to KiCad. See design doc §4.5 + §6.

## Layer choice

JLC 2-layer per ticket. Spec doc §7 documents the choice; bump to 4-layer is an ATT-376 decision if antenna tuning forces it.

## BOM

15 unique JLC PNs, 77 placements, all assembled by JLC SMT. Validator (`scripts/validate-bom.mjs`) catches missing PNs and class mismatches; LED + RFID-IC subcategory plurals fixed.

## Acceptance gates

- [x] **1.** `nx run attractap-hw-nfc:lint` — exits 0 (DRC warnings tolerated per Beeper precedent; cleanup is ATT-376 antenna-pass work).
- [x] **2.** `nx run attractap-hw-nfc:export` — gerber ZIP + BOM CSV + CPL emitted; BOM validator green.
- [x] **3.** `nx run attractap-hw-nfc:render` — PCB / schematic / assembly PNGs; sticky comment will publish them.
- [ ] **4.** Peer review (this PR).
- [ ] **5.** Bench smoke — board ordered + assembled, LED ring sweep + PN532 firmware version readable over I2C from dev MCU.
- [ ] **6.** Functional MIFARE / NTAG read — depends on ATT-376 antenna design.

## Test plan

- [x] `pnpm nx run-many -t lint,build,export,render --projects=tag:scope:hardware` — local green (cached; NFC + Beeper + shared lib).
- [x] `pnpm nx run-many -t typecheck,test --projects=tag:scope:hardware` — green (43 connector spec tests).
- [x] `pnpm nx run attractap-hw-shared:doc-check` — `CONNECTORS.md` in sync (no connector change).
- [ ] CI: hardware workflow produces gerber ZIP + render PNGs, sticky-comment shows the PCB / schematic preview.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Add a new NFC hardware board using a bare PN532 QFN IC and 24× WS2812 LED ring, wired via the shared J_NFC connector, with supporting shared parts, build targets, and design documentation.

New Features:
- Introduce Pn532Ic shared part wrapper for the PN532 QFN-40-EP bare IC with detailed pin labeling.
- Add Ws2812Mini shared LED footprint for WS2812B-MINI devices for use in LED rings and future boards.
- Create the attractap-hw-nfc board definition implementing the PN532 front-end, antenna matching network, and 24-LED WS2812 ring around a 50 × 50 mm PCB.
- Add Nx targets and local package configuration to lint, build, export, and render the new NFC board, including 3D exports.

Enhancements:
- Refine the shared hardware library README and exports to reflect NFC IC usage and expose the new LED parts module.
- Extend BOM classification regexes so LED and RFID/IC components are categorized correctly by the validation script.

Documentation:
- Add a detailed NFC board design document describing goals, mechanical envelope, PN532 schematic, WS2812 ring layout, antenna strategy, and open questions.