### PR TITLE
fix(frontend): wire create form button to navigate to new editor (ATT-365)

### DIFF
--- a/apps/frontend/src/app/resources/details/forms/FormListPage.tsx
+++ b/apps/frontend/src/app/resources/details/forms/FormListPage.tsx
@@ -33,7 +33,7 @@ export function FormListPage() {
         subtitle={t('list.subtitle')}
         backTo={`/resources/${resourceId}`}
         actions={
-          <Button variant="primary">
+          <Button variant="primary" onPress={() => navigate(`/resources/${resourceId}/forms/new`)}>
             {t('list.create')}
           </Button>
         }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes [ATT-365](https://linear.app/attraccess/issue/ATT-365/resource-forms-list-create-form-button-does-nothing). The "Create form" button on the resource forms list page had no `onPress` handler after the HeroUI v3 migration, so clicking it did nothing. Added an `onPress` that navigates to `/resources/:id/forms/new`, which is the route the editor already handles in create mode (`formId === 'new'`).

## Test plan

- [x] Lint & typecheck pass
- [x] Manual verification: logged in, opened `/resources/1/forms`, clicked "Create form" → routes to `/resources/1/forms/new` and the editor renders with "Create form" title
- [x] Browser screenshots captured (before click + after click)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Restore navigation behavior for the "Create form" button on the resource forms list page so it opens the new form editor.