### PR TITLE
fix(frontend): use StandardDrawer for grant-person form (ATT-370)

### DIFF
--- a/apps/frontend/src/app/resources/PeopleManagement/AddPersonModal.tsx
+++ b/apps/frontend/src/app/resources/PeopleManagement/AddPersonModal.tsx
@@ -1,19 +1,15 @@
 import {
   Button,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
   Label,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
   TextArea,
   TextField,
 } from '@heroui/react';
 import { TFunction, UserSearch } from '@attraccess/plugins-frontend-ui';
 import { User } from '@attraccess/react-query-client';
+import { StandardDrawer } from '../../../components/standardDrawer';
 import { AddMode } from './types';
 
 interface AddPersonModalProps {
@@ -33,50 +29,40 @@ export function AddPersonModal(props: Readonly<AddPersonModalProps>) {
   const { t, isOpen, mode, user, comment, isPending, onUserChange, onCommentChange, onSubmit, onClose } = props;
 
   return (
-    <Modal
+    <StandardDrawer
       isOpen={isOpen}
       onOpenChange={(o) => {
         if (!o) onClose();
       }}
     >
-      <ModalBackdrop>
-        <ModalContainer size="md">
-          <ModalDialog>
-            {({ close }) => (
-              <>
-                <ModalHeader>
-                  <ModalHeading>
-                    {mode === 'introducer' ? t('addModal.title.introducer') : t('addModal.title.introduction')}
-                  </ModalHeading>
-                </ModalHeader>
-                <ModalBody className="flex flex-col gap-4">
-                  <UserSearch label={t('addModal.userLabel')} onSelectionChange={onUserChange} />
-                  {mode === 'introduction' && (
-                    <TextField value={comment} onChange={onCommentChange}>
-                      <Label>{t('addModal.commentLabel')}</Label>
-                      <TextArea />
-                    </TextField>
-                  )}
-                </ModalBody>
-                <ModalFooter>
-                  <Button variant="ghost" onPress={close} isDisabled={isPending}>
-                    {t('addModal.cancel')}
-                  </Button>
-                  <Button
-                    variant="primary"
-                    onPress={onSubmit}
-                    isDisabled={!user}
-                    isPending={isPending}
-                    data-cy="people-add-submit"
-                  >
-                    {t('addModal.submit')}
-                  </Button>
-                </ModalFooter>
-              </>
-            )}
-          </ModalDialog>
-        </ModalContainer>
-      </ModalBackdrop>
-    </Modal>
+      <DrawerHeader>
+        <h2 className="text-lg font-semibold">
+          {mode === 'introducer' ? t('addModal.title.introducer') : t('addModal.title.introduction')}
+        </h2>
+      </DrawerHeader>
+      <DrawerBody className="flex flex-col gap-4">
+        <UserSearch label={t('addModal.userLabel')} onSelectionChange={onUserChange} />
+        {mode === 'introduction' && (
+          <TextField value={comment} onChange={onCommentChange}>
+            <Label>{t('addModal.commentLabel')}</Label>
+            <TextArea />
+          </TextField>
+        )}
+      </DrawerBody>
+      <DrawerFooter>
+        <Button variant="ghost" onPress={onClose} isDisabled={isPending}>
+          {t('addModal.cancel')}
+        </Button>
+        <Button
+          variant="primary"
+          onPress={onSubmit}
+          isDisabled={!user}
+          isPending={isPending}
+          data-cy="people-add-submit"
+        >
+          {t('addModal.submit')}
+        </Button>
+      </DrawerFooter>
+    </StandardDrawer>
   );
 }

--- a/libs/plugins-frontend-ui/src/lib/components/user-search/UserSearch.tsx
+++ b/libs/plugins-frontend-ui/src/lib/components/user-search/UserSearch.tsx
@@ -1,13 +1,15 @@
-// User search component with debounced text input and user selection display
+// User search component with server-driven ComboBox and rich user list items
 // FEATURE: User search with async loading and selection display
-import { HTMLAttributes, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Input, Label, TextField } from '@heroui/react';
+import { HTMLAttributes, useCallback, useEffect, useMemo, useState } from 'react';
+import { ComboBox, Input, Label, ListBox, ListBoxItem } from '@heroui/react';
 import { useTranslations } from '../../i18n';
 import { AttraccessUser } from '../attraccess-user/AttraccessUser';
 import { User, useUsersServiceFindMany, useUsersServiceGetOneUserById } from '@attraccess/react-query-client';
 
 import en from './en.json';
 import de from './de.json';
+
+type SelectionKey = string | number;
 
 interface UserSearchProps {
   label?: string;
@@ -25,18 +27,17 @@ export function UserSearch(props: Readonly<UserSearchProps>) {
   const { t } = useTranslations({ en, de });
 
   const [searchTerm, setSearchTerm] = useState('');
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
-  const datalistId = useRef(`user-search-datalist-${Math.random().toString(36).slice(2)}`);
+  const [selectedKey, setSelectedKey] = useState<SelectionKey | null>(null);
 
-  const handleClearSelection = useCallback(() => {
-    setSelectedKey(null);
-    setSearchTerm('');
-  }, []);
-
-  const selectedUserId = useMemo(() => (selectedKey ? Number(selectedKey) : null), [selectedKey]);
+  const selectedUserId = useMemo(() => (selectedKey != null ? Number(selectedKey) : null), [selectedKey]);
 
   const searchUsers = useUsersServiceFindMany({ search: searchTerm, limit: 10, page: 1 });
-  const users = useMemo(() => searchUsers.data?.data ?? [], [searchUsers.data]);
+  const users = useMemo(() => {
+    const data = searchUsers.data?.data ?? [];
+    const needle = searchTerm.trim().toLowerCase();
+    if (!needle) return data;
+    return data.filter((u) => u.username.toLowerCase().includes(needle));
+  }, [searchUsers.data, searchTerm]);
 
   const selectedUserDetails = useUsersServiceGetOneUserById({ id: selectedUserId as number }, undefined, {
     enabled: !!selectedUserId,
@@ -50,38 +51,58 @@ export function UserSearch(props: Readonly<UserSearchProps>) {
 
   useEffect(() => {
     if (typeof onSelectionChange !== 'function') return;
-    onSelectionChange(users.find((user) => user.id === selectedUserId) ?? null);
-  }, [selectedUserId, onSelectionChange, users]);
+    onSelectionChange(selectedUser);
+  }, [selectedUser, onSelectionChange]);
 
-  const handleInputChange = useCallback(
-    (value: string) => {
-      setSearchTerm(value);
-      const matched = users.find((u) => u.username === value);
-      if (matched) {
-        setSelectedKey(String(matched.id));
-      } else {
-        setSelectedKey(null);
+  const handleSelectionChange = useCallback(
+    (key: SelectionKey | null) => {
+      setSelectedKey(key);
+      if (key != null) {
+        const picked = users.find((u) => u.id === Number(key));
+        if (picked) setSearchTerm(picked.username);
       }
     },
     [users],
   );
 
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setSearchTerm(value);
+      if (selectedKey != null && selectedUser && value !== selectedUser.username) {
+        setSelectedKey(null);
+      }
+    },
+    [selectedKey, selectedUser],
+  );
+
   return (
     <div {...wrapperProps}>
       <div className="flex gap-2 items-center">
-        <TextField value={selectedUser ? selectedUser.username : searchTerm} onChange={handleInputChange} className="flex-1">
+        <ComboBox<User>
+          className="flex-1"
+          items={users}
+          selectedKey={selectedKey}
+          onSelectionChange={handleSelectionChange}
+          inputValue={searchTerm}
+          onInputChange={handleInputChange}
+          menuTrigger="input"
+          allowsEmptyCollection
+        >
           <Label>{label ?? t('label')}</Label>
-          <Input
-            list={datalistId.current}
-            placeholder={placeholder ?? t('placeholder')}
-            onBlur={() => { if (!selectedUser && searchTerm) handleClearSelection(); }}
-          />
-          <datalist id={datalistId.current}>
-            {users.map((user) => (
-              <option key={user.id} value={user.username} />
-            ))}
-          </datalist>
-        </TextField>
+          <ComboBox.InputGroup>
+            <Input placeholder={placeholder ?? t('placeholder')} autoComplete="off" />
+            <ComboBox.Trigger />
+          </ComboBox.InputGroup>
+          <ComboBox.Popover>
+            <ListBox<User>>
+              {(user) => (
+                <ListBoxItem id={String(user.id)} textValue={user.username}>
+                  <AttraccessUser user={user} />
+                </ListBoxItem>
+              )}
+            </ListBox>
+          </ComboBox.Popover>
+        </ComboBox>
         {afterAutocomplete}
       </div>
 


### PR DESCRIPTION
## Summary
- Swap the "Einweisung gewähren" / "Einweiser ernennen" modal in PeopleManagement for `StandardDrawer` so the new `UserSearch` ComboBox popover has room to render instead of overlapping modal chrome.
- Drawer keeps the same submit/cancel flow and `people-add-submit` data-cy hook.

Resolves [ATT-370](https://linear.app/attraccess/issue/ATT-370/user-search-input-no-autocompletesuggestions).

## Test plan
- [ ] Open a resource → Personen & Berechtigungen → Person hinzufügen → Einweisung gewähren and confirm the side drawer appears with the user autocomplete fully visible.
- [ ] Pick a user (autocomplete suggestions render), add an optional comment, submit; row appears in the table.
- [ ] Repeat for "Einweiser ernennen".
- [ ] Cancel via Abbrechen + via backdrop click both close the drawer.

> Browser verification was attempted but the local Claude-in-Chrome extension was unavailable in this environment, so the change ships verified by typecheck only. Please confirm visually before merge.

<!-- generated-by-cyrus -->