### PR TITLE
fix(frontend): restore payments row click and surface refund button (ATT-369)

### DIFF
--- a/apps/frontend/src/app/billing/dashboard/summary/de.json
+++ b/apps/frontend/src/app/billing/dashboard/summary/de.json
@@ -13,6 +13,9 @@
         "amount": "Betrag",
         "actions": "Aktionen"
       },
+      "actions": {
+        "refund": "Transaktion erstatten"
+      },
       "cells": {
         "details": {
           "unknown": "Transaktionsart unbekannt",

--- a/apps/frontend/src/app/billing/dashboard/summary/en.json
+++ b/apps/frontend/src/app/billing/dashboard/summary/en.json
@@ -13,6 +13,9 @@
         "amount": "Amount",
         "actions": "Actions"
       },
+      "actions": {
+        "refund": "Refund transaction"
+      },
       "cells": {
         "details": {
           "unknown": "Unknown transaction type",

--- a/apps/frontend/src/app/billing/dashboard/summary/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/index.tsx
@@ -12,10 +12,11 @@ import {
   useBillingServiceGetBillingConfiguration,
   useBillingServiceGetBillingTransactions,
 } from '@attraccess/react-query-client';
-import { CreditCardIcon, ReceiptTextIcon } from 'lucide-react';
+import { CreditCardIcon, RotateCcwIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { dbCurrencyToUserCurrency } from '@attraccess/shared';
 import { TransactionDetailsModal } from './transactionDetailsModal';
+import { RefundModal } from './transactionDetailsModal/refund';
 
 interface Props {
   className?: string;
@@ -137,6 +138,11 @@ export function SummaryCard(props: Props) {
   const [openedTransactionId, setOpenedTransactionId] = useState<number | undefined>(undefined);
   const [isOpenDetails, setIsOpenDetails] = useState(false);
 
+  const openDetails = useCallback((transactionId: number) => {
+    setOpenedTransactionId(transactionId);
+    setIsOpenDetails(true);
+  }, []);
+
   if (!configuration) {
     return <Skeleton className="h-10 w-full" />;
   }
@@ -157,7 +163,7 @@ export function SummaryCard(props: Props) {
       )}
 
       <Table>
-        <TableContent aria-label={t('transactions.table.ariaLabel')}>
+        <TableContent aria-label={t('transactions.table.ariaLabel')} onRowAction={(key) => openDetails(Number(key))}>
           <TableHeader>
             <TableColumn isRowHeader>{t('transactions.table.columns.id')}</TableColumn>
             <TableColumn>{t('transactions.table.columns.dateTime')}</TableColumn>
@@ -186,16 +192,18 @@ export function SummaryCard(props: Props) {
                   {formatNumber(dbCurrencyToUserCurrency(transaction.amount, configuration.minorUnit))}
                 </TableCell>
                 <TableCell>
-                  <Button
-                    isIconOnly
-                    variant="ghost"
-                    onPress={() => {
-                      setOpenedTransactionId(transaction.id);
-                      setIsOpenDetails(true);
-                    }}
-                  >
-                    <ReceiptTextIcon />
-                  </Button>
+                  <RefundModal transactionId={transaction.id}>
+                    {(onOpen) => (
+                      <Button
+                        isIconOnly
+                        variant="danger-soft"
+                        aria-label={t('transactions.table.actions.refund') as string}
+                        onPress={onOpen}
+                      >
+                        <RotateCcwIcon />
+                      </Button>
+                    )}
+                  </RefundModal>
                 </TableCell>
               </TableRow>
             )}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
- Wire `onRowAction` on the transactions table so clicking a row opens the details modal again — this was lost during the HeroUI v3 migration when `onRowAction` was dropped from `Table`.
- Replace the per-row details `<Button>` with a `<RefundModal>` trigger so the actions cell now exposes a refund action (manager-only, since `RefundModal` returns `null` without `canManageBilling`). React Aria's Row component isolates presses on interactive descendants from `onRowAction`, so the refund button no longer also triggers the details modal.

## Linear
[ATT-369](https://linear.app/attraccess/issue/ATT-369/payments-overview-row-click-missing-refund-button-opens-refund-and)

## Test plan
- [ ] Manual: open Billing Dashboard → Summary, click a transaction row → details modal opens.
- [ ] Manual (manager): click the refund icon button on a row → only the refund drawer opens (no details modal flash).
- [ ] Manual (non-manager): refund button is hidden; row click still opens details.
- [ ] Confirm refund flow still works from inside the details modal header.

## Notes
- Browser verification with screenshots was not performed — the in-CLI Chrome extension was not connected in this environment, so I could not capture before/after screenshots. Visual sign-off needed before merge.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Restore transaction row click behavior and expose a dedicated refund action in the billing summary transactions table.

New Features:
- Add a refund action button per transaction row in the billing summary that opens the refund modal for eligible users.

Bug Fixes:
- Re-enable opening the transaction details modal when clicking on a transaction row in the billing summary.