### PR TITLE
fix(frontend): wire segmented toggle onSelectionChange (ATT-361)

### DIFF
--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
@@ -234,7 +234,7 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
               </div>
 
               <div className="flex flex-col gap-2 w-full">
-                <Tabs selectedKey={formData.type}>
+                <Tabs selectedKey={formData.type} onSelectionChange={(k) => setField('type', k as ResourceType)}>
                   <TabList>
                     <Tab id="machine">{t('inputs.type.options.machine')}</Tab>
                     <Tab id="door">{t('inputs.type.options.door')}</Tab>

--- a/apps/frontend/src/app/user-management/invite-user-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/invite-user-modal/index.tsx
@@ -118,7 +118,7 @@ export function InviteUserModal(props: Props) {
     });
   }, [inviteUser, trimmedEmail, trimmedUsername, usernameError]);
 
-  const [tab] = useState<'single' | 'csv'>('single');
+  const [tab, setTab] = useState<'single' | 'csv'>('single');
 
   return (
     <>
@@ -133,7 +133,7 @@ export function InviteUserModal(props: Props) {
           <h2 className="text-lg font-semibold">{t('title')}</h2>
         </DrawerHeader>
         <DrawerBody>
-          <Tabs selectedKey={tab}>
+          <Tabs selectedKey={tab} onSelectionChange={(k) => setTab(k as 'single' | 'csv')}>
             <TabList>
               <Tab id="single">{t('tabs.single')}</Tab>
               <Tab id="csv">{t('tabs.csv')}</Tab>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Segmented/toggle control (HeroUI `Tabs`) was non-functional in two places after the HeroUI v3 migration: clicking either option did not update the selected tab.

Root cause: both modals controlled `Tabs` via `selectedKey` but never passed `onSelectionChange`, so React Aria treated the component as read-only.

Fixes:
- `apps/frontend/src/app/resources/editModal/resourceEditModal.tsx` — pass `onSelectionChange` and update `formData.type` via `setField` (machine/door).
- `apps/frontend/src/app/user-management/invite-user-modal/index.tsx` — destructure `setTab` from `useState` and wire `onSelectionChange` (single/csv).

Audit: the other two `Tabs` usages (`maintenance-hub`, `DocumentationEditor`) already wire `onSelectionChange` correctly — no change needed.

## Test plan

- [x] Frontend typecheck passes (`nx typecheck frontend`)
- [x] Frontend lint passes (`nx lint frontend`)
- [x] Manual browser verification: resource editor machine ↔ door switches selection and panel content
- [x] Manual browser verification: invite user single ↔ csv switches selection and panel content
- [x] Both directions (forward + back) confirmed

Linear: [ATT-361](https://linear.app/attraccess/issue/ATT-361/segmentedtoggle-control-is-non-functional-system-wide)

Screenshots posted to the Linear issue.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Wire tab selection handlers for segmented controls so the corresponding content updates correctly in resource editing and invite user modals.

Bug Fixes:
- Fix resource edit modal type selector so changing between machine and door updates the selected tab and form state.
- Fix invite user modal tab selector so switching between single and CSV modes updates the selected tab and displayed panel.