### PR TITLE
fix(frontend): restore StandardDrawer dismiss + clear backdrop (ATT-358)

### DIFF
--- a/apps/frontend/src/components/standardDrawer.tsx
+++ b/apps/frontend/src/components/standardDrawer.tsx
@@ -1,6 +1,5 @@
 import type { CSSProperties, ReactNode } from 'react';
 import {
-  Drawer,
   DrawerBackdrop,
   DrawerContent,
   DrawerDialog,
@@ -13,7 +12,7 @@ interface Props {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   children: ReactNode;
-  backdropProps?: Omit<DrawerBackdropProps, 'children'>;
+  backdropProps?: Omit<DrawerBackdropProps, 'children' | 'isOpen' | 'onOpenChange'>;
   contentProps?: Omit<DrawerContentProps, 'children'>;
   dialogProps?: Omit<DrawerDialogProps, 'children'>;
 }
@@ -35,13 +34,12 @@ export function StandardDrawer(props: Props) {
   const mergedStyle = { ...FIELD_CONTRAST_STYLE, ...dialogProps?.style };
 
   return (
-    <Drawer isOpen={isOpen} onOpenChange={onOpenChange}>
-      <DrawerBackdrop {...backdropProps} />
+    <DrawerBackdrop {...backdropProps} isOpen={isOpen} onOpenChange={onOpenChange}>
       <DrawerContent {...contentProps}>
         <DrawerDialog {...dialogProps} className={mergedDialogClassName} style={mergedStyle}>
           {children}
         </DrawerDialog>
       </DrawerContent>
-    </Drawer>
+    </DrawerBackdrop>
   );
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes [ATT-358](https://linear.app/attraccess/issue/ATT-358/standard-drawer-cannot-be-dismissed-by-clicking-outside-backdrop). Two regressions after the HeroUI v3 migration (ATT-280):

- Clicking outside the standard drawer did not close it.
- After closing the drawer, the backdrop stayed mounted on top of the page and intercepted clicks.

## Root cause

HeroUI v3's `Drawer.Backdrop` (which is a React Aria `ModalOverlay`) owns the controlled overlay state — `isOpen`, `onOpenChange`, `isDismissable` — and `Drawer.Content` must be nested **inside** `Drawer.Backdrop`. `StandardDrawer` was putting `isOpen`/`onOpenChange` on the `Drawer` wrapper and rendering `DrawerContent` as a sibling of `DrawerBackdrop`. The backdrop was effectively uncontrolled, so it didn't close on outside click and didn't unmount on state change.

## Fix

Restructure the wrapper to the v3 controlled pattern: drop the `Drawer` wrapper (only used to provide trigger context, which we don't need when controlled), nest `DrawerContent` inside `DrawerBackdrop`, and pass `isOpen`/`onOpenChange` to `DrawerBackdrop`.

## Test plan

- [x] Typecheck passes (\`pnpm nx typecheck frontend\`)
- [x] Lint passes (\`pnpm nx run frontend:lint\`)
- [x] Unit tests pass (\`pnpm nx test frontend\` — 76/76)
- [x] Manual browser verification on \`/account\` → "Delete account" drawer:
  - [x] Outside click closes the drawer
  - [x] Backdrop fully unmounts after close — page is interactive (clicked sidebar to confirm)
  - [x] Cancel button still closes
  - [x] ESC key still closes
  - [x] Reopen after close still works

Screenshots posted on the Linear issue.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Fix StandardDrawer to correctly control the HeroUI v3 drawer backdrop so it dismisses on outside click and fully unmounts when closed.

Bug Fixes:
- Restore ability to dismiss the standard drawer by clicking outside its backdrop.
- Ensure the drawer backdrop unmounts after the drawer is closed instead of intercepting further page interaction.

Enhancements:
- Align StandardDrawer with HeroUI v3 controlled drawer pattern by delegating open state to the backdrop and simplifying the component structure.