### PR TITLE
fix(frontend): lock app shell, scroll only content (ATT-374)

### DIFF
--- a/apps/frontend/src/app/layout/layout.tsx
+++ b/apps/frontend/src/app/layout/layout.tsx
@@ -69,7 +69,7 @@ export function Layout({ children, noLayout }: LayoutProps) {
 
   if (noLayout) {
     return (
-      <div className="bg-background min-h-screen flex flex-col">
+      <div className="bg-background h-screen flex flex-col overflow-y-auto">
         <ServerNotAvailable />
         {children}
       </div>

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -5,13 +5,20 @@
 @theme {
   /* Custom keyframes */
   --animation-draw: draw 2s ease-in-out forwards;
-  
+
   @keyframes draw {
     to {
       stroke-dashoffset: 0;
       stroke-dasharray: 0;
     }
   }
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  overflow: hidden;
 }
 
 /* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes ATT-374 — under HeroUI v3 the whole page scrolled instead of just the content area. The layout already has `flex h-screen` on the shell and `overflow-auto` on `<main>`, but the html/body/#root chain had no fixed height, so any sub-tree growing past 100vh dragged the entire body with it.

## Changes
- `styles.css` — lock `html`, `body`, `#root` to `height: 100%; overflow: hidden`. Establishes the height chain `react-simple-pull-to-refresh` and the layout's `h-screen` rely on, and prevents the document from ever scrolling.
- `layout.tsx` — the `noLayout` (login) container changes from `min-h-screen` to `h-screen overflow-y-auto`. Under the new constraint `min-h-screen` would grow past the clipped viewport, so it now scrolls inside its own bounded box instead.

## Verification
Local dev server, devadmin account, `/settings` (long content).

- Desktop 1440×900 — sidebar + page header stay fixed, only `<main>` scrolls. `document.scrollTop` stays at 0 after `main.scrollTop=1200`.
- Mobile 375×400 — top bar stays fixed, only `<main>` scrolls. `document.scrollTop` stays at 0 after `main.scrollTop=1500`.
- Mobile login 375×400 — login form taller than viewport scrolls inside the `noLayout` container; document does not scroll.

Screenshots posted on the Linear issue.

Lint + typecheck + build + test pass via `pnpm nx run-many ... -p frontend` (cached) at commit time.

[Linear ATT-374](https://linear.app/attraccess/issue/ATT-374/whole-page-scrolls-instead-of-only-the-content-area-shell-should-stay)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->

## Summary by Sourcery

Ensure the app shell remains fixed while only the main content area scrolls.

Enhancements:
- Lock html, body, and #root to a fixed full-height, non-scrolling container to support the layout’s h-screen content scrolling.
- Update the noLayout (login) container to use a fixed-height, scrollable viewport so taller login content scrolls within its own box instead of the document.