### PR TITLE
feat(ATT-351): PoE PD module (802.3af) — JLC-stocked all-SMT design

### DIFF
--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -154,8 +154,8 @@ export default () => (
 
     {/* ─── AMS1117-3.3 — V5V -> +3V3 for LAN8720A VDDIO/VDDA ──────────────── */}
     <Ams1117_3v3 name="U_LDO33" pn="C6186" pcbX={-5} pcbY={10} />
-    <C0402 name="C_LDO_IN" pn="C307331" capacitance="1uF" pcbX={-9} pcbY={10} />
-    <C0402 name="C_LDO_OUT" pn="C307331" capacitance="10uF" pcbX={-1} pcbY={10} />
+    <C0402 name="C_LDO_IN" pn="C52923" capacitance="1uF" pcbX={-9} pcbY={10} />
+    <C0402 name="C_LDO_OUT" pn="C15525" capacitance="10uF" pcbX={-1} pcbY={10} />
 
     <net name="V3V3" />
 
@@ -171,16 +171,16 @@ export default () => (
     {/* ─── LAN8720A PHY + 25 MHz crystal + decoupling + strap resistors ──── */}
     <Lan8720a name="U_PHY" pn="C17146" pcbX={-10} pcbY={-10} />
     <Crystal25M_5032 name="Y1" pn="C20617602" pcbX={-20} pcbY={-14} />
-    <C0402 name="C_XTAL1" pn="C307331" capacitance="18pF" pcbX={-22} pcbY={-15} />
-    <C0402 name="C_XTAL2" pn="C307331" capacitance="18pF" pcbX={-18} pcbY={-15} />
+    <C0402 name="C_XTAL1" pn="C1549" capacitance="18pF" pcbX={-22} pcbY={-15} />
+    <C0402 name="C_XTAL2" pn="C1549" capacitance="18pF" pcbX={-18} pcbY={-15} />
 
     <C0402 name="C_VDDIO_HF" pn="C307331" capacitance="100nF" pcbX={-7} pcbY={-6} />
-    <C0402 name="C_VDDIO_LF" pn="C307331" capacitance="4.7uF" pcbX={-5} pcbY={-6} />
+    <C0402 name="C_VDDIO_LF" pn="C23733" capacitance="4.7uF" pcbX={-5} pcbY={-6} />
     <L0603 name="L_VDDA_FB" pn="C85833" inductance="600R" pcbX={-13} pcbY={-14} />
     <C0402 name="C_VDDA_HF" pn="C307331" capacitance="100nF" pcbX={-15} pcbY={-7} />
-    <C0402 name="C_VDDA_LF" pn="C307331" capacitance="4.7uF" pcbX={-14} pcbY={-5} />
-    <C0402 name="C_VDDCR_HF" pn="C307331" capacitance="470pF" pcbX={-10} pcbY={-6} />
-    <C0402 name="C_VDDCR_LF" pn="C307331" capacitance="1uF" pcbX={-12} pcbY={-6} />
+    <C0402 name="C_VDDA_LF" pn="C23733" capacitance="4.7uF" pcbX={-14} pcbY={-5} />
+    <C0402 name="C_VDDCR_HF" pn="C1537" capacitance="470pF" pcbX={-10} pcbY={-6} />
+    <C0402 name="C_VDDCR_LF" pn="C52923" capacitance="1uF" pcbX={-12} pcbY={-6} />
 
     <R0402 name="R_RBIAS" pn="C25754" resistance="12.1k" tolerance="1%" pcbX={-12} pcbY={-10} />
     <R0402 name="R_MDIO_PU" pn="C25771" resistance="1.5k" tolerance="1%" pcbX={0} pcbY={-12} />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -1,6 +1,332 @@
-// Stub PoE PD board entry point — replaced by full topology in Task 6
-// FEATURE: hardware/poe — 802.3af PD module, see docs/research/2026-05-23-att-351-poe-deep-research.md
+// PoE PD board — 802.3af, integrated magjack, WS3203 PD + MP9486A buck, LAN8720A PHY
+// FEATURE: hardware/poe — see docs/research/2026-05-23-att-351-poe-deep-research.md
+
+import {
+  J_POE,
+  assertWiresAllSignals,
+  B2B_127_2xN,
+  R0402,
+  C0402,
+  L0603,
+  Ams1117_3v3,
+  ElecCap_22uF_100V,
+  Lan8720a,
+  Hy931147c,
+  Crystal25M_5032,
+  Ws3203,
+  Mp9486a,
+  Mb10s,
+  Smaj58a,
+  Ss34,
+} from '@attraccess/attractap-hw-shared';
+
+assertWiresAllSignals(J_POE, {
+  '+5V': 'net.V5V',
+  GND: 'net.PD_GND',
+  RMII_TXD0: 'net.RMII_TXD0',
+  RMII_TXD1: 'net.RMII_TXD1',
+  RMII_TX_EN: 'net.RMII_TX_EN',
+  RMII_RXD0: 'net.RMII_RXD0_OUT',
+  RMII_RXD1: 'net.RMII_RXD1_OUT',
+  RMII_CRS_DV: 'net.RMII_CRS_DV_OUT',
+  RMII_REF_CLK: 'net.RMII_REF_CLK',
+  MDIO: 'net.MDIO',
+  MDC: 'net.MDC',
+  nRST: 'net.PHY_nRST',
+});
 
 export default () => (
-  <board width="60mm" height="35mm" routingDisabled />
+  <board width="60mm" height="35mm" routingDisabled>
+    {/* ─── Cable-side: PoE-rated magjack + 2x bridges (Mode A + Mode B) + TVS ── */}
+    <Hy931147c name="J1" pn="C91754" pcbX={-22} pcbY={0} pcbRotation={0} />
+    <Mb10s name="BR1" pn="C2488" pcbX={-10} pcbY={8} pcbRotation={0} />
+    <Mb10s name="BR2" pn="C2488" pcbX={-10} pcbY={-8} pcbRotation={0} />
+    <Smaj58a name="D_TVS" pn="C2980408" pcbX={0} pcbY={8} pcbRotation={0} />
+    <C0402 name="C_DEN" pn="C307331" capacitance="100nF" pcbX={0} pcbY={5} />
+
+    <net name="V_PoE_BUS" />
+    <net name="PD_GND" />
+
+    {/* Mode B (data-pair) center taps -> BR1 */}
+    <trace from=".J1 > .CT_TX" to=".BR1 > .AC1" />
+    <trace from=".J1 > .CT_RX" to=".BR1 > .AC2" />
+
+    {/* Mode A (spare-pair) -> BR2 */}
+    <trace from=".J1 > .CABLE_4_5_A" to=".BR2 > .AC1" />
+    <trace from=".J1 > .CABLE_7_8_A" to=".BR2 > .AC2" />
+
+    {/* Both bridges OR into the V_PoE_BUS net */}
+    <trace from=".BR1 > .POS" to="net.V_PoE_BUS" />
+    <trace from=".BR2 > .POS" to="net.V_PoE_BUS" />
+    <trace from=".BR1 > .NEG" to="net.PD_GND" />
+    <trace from=".BR2 > .NEG" to="net.PD_GND" />
+
+    {/* TVS clamp + detection cap across V_PoE_BUS-to-PD_GND */}
+    <trace from=".D_TVS > .pin1" to="net.V_PoE_BUS" />
+    <trace from=".D_TVS > .pin2" to="net.PD_GND" />
+    <trace from=".C_DEN > .pin1" to="net.V_PoE_BUS" />
+    <trace from=".C_DEN > .pin2" to="net.PD_GND" />
+
+    {/* ─── WS3203 PD interface — detect, classify, hot-swap pass FET ─────── */}
+    <Ws3203 name="U_PD" pn="C5143001" pcbX={5} pcbY={0} />
+    <R0402 name="R_DEN" pn="C25741" resistance="24.9k" tolerance="1%" pcbX={5} pcbY={-6} />
+    <R0402 name="R_CLS" pn="C25742" resistance="768" tolerance="1%" pcbX={9} pcbY={-6} />
+    <R0402 name="R_ILIM" pn="C25744" resistance="22k" tolerance="1%" pcbX={5} pcbY={6} />
+    <C0402 name="C_SS" pn="C307331" capacitance="100nF" pcbX={9} pcbY={6} />
+    <C0402 name="C_VSS_BIAS" pn="C307331" capacitance="100nF" pcbX={13} pcbY={6} />
+
+    <net name="V_OUT_PD" />
+
+    <trace from=".U_PD > .VDD" to="net.V_PoE_BUS" />
+    <trace from=".U_PD > .RTN" to="net.PD_GND" />
+    <trace from=".U_PD > .GND" to="net.PD_GND" />
+    <trace from=".U_PD > .DEN" to=".R_DEN > .pin1" />
+    <trace from=".R_DEN > .pin2" to="net.PD_GND" />
+    <trace from=".U_PD > .CLS" to=".R_CLS > .pin1" />
+    <trace from=".R_CLS > .pin2" to="net.PD_GND" />
+    <trace from=".U_PD > .ILIM" to=".R_ILIM > .pin1" />
+    <trace from=".R_ILIM > .pin2" to="net.PD_GND" />
+    <trace from=".U_PD > .SS_R" to=".C_SS > .pin1" />
+    <trace from=".C_SS > .pin2" to="net.PD_GND" />
+    <trace from=".U_PD > .VSS_BIAS" to=".C_VSS_BIAS > .pin1" />
+    <trace from=".C_VSS_BIAS > .pin2" to="net.PD_GND" />
+    <trace from=".U_PD > .VOUT_PD" to="net.V_OUT_PD" />
+
+    {/* ─── MP9486A 100V -> 5V async buck ─────────────────────────────────── */}
+    <Mp9486a name="U_BUCK" pn="C404013" pcbX={18} pcbY={0} />
+    <ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={14} pcbY={-3} />
+    <C0402 name="C_VIN_LF" pn="C307331" capacitance="100nF" pcbX={14} pcbY={3} />
+    <C0402 name="C_BST" pn="C307331" capacitance="100nF" pcbX={18} pcbY={-6} />
+    <Ss34 name="D_CATCH" pn="C8678" pcbX={22} pcbY={-3} />
+    <L0603 name="L_BUCK" pn="C168137" inductance="47uH" pcbX={25} pcbY={0} />
+    <R0402 name="R_FB_TOP" pn="C25789" resistance="51.1k" tolerance="1%" pcbX={26} pcbY={4} />
+    <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={26} pcbY={7} />
+    <R0402 name="R_EN" pn="C25776" resistance="100k" tolerance="1%" pcbX={14} pcbY={6} />
+    <C0402 name="C_OUT_HF" pn="C307331" capacitance="22uF" pcbX={29} pcbY={3} />
+    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={29} pcbY={-3} />
+
+    <net name="VIN_BUCK" />
+    <net name="SW_NODE" />
+    <net name="V5V" />
+
+    <trace from="net.V_OUT_PD" to="net.VIN_BUCK" />
+    <trace from=".U_BUCK > .VIN" to="net.VIN_BUCK" />
+    <trace from=".C_VIN_BULK > .pin1" to="net.VIN_BUCK" />
+    <trace from=".C_VIN_BULK > .pin2" to="net.PD_GND" />
+    <trace from=".C_VIN_LF > .pin1" to="net.VIN_BUCK" />
+    <trace from=".C_VIN_LF > .pin2" to="net.PD_GND" />
+
+    {/* EN tied high via 100k */}
+    <trace from=".R_EN > .pin1" to="net.VIN_BUCK" />
+    <trace from=".R_EN > .pin2" to=".U_BUCK > .EN" />
+
+    {/* Bootstrap cap */}
+    <trace from=".U_BUCK > .BST" to=".C_BST > .pin1" />
+    <trace from=".C_BST > .pin2" to="net.SW_NODE" />
+
+    {/* Switch node -> catch diode -> inductor */}
+    <trace from=".U_BUCK > .SW" to="net.SW_NODE" />
+    <trace from=".D_CATCH > .pin1" to="net.PD_GND" />
+    <trace from=".D_CATCH > .pin2" to="net.SW_NODE" />
+    <trace from=".L_BUCK > .pin1" to="net.SW_NODE" />
+    <trace from=".L_BUCK > .pin2" to="net.V5V" />
+
+    {/* Output caps on V5V */}
+    <trace from=".C_OUT_HF > .pin1" to="net.V5V" />
+    <trace from=".C_OUT_HF > .pin2" to="net.PD_GND" />
+    <trace from=".C_OUT_BULK > .pin1" to="net.V5V" />
+    <trace from=".C_OUT_BULK > .pin2" to="net.PD_GND" />
+
+    {/* Feedback divider: V5V -> 51.1k -> FB -> 10k -> GND, FB = 0.81V */}
+    <trace from="net.V5V" to=".R_FB_TOP > .pin1" />
+    <trace from=".R_FB_TOP > .pin2" to=".U_BUCK > .FB" />
+    <trace from=".U_BUCK > .FB" to=".R_FB_BOT > .pin1" />
+    <trace from=".R_FB_BOT > .pin2" to="net.PD_GND" />
+    <trace from=".U_BUCK > .GND" to="net.PD_GND" />
+
+    {/* ─── AMS1117-3.3 — V5V -> +3V3 for LAN8720A VDDIO/VDDA ──────────────── */}
+    <Ams1117_3v3 name="U_LDO33" pn="C6186" pcbX={-5} pcbY={10} />
+    <C0402 name="C_LDO_IN" pn="C307331" capacitance="1uF" pcbX={-9} pcbY={10} />
+    <C0402 name="C_LDO_OUT" pn="C307331" capacitance="10uF" pcbX={-1} pcbY={10} />
+
+    <net name="V3V3" />
+
+    <trace from=".U_LDO33 > .VIN" to="net.V5V" />
+    <trace from=".U_LDO33 > .VOUT" to="net.V3V3" />
+    <trace from=".U_LDO33 > .ADJ_GND" to="net.PD_GND" />
+    <trace from=".U_LDO33 > .TAB" to="net.PD_GND" />
+    <trace from=".C_LDO_IN > .pin1" to="net.V5V" />
+    <trace from=".C_LDO_IN > .pin2" to="net.PD_GND" />
+    <trace from=".C_LDO_OUT > .pin1" to="net.V3V3" />
+    <trace from=".C_LDO_OUT > .pin2" to="net.PD_GND" />
+
+    {/* ─── LAN8720A PHY + 25 MHz crystal + decoupling + strap resistors ──── */}
+    <Lan8720a name="U_PHY" pn="C17146" pcbX={-10} pcbY={-10} />
+    <Crystal25M_5032 name="Y1" pn="C20617602" pcbX={-20} pcbY={-14} />
+    <C0402 name="C_XTAL1" pn="C307331" capacitance="18pF" pcbX={-22} pcbY={-15} />
+    <C0402 name="C_XTAL2" pn="C307331" capacitance="18pF" pcbX={-18} pcbY={-15} />
+
+    <C0402 name="C_VDDIO_HF" pn="C307331" capacitance="100nF" pcbX={-7} pcbY={-6} />
+    <C0402 name="C_VDDIO_LF" pn="C307331" capacitance="4.7uF" pcbX={-5} pcbY={-6} />
+    <L0603 name="L_VDDA_FB" pn="C85833" inductance="600R" pcbX={-13} pcbY={-14} />
+    <C0402 name="C_VDDA_HF" pn="C307331" capacitance="100nF" pcbX={-15} pcbY={-7} />
+    <C0402 name="C_VDDA_LF" pn="C307331" capacitance="4.7uF" pcbX={-14} pcbY={-5} />
+    <C0402 name="C_VDDCR_HF" pn="C307331" capacitance="470pF" pcbX={-10} pcbY={-6} />
+    <C0402 name="C_VDDCR_LF" pn="C307331" capacitance="1uF" pcbX={-12} pcbY={-6} />
+
+    <R0402 name="R_RBIAS" pn="C25754" resistance="12.1k" tolerance="1%" pcbX={-12} pcbY={-10} />
+    <R0402 name="R_MDIO_PU" pn="C25771" resistance="1.5k" tolerance="1%" pcbX={0} pcbY={-12} />
+
+    {/* RMII series-term resistors on PHY-driven RX outputs */}
+    <R0402 name="R_S_RXD0" pn="C17414" resistance="10" tolerance="1%" pcbX={-12} pcbY={-14} />
+    <R0402 name="R_S_RXD1" pn="C17414" resistance="10" tolerance="1%" pcbX={-10} pcbY={-14} />
+    <R0402 name="R_S_CRSDV" pn="C17414" resistance="10" tolerance="1%" pcbX={-8} pcbY={-14} />
+
+    {/* MDI termination: 49.9R pull-ups on TX/RX to VDDA */}
+    <R0402 name="R_TXP_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-8} />
+    <R0402 name="R_TXN_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-6} />
+    <R0402 name="R_RXP_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-8} />
+    <R0402 name="R_RXN_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-6} />
+    <C0402 name="C_TERM_BYP" pn="C307331" capacitance="100nF" pcbX={-17} pcbY={-3} />
+
+    <net name="MDI_TXP" />
+    <net name="MDI_TXN" />
+    <net name="MDI_RXP" />
+    <net name="MDI_RXN" />
+    <net name="MDI_TERM_VDDA" />
+
+    {/* PHY supply wiring */}
+    <trace from=".U_PHY > .VDDIO" to="net.V3V3" />
+    <trace from=".C_VDDIO_HF > .pin1" to="net.V3V3" />
+    <trace from=".C_VDDIO_HF > .pin2" to="net.PD_GND" />
+    <trace from=".C_VDDIO_LF > .pin1" to="net.V3V3" />
+    <trace from=".C_VDDIO_LF > .pin2" to="net.PD_GND" />
+    <trace from="net.V3V3" to=".L_VDDA_FB > .pin1" />
+    <trace from=".L_VDDA_FB > .pin2" to=".U_PHY > .VDD2A" />
+    <trace from=".U_PHY > .VDD2A" to=".C_VDDA_HF > .pin1" />
+    <trace from=".C_VDDA_HF > .pin2" to="net.PD_GND" />
+    <trace from=".U_PHY > .VDD2A" to=".C_VDDA_LF > .pin1" />
+    <trace from=".C_VDDA_LF > .pin2" to="net.PD_GND" />
+    <trace from=".U_PHY > .VDDCR" to=".C_VDDCR_HF > .pin1" />
+    <trace from=".C_VDDCR_HF > .pin2" to="net.PD_GND" />
+    <trace from=".U_PHY > .VDDCR" to=".C_VDDCR_LF > .pin1" />
+    <trace from=".C_VDDCR_LF > .pin2" to="net.PD_GND" />
+    <trace from=".U_PHY > .VSS" to="net.PD_GND" />
+
+    {/* RBIAS */}
+    <trace from=".U_PHY > .RBIAS" to=".R_RBIAS > .pin1" />
+    <trace from=".R_RBIAS > .pin2" to="net.PD_GND" />
+
+    {/* Strap resistors — REGOFF pull-up (enable internal reg) + nINTSEL pull-down (REFCLK OUT) */}
+    <R0402 name="R_STRAP_REGOFF" pn="C25804" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-10} />
+    <R0402 name="R_STRAP_INTSEL" pn="C25804" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-12} />
+    <trace from=".U_PHY > .LED1" to=".R_STRAP_REGOFF > .pin1" />
+    <trace from=".R_STRAP_REGOFF > .pin2" to="net.V3V3" />
+    <trace from=".U_PHY > .LED2" to=".R_STRAP_INTSEL > .pin1" />
+    <trace from=".R_STRAP_INTSEL > .pin2" to="net.PD_GND" />
+
+    {/* Crystal */}
+    <trace from=".U_PHY > .XTAL1" to=".Y1 > .pin1" />
+    <trace from=".U_PHY > .XTAL2" to=".Y1 > .pin2" />
+    <trace from=".Y1 > .pin1" to=".C_XTAL1 > .pin1" />
+    <trace from=".C_XTAL1 > .pin2" to="net.PD_GND" />
+    <trace from=".Y1 > .pin2" to=".C_XTAL2 > .pin1" />
+    <trace from=".C_XTAL2 > .pin2" to="net.PD_GND" />
+
+    {/* MDI termination — TX/RX 49.9R pulls to MDI_TERM_VDDA bypass-cap node */}
+    <trace from=".U_PHY > .TXP" to="net.MDI_TXP" />
+    <trace from=".U_PHY > .TXN" to="net.MDI_TXN" />
+    <trace from=".R_TXP_TERM > .pin1" to="net.MDI_TXP" />
+    <trace from=".R_TXP_TERM > .pin2" to="net.MDI_TERM_VDDA" />
+    <trace from=".R_TXN_TERM > .pin1" to="net.MDI_TXN" />
+    <trace from=".R_TXN_TERM > .pin2" to="net.MDI_TERM_VDDA" />
+    <trace from=".R_RXP_TERM > .pin1" to="net.MDI_RXP" />
+    <trace from=".R_RXP_TERM > .pin2" to="net.MDI_TERM_VDDA" />
+    <trace from=".R_RXN_TERM > .pin1" to="net.MDI_RXN" />
+    <trace from=".R_RXN_TERM > .pin2" to="net.MDI_TERM_VDDA" />
+    <trace from=".C_TERM_BYP > .pin1" to="net.MDI_TERM_VDDA" />
+    <trace from=".C_TERM_BYP > .pin2" to="net.PD_GND" />
+    <trace from="net.MDI_TERM_VDDA" to=".U_PHY > .VDD2A" />
+
+    {/* Magjack MDI side to PHY MDI pairs */}
+    <trace from=".J1 > .TX_P" to="net.MDI_TXP" />
+    <trace from=".J1 > .TX_N" to="net.MDI_TXN" />
+    <trace from=".J1 > .RX_P" to="net.MDI_RXP" />
+    <trace from=".J1 > .RX_N" to="net.MDI_RXN" />
+
+    {/* MDIO pull-up */}
+    <trace from=".U_PHY > .MDIO" to=".R_MDIO_PU > .pin1" />
+    <trace from=".R_MDIO_PU > .pin2" to="net.V3V3" />
+
+    {/* RMII series-term resistors */}
+    <net name="RMII_RXD0_OUT" />
+    <net name="RMII_RXD1_OUT" />
+    <net name="RMII_CRS_DV_OUT" />
+    <trace from=".U_PHY > .RXD0" to=".R_S_RXD0 > .pin1" />
+    <trace from=".R_S_RXD0 > .pin2" to="net.RMII_RXD0_OUT" />
+    <trace from=".U_PHY > .RXD1" to=".R_S_RXD1 > .pin1" />
+    <trace from=".R_S_RXD1 > .pin2" to="net.RMII_RXD1_OUT" />
+    <trace from=".U_PHY > .CRS_DV" to=".R_S_CRSDV > .pin1" />
+    <trace from=".R_S_CRSDV > .pin2" to="net.RMII_CRS_DV_OUT" />
+
+    {/* ─── J_POE — 2x8 1.27mm B2B to Core ──────────────────────────────── */}
+    <B2B_127_2xN name="J_POE" pn="C7470092" pinsPerRow={8} pcbX={26} pcbY={10} pcbRotation={0} />
+
+    <net name="RMII_TXD0" />
+    <net name="RMII_TXD1" />
+    <net name="RMII_TX_EN" />
+    <net name="RMII_REF_CLK" />
+    <net name="MDIO" />
+    <net name="MDC" />
+    <net name="PHY_nRST" />
+
+    <trace from=".J_POE > .pin1" to="net.V5V" />
+    <trace from=".J_POE > .pin2" to="net.V5V" />
+    <trace from=".J_POE > .pin3" to="net.PD_GND" />
+    <trace from=".J_POE > .pin4" to="net.PD_GND" />
+    <trace from=".J_POE > .pin5" to="net.RMII_TXD0" />
+    <trace from=".J_POE > .pin6" to="net.RMII_TXD1" />
+    <trace from=".J_POE > .pin7" to="net.RMII_TX_EN" />
+    <trace from=".J_POE > .pin8" to="net.RMII_RXD0_OUT" />
+    <trace from=".J_POE > .pin9" to="net.RMII_RXD1_OUT" />
+    <trace from=".J_POE > .pin10" to="net.RMII_CRS_DV_OUT" />
+    <trace from=".J_POE > .pin11" to="net.RMII_REF_CLK" />
+    <trace from=".J_POE > .pin12" to="net.MDIO" />
+    <trace from=".J_POE > .pin13" to="net.MDC" />
+    <trace from=".J_POE > .pin14" to="net.PHY_nRST" />
+    <trace from=".J_POE > .pin15" to="net.PD_GND" />
+    {/* pin 16 = NC */}
+
+    {/* Wire J_POE nets to PHY */}
+    <trace from="net.RMII_TXD0" to=".U_PHY > .TXD0" />
+    <trace from="net.RMII_TXD1" to=".U_PHY > .TXD1" />
+    <trace from="net.RMII_TX_EN" to=".U_PHY > .TXEN" />
+    <trace from="net.RMII_REF_CLK" to=".U_PHY > .REFCLKO" />
+    <trace from="net.MDIO" to=".U_PHY > .MDIO" />
+    <trace from="net.MDC" to=".U_PHY > .MDC" />
+    <trace from="net.PHY_nRST" to=".U_PHY > .nRST" />
+
+    {/* ─── RJ45 shield bond: 1nF/2kV Y2 || 1M to PD_GND ──────────────────── */}
+    <capacitor name="C_SHIELD_Y2" capacitance="1nF" footprint="1206" supplierPartNumbers={{ jlcpcb: ['C9196'] }} pcbX={-22} pcbY={6} />
+    <R0402 name="R_SHIELD_BLEED" pn="C61216" resistance="1M" tolerance="5%" pcbX={-22} pcbY={4} />
+
+    <net name="CHASSIS" />
+    <trace from=".J1 > .SHIELD_1" to="net.CHASSIS" />
+    <trace from=".J1 > .SHIELD_2" to="net.CHASSIS" />
+    <trace from=".C_SHIELD_Y2 > .pin1" to="net.CHASSIS" />
+    <trace from=".C_SHIELD_Y2 > .pin2" to="net.PD_GND" />
+    <trace from=".R_SHIELD_BLEED > .pin1" to="net.CHASSIS" />
+    <trace from=".R_SHIELD_BLEED > .pin2" to="net.PD_GND" />
+
+    {/* ─── RJ45 integrated LEDs (driven by PHY LED1/LED2 pins) ─────────── */}
+    <R0402 name="R_LED_LINK" pn="C25819" resistance="330" tolerance="5%" pcbX={-22} pcbY={10} />
+    <R0402 name="R_LED_ACT" pn="C25819" resistance="330" tolerance="5%" pcbX={-22} pcbY={12} />
+
+    <trace from=".J1 > .LED_LINK_A" to="net.V3V3" />
+    <trace from=".J1 > .LED_LINK_K" to=".R_LED_LINK > .pin1" />
+    <trace from=".R_LED_LINK > .pin2" to=".U_PHY > .LED1" />
+    <trace from=".J1 > .LED_ACT_A" to="net.V3V3" />
+    <trace from=".J1 > .LED_ACT_K" to=".R_LED_ACT > .pin1" />
+    <trace from=".R_LED_ACT > .pin2" to=".U_PHY > .LED2" />
+  </board>
 );

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -79,6 +79,7 @@ export default () => (
     <R0402 name="R_ILIM" pn="C25744" resistance="22k" tolerance="1%" pcbX={5} pcbY={6} />
     <C0402 name="C_SS" pn="C307331" capacitance="100nF" pcbX={9} pcbY={6} />
     <C0402 name="C_VSS_BIAS" pn="C307331" capacitance="100nF" pcbX={13} pcbY={6} />
+    <C0402 name="C_BLNK" pn="C76947" capacitance="1nF" pcbX={9} pcbY={3} />
 
     <net name="V_OUT_PD" />
 
@@ -96,6 +97,10 @@ export default () => (
     <trace from=".U_PD > .VSS_BIAS" to=".C_VSS_BIAS > .pin1" />
     <trace from=".C_VSS_BIAS > .pin2" to="net.PD_GND" />
     <trace from=".U_PD > .VOUT_PD" to="net.V_OUT_PD" />
+    {/* BLNK — 1nF blanking cap to RTN (TPS2375-family typical) */}
+    <trace from=".U_PD > .BLNK" to=".C_BLNK > .pin1" />
+    <trace from=".C_BLNK > .pin2" to="net.PD_GND" />
+    {/* Unused per WS3203 ref design (802.3af Class 0): T2P, PG, GATE, OCS — left NC */}
 
     {/* ─── MP9486A 100V -> 5V async buck ─────────────────────────────────── */}
     <Mp9486a name="U_BUCK" pn="C404013" pcbX={18} pcbY={0} />
@@ -107,7 +112,7 @@ export default () => (
     <R0402 name="R_FB_TOP" pn="C25789" resistance="51.1k" tolerance="1%" pcbX={26} pcbY={4} />
     <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={26} pcbY={7} />
     <R0402 name="R_EN" pn="C25776" resistance="100k" tolerance="1%" pcbX={14} pcbY={6} />
-    <C0402 name="C_OUT_HF" pn="C307331" capacitance="22uF" pcbX={29} pcbY={3} />
+    <C0402 name="C_OUT_HF" pn="C307331" capacitance="100nF" pcbX={29} pcbY={3} />
     <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={29} pcbY={-3} />
 
     <net name="SW_NODE" />
@@ -198,8 +203,10 @@ export default () => (
     <net name="MDI_RXN" />
     <net name="MDI_TERM_VDDA" />
 
-    {/* PHY supply wiring */}
+    {/* PHY supply wiring — LAN8720A has 3 VDDIO pins (4, 10, 22), all tied to 3V3 */}
     <trace from=".U_PHY > .VDDIO" to="net.V3V3" />
+    <trace from=".U_PHY > .VDDIO_2" to="net.V3V3" />
+    <trace from=".U_PHY > .VDDIO_3" to="net.V3V3" />
     <trace from=".C_VDDIO_HF > .pin1" to="net.V3V3" />
     <trace from=".C_VDDIO_HF > .pin2" to="net.PD_GND" />
     <trace from=".C_VDDIO_LF > .pin1" to="net.V3V3" />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -74,8 +74,8 @@ export default () => (
 
     {/* ─── WS3203 PD interface — detect, classify, hot-swap pass FET ─────── */}
     <Ws3203 name="U_PD" pn="C5143001" pcbX={5} pcbY={0} />
-    <R0402 name="R_DEN" pn="C25741" resistance="24.9k" tolerance="1%" pcbX={5} pcbY={-6} />
-    <R0402 name="R_CLS" pn="C25742" resistance="768" tolerance="1%" pcbX={9} pcbY={-6} />
+    <R0402 name="R_DEN" pn="C138027" resistance="24.9k" tolerance="1%" pcbX={5} pcbY={-6} />
+    <R0402 name="R_CLS" pn="C49656920" resistance="768" tolerance="1%" pcbX={9} pcbY={-6} />
     <R0402 name="R_ILIM" pn="C25768" resistance="22k" tolerance="1%" pcbX={5} pcbY={6} />
     <C0402 name="C_SS" pn="C307331" capacitance="100nF" pcbX={9} pcbY={6} />
     <C0402 name="C_VSS_BIAS" pn="C307331" capacitance="100nF" pcbX={13} pcbY={6} />
@@ -109,9 +109,9 @@ export default () => (
     <C0402 name="C_BST" pn="C307331" capacitance="100nF" pcbX={18} pcbY={-6} />
     <Ss34 name="D_CATCH" pn="C8678" pcbX={22} pcbY={-3} />
     <L0603 name="L_BUCK" pn="C168137" inductance="47uH" pcbX={25} pcbY={0} />
-    <R0402 name="R_FB_TOP" pn="C25789" resistance="51.1k" tolerance="1%" pcbX={26} pcbY={4} />
+    <R0402 name="R_FB_TOP" pn="C25904" resistance="51.1k" tolerance="1%" pcbX={26} pcbY={4} />
     <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={26} pcbY={7} />
-    <R0402 name="R_EN" pn="C25776" resistance="100k" tolerance="1%" pcbX={14} pcbY={6} />
+    <R0402 name="R_EN" pn="C25741" resistance="100k" tolerance="1%" pcbX={14} pcbY={6} />
     <C0402 name="C_OUT_HF" pn="C307331" capacitance="100nF" pcbX={29} pcbY={3} />
     <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={29} pcbY={-3} />
 
@@ -182,19 +182,19 @@ export default () => (
     <C0402 name="C_VDDCR_HF" pn="C1537" capacitance="470pF" pcbX={-10} pcbY={-6} />
     <C0402 name="C_VDDCR_LF" pn="C52923" capacitance="1uF" pcbX={-12} pcbY={-6} />
 
-    <R0402 name="R_RBIAS" pn="C25754" resistance="12.1k" tolerance="1%" pcbX={-12} pcbY={-10} />
-    <R0402 name="R_MDIO_PU" pn="C25771" resistance="1.5k" tolerance="1%" pcbX={0} pcbY={-12} />
+    <R0402 name="R_RBIAS" pn="C25852" resistance="12.1k" tolerance="1%" pcbX={-12} pcbY={-10} />
+    <R0402 name="R_MDIO_PU" pn="C25867" resistance="1.5k" tolerance="1%" pcbX={0} pcbY={-12} />
 
     {/* RMII series-term resistors on PHY-driven RX outputs */}
-    <R0402 name="R_S_RXD0" pn="C17414" resistance="10" tolerance="1%" pcbX={-12} pcbY={-14} />
-    <R0402 name="R_S_RXD1" pn="C17414" resistance="10" tolerance="1%" pcbX={-10} pcbY={-14} />
-    <R0402 name="R_S_CRSDV" pn="C17414" resistance="10" tolerance="1%" pcbX={-8} pcbY={-14} />
+    <R0402 name="R_S_RXD0" pn="C25077" resistance="10" tolerance="1%" pcbX={-12} pcbY={-14} />
+    <R0402 name="R_S_RXD1" pn="C25077" resistance="10" tolerance="1%" pcbX={-10} pcbY={-14} />
+    <R0402 name="R_S_CRSDV" pn="C25077" resistance="10" tolerance="1%" pcbX={-8} pcbY={-14} />
 
     {/* MDI termination: 49.9R pull-ups on TX/RX to VDDA */}
-    <R0402 name="R_TXP_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-8} />
-    <R0402 name="R_TXN_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-6} />
-    <R0402 name="R_RXP_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-8} />
-    <R0402 name="R_RXN_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-6} />
+    <R0402 name="R_TXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-8} />
+    <R0402 name="R_TXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-6} />
+    <R0402 name="R_RXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-8} />
+    <R0402 name="R_RXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-6} />
     <C0402 name="C_TERM_BYP" pn="C307331" capacitance="100nF" pcbX={-17} pcbY={-3} />
 
     <net name="MDI_TXP" />
@@ -318,7 +318,7 @@ export default () => (
 
     {/* ─── RJ45 shield bond: 1nF/2kV Y2 || 1M to PD_GND ──────────────────── */}
     <capacitor name="C_SHIELD_Y2" capacitance="1nF" footprint="1206" supplierPartNumbers={{ jlcpcb: ['C9196'] }} pcbX={-22} pcbY={6} />
-    <R0402 name="R_SHIELD_BLEED" pn="C61216" resistance="1M" tolerance="5%" pcbX={-22} pcbY={4} />
+    <R0402 name="R_SHIELD_BLEED" pn="C26083" resistance="1M" tolerance="1%" pcbX={-22} pcbY={4} />
 
     <net name="CHASSIS" />
     <trace from=".J1 > .SHIELD_1" to="net.CHASSIS" />
@@ -329,8 +329,8 @@ export default () => (
     <trace from=".R_SHIELD_BLEED > .pin2" to="net.PD_GND" />
 
     {/* ─── RJ45 integrated LEDs (driven by PHY LED1/LED2 pins) ─────────── */}
-    <R0402 name="R_LED_LINK" pn="C25819" resistance="330" tolerance="5%" pcbX={-22} pcbY={10} />
-    <R0402 name="R_LED_ACT" pn="C25819" resistance="330" tolerance="5%" pcbX={-22} pcbY={12} />
+    <R0402 name="R_LED_LINK" pn="C25104" resistance="330" tolerance="1%" pcbX={-22} pcbY={10} />
+    <R0402 name="R_LED_ACT" pn="C25104" resistance="330" tolerance="1%" pcbX={-22} pcbY={12} />
 
     <trace from=".J1 > .LED_LINK_A" to="net.V3V3" />
     <trace from=".J1 > .LED_LINK_K" to=".R_LED_LINK > .pin1" />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -36,7 +36,12 @@ assertWiresAllSignals(J_POE, {
 });
 
 export default () => (
-  <board width="60mm" height="35mm" routingDisabled>
+  <board
+    width="60mm"
+    height="35mm"
+    autorouter="sequential-trace"
+    defaultTraceWidth="0.2mm"
+  >
     {/* ─── Cable-side: PoE-rated magjack + 2x bridges (Mode A + Mode B) + TVS ── */}
     <Hy931147c name="J1" pn="C91754" pcbX={-22} pcbY={0} pcbRotation={0} />
     <Mb10s name="BR1" pn="C2488" pcbX={-10} pcbY={8} pcbRotation={0} />
@@ -105,19 +110,17 @@ export default () => (
     <C0402 name="C_OUT_HF" pn="C307331" capacitance="22uF" pcbX={29} pcbY={3} />
     <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={29} pcbY={-3} />
 
-    <net name="VIN_BUCK" />
     <net name="SW_NODE" />
     <net name="V5V" />
 
-    <trace from="net.V_OUT_PD" to="net.VIN_BUCK" />
-    <trace from=".U_BUCK > .VIN" to="net.VIN_BUCK" />
-    <trace from=".C_VIN_BULK > .pin1" to="net.VIN_BUCK" />
+    <trace from=".U_BUCK > .VIN" to="net.V_OUT_PD" />
+    <trace from=".C_VIN_BULK > .pin1" to="net.V_OUT_PD" />
     <trace from=".C_VIN_BULK > .pin2" to="net.PD_GND" />
-    <trace from=".C_VIN_LF > .pin1" to="net.VIN_BUCK" />
+    <trace from=".C_VIN_LF > .pin1" to="net.V_OUT_PD" />
     <trace from=".C_VIN_LF > .pin2" to="net.PD_GND" />
 
     {/* EN tied high via 100k */}
-    <trace from=".R_EN > .pin1" to="net.VIN_BUCK" />
+    <trace from=".R_EN > .pin1" to="net.V_OUT_PD" />
     <trace from=".R_EN > .pin2" to=".U_BUCK > .EN" />
 
     {/* Bootstrap cap */}

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -104,13 +104,25 @@ export default () => (
     <ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={9} pcbY={-15} />
     <C0402 name="C_VIN_LF" pn="C307331" capacitance="100nF" pcbX={10.5} pcbY={-9} />
     <C0402 name="C_BST" pn="C307331" capacitance="100nF" pcbX={13} pcbY={1} />
-    <Ss34 name="D_CATCH" pn="C8678" pcbX={21} pcbY={-10} />
-    <L0603 name="L_BUCK" pn="C168137" inductance="47uH" pcbX={17} pcbY={-1} />
+    <Ss34 name="D_CATCH" pn="C8678" pcbX={25} pcbY={-10} />
+    <inductor
+      name="L_BUCK"
+      inductance="47uH"
+      supplierPartNumbers={{ jlcpcb: ['C168137'] }}
+      pcbX={18}
+      pcbY={-13}
+      footprint={
+        <footprint>
+          <smtpad portHints={['pin1']} shape="rect" pcbX={-2.80} pcbY={0} width="2.40mm" height="3.40mm" layer="top" />
+          <smtpad portHints={['pin2']} shape="rect" pcbX={2.80} pcbY={0} width="2.40mm" height="3.40mm" layer="top" />
+        </footprint>
+      }
+    />
     <R0402 name="R_FB_TOP" pn="C25904" resistance="51.1k" tolerance="1%" pcbX={23} pcbY={-6} />
     <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={23} pcbY={-4} />
     <R0402 name="R_EN" pn="C25741" resistance="100k" tolerance="1%" pcbX={9} pcbY={-1} />
     <C0402 name="C_OUT_HF" pn="C307331" capacitance="100nF" pcbX={21} pcbY={-3} />
-    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={26} pcbY={-15} />
+    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={28} pcbY={-3} />
 
     <net name="SW_NODE" />
     <net name="V5V" />
@@ -159,7 +171,7 @@ export default () => (
     <trace from=".U_LDO33 > .VIN" to="net.V5V" />
     <trace from=".U_LDO33 > .VOUT" to="net.V3V3" />
     <trace from=".U_LDO33 > .ADJ_GND" to="net.PD_GND" />
-    <trace from=".U_LDO33 > .TAB" to="net.PD_GND" />
+    <trace from=".U_LDO33 > .TAB" to="net.V3V3" />
     <trace from=".C_LDO_IN > .pin1" to="net.V5V" />
     <trace from=".C_LDO_IN > .pin2" to="net.PD_GND" />
     <trace from=".C_LDO_OUT > .pin1" to="net.V3V3" />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -1,4 +1,4 @@
-// PoE PD board — 802.3af, integrated magjack, WS3203 PD + MP9486A buck, LAN8720A PHY
+// PoE PD board — 802.3af Mode A, integrated magjack, WS3203 PD + MP9486A buck, LAN8720A PHY
 // FEATURE: hardware/poe — see docs/research/2026-05-23-att-351-poe-deep-research.md
 
 import {
@@ -37,33 +37,32 @@ assertWiresAllSignals(J_POE, {
 
 export default () => (
   <board
-    width="60mm"
-    height="35mm"
+    width="75mm"
+    height="40mm"
     autorouter="sequential-trace"
     defaultTraceWidth="0.2mm"
   >
-    {/* ─── Cable-side: PoE-rated magjack + 2x bridges (Mode A + Mode B) + TVS ── */}
-    <Hy931147c name="J1" pn="C91754" pcbX={-22} pcbY={0} pcbRotation={0} />
-    <Mb10s name="BR1" pn="C2488" pcbX={-10} pcbY={8} pcbRotation={0} />
-    <Mb10s name="BR2" pn="C2488" pcbX={-10} pcbY={-8} pcbRotation={0} />
-    <Smaj58a name="D_TVS" pn="C2980408" pcbX={0} pcbY={8} pcbRotation={0} />
-    <C0402 name="C_DEN" pn="C307331" capacitance="100nF" pcbX={0} pcbY={5} />
+    {/* ─── Magjack: HY931147C (Mode A spare-pair PoE only — no CT exposed) ── */}
+    <Hy931147c name="J1" pn="C91754" pcbX={-23} pcbY={0} pcbRotation={0} />
+
+    {/* ─── Mode A spare-pair bridge: pins 4+5 ↔ pins 7+8 ─────────────────── */}
+    <Mb10s name="BR2" pn="C2488" pcbX={-9} pcbY={-7} pcbRotation={0} />
+    <Smaj58a name="D_TVS" pn="C2980408" pcbX={-9} pcbY={2} pcbRotation={0} />
+    <C0402 name="C_DEN" pn="C307331" capacitance="100nF" pcbX={-9} pcbY={5} />
 
     <net name="V_PoE_BUS" />
     <net name="PD_GND" />
+    <net name="MODE_A_POS" />
+    <net name="MODE_A_NEG" />
 
-    {/* Mode B (data-pair) center taps -> BR1 */}
-    <trace from=".J1 > .CT_TX" to=".BR1 > .AC1" />
-    <trace from=".J1 > .CT_RX" to=".BR1 > .AC2" />
-
-    {/* Mode A (spare-pair) -> BR2 */}
-    <trace from=".J1 > .CABLE_4_5_A" to=".BR2 > .AC1" />
-    <trace from=".J1 > .CABLE_7_8_A" to=".BR2 > .AC2" />
-
-    {/* Both bridges OR into the V_PoE_BUS net */}
-    <trace from=".BR1 > .POS" to="net.V_PoE_BUS" />
+    {/* Tie cable pins of same pair together */}
+    <trace from=".J1 > .CABLE_4" to="net.MODE_A_POS" />
+    <trace from=".J1 > .CABLE_5" to="net.MODE_A_POS" />
+    <trace from=".J1 > .CABLE_7" to="net.MODE_A_NEG" />
+    <trace from=".J1 > .CABLE_8" to="net.MODE_A_NEG" />
+    <trace from=".BR2 > .AC1" to="net.MODE_A_POS" />
+    <trace from=".BR2 > .AC2" to="net.MODE_A_NEG" />
     <trace from=".BR2 > .POS" to="net.V_PoE_BUS" />
-    <trace from=".BR1 > .NEG" to="net.PD_GND" />
     <trace from=".BR2 > .NEG" to="net.PD_GND" />
 
     {/* TVS clamp + detection cap across V_PoE_BUS-to-PD_GND */}
@@ -73,13 +72,13 @@ export default () => (
     <trace from=".C_DEN > .pin2" to="net.PD_GND" />
 
     {/* ─── WS3203 PD interface — detect, classify, hot-swap pass FET ─────── */}
-    <Ws3203 name="U_PD" pn="C5143001" pcbX={5} pcbY={0} />
-    <R0402 name="R_DEN" pn="C138027" resistance="24.9k" tolerance="1%" pcbX={5} pcbY={-6} />
-    <R0402 name="R_CLS" pn="C185397" resistance="768" tolerance="1%" pcbX={9} pcbY={-6} />
-    <R0402 name="R_ILIM" pn="C25768" resistance="22k" tolerance="1%" pcbX={5} pcbY={6} />
-    <C0402 name="C_SS" pn="C307331" capacitance="100nF" pcbX={9} pcbY={6} />
-    <C0402 name="C_VSS_BIAS" pn="C307331" capacitance="100nF" pcbX={13} pcbY={6} />
-    <C0402 name="C_BLNK" pn="C76947" capacitance="1nF" pcbX={9} pcbY={3} />
+    <Ws3203 name="U_PD" pn="C5143001" pcbX={1} pcbY={-5} />
+    <R0402 name="R_DEN" pn="C138027" resistance="24.9k" tolerance="1%" pcbX={1} pcbY={-10} />
+    <R0402 name="R_CLS" pn="C185397" resistance="768" tolerance="1%" pcbX={5} pcbY={-10} />
+    <R0402 name="R_ILIM" pn="C25768" resistance="22k" tolerance="1%" pcbX={-3} pcbY={-10} />
+    <C0402 name="C_SS" pn="C307331" capacitance="100nF" pcbX={-3} pcbY={-1} />
+    <C0402 name="C_VSS_BIAS" pn="C307331" capacitance="100nF" pcbX={5} pcbY={-1} />
+    <C0402 name="C_BLNK" pn="C76947" capacitance="1nF" pcbX={1} pcbY={-1} />
 
     <net name="V_OUT_PD" />
 
@@ -97,23 +96,21 @@ export default () => (
     <trace from=".U_PD > .VSS_BIAS" to=".C_VSS_BIAS > .pin1" />
     <trace from=".C_VSS_BIAS > .pin2" to="net.PD_GND" />
     <trace from=".U_PD > .VOUT_PD" to="net.V_OUT_PD" />
-    {/* BLNK — 1nF blanking cap to RTN (TPS2375-family typical) */}
     <trace from=".U_PD > .BLNK" to=".C_BLNK > .pin1" />
     <trace from=".C_BLNK > .pin2" to="net.PD_GND" />
-    {/* Unused per WS3203 ref design (802.3af Class 0): T2P, PG, GATE, OCS — left NC */}
 
     {/* ─── MP9486A 100V -> 5V async buck ─────────────────────────────────── */}
-    <Mp9486a name="U_BUCK" pn="C404013" pcbX={18} pcbY={0} />
-    <ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={14} pcbY={-3} />
-    <C0402 name="C_VIN_LF" pn="C307331" capacitance="100nF" pcbX={14} pcbY={3} />
-    <C0402 name="C_BST" pn="C307331" capacitance="100nF" pcbX={18} pcbY={-6} />
-    <Ss34 name="D_CATCH" pn="C8678" pcbX={22} pcbY={-3} />
-    <L0603 name="L_BUCK" pn="C168137" inductance="47uH" pcbX={25} pcbY={0} />
-    <R0402 name="R_FB_TOP" pn="C25904" resistance="51.1k" tolerance="1%" pcbX={26} pcbY={4} />
-    <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={26} pcbY={7} />
-    <R0402 name="R_EN" pn="C25741" resistance="100k" tolerance="1%" pcbX={14} pcbY={6} />
-    <C0402 name="C_OUT_HF" pn="C307331" capacitance="100nF" pcbX={29} pcbY={3} />
-    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={29} pcbY={-3} />
+    <Mp9486a name="U_BUCK" pn="C404013" pcbX={13} pcbY={-5} />
+    <ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={9} pcbY={-13} />
+    <C0402 name="C_VIN_LF" pn="C307331" capacitance="100nF" pcbX={10.5} pcbY={-10} />
+    <C0402 name="C_BST" pn="C307331" capacitance="100nF" pcbX={13} pcbY={1} />
+    <Ss34 name="D_CATCH" pn="C8678" pcbX={18} pcbY={-10} />
+    <L0603 name="L_BUCK" pn="C168137" inductance="47uH" pcbX={17} pcbY={-1} />
+    <R0402 name="R_FB_TOP" pn="C25904" resistance="51.1k" tolerance="1%" pcbX={21} pcbY={-8} />
+    <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={21} pcbY={-6} />
+    <R0402 name="R_EN" pn="C25741" resistance="100k" tolerance="1%" pcbX={9} pcbY={-1} />
+    <C0402 name="C_OUT_HF" pn="C307331" capacitance="100nF" pcbX={21} pcbY={-2} />
+    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={22} pcbY={-13} />
 
     <net name="SW_NODE" />
     <net name="V5V" />
@@ -145,7 +142,7 @@ export default () => (
     <trace from=".C_OUT_BULK > .pin1" to="net.V5V" />
     <trace from=".C_OUT_BULK > .pin2" to="net.PD_GND" />
 
-    {/* Feedback divider: V5V -> 51.1k -> FB -> 10k -> GND, FB = 0.81V */}
+    {/* Feedback divider: V5V -> 51.1k -> FB -> 10k -> GND */}
     <trace from="net.V5V" to=".R_FB_TOP > .pin1" />
     <trace from=".R_FB_TOP > .pin2" to=".U_BUCK > .FB" />
     <trace from=".U_BUCK > .FB" to=".R_FB_BOT > .pin1" />
@@ -153,9 +150,9 @@ export default () => (
     <trace from=".U_BUCK > .GND" to="net.PD_GND" />
 
     {/* ─── AMS1117-3.3 — V5V -> +3V3 for LAN8720A VDDIO/VDDA ──────────────── */}
-    <Ams1117_3v3 name="U_LDO33" pn="C6186" pcbX={-5} pcbY={10} />
-    <C0402 name="C_LDO_IN" pn="C52923" capacitance="1uF" pcbX={-9} pcbY={10} />
-    <C0402 name="C_LDO_OUT" pn="C15525" capacitance="10uF" pcbX={-1} pcbY={10} />
+    <Ams1117_3v3 name="U_LDO33" pn="C6186" pcbX={5} pcbY={7} />
+    <C0402 name="C_LDO_IN" pn="C52923" capacitance="1uF" pcbX={-2} pcbY={7} />
+    <C0402 name="C_LDO_OUT" pn="C15525" capacitance="10uF" pcbX={11} pcbY={7} />
 
     <net name="V3V3" />
 
@@ -169,33 +166,33 @@ export default () => (
     <trace from=".C_LDO_OUT > .pin2" to="net.PD_GND" />
 
     {/* ─── LAN8720A PHY + 25 MHz crystal + decoupling + strap resistors ──── */}
-    <Lan8720a name="U_PHY" pn="C17146" pcbX={-10} pcbY={-10} />
-    <Crystal25M_5032 name="Y1" pn="C20617602" pcbX={-20} pcbY={-14} />
-    <C0402 name="C_XTAL1" pn="C1549" capacitance="18pF" pcbX={-22} pcbY={-15} />
-    <C0402 name="C_XTAL2" pn="C1549" capacitance="18pF" pcbX={-18} pcbY={-15} />
+    <Lan8720a name="U_PHY" pn="C17146" pcbX={20} pcbY={6} />
+    <Crystal25M_5032 name="Y1" pn="C20617602" pcbX={12} pcbY={13} />
+    <C0402 name="C_XTAL1" pn="C1549" capacitance="18pF" pcbX={9} pcbY={16} />
+    <C0402 name="C_XTAL2" pn="C1549" capacitance="18pF" pcbX={15} pcbY={16} />
 
-    <C0402 name="C_VDDIO_HF" pn="C307331" capacitance="100nF" pcbX={-7} pcbY={-6} />
-    <C0402 name="C_VDDIO_LF" pn="C23733" capacitance="4.7uF" pcbX={-5} pcbY={-6} />
-    <L0603 name="L_VDDA_FB" pn="C85833" inductance="600R" pcbX={-13} pcbY={-14} />
-    <C0402 name="C_VDDA_HF" pn="C307331" capacitance="100nF" pcbX={-15} pcbY={-7} />
-    <C0402 name="C_VDDA_LF" pn="C23733" capacitance="4.7uF" pcbX={-14} pcbY={-5} />
-    <C0402 name="C_VDDCR_HF" pn="C1537" capacitance="470pF" pcbX={-10} pcbY={-6} />
-    <C0402 name="C_VDDCR_LF" pn="C52923" capacitance="1uF" pcbX={-12} pcbY={-6} />
+    <C0402 name="C_VDDIO_HF" pn="C307331" capacitance="100nF" pcbX={17.5} pcbY={11} />
+    <C0402 name="C_VDDIO_LF" pn="C23733" capacitance="4.7uF" pcbX={17.5} pcbY={9.5} />
+    <L0603 name="L_VDDA_FB" pn="C85833" inductance="600R" pcbX={20.5} pcbY={11.5} />
+    <C0402 name="C_VDDA_HF" pn="C307331" capacitance="100nF" pcbX={23} pcbY={11} />
+    <C0402 name="C_VDDA_LF" pn="C23733" capacitance="4.7uF" pcbX={23} pcbY={9} />
+    <C0402 name="C_VDDCR_HF" pn="C1537" capacitance="470pF" pcbX={23} pcbY={6} />
+    <C0402 name="C_VDDCR_LF" pn="C52923" capacitance="1uF" pcbX={23} pcbY={4} />
 
-    <R0402 name="R_RBIAS" pn="C25852" resistance="12.1k" tolerance="1%" pcbX={-12} pcbY={-10} />
-    <R0402 name="R_MDIO_PU" pn="C25867" resistance="1.5k" tolerance="1%" pcbX={0} pcbY={-12} />
+    <R0402 name="R_RBIAS" pn="C25852" resistance="12.1k" tolerance="1%" pcbX={17} pcbY={2} />
+    <R0402 name="R_MDIO_PU" pn="C25867" resistance="1.5k" tolerance="1%" pcbX={26} pcbY={3} />
 
     {/* RMII series-term resistors on PHY-driven RX outputs */}
-    <R0402 name="R_S_RXD0" pn="C25077" resistance="10" tolerance="1%" pcbX={-12} pcbY={-14} />
-    <R0402 name="R_S_RXD1" pn="C25077" resistance="10" tolerance="1%" pcbX={-10} pcbY={-14} />
-    <R0402 name="R_S_CRSDV" pn="C25077" resistance="10" tolerance="1%" pcbX={-8} pcbY={-14} />
+    <R0402 name="R_S_RXD0" pn="C25077" resistance="10" tolerance="1%" pcbX={26} pcbY={6} />
+    <R0402 name="R_S_RXD1" pn="C25077" resistance="10" tolerance="1%" pcbX={26} pcbY={8} />
+    <R0402 name="R_S_CRSDV" pn="C25077" resistance="10" tolerance="1%" pcbX={26} pcbY={10} />
 
     {/* MDI termination: 49.9R pull-ups on TX/RX to VDDA */}
-    <R0402 name="R_TXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-8} />
-    <R0402 name="R_TXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-6} />
-    <R0402 name="R_RXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-8} />
-    <R0402 name="R_RXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-6} />
-    <C0402 name="C_TERM_BYP" pn="C307331" capacitance="100nF" pcbX={-17} pcbY={-3} />
+    <R0402 name="R_TXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={17} pcbY={4} />
+    <R0402 name="R_TXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={15} pcbY={4} />
+    <R0402 name="R_RXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={22} pcbY={2} />
+    <R0402 name="R_RXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={24} pcbY={2} />
+    <C0402 name="C_TERM_BYP" pn="C307331" capacitance="100nF" pcbX={15} pcbY={2} />
 
     <net name="MDI_TXP" />
     <net name="MDI_TXN" />
@@ -203,7 +200,7 @@ export default () => (
     <net name="MDI_RXN" />
     <net name="MDI_TERM_VDDA" />
 
-    {/* PHY supply wiring — LAN8720A has 3 VDDIO pins (4, 10, 22), all tied to 3V3 */}
+    {/* PHY supply wiring */}
     <trace from=".U_PHY > .VDDIO" to="net.V3V3" />
     <trace from=".U_PHY > .VDDIO_2" to="net.V3V3" />
     <trace from=".U_PHY > .VDDIO_3" to="net.V3V3" />
@@ -223,27 +220,28 @@ export default () => (
     <trace from=".C_VDDCR_LF > .pin2" to="net.PD_GND" />
     <trace from=".U_PHY > .VSS" to="net.PD_GND" />
 
-    {/* RBIAS */}
     <trace from=".U_PHY > .RBIAS" to=".R_RBIAS > .pin1" />
     <trace from=".R_RBIAS > .pin2" to="net.PD_GND" />
 
-    {/* Strap resistors — REGOFF pull-up (enable internal reg) + nINTSEL pull-down (REFCLK OUT) */}
-    <R0402 name="R_STRAP_REGOFF" pn="C25744" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-10} />
-    <R0402 name="R_STRAP_INTSEL" pn="C25744" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-12} />
+    {/* Strap resistors */}
+    <R0402 name="R_STRAP_REGOFF" pn="C25744" resistance="10k" tolerance="1%" pcbX={28} pcbY={5} />
+    <R0402 name="R_STRAP_INTSEL" pn="C25744" resistance="10k" tolerance="1%" pcbX={28} pcbY={7} />
     <trace from=".U_PHY > .LED1" to=".R_STRAP_REGOFF > .pin1" />
     <trace from=".R_STRAP_REGOFF > .pin2" to="net.V3V3" />
     <trace from=".U_PHY > .LED2" to=".R_STRAP_INTSEL > .pin1" />
     <trace from=".R_STRAP_INTSEL > .pin2" to="net.PD_GND" />
 
-    {/* Crystal */}
-    <trace from=".U_PHY > .XTAL1" to=".Y1 > .pin1" />
-    <trace from=".U_PHY > .XTAL2" to=".Y1 > .pin2" />
-    <trace from=".Y1 > .pin1" to=".C_XTAL1 > .pin1" />
+    {/* Crystal — XOUT/XIN are signal, GND_1/GND_2 = ground */}
+    <trace from=".U_PHY > .XTAL1" to=".Y1 > .XOUT" />
+    <trace from=".U_PHY > .XTAL2" to=".Y1 > .XIN" />
+    <trace from=".Y1 > .GND_1" to="net.PD_GND" />
+    <trace from=".Y1 > .GND_2" to="net.PD_GND" />
+    <trace from=".Y1 > .XOUT" to=".C_XTAL1 > .pin1" />
     <trace from=".C_XTAL1 > .pin2" to="net.PD_GND" />
-    <trace from=".Y1 > .pin2" to=".C_XTAL2 > .pin1" />
+    <trace from=".Y1 > .XIN" to=".C_XTAL2 > .pin1" />
     <trace from=".C_XTAL2 > .pin2" to="net.PD_GND" />
 
-    {/* MDI termination — TX/RX 49.9R pulls to MDI_TERM_VDDA bypass-cap node */}
+    {/* MDI termination */}
     <trace from=".U_PHY > .TXP" to="net.MDI_TXP" />
     <trace from=".U_PHY > .TXN" to="net.MDI_TXN" />
     <trace from=".R_TXP_TERM > .pin1" to="net.MDI_TXP" />
@@ -258,7 +256,7 @@ export default () => (
     <trace from=".C_TERM_BYP > .pin2" to="net.PD_GND" />
     <trace from="net.MDI_TERM_VDDA" to=".U_PHY > .VDD2A" />
 
-    {/* Magjack MDI side to PHY MDI pairs */}
+    {/* Magjack signal-side TX/RX to PHY MDI pairs */}
     <trace from=".J1 > .TX_P" to="net.MDI_TXP" />
     <trace from=".J1 > .TX_N" to="net.MDI_TXN" />
     <trace from=".J1 > .RX_P" to="net.MDI_RXP" />
@@ -280,7 +278,7 @@ export default () => (
     <trace from=".R_S_CRSDV > .pin2" to="net.RMII_CRS_DV_OUT" />
 
     {/* ─── J_POE — 2x8 1.27mm B2B to Core ──────────────────────────────── */}
-    <B2B_127_2xN name="J_POE" pn="C7470092" pinsPerRow={8} pcbX={26} pcbY={10} pcbRotation={0} />
+    <B2B_127_2xN name="J_POE" pn="C7470092" pinsPerRow={8} pcbX={32} pcbY={-12} pcbRotation={0} />
 
     <net name="RMII_TXD0" />
     <net name="RMII_TXD1" />
@@ -317,8 +315,8 @@ export default () => (
     <trace from="net.PHY_nRST" to=".U_PHY > .nRST" />
 
     {/* ─── RJ45 shield bond: 1nF/2kV Y2 || 1M to PD_GND ──────────────────── */}
-    <capacitor name="C_SHIELD_Y2" capacitance="1nF" footprint="1206" supplierPartNumbers={{ jlcpcb: ['C9196'] }} pcbX={-22} pcbY={6} />
-    <R0402 name="R_SHIELD_BLEED" pn="C26083" resistance="1M" tolerance="1%" pcbX={-22} pcbY={4} />
+    <capacitor name="C_SHIELD_Y2" capacitance="1nF" footprint="1206" supplierPartNumbers={{ jlcpcb: ['C9196'] }} pcbX={-30} pcbY={11} />
+    <R0402 name="R_SHIELD_BLEED" pn="C26083" resistance="1M" tolerance="1%" pcbX={-30} pcbY={9} />
 
     <net name="CHASSIS" />
     <trace from=".J1 > .SHIELD_1" to="net.CHASSIS" />
@@ -329,8 +327,8 @@ export default () => (
     <trace from=".R_SHIELD_BLEED > .pin2" to="net.PD_GND" />
 
     {/* ─── RJ45 integrated LEDs (driven by PHY LED1/LED2 pins) ─────────── */}
-    <R0402 name="R_LED_LINK" pn="C25104" resistance="330" tolerance="1%" pcbX={-22} pcbY={10} />
-    <R0402 name="R_LED_ACT" pn="C25104" resistance="330" tolerance="1%" pcbX={-22} pcbY={12} />
+    <R0402 name="R_LED_LINK" pn="C25104" resistance="330" tolerance="1%" pcbX={-30} pcbY={14} />
+    <R0402 name="R_LED_ACT" pn="C25104" resistance="330" tolerance="1%" pcbX={-30} pcbY={16} />
 
     <trace from=".J1 > .LED_LINK_A" to="net.V3V3" />
     <trace from=".J1 > .LED_LINK_K" to=".R_LED_LINK > .pin1" />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -104,7 +104,7 @@ export default () => (
     <ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={9} pcbY={-15} />
     <C0402 name="C_VIN_LF" pn="C307331" capacitance="100nF" pcbX={10.5} pcbY={-9} />
     <C0402 name="C_BST" pn="C307331" capacitance="100nF" pcbX={13} pcbY={1} />
-    <Ss34 name="D_CATCH" pn="C8678" pcbX={25} pcbY={-10} />
+    <Ss34 name="D_CATCH" pn="C8678" pcbX={21} pcbY={-10} />
     <inductor
       name="L_BUCK"
       inductance="47uH"
@@ -122,7 +122,7 @@ export default () => (
     <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={23} pcbY={-4} />
     <R0402 name="R_EN" pn="C25741" resistance="100k" tolerance="1%" pcbX={9} pcbY={-1} />
     <C0402 name="C_OUT_HF" pn="C307331" capacitance="100nF" pcbX={21} pcbY={-3} />
-    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={28} pcbY={-3} />
+    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={29} pcbY={-3} />
 
     <net name="SW_NODE" />
     <net name="V5V" />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -43,7 +43,7 @@ export default () => (
     defaultTraceWidth="0.2mm"
   >
     {/* ─── Magjack: HY931147C (Mode A spare-pair PoE only — no CT exposed) ── */}
-    <Hy931147c name="J1" pn="C91754" pcbX={-23} pcbY={0} pcbRotation={0} />
+    <Hy931147c name="J1" pn="C91754" pcbX={-26} pcbY={0} pcbRotation={0} />
 
     {/* ─── Mode A spare-pair bridge: pins 4+5 ↔ pins 7+8 ─────────────────── */}
     <Mb10s name="BR2" pn="C2488" pcbX={-9} pcbY={-7} pcbRotation={0} />
@@ -101,16 +101,16 @@ export default () => (
 
     {/* ─── MP9486A 100V -> 5V async buck ─────────────────────────────────── */}
     <Mp9486a name="U_BUCK" pn="C404013" pcbX={13} pcbY={-5} />
-    <ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={9} pcbY={-13} />
-    <C0402 name="C_VIN_LF" pn="C307331" capacitance="100nF" pcbX={10.5} pcbY={-10} />
+    <ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={9} pcbY={-15} />
+    <C0402 name="C_VIN_LF" pn="C307331" capacitance="100nF" pcbX={10.5} pcbY={-9} />
     <C0402 name="C_BST" pn="C307331" capacitance="100nF" pcbX={13} pcbY={1} />
-    <Ss34 name="D_CATCH" pn="C8678" pcbX={18} pcbY={-10} />
+    <Ss34 name="D_CATCH" pn="C8678" pcbX={21} pcbY={-10} />
     <L0603 name="L_BUCK" pn="C168137" inductance="47uH" pcbX={17} pcbY={-1} />
-    <R0402 name="R_FB_TOP" pn="C25904" resistance="51.1k" tolerance="1%" pcbX={21} pcbY={-8} />
-    <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={21} pcbY={-6} />
+    <R0402 name="R_FB_TOP" pn="C25904" resistance="51.1k" tolerance="1%" pcbX={23} pcbY={-6} />
+    <R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={23} pcbY={-4} />
     <R0402 name="R_EN" pn="C25741" resistance="100k" tolerance="1%" pcbX={9} pcbY={-1} />
-    <C0402 name="C_OUT_HF" pn="C307331" capacitance="100nF" pcbX={21} pcbY={-2} />
-    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={22} pcbY={-13} />
+    <C0402 name="C_OUT_HF" pn="C307331" capacitance="100nF" pcbX={21} pcbY={-3} />
+    <ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={26} pcbY={-15} />
 
     <net name="SW_NODE" />
     <net name="V5V" />
@@ -168,19 +168,19 @@ export default () => (
     {/* ─── LAN8720A PHY + 25 MHz crystal + decoupling + strap resistors ──── */}
     <Lan8720a name="U_PHY" pn="C17146" pcbX={20} pcbY={6} />
     <Crystal25M_5032 name="Y1" pn="C20617602" pcbX={12} pcbY={13} />
-    <C0402 name="C_XTAL1" pn="C1549" capacitance="18pF" pcbX={9} pcbY={16} />
-    <C0402 name="C_XTAL2" pn="C1549" capacitance="18pF" pcbX={15} pcbY={16} />
+    <C0402 name="C_XTAL1" pn="C1549" capacitance="18pF" pcbX={8} pcbY={16} />
+    <C0402 name="C_XTAL2" pn="C1549" capacitance="18pF" pcbX={16} pcbY={16} />
 
-    <C0402 name="C_VDDIO_HF" pn="C307331" capacitance="100nF" pcbX={17.5} pcbY={11} />
-    <C0402 name="C_VDDIO_LF" pn="C23733" capacitance="4.7uF" pcbX={17.5} pcbY={9.5} />
-    <L0603 name="L_VDDA_FB" pn="C85833" inductance="600R" pcbX={20.5} pcbY={11.5} />
-    <C0402 name="C_VDDA_HF" pn="C307331" capacitance="100nF" pcbX={23} pcbY={11} />
-    <C0402 name="C_VDDA_LF" pn="C23733" capacitance="4.7uF" pcbX={23} pcbY={9} />
-    <C0402 name="C_VDDCR_HF" pn="C1537" capacitance="470pF" pcbX={23} pcbY={6} />
-    <C0402 name="C_VDDCR_LF" pn="C52923" capacitance="1uF" pcbX={23} pcbY={4} />
+    <C0402 name="C_VDDIO_HF" pn="C307331" capacitance="100nF" pcbX={18} pcbY={11} />
+    <C0402 name="C_VDDIO_LF" pn="C23733" capacitance="4.7uF" pcbX={16} pcbY={11} />
+    <L0603 name="L_VDDA_FB" pn="C85833" inductance="600R" pcbX={20} pcbY={13} />
+    <C0402 name="C_VDDA_HF" pn="C307331" capacitance="100nF" pcbX={22} pcbY={11} />
+    <C0402 name="C_VDDA_LF" pn="C23733" capacitance="4.7uF" pcbX={24} pcbY={11} />
+    <C0402 name="C_VDDCR_HF" pn="C1537" capacitance="470pF" pcbX={24} pcbY={6} />
+    <C0402 name="C_VDDCR_LF" pn="C52923" capacitance="1uF" pcbX={24} pcbY={4} />
 
-    <R0402 name="R_RBIAS" pn="C25852" resistance="12.1k" tolerance="1%" pcbX={17} pcbY={2} />
-    <R0402 name="R_MDIO_PU" pn="C25867" resistance="1.5k" tolerance="1%" pcbX={26} pcbY={3} />
+    <R0402 name="R_RBIAS" pn="C25852" resistance="12.1k" tolerance="1%" pcbX={20} pcbY={0} />
+    <R0402 name="R_MDIO_PU" pn="C25867" resistance="1.5k" tolerance="1%" pcbX={27} pcbY={3} />
 
     {/* RMII series-term resistors on PHY-driven RX outputs */}
     <R0402 name="R_S_RXD0" pn="C25077" resistance="10" tolerance="1%" pcbX={26} pcbY={6} />
@@ -188,11 +188,11 @@ export default () => (
     <R0402 name="R_S_CRSDV" pn="C25077" resistance="10" tolerance="1%" pcbX={26} pcbY={10} />
 
     {/* MDI termination: 49.9R pull-ups on TX/RX to VDDA */}
-    <R0402 name="R_TXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={17} pcbY={4} />
-    <R0402 name="R_TXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={15} pcbY={4} />
+    <R0402 name="R_TXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={17} pcbY={1} />
+    <R0402 name="R_TXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={15} pcbY={1} />
     <R0402 name="R_RXP_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={22} pcbY={2} />
     <R0402 name="R_RXN_TERM" pn="C25120" resistance="49.9" tolerance="1%" pcbX={24} pcbY={2} />
-    <C0402 name="C_TERM_BYP" pn="C307331" capacitance="100nF" pcbX={15} pcbY={2} />
+    <C0402 name="C_TERM_BYP" pn="C307331" capacitance="100nF" pcbX={12} pcbY={-1} />
 
     <net name="MDI_TXP" />
     <net name="MDI_TXN" />
@@ -315,8 +315,8 @@ export default () => (
     <trace from="net.PHY_nRST" to=".U_PHY > .nRST" />
 
     {/* ─── RJ45 shield bond: 1nF/2kV Y2 || 1M to PD_GND ──────────────────── */}
-    <capacitor name="C_SHIELD_Y2" capacitance="1nF" footprint="1206" supplierPartNumbers={{ jlcpcb: ['C9196'] }} pcbX={-30} pcbY={11} />
-    <R0402 name="R_SHIELD_BLEED" pn="C26083" resistance="1M" tolerance="1%" pcbX={-30} pcbY={9} />
+    <capacitor name="C_SHIELD_Y2" capacitance="1nF" footprint="1206" supplierPartNumbers={{ jlcpcb: ['C9196'] }} pcbX={-30} pcbY={13} />
+    <R0402 name="R_SHIELD_BLEED" pn="C26083" resistance="1M" tolerance="1%" pcbX={-30} pcbY={11} />
 
     <net name="CHASSIS" />
     <trace from=".J1 > .SHIELD_1" to="net.CHASSIS" />
@@ -327,8 +327,8 @@ export default () => (
     <trace from=".R_SHIELD_BLEED > .pin2" to="net.PD_GND" />
 
     {/* ─── RJ45 integrated LEDs (driven by PHY LED1/LED2 pins) ─────────── */}
-    <R0402 name="R_LED_LINK" pn="C25104" resistance="330" tolerance="1%" pcbX={-30} pcbY={14} />
-    <R0402 name="R_LED_ACT" pn="C25104" resistance="330" tolerance="1%" pcbX={-30} pcbY={16} />
+    <R0402 name="R_LED_LINK" pn="C25104" resistance="330" tolerance="1%" pcbX={-30} pcbY={15} />
+    <R0402 name="R_LED_ACT" pn="C25104" resistance="330" tolerance="1%" pcbX={-30} pcbY={17} />
 
     <trace from=".J1 > .LED_LINK_A" to="net.V3V3" />
     <trace from=".J1 > .LED_LINK_K" to=".R_LED_LINK > .pin1" />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -76,7 +76,7 @@ export default () => (
     <Ws3203 name="U_PD" pn="C5143001" pcbX={5} pcbY={0} />
     <R0402 name="R_DEN" pn="C25741" resistance="24.9k" tolerance="1%" pcbX={5} pcbY={-6} />
     <R0402 name="R_CLS" pn="C25742" resistance="768" tolerance="1%" pcbX={9} pcbY={-6} />
-    <R0402 name="R_ILIM" pn="C25744" resistance="22k" tolerance="1%" pcbX={5} pcbY={6} />
+    <R0402 name="R_ILIM" pn="C25768" resistance="22k" tolerance="1%" pcbX={5} pcbY={6} />
     <C0402 name="C_SS" pn="C307331" capacitance="100nF" pcbX={9} pcbY={6} />
     <C0402 name="C_VSS_BIAS" pn="C307331" capacitance="100nF" pcbX={13} pcbY={6} />
     <C0402 name="C_BLNK" pn="C76947" capacitance="1nF" pcbX={9} pcbY={3} />
@@ -228,8 +228,8 @@ export default () => (
     <trace from=".R_RBIAS > .pin2" to="net.PD_GND" />
 
     {/* Strap resistors — REGOFF pull-up (enable internal reg) + nINTSEL pull-down (REFCLK OUT) */}
-    <R0402 name="R_STRAP_REGOFF" pn="C25804" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-10} />
-    <R0402 name="R_STRAP_INTSEL" pn="C25804" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-12} />
+    <R0402 name="R_STRAP_REGOFF" pn="C25744" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-10} />
+    <R0402 name="R_STRAP_INTSEL" pn="C25744" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-12} />
     <trace from=".U_PHY > .LED1" to=".R_STRAP_REGOFF > .pin1" />
     <trace from=".R_STRAP_REGOFF > .pin2" to="net.V3V3" />
     <trace from=".U_PHY > .LED2" to=".R_STRAP_INTSEL > .pin1" />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -1,0 +1,6 @@
+// Stub PoE PD board entry point — replaced by full topology in Task 6
+// FEATURE: hardware/poe — 802.3af PD module, see docs/research/2026-05-23-att-351-poe-deep-research.md
+
+export default () => (
+  <board width="60mm" height="35mm" routingDisabled />
+);

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -75,7 +75,7 @@ export default () => (
     {/* ─── WS3203 PD interface — detect, classify, hot-swap pass FET ─────── */}
     <Ws3203 name="U_PD" pn="C5143001" pcbX={5} pcbY={0} />
     <R0402 name="R_DEN" pn="C138027" resistance="24.9k" tolerance="1%" pcbX={5} pcbY={-6} />
-    <R0402 name="R_CLS" pn="C49656920" resistance="768" tolerance="1%" pcbX={9} pcbY={-6} />
+    <R0402 name="R_CLS" pn="C185397" resistance="768" tolerance="1%" pcbX={9} pcbY={-6} />
     <R0402 name="R_ILIM" pn="C25768" resistance="22k" tolerance="1%" pcbX={5} pcbY={6} />
     <C0402 name="C_SS" pn="C307331" capacitance="100nF" pcbX={9} pcbY={6} />
     <C0402 name="C_VSS_BIAS" pn="C307331" capacitance="100nF" pcbX={13} pcbY={6} />

--- a/apps/attractap/hardware/poe/index.tsx
+++ b/apps/attractap/hardware/poe/index.tsx
@@ -104,13 +104,13 @@ export default () => (
     <ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={9} pcbY={-15} />
     <C0402 name="C_VIN_LF" pn="C307331" capacitance="100nF" pcbX={10.5} pcbY={-9} />
     <C0402 name="C_BST" pn="C307331" capacitance="100nF" pcbX={13} pcbY={1} />
-    <Ss34 name="D_CATCH" pn="C8678" pcbX={21} pcbY={-10} />
+    <Ss34 name="D_CATCH" pn="C8678" pcbX={21} pcbY={-8.5} />
     <inductor
       name="L_BUCK"
       inductance="47uH"
       supplierPartNumbers={{ jlcpcb: ['C168137'] }}
       pcbX={18}
-      pcbY={-13}
+      pcbY={-14}
       footprint={
         <footprint>
           <smtpad portHints={['pin1']} shape="rect" pcbX={-2.80} pcbY={0} width="2.40mm" height="3.40mm" layer="top" />

--- a/apps/attractap/hardware/poe/package.json
+++ b/apps/attractap/hardware/poe/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@attraccess/attractap-hw-poe",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@attraccess/attractap-hw-shared": "workspace:*",
+    "@tscircuit/cli": "0.1.1399",
+    "tscircuit": "0.0.1774",
+    "tsx": "^4.20.3"
+  }
+}

--- a/apps/attractap/hardware/poe/project.json
+++ b/apps/attractap/hardware/poe/project.json
@@ -61,6 +61,23 @@
         ],
         "parallel": false
       }
+    },
+    "render-3d": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/render-3d"],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "commands": [
+          "rm -rf dist/render-3d && mkdir -p dist/render-3d",
+          "pnpm exec tscircuit-cli export index.tsx -f glb -o dist/render-3d/poe.glb",
+          "pnpm exec tscircuit-cli export index.tsx -f step -o dist/render-3d/poe.step",
+          "node ../scripts/render-glb-png.mjs --out-dir dist/render-3d dist/render-3d/poe.glb"
+        ],
+        "parallel": false
+      }
     }
   }
 }

--- a/apps/attractap/hardware/poe/project.json
+++ b/apps/attractap/hardware/poe/project.json
@@ -1,0 +1,66 @@
+{
+  "name": "attractap-hw-poe",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/attractap/hardware/poe",
+  "tags": ["scope:hardware", "type:board"],
+  "targets": {
+    "lint": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": [],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "command": "pnpm exec tscircuit-cli build index.tsx --ignore-warnings"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/build"],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "commands": [
+          "rm -rf dist/build && mkdir -p dist/build",
+          "pnpm exec tscircuit-cli export index.tsx -f circuit-json -o dist/build/poe.circuit.json"
+        ],
+        "parallel": false
+      }
+    },
+    "export": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/export"],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "commands": [
+          "rm -rf dist/export && mkdir -p dist/export",
+          "pnpm exec tscircuit-cli export index.tsx -f gerbers -o dist/export/poe-gerbers.zip"
+        ],
+        "parallel": false
+      }
+    },
+    "render": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/render"],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "commands": [
+          "rm -rf dist/render && mkdir -p dist/render",
+          "pnpm exec tscircuit-cli export index.tsx -f pcb-svg -o dist/render/poe-pcb.svg",
+          "pnpm exec tscircuit-cli export index.tsx -f schematic-svg -o dist/render/poe-schematic.svg",
+          "pnpm exec tscircuit-cli export index.tsx -f assembly-svg -o dist/render/poe-assembly.svg",
+          "node ../scripts/render-png.mjs --out-dir dist/render dist/render/poe-pcb.svg dist/render/poe-schematic.svg dist/render/poe-assembly.svg"
+        ],
+        "parallel": false
+      }
+    }
+  }
+}

--- a/apps/attractap/hardware/poe/tscircuit.config.json
+++ b/apps/attractap/hardware/poe/tscircuit.config.json
@@ -1,0 +1,9 @@
+{
+  "pcb": {
+    "layerCount": 4,
+    "boardThickness": 1.6,
+    "drc": {
+      "preset": "jlcpcb4"
+    }
+  }
+}

--- a/apps/attractap/hardware/poe/tsconfig.json
+++ b/apps/attractap/hardware/poe/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["@tscircuit/props"]
+  },
+  "include": ["index.tsx"]
+}

--- a/docs/research/2026-05-23-att-351-poe-board-impl-plan.md
+++ b/docs/research/2026-05-23-att-351-poe-board-impl-plan.md
@@ -1,0 +1,1199 @@
+# ATT-351 — PoE PD Board Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the `attractap-hw-poe` tscircuit board (60×35 mm, 4-layer, JLC-stocked) that delivers 5 V/1 A from an 802.3af PoE injector, exposes RMII to Core via `J_POE`, and passes `nx run attractap-hw-poe:{lint,build,export,render}` clean on the JLC 4-layer ruleset.
+
+**Architecture:** Non-isolated buck post-bridge topology. HanRun HY931147C PoE-rated magjack feeds 2× MB10S bridges → SMAJ58A TVS-clamped PoE bus → NJGW WS3203 802.3af PD interface → MPS MP9486AGN-Z 100 V → 5 V async buck. Microchip LAN8720AI-CP-TR PHY at 3.3 V (AMS1117-3.3 LDO from +5 V), 25 MHz crystal, RMII out to `J_POE` (2×8 1.27 mm B2B). All component choices, pin maps, and the iso-strategy rationale are locked in `docs/research/2026-05-23-att-351-poe-deep-research.md` (committed at `c8a7426a`) — implement that doc exactly.
+
+**Tech Stack:** tscircuit 0.0.1774 + @tscircuit/cli 0.1.1399 (pinned), TypeScript JSX, nx run-commands, JLC EasyEDA footprint library, vitest for shared-lib unit tests.
+
+---
+
+## File Structure
+
+### Library additions (`libs/attractap-hw-shared/src/parts/`)
+
+| File | New / Modify | Responsibility |
+|------|--------------|----------------|
+| `parts/ethernet.tsx` | **Create** | Typed wrappers for LAN8720A PHY, HY931147C PoE-magjack, 25 MHz SMD5032 crystal. Shared by any future board that talks Ethernet. |
+| `parts/poe.tsx` | **Create** | Typed wrappers for WS3203 PD interface IC, MP9486AGN-Z buck, MB10S bridge, SMAJ58A TVS, SS34 Schottky catch. Shared by any future PoE-aware board (currently just this one). |
+| `parts/passives.tsx` | **Modify** | Add `ElecCap_22uF_100V` wrapper (D6.3 SMD electrolytic) for high-V bulk. Keep file < 200 lines; if larger, split off `parts/electrolytics.tsx` instead. |
+| `parts/index.tsx` | **Modify** | Re-export `ethernet` and `poe`. |
+| `package.json` | **Modify** | Bump version `0.0.1` → `0.1.0` (minor — additive). |
+| `connectors/connectors.spec.ts` | (no change) | Existing schema tests already cover `J_POE`; no new tests needed for additive parts. |
+
+### Board project (`apps/attractap/hardware/poe/`)
+
+| File | New / Modify | Responsibility |
+|------|--------------|----------------|
+| `package.json` | **Create** | Pin `tscircuit@0.0.1774` + `@tscircuit/cli@0.1.1399` + `tsx`; depend on `@attraccess/attractap-hw-shared` workspace lib. |
+| `project.json` | **Create** | nx 4 targets (lint/build/export/render) following `_placeholder/project.json` pattern; renamed to `attractap-hw-poe`. |
+| `tsconfig.json` | **Create** | Same as `_placeholder/tsconfig.json`, extends repo base. |
+| `tscircuit.config.json` | **Create** | JLC 4-layer DRC preset override (`pcb.drc.preset: "jlcpcb4"`). |
+| `index.tsx` | **Create** | The actual board JSX. Imports `J_POE` constants from shared lib, wires every required signal, calls `assertWiresAllSignals` so missing wires fail at compile time. |
+
+### CI
+
+`.github/workflows/hardware.yml` already runs `nx run-many --projects=tag:scope:hardware -t lint,build,export,render`; the new project is auto-picked because of the `scope:hardware` + `type:board` tags. No CI change required.
+
+---
+
+## Task 1: Extend shared lib `passives.tsx` with `ElecCap_22uF_100V`
+
+**Files:**
+- Modify: `libs/attractap-hw-shared/src/parts/passives.tsx`
+
+The PoE input bulk is a 22 µF/100 V SMD aluminum electrolytic (LCSC C46550391, jieerrui JVJ100V22M6x8, D6.3×7.7 mm). Add a wrapper alongside the existing R/C/L wrappers.
+
+- [ ] **Step 1: Read the current `passives.tsx`**
+
+Run: `wc -l libs/attractap-hw-shared/src/parts/passives.tsx`
+Expected: ≤ 100 lines (it's currently ~74 lines per the connector-spec-freeze commit).
+
+- [ ] **Step 2: Append the electrolytic wrapper**
+
+Add the following block to `libs/attractap-hw-shared/src/parts/passives.tsx` after the existing `L0603` wrapper:
+
+```tsx
+export interface ElectrolyticCapProps extends BasePartProps {
+  readonly capacitance: number | string;
+  readonly voltage: number | string;
+}
+
+export const ElecCap_22uF_100V = ({ name, pn, ...rest }: BasePartProps) => (
+  <capacitor
+    name={name}
+    capacitance="22uF"
+    footprint="cap_smd_d6.3_h7.7_p2.5"
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  />
+);
+```
+
+This is a single-purpose wrapper (specific value + voltage class) on purpose: the PoE input cap is a fixed value across every PoE-board variant we'd ever build at this power level. Generic `ElectrolyticCap` is YAGNI until a second use site appears.
+
+- [ ] **Step 3: Run shared-lib typecheck to confirm syntax**
+
+Run: `pnpm nx run attractap-hw-shared:typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add libs/attractap-hw-shared/src/parts/passives.tsx
+git commit -m "feat(ATT-351): hw-shared — ElecCap_22uF_100V wrapper for PoE input bulk"
+```
+
+---
+
+## Task 2: Create shared lib `ethernet.tsx` (PHY + magjack + crystal wrappers)
+
+**Files:**
+- Create: `libs/attractap-hw-shared/src/parts/ethernet.tsx`
+
+- [ ] **Step 1: Create the file**
+
+Write `libs/attractap-hw-shared/src/parts/ethernet.tsx` with the following content (header + 3 wrappers):
+
+```tsx
+// Typed tscircuit wrappers for the Ethernet IC family used by Attractap V2 PoE
+// FEATURE: hw-shared/ethernet — LAN8720A PHY, HanRun PoE magjack, 25 MHz crystal
+
+import type { BasePartProps } from './types';
+import { jlcSupplier } from './types';
+
+const LAN8720A_PINS = {
+  pin1: ['VDDCR'],
+  pin2: ['VDD2A'],
+  pin3: ['RBIAS'],
+  pin4: ['VDDIO'],
+  pin5: ['LED2', 'nINTSEL'],
+  pin6: ['LED1', 'REGOFF'],
+  pin7: ['XTAL2'],
+  pin8: ['XTAL1', 'CLKIN'],
+  pin9: ['VSS'],
+  pin10: ['VDDIO_NC1'],
+  pin11: ['nRST'],
+  pin12: ['MDIO'],
+  pin13: ['MDC'],
+  pin14: ['RXER'],
+  pin15: ['RXD1', 'PHYAD2'],
+  pin16: ['RXD0', 'PHYAD1'],
+  pin17: ['CRS_DV', 'PHYAD0', 'MODE2'],
+  pin18: ['REFCLKO'],
+  pin19: ['TXEN'],
+  pin20: ['TXD0'],
+  pin21: ['TXD1'],
+  pin22: ['VDDIO_NC2'],
+  pin23: ['TXP'],
+  pin24: ['TXN'],
+} as const;
+
+export type Lan8720aProps = BasePartProps;
+
+export const Lan8720a = ({ name, pn, ...rest }: Lan8720aProps) => (
+  <chip
+    name={name}
+    footprint="qfn24_p0.5_w4_h4_ep2.5"
+    pinLabels={LAN8720A_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="LAN8720A 10/100 Ethernet PHY (RMII)" />
+  </chip>
+);
+
+const HY931147C_PINS = {
+  pin1: ['TX_P'],
+  pin2: ['TX_N'],
+  pin3: ['RX_P'],
+  pin4: ['CT_TX'],
+  pin5: ['CT_RX'],
+  pin6: ['RX_N'],
+  pin7: ['CABLE_3'],
+  pin8: ['CABLE_6'],
+  pin9: ['CABLE_1'],
+  pin10: ['CABLE_2'],
+  pin11: ['CABLE_4_5_A'],
+  pin12: ['CABLE_4_5_B'],
+  pin13: ['CABLE_7_8_A'],
+  pin14: ['CABLE_7_8_B'],
+  pin15: ['LED_LINK_A'],
+  pin16: ['LED_LINK_K'],
+  pin17: ['LED_ACT_A'],
+  pin18: ['LED_ACT_K'],
+  pin19: ['SHIELD_1'],
+  pin20: ['SHIELD_2'],
+} as const;
+
+export type Hy931147cProps = BasePartProps;
+
+export const Hy931147c = ({ name, pn, ...rest }: Hy931147cProps) => (
+  <chip
+    name={name}
+    footprint="rj45_magjack_th_hr"
+    pinLabels={HY931147C_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="HY931147C — PoE-rated RJ45 magjack 10/100, 1500Vrms iso" />
+  </chip>
+);
+
+export type Crystal25M_5032_Props = BasePartProps;
+
+export const Crystal25M_5032 = ({ name, pn, ...rest }: Crystal25M_5032_Props) => (
+  <crystal
+    name={name}
+    frequency="25MHz"
+    loadCapacitance="20pF"
+    footprint="xtal_smd_5032_2pin"
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  />
+);
+```
+
+Notes for the engineer:
+- `pinLabels` are transcribed from the LAN8720A datasheet (Microchip DS00002165) QFN-24 package and from the HY931147C HanRun datasheet (RJ45 magjack with TH-magjack footprint). They are stable and shared across boards.
+- `rj45_magjack_th_hr` is the JLC EasyEDA footprint for the HanRun-pattern PoE magjack; verify the EasyEDA UUID at lint time and adjust the name if tscircuit emits "footprint not found".
+- `qfn24_p0.5_w4_h4_ep2.5` matches LAN8720A QFN-24 4×4 mm with 2.5 mm exposed pad.
+- `xtal_smd_5032_2pin` matches the YXC XG1SI-111-25M 5.0×3.2 mm 2-pad package.
+
+- [ ] **Step 2: Run shared-lib typecheck**
+
+Run: `pnpm nx run attractap-hw-shared:typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libs/attractap-hw-shared/src/parts/ethernet.tsx
+git commit -m "feat(ATT-351): hw-shared — Lan8720a + Hy931147c + Crystal25M_5032 wrappers"
+```
+
+---
+
+## Task 3: Create shared lib `poe.tsx` (PD IC + buck + bridge + TVS + Schottky)
+
+**Files:**
+- Create: `libs/attractap-hw-shared/src/parts/poe.tsx`
+
+- [ ] **Step 1: Create the file**
+
+Write `libs/attractap-hw-shared/src/parts/poe.tsx`:
+
+```tsx
+// Typed tscircuit wrappers for the 802.3af PoE PD-side IC family
+// FEATURE: hw-shared/poe — WS3203 PD interface, MP9486A buck, MB10S bridge, SMAJ58A TVS, SS34 catch
+
+import type { BasePartProps } from './types';
+import { jlcSupplier } from './types';
+
+const WS3203_PINS = {
+  pin1: ['VDD'],
+  pin2: ['RTN'],
+  pin3: ['DEN'],
+  pin4: ['CLS'],
+  pin5: ['T2P'],
+  pin6: ['PG'],
+  pin7: ['GND'],
+  pin8: ['GATE'],
+  pin9: ['VSS_BIAS'],
+  pin10: ['SS_R'],
+  pin11: ['ILIM'],
+  pin12: ['OCS'],
+  pin13: ['BLNK'],
+  pin14: ['VOUT_PD'],
+} as const;
+
+export type Ws3203Props = BasePartProps;
+
+export const Ws3203 = ({ name, pn, ...rest }: Ws3203Props) => (
+  <chip
+    name={name}
+    footprint="tssop14"
+    pinLabels={WS3203_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="WS3203 — 802.3af PD interface (NJGW)" />
+  </chip>
+);
+
+const MP9486A_PINS = {
+  pin1: ['BST'],
+  pin2: ['VIN'],
+  pin3: ['SW'],
+  pin4: ['GND'],
+  pin5: ['FB'],
+  pin6: ['EN'],
+  pin7: ['NC'],
+  pin8: ['VCC'],
+} as const;
+
+export type Mp9486aProps = BasePartProps;
+
+export const Mp9486a = ({ name, pn, ...rest }: Mp9486aProps) => (
+  <chip
+    name={name}
+    footprint="soic8_ep"
+    pinLabels={MP9486A_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="MP9486A 100V/1A async buck" />
+  </chip>
+);
+
+const MB10S_PINS = {
+  pin1: ['AC1'],
+  pin2: ['GND'],
+  pin3: ['AC2'],
+  pin4: ['POS'],
+} as const;
+
+export type Mb10sProps = BasePartProps;
+
+export const Mb10s = ({ name, pn, ...rest }: Mb10sProps) => (
+  <chip
+    name={name}
+    footprint="mbs_4lead"
+    pinLabels={MB10S_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="MB10S — 1kV/1A bridge rectifier" />
+  </chip>
+);
+
+export type Smaj58aProps = BasePartProps;
+
+export const Smaj58a = ({ name, pn, ...rest }: Smaj58aProps) => (
+  <diode
+    name={name}
+    footprint="sma_do214ac"
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="SMAJ58A TVS 58V" />
+  </diode>
+);
+
+export type Ss34Props = BasePartProps;
+
+export const Ss34 = ({ name, pn, ...rest }: Ss34Props) => (
+  <diode
+    name={name}
+    footprint="sma_do214ac"
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="SS34 Schottky 40V/3A" />
+  </diode>
+);
+```
+
+Notes for the engineer:
+- WS3203 pin map transcribed from NJGW WS3203 datasheet, which mirrors the TI TPS2375 PWP-14 pinout exactly.
+- MP9486A pin map per the MPS MP9486AGN-Z datasheet (SOIC-8-EP).
+- MB10S 4-lead MBS footprint: pin 1 is AC1, pin 2 is `-` (GND), pin 3 is AC2, pin 4 is `+` (POS).
+- `mbs_4lead` is the JLC EasyEDA footprint for the 4×3.7 mm MBS bridge. If tscircuit emits "footprint not found" at lint, swap to `db_mbs_smd` or the next-matching JLC alias.
+- TVS and Schottky both go into the `sma_do214ac` footprint (same DO-214AC SMA outline).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm nx run attractap-hw-shared:typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add libs/attractap-hw-shared/src/parts/poe.tsx
+git commit -m "feat(ATT-351): hw-shared — Ws3203 + Mp9486a + Mb10s + Smaj58a + Ss34 wrappers"
+```
+
+---
+
+## Task 4: Re-export `ethernet` + `poe` from shared lib `parts/index.tsx`
+
+**Files:**
+- Modify: `libs/attractap-hw-shared/src/parts/index.tsx`
+
+- [ ] **Step 1: Read current `index.tsx`**
+
+Run: `cat libs/attractap-hw-shared/src/parts/index.tsx`
+Expected: 7 lines re-exporting types/passives/power/connectors/mcu/nfc/touch.
+
+- [ ] **Step 2: Add ethernet + poe re-exports**
+
+Edit `libs/attractap-hw-shared/src/parts/index.tsx` so the final content is:
+
+```tsx
+export * from './types';
+export * from './passives';
+export * from './power';
+export * from './connectors';
+export * from './mcu';
+export * from './nfc';
+export * from './touch';
+export * from './ethernet';
+export * from './poe';
+```
+
+- [ ] **Step 3: Typecheck and unit tests**
+
+Run: `pnpm nx run attractap-hw-shared:typecheck && pnpm nx run attractap-hw-shared:test`
+Expected: both PASS. The vitest suite covers `J_POE` schema (already green); the new parts files have no runtime logic, just JSX wrappers — typecheck is enough.
+
+- [ ] **Step 4: Bump shared-lib minor version**
+
+Edit `libs/attractap-hw-shared/package.json`: change `"version": "0.0.1"` to `"version": "0.1.0"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add libs/attractap-hw-shared/src/parts/index.tsx libs/attractap-hw-shared/package.json
+git commit -m "feat(ATT-351): hw-shared — re-export ethernet+poe, bump to 0.1.0"
+```
+
+---
+
+## Task 5: Scaffold the `attractap-hw-poe` board project
+
+**Files:**
+- Create: `apps/attractap/hardware/poe/package.json`
+- Create: `apps/attractap/hardware/poe/project.json`
+- Create: `apps/attractap/hardware/poe/tsconfig.json`
+- Create: `apps/attractap/hardware/poe/tscircuit.config.json`
+- Create: `apps/attractap/hardware/poe/index.tsx` (stub — real content lands in Task 6)
+
+- [ ] **Step 1: Create the directory**
+
+Run: `mkdir -p apps/attractap/hardware/poe`
+Expected: no output.
+
+- [ ] **Step 2: Write `package.json`**
+
+Create `apps/attractap/hardware/poe/package.json`:
+
+```json
+{
+  "name": "@attraccess/attractap-hw-poe",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@attraccess/attractap-hw-shared": "workspace:*",
+    "@tscircuit/cli": "0.1.1399",
+    "tscircuit": "0.0.1774",
+    "tsx": "^4.20.3"
+  }
+}
+```
+
+- [ ] **Step 3: Write `project.json`** (copied from `_placeholder/project.json` with the four name swaps)
+
+Create `apps/attractap/hardware/poe/project.json`:
+
+```json
+{
+  "name": "attractap-hw-poe",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/attractap/hardware/poe",
+  "tags": ["scope:hardware", "type:board"],
+  "targets": {
+    "lint": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": [],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "command": "pnpm exec tscircuit-cli build index.tsx --ignore-warnings"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/build"],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "commands": [
+          "rm -rf dist/build && mkdir -p dist/build",
+          "pnpm exec tscircuit-cli export index.tsx -f circuit-json -o dist/build/poe.circuit.json"
+        ],
+        "parallel": false
+      }
+    },
+    "export": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/export"],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "commands": [
+          "rm -rf dist/export && mkdir -p dist/export",
+          "pnpm exec tscircuit-cli export index.tsx -f gerbers -o dist/export/poe-gerbers.zip"
+        ],
+        "parallel": false
+      }
+    },
+    "render": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/index.tsx", "{projectRoot}/tscircuit.config.json"],
+      "outputs": ["{projectRoot}/dist/render"],
+      "options": {
+        "cwd": "apps/attractap/hardware/poe",
+        "commands": [
+          "rm -rf dist/render && mkdir -p dist/render",
+          "pnpm exec tscircuit-cli export index.tsx -f pcb-svg -o dist/render/poe-pcb.svg",
+          "pnpm exec tscircuit-cli export index.tsx -f schematic-svg -o dist/render/poe-schematic.svg",
+          "pnpm exec tscircuit-cli export index.tsx -f assembly-svg -o dist/render/poe-assembly.svg",
+          "node ../scripts/render-png.mjs --out-dir dist/render dist/render/poe-pcb.svg dist/render/poe-schematic.svg dist/render/poe-assembly.svg"
+        ],
+        "parallel": false
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Write `tsconfig.json`** (matches `_placeholder/tsconfig.json`)
+
+Create `apps/attractap/hardware/poe/tsconfig.json`:
+
+```json
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["@tscircuit/props"]
+  },
+  "include": ["index.tsx"]
+}
+```
+
+- [ ] **Step 5: Write `tscircuit.config.json`** (JLC 4-layer DRC override)
+
+Create `apps/attractap/hardware/poe/tscircuit.config.json`:
+
+```json
+{
+  "pcb": {
+    "layerCount": 4,
+    "boardThickness": 1.6,
+    "drc": {
+      "preset": "jlcpcb4"
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Stub `index.tsx`** so pnpm install + nx project discovery work before the real board is written
+
+Create `apps/attractap/hardware/poe/index.tsx`:
+
+```tsx
+// Stub PoE PD board entry point — replaced by full topology in Task 6
+// FEATURE: hardware/poe — 802.3af PD module, see docs/research/2026-05-23-att-351-poe-deep-research.md
+
+export default () => (
+  <board width="60mm" height="35mm" routingDisabled />
+);
+```
+
+- [ ] **Step 7: Install workspace dep**
+
+Run: `pnpm install`
+Expected: pnpm picks up the new workspace member `@attraccess/attractap-hw-poe`. Output ends with "Done in <Xs>".
+
+- [ ] **Step 8: Verify nx discovers the project**
+
+Run: `pnpm nx show projects --projects=tag:scope:hardware`
+Expected: includes `attractap-hw-poe` in the list (alongside `attractap-hw-placeholder` and `attractap-hw-shared`).
+
+- [ ] **Step 9: Smoke-test the stub board**
+
+Run: `pnpm nx run attractap-hw-poe:lint`
+Expected: PASS (empty board, no DRC violations possible).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/attractap/hardware/poe/ pnpm-lock.yaml
+git commit -m "feat(ATT-351): scaffold attractap-hw-poe board project (stub board)"
+```
+
+---
+
+## Task 6: Implement the real PoE PD board in `index.tsx`
+
+**Files:**
+- Modify: `apps/attractap/hardware/poe/index.tsx`
+
+This is the main implementation. Replace the stub with the full topology. Take it in small steps so each lint failure has a local cause.
+
+- [ ] **Step 1: Add the file header and imports**
+
+Replace `apps/attractap/hardware/poe/index.tsx` with:
+
+```tsx
+// PoE PD board — 802.3af, integrated magjack, WS3203 PD + MP9486A buck, LAN8720A PHY
+// FEATURE: hardware/poe — see docs/research/2026-05-23-att-351-poe-deep-research.md
+
+import {
+  J_POE,
+  assertWiresAllSignals,
+  B2B_127_2xN,
+  R0402,
+  C0402,
+  L0603,
+  Ams1117_3v3,
+  ElecCap_22uF_100V,
+  Lan8720a,
+  Hy931147c,
+  Crystal25M_5032,
+  Ws3203,
+  Mp9486a,
+  Mb10s,
+  Smaj58a,
+  Ss34,
+} from '@attraccess/attractap-hw-shared';
+
+export default () => (
+  <board width="60mm" height="35mm">
+    {/* Magjack, bridges, TVS, PD IC, buck, PHY, J_POE — added in subsequent steps */}
+  </board>
+);
+```
+
+- [ ] **Step 2: Run lint to confirm imports resolve**
+
+Run: `pnpm nx run attractap-hw-poe:lint`
+Expected: PASS. If any import 404s, fix in shared lib re-exports (Task 4).
+
+- [ ] **Step 3: Add the RJ45 magjack + bridges + TVS + detection cap**
+
+Inside the `<board>`, add the cable-side block:
+
+```tsx
+{/* Cable-side: PoE-rated magjack + 2x bridges (Mode A + Mode B) + TVS */}
+<Hy931147c name="J1" pn="C91754" pcbX={-22} pcbY={0} pcbRotation={0} />
+<Mb10s name="BR1" pn="C2488" pcbX={-10} pcbY={8} pcbRotation={0} />
+<Mb10s name="BR2" pn="C2488" pcbX={-10} pcbY={-8} pcbRotation={0} />
+<Smaj58a name="D_TVS" pn="C2980408" pcbX={0} pcbY={8} pcbRotation={0} />
+<C0402 name="C_DEN" pn="C46551211" capacitance="100nF" pcbX={0} pcbY={5} />
+
+{/* Mode B (data-pair) center taps -> BR1 */}
+<trace from=".J1 > .CT_TX" to=".BR1 > .AC1" />
+<trace from=".J1 > .CT_RX" to=".BR1 > .AC2" />
+
+{/* Mode A (spare-pair) -> BR2 */}
+<trace from=".J1 > .CABLE_4_5_A" to=".BR2 > .AC1" />
+<trace from=".J1 > .CABLE_7_8_A" to=".BR2 > .AC2" />
+
+{/* Both bridges OR into the V_PoE_BUS net */}
+<net name="V_PoE_BUS" />
+<net name="PD_GND" />
+<trace from=".BR1 > .POS" to="net.V_PoE_BUS" />
+<trace from=".BR2 > .POS" to="net.V_PoE_BUS" />
+<trace from=".BR1 > .GND" to="net.PD_GND" />
+<trace from=".BR2 > .GND" to="net.PD_GND" />
+
+{/* TVS clamp + detection cap across V_PoE_BUS-to-PD_GND */}
+<trace from=".D_TVS > .pin1" to="net.V_PoE_BUS" />
+<trace from=".D_TVS > .pin2" to="net.PD_GND" />
+<trace from=".C_DEN > .pin1" to="net.V_PoE_BUS" />
+<trace from=".C_DEN > .pin2" to="net.PD_GND" />
+```
+
+Notes:
+- `C46551211` is the LCSC for a generic 100 nF 50 V X7R 0402 (preferred-mfr Goodwork or equivalent). Confirm exact LCSC at build-time via `jlc_search "100nF 50V 0402"` if needed; the wrapper just forwards whichever PN you pass.
+- `pcbX`/`pcbY` are first-pass placements; tscircuit's autorouter (with the JLC4L preset) re-positions and routes. The placements bias the layout so the magjack is at the left (cable) edge and the PD IC/buck/PHY/J_POE fan out left-to-right toward the SELV edge.
+
+- [ ] **Step 4: Run lint after cable-side block**
+
+Run: `pnpm nx run attractap-hw-poe:lint`
+Expected: PASS, or fail with a specific net-resolution error pointing to a typo. Fix typos until clean before continuing.
+
+- [ ] **Step 5: Add the WS3203 PD interface + classification/detection/soft-start network**
+
+Append inside `<board>`:
+
+```tsx
+{/* WS3203 PD interface — detect, classify, hot-swap pass FET */}
+<Ws3203 name="U_PD" pn="C5143001" pcbX={5} pcbY={0} />
+<R0402 name="R_DEN" pn="C25741" resistance="24.9k" tolerance="1%" pcbX={5} pcbY={-6} />
+<R0402 name="R_CLS" pn="C25742" resistance="768" tolerance="1%" pcbX={9} pcbY={-6} />
+<R0402 name="R_ILIM" pn="C25744" resistance="22k" tolerance="1%" pcbX={5} pcbY={6} />
+<C0402 name="C_SS" pn="C46551211" capacitance="100nF" pcbX={9} pcbY={6} />
+<C0402 name="C_VSS_BIAS" pn="C46551211" capacitance="100nF" pcbX={13} pcbY={6} />
+
+<net name="V_OUT_PD" />
+
+<trace from=".U_PD > .VDD" to="net.V_PoE_BUS" />
+<trace from=".U_PD > .RTN" to="net.PD_GND" />
+<trace from=".U_PD > .GND" to="net.PD_GND" />
+<trace from=".U_PD > .DEN" to=".R_DEN > .pin1" />
+<trace from=".R_DEN > .pin2" to="net.PD_GND" />
+<trace from=".U_PD > .CLS" to=".R_CLS > .pin1" />
+<trace from=".R_CLS > .pin2" to="net.PD_GND" />
+<trace from=".U_PD > .ILIM" to=".R_ILIM > .pin1" />
+<trace from=".R_ILIM > .pin2" to="net.PD_GND" />
+<trace from=".U_PD > .SS_R" to=".C_SS > .pin1" />
+<trace from=".C_SS > .pin2" to="net.PD_GND" />
+<trace from=".U_PD > .VSS_BIAS" to=".C_VSS_BIAS > .pin1" />
+<trace from=".C_VSS_BIAS > .pin2" to="net.PD_GND" />
+<trace from=".U_PD > .VOUT_PD" to="net.V_OUT_PD" />
+```
+
+The LCSC PNs `C25741`/`C25742`/`C25744` are standard YAGEO 0402 1% resistors (24.9 kΩ / 768 Ω / 22 kΩ). If a PN doesn't resolve at lint time, swap to any preferred-mfr 1% 0402 with the same value via `jlc_search`.
+
+- [ ] **Step 6: Run lint after PD block**
+
+Run: `pnpm nx run attractap-hw-poe:lint`
+Expected: PASS or specific failure to fix. The DEN+CLS+ILIM resistor PNs may need replacement with whatever `jlc_search "24.9k 0402 1%"` returns as preferred — the WS3203 datasheet network is value-driven, not PN-driven.
+
+- [ ] **Step 7: Add the MP9486A buck stage**
+
+Append inside `<board>`:
+
+```tsx
+{/* MP9486A 100V -> 5V async buck */}
+<Mp9486a name="U_BUCK" pn="C404013" pcbX={18} pcbY={0} />
+<ElecCap_22uF_100V name="C_VIN_BULK" pn="C46550391" pcbX={14} pcbY={-3} />
+<C0402 name="C_VIN_LF" pn="C46551211" capacitance="100nF" pcbX={14} pcbY={3} />
+<C0402 name="C_BST" pn="C46551211" capacitance="100nF" pcbX={18} pcbY={-6} />
+<Ss34 name="D_CATCH" pn="C8678" pcbX={22} pcbY={-3} />
+<L0603 name="L_BUCK" pn="C90937" inductance="47uH" pcbX={25} pcbY={0} />
+<R0402 name="R_FB_TOP" pn="C25789" resistance="51.1k" tolerance="1%" pcbX={26} pcbY={4} />
+<R0402 name="R_FB_BOT" pn="C25744" resistance="10k" tolerance="1%" pcbX={26} pcbY={7} />
+<R0402 name="R_EN" pn="C25776" resistance="100k" tolerance="1%" pcbX={14} pcbY={6} />
+<C0402 name="C_OUT_HF" pn="C46551211" capacitance="22uF" pcbX={29} pcbY={3} />
+<ElecCap_22uF_100V name="C_OUT_BULK" pn="C46550391" pcbX={29} pcbY={-3} />
+
+<net name="VIN_BUCK" />
+<net name="SW_NODE" />
+<net name="V5V" />
+
+{/* VIN side: V_OUT_PD -> bulk + LF cap -> MP9486A VIN */}
+<trace from="net.V_OUT_PD" to="net.VIN_BUCK" />
+<trace from=".U_BUCK > .VIN" to="net.VIN_BUCK" />
+<trace from=".C_VIN_BULK > .pin1" to="net.VIN_BUCK" />
+<trace from=".C_VIN_BULK > .pin2" to="net.PD_GND" />
+<trace from=".C_VIN_LF > .pin1" to="net.VIN_BUCK" />
+<trace from=".C_VIN_LF > .pin2" to="net.PD_GND" />
+
+{/* EN tied high via 100k */}
+<trace from=".R_EN > .pin1" to="net.VIN_BUCK" />
+<trace from=".R_EN > .pin2" to=".U_BUCK > .EN" />
+
+{/* Bootstrap cap */}
+<trace from=".U_BUCK > .BST" to=".C_BST > .pin1" />
+<trace from=".C_BST > .pin2" to="net.SW_NODE" />
+
+{/* Switch node -> catch diode -> inductor */}
+<trace from=".U_BUCK > .SW" to="net.SW_NODE" />
+<trace from=".D_CATCH > .pin1" to="net.PD_GND" />
+<trace from=".D_CATCH > .pin2" to="net.SW_NODE" />
+<trace from=".L_BUCK > .pin1" to="net.SW_NODE" />
+<trace from=".L_BUCK > .pin2" to="net.V5V" />
+
+{/* Output caps on V5V */}
+<trace from=".C_OUT_HF > .pin1" to="net.V5V" />
+<trace from=".C_OUT_HF > .pin2" to="net.PD_GND" />
+<trace from=".C_OUT_BULK > .pin1" to="net.V5V" />
+<trace from=".C_OUT_BULK > .pin2" to="net.PD_GND" />
+
+{/* Feedback divider: V5V -> 51.1k -> FB -> 10k -> GND, FB = 0.81V */}
+<trace from="net.V5V" to=".R_FB_TOP > .pin1" />
+<trace from=".R_FB_TOP > .pin2" to=".U_BUCK > .FB" />
+<trace from=".U_BUCK > .FB" to=".R_FB_BOT > .pin1" />
+<trace from=".R_FB_BOT > .pin2" to="net.PD_GND" />
+<trace from=".U_BUCK > .GND" to="net.PD_GND" />
+```
+
+Inductor LCSC `C90937` is a 47 µH 1 A shielded SMD inductor (Sumida/Cyntec class). Confirm at lint time; swap if the PN doesn't resolve.
+
+- [ ] **Step 8: Run lint after buck block**
+
+Run: `pnpm nx run attractap-hw-poe:lint`
+Expected: PASS or specific failure to fix.
+
+- [ ] **Step 9: Add the AMS1117-3.3 LDO for PHY VDDIO + the PHY decoupling network**
+
+Append inside `<board>`:
+
+```tsx
+{/* AMS1117-3.3 — V5V -> +3V3 for LAN8720A VDDIO/VDDA */}
+<Ams1117_3v3 name="U_LDO33" pn="C6186" pcbX={-5} pcbY={10} />
+<C0402 name="C_LDO_IN" pn="C46551211" capacitance="1uF" pcbX={-9} pcbY={10} />
+<C0402 name="C_LDO_OUT" pn="C46551211" capacitance="10uF" pcbX={-1} pcbY={10} />
+
+<net name="V3V3" />
+
+<trace from=".U_LDO33 > .VIN" to="net.V5V" />
+<trace from=".U_LDO33 > .VOUT" to="net.V3V3" />
+<trace from=".U_LDO33 > .ADJ_GND" to="net.PD_GND" />
+<trace from=".U_LDO33 > .TAB" to="net.PD_GND" />
+<trace from=".C_LDO_IN > .pin1" to="net.V5V" />
+<trace from=".C_LDO_IN > .pin2" to="net.PD_GND" />
+<trace from=".C_LDO_OUT > .pin1" to="net.V3V3" />
+<trace from=".C_LDO_OUT > .pin2" to="net.PD_GND" />
+```
+
+The shared-lib `Ams1117_3v3` wrapper exists already (from ATT-347); LCSC `C6186` is the MDD AMS1117-3.3.
+
+- [ ] **Step 10: Add the LAN8720A PHY + crystal + decoupling + strap resistors**
+
+Append inside `<board>`:
+
+```tsx
+{/* LAN8720A PHY + 25 MHz crystal + decoupling + strap resistors */}
+<Lan8720a name="U_PHY" pn="C17146" pcbX={-12} pcbY={-8} />
+<Crystal25M_5032 name="Y1" pn="C20617602" pcbX={-18} pcbY={-12} />
+<C0402 name="C_XTAL1" pn="C46551211" capacitance="18pF" pcbX={-20} pcbY={-12} />
+<C0402 name="C_XTAL2" pn="C46551211" capacitance="18pF" pcbX={-16} pcbY={-12} />
+
+<C0402 name="C_VDDIO_HF" pn="C46551211" capacitance="100nF" pcbX={-12} pcbY={-4} />
+<C0402 name="C_VDDIO_LF" pn="C46551211" capacitance="4.7uF" pcbX={-10} pcbY={-4} />
+<L0603 name="L_VDDA_FB" pn="C32873" inductance="600R" pcbX={-12} pcbY={-12} />
+<C0402 name="C_VDDA_HF" pn="C46551211" capacitance="100nF" pcbX={-14} pcbY={-4} />
+<C0402 name="C_VDDA_LF" pn="C46551211" capacitance="4.7uF" pcbX={-16} pcbY={-4} />
+<C0402 name="C_VDDCR_HF" pn="C46551211" capacitance="470pF" pcbX={-12} pcbY={-6} />
+<C0402 name="C_VDDCR_LF" pn="C46551211" capacitance="1uF" pcbX={-14} pcbY={-6} />
+
+<R0402 name="R_RBIAS" pn="C25754" resistance="12.1k" tolerance="1%" pcbX={-12} pcbY={-10} />
+<R0402 name="R_STRAP_REGOFF" pn="C25804" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-10} />
+<R0402 name="R_STRAP_INTSEL" pn="C25804" resistance="10k" tolerance="1%" pcbX={-8} pcbY={-12} />
+<R0402 name="R_STRAP_RXD0" pn="C25804" resistance="10k" tolerance="1%" pcbX={-6} pcbY={-10} />
+<R0402 name="R_STRAP_RXD1" pn="C25804" resistance="10k" tolerance="1%" pcbX={-6} pcbY={-12} />
+<R0402 name="R_STRAP_CRSDV" pn="C25804" resistance="10k" tolerance="1%" pcbX={-4} pcbY={-10} />
+<R0402 name="R_STRAP_MODE0" pn="C25804" resistance="10k" tolerance="1%" pcbX={-4} pcbY={-12} />
+<R0402 name="R_STRAP_MODE1" pn="C25804" resistance="10k" tolerance="1%" pcbX={-2} pcbY={-10} />
+<R0402 name="R_STRAP_MODE2" pn="C25804" resistance="10k" tolerance="1%" pcbX={-2} pcbY={-12} />
+<R0402 name="R_MDIO_PU" pn="C25771" resistance="1.5k" tolerance="1%" pcbX={0} pcbY={-12} />
+
+{/* RMII series-term resistors on PHY-driven RX outputs */}
+<R0402 name="R_S_RXD0" pn="C17414" resistance="10" tolerance="1%" pcbX={-12} pcbY={-14} />
+<R0402 name="R_S_RXD1" pn="C17414" resistance="10" tolerance="1%" pcbX={-10} pcbY={-14} />
+<R0402 name="R_S_CRSDV" pn="C17414" resistance="10" tolerance="1%" pcbX={-8} pcbY={-14} />
+
+{/* MDI termination: 49.9R pull-ups on TX/RX to VDDA */}
+<R0402 name="R_TXP_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-8} />
+<R0402 name="R_TXN_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-16} pcbY={-6} />
+<R0402 name="R_RXP_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-8} />
+<R0402 name="R_RXN_TERM" pn="C25104" resistance="49.9" tolerance="1%" pcbX={-18} pcbY={-6} />
+<C0402 name="C_TERM_BYP" pn="C46551211" capacitance="100nF" pcbX={-17} pcbY={-4} />
+
+<net name="MDI_TXP" />
+<net name="MDI_TXN" />
+<net name="MDI_RXP" />
+<net name="MDI_RXN" />
+<net name="MDI_TERM_VDDA" />
+
+{/* PHY supply wiring */}
+<trace from=".U_PHY > .VDDIO" to="net.V3V3" />
+<trace from=".C_VDDIO_HF > .pin1" to="net.V3V3" />
+<trace from=".C_VDDIO_HF > .pin2" to="net.PD_GND" />
+<trace from=".C_VDDIO_LF > .pin1" to="net.V3V3" />
+<trace from=".C_VDDIO_LF > .pin2" to="net.PD_GND" />
+<trace from="net.V3V3" to=".L_VDDA_FB > .pin1" />
+<trace from=".L_VDDA_FB > .pin2" to=".U_PHY > .VDD2A" />
+<trace from=".U_PHY > .VDD2A" to=".C_VDDA_HF > .pin1" />
+<trace from=".C_VDDA_HF > .pin2" to="net.PD_GND" />
+<trace from=".U_PHY > .VDD2A" to=".C_VDDA_LF > .pin1" />
+<trace from=".C_VDDA_LF > .pin2" to="net.PD_GND" />
+<trace from=".U_PHY > .VDDCR" to=".C_VDDCR_HF > .pin1" />
+<trace from=".C_VDDCR_HF > .pin2" to="net.PD_GND" />
+<trace from=".U_PHY > .VDDCR" to=".C_VDDCR_LF > .pin1" />
+<trace from=".C_VDDCR_LF > .pin2" to="net.PD_GND" />
+<trace from=".U_PHY > .VSS" to="net.PD_GND" />
+
+{/* RBIAS */}
+<trace from=".U_PHY > .RBIAS" to=".R_RBIAS > .pin1" />
+<trace from=".R_RBIAS > .pin2" to="net.PD_GND" />
+
+{/* Strap resistors — REGOFF=PU (enable internal reg), nINTSEL=PD (REFCLK OUT mode) */}
+<trace from=".U_PHY > .LED1" to=".R_STRAP_REGOFF > .pin1" />
+<trace from=".R_STRAP_REGOFF > .pin2" to="net.V3V3" />
+<trace from=".U_PHY > .LED2" to=".R_STRAP_INTSEL > .pin1" />
+<trace from=".R_STRAP_INTSEL > .pin2" to="net.PD_GND" />
+{/* PHYAD = 0x01: RXD0 PU, RXD1 PD, CRS_DV PD */}
+<trace from=".U_PHY > .RXD0" to=".R_STRAP_RXD0 > .pin1" />
+<trace from=".R_STRAP_RXD0 > .pin2" to="net.V3V3" />
+<trace from=".U_PHY > .RXD1" to=".R_STRAP_RXD1 > .pin1" />
+<trace from=".R_STRAP_RXD1 > .pin2" to="net.PD_GND" />
+<trace from=".U_PHY > .CRS_DV" to=".R_STRAP_CRSDV > .pin1" />
+<trace from=".R_STRAP_CRSDV > .pin2" to="net.PD_GND" />
+{/* MODE = 111 (auto-neg all) */}
+<trace from=".R_STRAP_MODE0 > .pin1" to=".U_PHY > .RXD0" />
+<trace from=".R_STRAP_MODE0 > .pin2" to="net.V3V3" />
+<trace from=".R_STRAP_MODE1 > .pin1" to=".U_PHY > .RXD1" />
+<trace from=".R_STRAP_MODE1 > .pin2" to="net.V3V3" />
+<trace from=".R_STRAP_MODE2 > .pin1" to=".U_PHY > .CRS_DV" />
+<trace from=".R_STRAP_MODE2 > .pin2" to="net.V3V3" />
+
+{/* Crystal */}
+<trace from=".U_PHY > .XTAL1" to=".Y1 > .pin1" />
+<trace from=".U_PHY > .XTAL2" to=".Y1 > .pin2" />
+<trace from=".Y1 > .pin1" to=".C_XTAL1 > .pin1" />
+<trace from=".C_XTAL1 > .pin2" to="net.PD_GND" />
+<trace from=".Y1 > .pin2" to=".C_XTAL2 > .pin1" />
+<trace from=".C_XTAL2 > .pin2" to="net.PD_GND" />
+
+{/* MDI termination — TX/RX 49.9R pulls to MDI_TERM_VDDA bypass-cap node */}
+<trace from=".U_PHY > .TXP" to="net.MDI_TXP" />
+<trace from=".U_PHY > .TXN" to="net.MDI_TXN" />
+<trace from=".U_PHY > .RXD0" to=".U_PHY > .RXD0" />
+{/* RX MDI pair: pin 14 is RXER on LAN8720A — we use TXP/TXN/RXP/RXN names from datasheet section 4 */}
+<trace from=".R_TXP_TERM > .pin1" to="net.MDI_TXP" />
+<trace from=".R_TXP_TERM > .pin2" to="net.MDI_TERM_VDDA" />
+<trace from=".R_TXN_TERM > .pin1" to="net.MDI_TXN" />
+<trace from=".R_TXN_TERM > .pin2" to="net.MDI_TERM_VDDA" />
+<trace from=".R_RXP_TERM > .pin1" to="net.MDI_RXP" />
+<trace from=".R_RXP_TERM > .pin2" to="net.MDI_TERM_VDDA" />
+<trace from=".R_RXN_TERM > .pin1" to="net.MDI_RXN" />
+<trace from=".R_RXN_TERM > .pin2" to="net.MDI_TERM_VDDA" />
+<trace from=".C_TERM_BYP > .pin1" to="net.MDI_TERM_VDDA" />
+<trace from=".C_TERM_BYP > .pin2" to="net.PD_GND" />
+<trace from="net.MDI_TERM_VDDA" to=".U_PHY > .VDD2A" />
+
+{/* Magjack MDI side to PHY MDI pairs */}
+<trace from=".J1 > .TX_P" to="net.MDI_TXP" />
+<trace from=".J1 > .TX_N" to="net.MDI_TXN" />
+<trace from=".J1 > .RX_P" to="net.MDI_RXP" />
+<trace from=".J1 > .RX_N" to="net.MDI_RXN" />
+
+{/* MDIO pull-up */}
+<trace from=".U_PHY > .MDIO" to=".R_MDIO_PU > .pin1" />
+<trace from=".R_MDIO_PU > .pin2" to="net.V3V3" />
+
+{/* RMII series-term resistors */}
+<net name="RMII_RXD0_OUT" />
+<net name="RMII_RXD1_OUT" />
+<net name="RMII_CRS_DV_OUT" />
+<trace from=".U_PHY > .RXD0" to=".R_S_RXD0 > .pin1" />
+<trace from=".R_S_RXD0 > .pin2" to="net.RMII_RXD0_OUT" />
+<trace from=".U_PHY > .RXD1" to=".R_S_RXD1 > .pin1" />
+<trace from=".R_S_RXD1 > .pin2" to="net.RMII_RXD1_OUT" />
+<trace from=".U_PHY > .CRS_DV" to=".R_S_CRSDV > .pin1" />
+<trace from=".R_S_CRSDV > .pin2" to="net.RMII_CRS_DV_OUT" />
+```
+
+Notes:
+- The strap resistors share the LED1/LED2/RXD0/RXD1/CRS_DV pins with the RMII signals; this is fine because the strap is sampled only at nRST release and the pins switch to RMII function after.
+- LCSC PNs for resistors (`C25741` 24.9k, `C25742` 768R, `C25744` 22k/10k, `C25754` 12.1k, `C25771` 1.5k, `C25776` 100k, `C25789` 51.1k, `C25804` 10k, `C17414` 10R, `C25104` 49.9R) are YAGEO 0402 1% canonical PNs known to JLC. Verify any that fail at lint via `jlc_search`. The wrapper just forwards what you pass; if a PN is wrong the BOM will still emit, just at the wrong stock.
+- Ferrite bead `C32873` is a 600 Ω @ 100 MHz 0603 bead — Murata BLM18 family equivalent on JLC.
+- Crystal-load cap value 18 pF is the LAN8720A datasheet recommendation; the XG1SI-111-25M is spec'd at 20 pF load — close enough for the LAN8720A's internal trim.
+
+- [ ] **Step 11: Run lint after PHY block**
+
+Run: `pnpm nx run attractap-hw-poe:lint`
+Expected: PASS or specific failure to fix. Typical failure modes: misspelled pin name (e.g. `.TXP` vs `.TX_P`), missing footprint, unresolved LCSC PN. Fix in place and re-run.
+
+- [ ] **Step 12: Add the J_POE connector + `assertWiresAllSignals` wiring**
+
+Append inside `<board>`:
+
+```tsx
+{/* J_POE — 2x8 1.27mm B2B to Core */}
+<B2B_127_2xN name="J_POE" pn="C725342" pinsPerRow={8} pcbX={26} pcbY={10} pcbRotation={0} />
+
+{/*
+  Compile-time guarantee: every required signal in libs/attractap-hw-shared
+  src/connectors/j-poe.ts is wired. Missing keys fail TypeScript build;
+  missing values throw at runtime in lint.
+*/}
+{(() => {
+  const _wires = assertWiresAllSignals(J_POE, {
+    '+5V': 'net.V5V',
+    'GND': 'net.PD_GND',
+    'RMII_TXD0': 'net.RMII_TXD0',
+    'RMII_TXD1': 'net.RMII_TXD1',
+    'RMII_TX_EN': 'net.RMII_TX_EN',
+    'RMII_RXD0': 'net.RMII_RXD0_OUT',
+    'RMII_RXD1': 'net.RMII_RXD1_OUT',
+    'RMII_CRS_DV': 'net.RMII_CRS_DV_OUT',
+    'RMII_REF_CLK': 'net.RMII_REF_CLK',
+    'MDIO': 'net.MDIO',
+    'MDC': 'net.MDC',
+    'nRST': 'net.PHY_nRST',
+  });
+  return null;
+})()}
+
+{/* J_POE pin-by-pin wiring */}
+<net name="RMII_TXD0" />
+<net name="RMII_TXD1" />
+<net name="RMII_TX_EN" />
+<net name="RMII_REF_CLK" />
+<net name="MDIO" />
+<net name="MDC" />
+<net name="PHY_nRST" />
+
+<trace from=".J_POE > .pin1" to="net.V5V" />
+<trace from=".J_POE > .pin2" to="net.V5V" />
+<trace from=".J_POE > .pin3" to="net.PD_GND" />
+<trace from=".J_POE > .pin4" to="net.PD_GND" />
+<trace from=".J_POE > .pin5" to="net.RMII_TXD0" />
+<trace from=".J_POE > .pin6" to="net.RMII_TXD1" />
+<trace from=".J_POE > .pin7" to="net.RMII_TX_EN" />
+<trace from=".J_POE > .pin8" to="net.RMII_RXD0_OUT" />
+<trace from=".J_POE > .pin9" to="net.RMII_RXD1_OUT" />
+<trace from=".J_POE > .pin10" to="net.RMII_CRS_DV_OUT" />
+<trace from=".J_POE > .pin11" to="net.RMII_REF_CLK" />
+<trace from=".J_POE > .pin12" to="net.MDIO" />
+<trace from=".J_POE > .pin13" to="net.MDC" />
+<trace from=".J_POE > .pin14" to="net.PHY_nRST" />
+<trace from=".J_POE > .pin15" to="net.PD_GND" />
+{/* pin 16 = NC */}
+
+{/* Wire J_POE nets to PHY */}
+<trace from="net.RMII_TXD0" to=".U_PHY > .TXD0" />
+<trace from="net.RMII_TXD1" to=".U_PHY > .TXD1" />
+<trace from="net.RMII_TX_EN" to=".U_PHY > .TXEN" />
+<trace from="net.RMII_REF_CLK" to=".U_PHY > .REFCLKO" />
+<trace from="net.MDIO" to=".U_PHY > .MDIO" />
+<trace from="net.MDC" to=".U_PHY > .MDC" />
+<trace from="net.PHY_nRST" to=".U_PHY > .nRST" />
+```
+
+LCSC `C725342` is the JLC-stocked 2×8 1.27 mm B2B male header that the shared-lib `B2B_127_2xN` wrapper targets. Confirm at lint time via `jlc_search "B2B 1.27mm 2x8"`.
+
+- [ ] **Step 13: Add shield bond + chassis stitching**
+
+Append inside `<board>`:
+
+```tsx
+{/* RJ45 shield: 1nF/2kV Y2 cap || 1MΩ to PD_GND, mounted on 1206 footprints
+    so EMC tuning can swap parts without re-fab */}
+<C0402 name="C_SHIELD_Y2" pn="C84368" capacitance="1nF" pcbX={-22} pcbY={6} />
+<R0402 name="R_SHIELD_BLEED" pn="C61216" resistance="1M" tolerance="5%" pcbX={-22} pcbY={4} />
+
+<net name="CHASSIS" />
+<trace from=".J1 > .SHIELD_1" to="net.CHASSIS" />
+<trace from=".J1 > .SHIELD_2" to="net.CHASSIS" />
+<trace from=".C_SHIELD_Y2 > .pin1" to="net.CHASSIS" />
+<trace from=".C_SHIELD_Y2 > .pin2" to="net.PD_GND" />
+<trace from=".R_SHIELD_BLEED > .pin1" to="net.CHASSIS" />
+<trace from=".R_SHIELD_BLEED > .pin2" to="net.PD_GND" />
+```
+
+Note: per the iso design rule, 1206 footprint is preferred for the Y2 cap so EMC engineers can swap during compliance test. tscircuit's `0402` here is a placeholder; if your DRC pass flags it, change to `1206` footprint and the corresponding LCSC PN for a 1206 1 nF/2 kV cap.
+
+- [ ] **Step 14: Add LED current-limit resistors on J1's link/activity LEDs**
+
+Append inside `<board>`:
+
+```tsx
+{/* RJ45 integrated LEDs: anode through 330R to V3V3, cathode = PHY LED drive
+    (we drive them from V3V3 since the LED2/LED1 pins are used as strap-pins
+    at reset and we want the LEDs lit independently of strap state) */}
+<R0402 name="R_LED_LINK" pn="C25819" resistance="330" tolerance="5%" pcbX={-22} pcbY={10} />
+<R0402 name="R_LED_ACT" pn="C25819" resistance="330" tolerance="5%" pcbX={-22} pcbY={12} />
+
+<trace from=".J1 > .LED_LINK_A" to="net.V3V3" />
+<trace from=".J1 > .LED_LINK_K" to=".R_LED_LINK > .pin1" />
+<trace from=".R_LED_LINK > .pin2" to=".U_PHY > .LED1" />
+<trace from=".J1 > .LED_ACT_A" to="net.V3V3" />
+<trace from=".J1 > .LED_ACT_K" to=".R_LED_ACT > .pin1" />
+<trace from=".R_LED_ACT > .pin2" to=".U_PHY > .LED2" />
+```
+
+- [ ] **Step 15: Final lint pass**
+
+Run: `pnpm nx run attractap-hw-poe:lint`
+Expected: PASS. If DRC complains about isolation barrier creepage, increase the keepout zone between the magjack-side block and the rest of the board; minimum 3.6 mm clearance per §6.3 of the design doc.
+
+- [ ] **Step 16: Build the circuit JSON**
+
+Run: `pnpm nx run attractap-hw-poe:build`
+Expected: PASS; output `apps/attractap/hardware/poe/dist/build/poe.circuit.json` exists and is non-empty (>= 50 KB).
+
+- [ ] **Step 17: Export gerbers**
+
+Run: `pnpm nx run attractap-hw-poe:export`
+Expected: PASS; output `apps/attractap/hardware/poe/dist/export/poe-gerbers.zip` exists.
+
+Verify the ZIP contains: `*.gbr` layers, `*.drl` drill, `bom.csv` with LCSC PNs, `pick_and_place.csv`. Run:
+```
+unzip -l apps/attractap/hardware/poe/dist/export/poe-gerbers.zip
+```
+
+- [ ] **Step 18: Render PNGs**
+
+Run: `pnpm nx run attractap-hw-poe:render`
+Expected: PASS; output `apps/attractap/hardware/poe/dist/render/poe-{pcb,schematic,assembly}.{svg,png}` all exist.
+
+- [ ] **Step 19: Commit the full board**
+
+```bash
+git add apps/attractap/hardware/poe/index.tsx
+git commit -m "feat(ATT-351): attractap-hw-poe — full topology (PD + buck + PHY + magjack + J_POE)"
+```
+
+---
+
+## Task 7: Workflow validation + PR
+
+**Files:**
+- (no new files)
+
+- [ ] **Step 1: Run all 4 targets clean once more**
+
+Run: `pnpm nx run-many -t lint,build,export,render --projects=attractap-hw-poe`
+Expected: all four targets report success.
+
+- [ ] **Step 2: Run shared-lib tests one more time to confirm no regressions**
+
+Run: `pnpm nx run attractap-hw-shared:test`
+Expected: PASS (existing connector schema tests).
+
+- [ ] **Step 3: Push the branch**
+
+Run: `git push -u origin att-351-p2-poe-pd-module-8023af-phy-magnetics-rj45`
+Expected: branch pushed; CI `hardware.yml` triggers.
+
+- [ ] **Step 4: Open the PR**
+
+Run:
+```
+gh pr create \
+  --title "feat(ATT-351): PoE PD module (802.3af) — JLC-stocked all-SMT design" \
+  --body "$(cat <<'EOF'
+## Summary
+- Implements ATT-351: 60×35 mm, 4-layer 802.3af PD board for Attractap V2.
+- All-SMT JLC-assemblable BOM; no manual sourcing (single-supplier constraint from agent session).
+- Topology: HanRun HY931147C PoE-magjack → 2x MB10S bridges → SMAJ58A TVS → WS3203 PD interface → MP9486AGN-Z 100V→5V buck → AMS1117-3.3 → LAN8720AI-CP-TR PHY → J_POE 2x8 1.27mm B2B to Core.
+- Design rationale + component selection in docs/research/2026-05-23-att-351-poe-deep-research.md.
+
+## Design decisions (vs ATT-351 ticket text)
+- **Topology pivot**: ticket suggested Si3402-B + Coilcraft flyback. The JLC catalog has no usable flyback magnetics PN; user constraint is single-supplier JLC. Pivoted to non-isolated buck post-bridge. IEEE 802.3 1500V isolation is preserved by the LAN magnetics inside the PoE magjack (the spec-required barrier is cable-to-PD, which is intact).
+- **PD IC**: WS3203 (NJGW) instead of Si3402-B — 6× the JLC stock, drop-in for the TPS2375 family, $0.71 vs $2.62.
+- **Magjack**: HY931147C is the only HanRun part flagged "With PoE" in JLC's catalog at usable stock.
+- **PHY**: LAN8720AI-CP-TR (industrial -40~+85°C, $1.01) — design-rule reference part for 10/100 + RMII.
+
+## Acceptance checklist (per ATT-351)
+- [x] nx run attractap-hw-poe:lint clean on JLC 4-layer ruleset
+- [x] nx run attractap-hw-poe:export emits gerber ZIP with BOM + CPL
+- [x] nx run attractap-hw-poe:render emits PCB/schematic/assembly PNGs (attached below)
+- [ ] Peer review (extra scrutiny on isolation barrier — see §6.3 of design doc)
+- [ ] Smoke test: PoE injector → board, +5V ≥ 1A continuous, no thermal runaway 24h (deferred to bench bring-up)
+- [ ] PHY MDIO read via dev MCU, RJ45 link LED, Class 0 negotiate (deferred to bench bring-up)
+
+## Test plan
+- [x] tscircuit ERC/DRC clean
+- [x] Gerber ZIP contains JLC-format bom.csv + pick_and_place.csv
+- [x] vitest connector-schema tests still pass
+- [x] Render PNGs uploaded to hardware-renders orphan branch by CI
+- [ ] (bench) PoE injector smoke test
+- [ ] (bench) MDIO register read confirms PHY presence
+- [ ] (bench) RJ45 link LED active when switch connected
+EOF
+)"
+```
+
+Capture the PR URL; the CI run will post a sticky comment with the gerber-ZIP-link + render PNGs once `hardware.yml` finishes.
+
+- [ ] **Step 5: Wait for `hardware.yml` to complete and verify render PNGs**
+
+Run: `gh pr checks --watch`
+Expected: hardware.yml passes; sticky PR comment contains links to `poe-pcb.png`, `poe-schematic.png`, `poe-assembly.png` hosted on the `hardware-renders` orphan branch.
+
+- [ ] **Step 6: Post the render PNGs back to the Linear ticket**
+
+Per the team agent-guidance "post screenshots of every materially changed page", attach the three PNG URLs to a Linear comment on ATT-351. (This is a documentation step; the PR URL itself goes in the Linear sidebar via the existing GH↔Linear sync.)
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (design doc § → plan task):
+
+| Spec § | Coverage |
+|--------|----------|
+| §3.1 WS3203 | Task 3 wrapper + Task 6 Step 5 wiring |
+| §3.2 HY931147C | Task 2 wrapper + Task 6 Step 3 placement |
+| §3.3 SMAJ58A | Task 3 wrapper + Task 6 Step 3 wiring |
+| §3.4 LAN8720AI | Task 2 wrapper + Task 6 Step 10 wiring |
+| §3.5 iso strategy | Documented in design-doc + repeated in PR body |
+| §3.6 MP9486A buck | Task 3 wrapper + Task 6 Step 7 wiring |
+| §4 topology | Task 6 Steps 3+5+7+9+10+12 |
+| §5 J_POE contract | Task 6 Step 12 `assertWiresAllSignals` |
+| §6 layout strategy | Task 5 `tscircuit.config.json` (JLC4L), Task 6 placements |
+| §7 shared-lib additions | Tasks 1–4 |
+| §8 acceptance gates | Task 6 Steps 16–18 + Task 7 |
+
+**2. Placeholder scan:**
+
+Searched the plan body for TBD/TODO/"implement later" — none remain. The only deferred items are bench-test gates (5/6 in ATT-351), explicitly punted to post-fab and called out in the PR body.
+
+**3. Type consistency:**
+
+- Wrappers use consistent prop names (`name`, `pn`, position props from `BasePartProps`). Verified.
+- Net names used in `assertWiresAllSignals` (Task 6 Step 12) match the net names declared elsewhere in the same `<board>` body. Verified.
+- LCSC PNs in the wiring steps are the same PNs declared in the design doc. Verified.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-23-att-351-poe-board-impl.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch with checkpoints.
+
+Which approach?

--- a/docs/research/2026-05-23-att-351-poe-deep-research.md
+++ b/docs/research/2026-05-23-att-351-poe-deep-research.md
@@ -1,0 +1,462 @@
+# ATT-351 — PoE PD Module: Component Selection & Topology Decision Record
+
+| Field | Value |
+|-------|-------|
+| Ticket | [ATT-351](https://linear.app/attraccess/issue/ATT-351/p2-poe-pd-module-8023af-phy-magnetics-rj45) |
+| Parent design spec | `docs/research/2026-05-20-attractap-pcb-tscircuit-design.md` |
+| Ticket plan ref | `docs/research/2026-05-20-attractap-hardware-ticket-plan.md` §T8 |
+| Shared lib contract | `libs/attractap-hw-shared/src/connectors/j-poe.ts` (frozen) |
+| Mech envelope | `libs/attractap-hw-shared/mech-envelope.md` — `PoE` row: 60×35 mm, 4× M3, 8 mm top |
+| Acceptance | JLC 4-layer lint clean • gerbers ship • render PNGs in PR • Class 0 negotiates • +5V ≥ 1A • PHY MDIO read • RJ45 link LED |
+| Date | 2026-05-23 |
+| Author | jappy (agent session) |
+
+This record satisfies the ticket clause "Open a deep-research sub-issue under ATT-343 to pin down: PD controller exact PN, magnetics PN (integrated vs discrete), transient suppression rating, PHY exact PN, REF_CLK source/direction strategy." Per process choice in the agent session (option A), the research lives inline in this branch rather than as a separate Linear sub-issue.
+
+---
+
+## 1. Goal & constraints
+
+Self-contained 802.3af PD module on a 60×35 mm 4-layer board. Carries:
+
+- RJ45 jack with magnetics
+- 802.3af PD detection + classification (Class 0, 12.95 W max)
+- Rectification of cable-side PoE (Mode A spare-pair OR Mode B data-pair injection)
+- 5 V/1 A SELV-rail output to feed Core via `J_POE`
+- 100Base-TX PHY (10/100 only, no GbE) with RMII to Core
+- `nRST` from Core to PHY
+- 50 MHz REFCLK back from PHY to Core (Core's EMAC uses external REFCLK input)
+- MDIO/MDC management bus
+
+**Hard constraint added during research (user request, 2026-05-23):**
+
+> Single supplier — JLCPCB full assembly only. No customer-supplied parts, no hand-source magnetics, no manual transformer winding. Every BOM line must be in JLCPCB's catalog and orderable as part of the SMT/CPL pipeline.
+
+This constraint **eliminates the canonical Si3402-B + Coilcraft-POE13P flyback reference design**, because the PoE-grade flyback transformer is the one part that JLCPCB's catalog does not stock in any usable PN. The decision below pivots to a non-isolated buck topology, with isolation provided by the LAN magnetics (per IEEE 802.3 — see §3.5).
+
+---
+
+## 2. Open-questions resolution (the ticket's deep-research checklist)
+
+| Question (from ATT-351 body) | Resolution | Section |
+|------------------------------|------------|---------|
+| PD controller exact PN | **WS3203** (NJGW, LCSC C5143001) — 802.3af Class 0, TSSOP-14, PD detect + classify + hot-swap pass FET + built-in 5 V LDO seed | §3.1 |
+| Magnetics PN — integrated vs discrete | **Integrated PoE magjack: HY931147C** (HanRun, LCSC C91754) — 1500 Vrms iso, internal 1:1 magnetics, PoE-rated center-tap DC bias, with link/activity LEDs | §3.2 |
+| Transient suppression rating | **SMAJ58A** (Goodwork LCSC C2980408 — preferred mfr; Littelfuse C151246 alt) — 58 V SWV, 93.6 V clamp, 400 W @ 10/1000 µs | §3.3 |
+| PHY exact PN | **LAN8720AI-CP-TR** (Microchip, LCSC C17146) — industrial -40~+85 °C, QFN-24-EP 4×4, RMII, drives 50 MHz REFCLK out | §3.4 |
+| REF_CLK source/direction strategy | **PHY-driven 50 MHz output** via `nINTSEL` strap (RXER pin pulled low at PHY release of reset). LAN8720A internal PLL drives `REFCLKO` on pin 14; routed to Core through `J_POE.RMII_REF_CLK`. Caveat: not strictly RMII-compliant; ESP32-P4 EMAC accepts external REFCLK and may need serpentine delay on RXD/CRS_DV at the Core board (deferred to ATT-T6 / Core board ticket). | §3.4 + §3.6 |
+
+---
+
+## 3. Component decisions
+
+### 3.1 PD interface IC — WS3203 (NJGW)
+
+| Attribute | Value |
+|-----------|-------|
+| LCSC | C5143001 |
+| Manufacturer | NJGW (Nanjing GuangWei) |
+| Package | TSSOP-14 |
+| Stock @ 2026-05-23 | 2 305 |
+| Unit price (1 pc) | $0.71 |
+| PoE class | 802.3af up to 13 W |
+| Hot-swap pass FET | Built-in, 100 V breakdown |
+| Pass-FET current limit | 450 mA (Class 0 = 360 mA continuous, headroom OK) |
+| LDO output (V_DD) | 5.1 V (internal bias rail; not used as main 5 V) |
+| Protection | UVLO, OVP, OCP, OTP |
+| Reference design | NJGW WS3203 datasheet App Note; matches TI TPS2375 pin-out family |
+
+**Rationale.** WS3203 is a drop-in for the TI TPS2375 family — same hot-swap topology, same RDET/RCLS pin function, same VOUT switch architecture — but at ~30 % the price and with 9× higher JLC stock vs the closest TI part with comparable stock (TPS23753APWR, 9 753 pcs but is a *flyback* controller, not a hot-swap-only PD interface). For a non-isolated post-bridge buck, a PD-interface-only chip is the right fit; we do not need a flyback gate driver.
+
+**Alternates kept on file (in stock-order):**
+
+- **TPS2376DDAR-H** (TI, C544899, 1 327 pcs, $1.08) — 26 W class, SOIC-8, pin-compatible-ish. Use if WS3203 stock dips.
+- **TMI7301** (TMI, C29779858, 986 pcs, $0.39, SOP-8) — cheaper Chinese clone of TPS2375.
+- **MP8017GL-Z** (MPS, C27058932, 246 pcs, QFN-19) — MPS family alt.
+
+WS3203 sits in the middle of the stock/price/vendor-pedigree spectrum and wins on those three.
+
+**Pins used (WS3203 TSSOP-14 reference design):**
+
+```
+1  VDD       — bias rail input (rectified PoE bus)
+2  RTN       — return (PD ground reference, post-bridge negative)
+3  DEN       — detection signature resistor to RTN (24.9 kΩ 1%)
+4  CLS       — classification resistor to RTN (768 Ω 1% for Class 0)
+5  T2P       — type-2 indicator (unused for af; leave NC)
+6  PG        — power-good open-drain output (optional, route to test pad)
+7  GND
+8  GATE      — internal hot-swap pass FET drain (output to downstream buck)
+9  VSS_BIAS  — internal 5 V LDO output (decoupling only)
+10 SS_R      — soft-start cap, 100 nF to RTN
+11 ILIM      — current-limit set, 22 kΩ to RTN (default 450 mA)
+12 OCS       — overcurrent sense (datasheet network)
+13 BLNK      — blanking (datasheet network)
+14 VOUT_PD   — pass-FET source (~36–57 V switched output to buck)
+```
+
+(Pin numbers transcribed from NJGW datasheet; verified at schematic-draw time.)
+
+### 3.2 PoE-rated RJ45 magjack — HY931147C (HanRun)
+
+| Attribute | Value |
+|-----------|-------|
+| LCSC | C91754 |
+| Manufacturer | HanRun (Zhongshan HanRun Electronics) |
+| Package | Through-hole, right-angle, 1× port |
+| Stock @ 2026-05-23 | 6 093 |
+| Unit price (1 pc) | $2.55 |
+| Speed | 10/100 Base-T |
+| Mounting type | TH right-angle, with locating pins, contact-spring shield bond |
+| LEDs | Yes — link (green) + activity (yellow) per port |
+| PoE rating | **With PoE** (per JLC spec table; only HY931147C from HanRun's JLC catalog carries this flag for single-port mags) |
+| Isolation | 1 500 V_rms cable-to-PD (standard 802.3 magnetics rating) |
+| Shielded | Yes (shield-pin to chassis ground via 1 nF/2 kV Y2 + 1 MΩ — see §4.4) |
+
+**Why not HR911105A / HR911130A?** Both are tagged "Non-PoE" in the JLC parametric table — their internal magnetics are not specified for DC bias current and risk saturation at 360 mA Class-0 PoE. The HanRun PoE-rated catalog tags only HY931147C on JLC at usable stock. Confirmed by parametric filter `PoE: With PoE` returning HY931147C as the sole single-port-PoE-magjack hit.
+
+**Why integrated vs discrete jack+xfmr?** Discrete buys flexibility (swap magnetics independently) at the cost of: two parts, two footprints, MDI trace routing length (jack→xfmr→PHY), and a bigger PCB area. For Class 0 (13 W max) the integrated magjack is the standard answer and removes the BOM line for external LAN transformers entirely.
+
+**Footprint.** HanRun's HY931147C footprint matches the de-facto 6-port-pin + 2-power-tap + 4-LED + 2-shield-pin TH pattern. tscircuit wrapper will use the JLC EasyEDA footprint (verified via `jlc_get_part` at implementation time).
+
+### 3.3 TVS on PoE bus — SMAJ58A
+
+| Attribute | Value |
+|-----------|-------|
+| LCSC (primary) | C2980408 (Goodwork, 48 011 pcs, $0.03) |
+| LCSC (vetted alt) | C151246 (Littelfuse, 20 996 pcs, $0.12) |
+| Package | DO-214AC (SMA) |
+| Reverse stand-off (V_RWM) | 58 V |
+| Breakdown (V_BR) | 71.2 V (Goodwork) / 64.4 V (some lots) |
+| Clamping (V_CL @ I_PP) | 93.6 V @ 4.3 A |
+| Peak pulse power | 400 W @ 10/1000 µs |
+
+**Rationale.** Per the `interfaces/ethernet` design-rule reference: *"TVS on VDD-VSS: SMAJ58A (58 V). Clamps at ~92 V. Do NOT use SMAJ64A or higher — 98 V clamp is too close to 100 V abs max. Field damage observed with higher ratings."* WS3203 and MP9486A both have 100 V abs-max breakdown; SMAJ58A clamps with margin.
+
+Placed across VDD-VSS at the PD controller input, downstream of bridges. One SMA part, parallel to the 0.1 µF detection cap.
+
+### 3.4 Ethernet PHY — LAN8720AI-CP-TR (Microchip)
+
+| Attribute | Value |
+|-----------|-------|
+| LCSC | C17146 |
+| Manufacturer | Microchip Technology |
+| Package | QFN-24-EP 4×4 mm |
+| Stock @ 2026-05-23 | 26 628 |
+| Unit price (1 pc) | $1.01 |
+| Op temp | -40 °C ~ +85 °C (industrial — important next to the PoE buck + magnetics that heat-soak this region) |
+| Supply | 3.3 V VDDIO; internal 1.2 V regulator (VDDCR) for core |
+| MAC interface | RMII (50 MHz reference clock, 7-pin data + MDIO/MDC) |
+| Standards | 10Base-T, 100Base-TX |
+| REFCLK | Pin 14 — drives 50 MHz OUT when `nINTSEL` is strapped low (REFCLK Out mode) |
+
+**Why industrial-grade vs commercial.** PoE buck switching at ~1 MHz adjacent to PHY + magnetics in a sealed enclosure will push the PCB hot-spot above commercial 0~70 °C in worst-case ambient. Industrial -40~+85 °C buys ~15 °C margin for the same price tier ($1.01 vs $0.77 for the commercial variant — negligible BOM impact, real reliability win).
+
+**Why LAN8720A vs alternates.**
+
+- **DP83848** (TI) — larger QFN-32, 5 V tolerant, more power. Overkill for this design.
+- **KSZ8081** (Microchip) — competing 10/100 PHY, similar footprint. LAN8720A wins on design-rule-reference status (the `interfaces/ethernet` rule explicitly names LAN8720A as "the de facto standard" for 10/100 + RMII).
+- **W5500** (WIZnet) — TCP/IP stack on chip, no MAC needed. Architecturally wrong here: ESP32-P4 has its own EMAC; we want a transparent PHY, not a stack offload.
+
+**Strap pins (LAN8720A defaults at nRST release):**
+
+| Pin | Strap signal | Setting | Effect |
+|-----|--------------|---------|--------|
+| 1   | `LED1/REGOFF` | pull-up 10 kΩ → enable internal 1.2 V regulator | use internal core regulator (saves an external rail) |
+| 2   | `LED2/nINTSEL` | **pull-down 10 kΩ → REFCLK Out mode** | PHY sources 50 MHz REFCLK on pin 14 |
+| 7   | `RXD0/PHYAD0` | pull-up 10 kΩ → PHY address bit 0 = 1 | MDIO addr 0x01 |
+| 8   | `RXD1/PHYAD1` | pull-down → PHY address bit 1 = 0 | MDIO addr 0x01 |
+| 9   | `CRS_DV/PHYAD2` | pull-down → PHY address bit 2 = 0 | MDIO addr 0x01 |
+| 17  | `MODE0` | pull-up → auto-neg modes 1 | enable all-capability auto-neg |
+| 18  | `MODE1` | pull-up → auto-neg modes 1 | (combined: enable 10/100 full+half auto-neg) |
+| 19  | `MODE2` | pull-up → auto-neg modes 1 | |
+
+Strap resistors are dedicated 10 kΩ 1% 0402; they share the package with the PHY-side `nRST` push-pull driver (Core supplies `nRST` via `J_POE.nRST`).
+
+**Decoupling network (per Microchip LAN8720A QFN schematic checklist):**
+
+| Pin | Cap | Notes |
+|-----|-----|-------|
+| `VDDIO` (3.3 V) | 100 nF + 4.7 µF | place within 1 mm of pin |
+| `VDDA` (3.3 V analog) | 100 nF + 4.7 µF + ferrite bead in series with VDDIO supply | analog supply, ferrite isolates from digital noise |
+| `VDDCR` (1.2 V internal core rail) | **470 pF + 1 µF** low-ESR ceramic | datasheet-specified, no other loads |
+| `XTAL1/XTAL2` | 2× 18 pF C0G load caps | crystal load |
+| `RBIAS` | — | **12.1 kΩ 1% 0402 to GND**, no traces under it |
+
+### 3.5 Galvanic isolation strategy — re-interpretation
+
+The ticket says "galvanic isolation barrier between cable-side (high-voltage, ~57V at PSE end) and SELV-side (everything past the buck output)."
+
+This wording, in the original spec context, was a placeholder for "the standard PoE PD isolation pattern." The actual IEEE 802.3 (Clause 33) requirement is:
+
+> A PD shall provide isolation between the cable plant (the wire pairs and shield) and any earth-referenced ground at the powered side, rated 1500 V_rms for one minute.
+
+This isolation is provided **by the LAN magnetics in HY931147C** (1 500 V_rms cable-to-PD-ground, standard 802.3 transformer rating). It is not, and per spec need not be, between the rectified PoE bus and the 5 V SELV output. The PoE bus already sits inside the PD-ground reference; it is fully on the "isolated from cable" side of the magjack.
+
+A non-isolated buck stepping the rectified PoE bus (37–57 V) down to 5 V is therefore IEEE 802.3 compliant *and* is the most common topology for sub-15 W PD designs (e.g., the dozens of off-the-shelf "PoE injectable" boards on the market). The Si3402-B + Coilcraft flyback reference design is a *second* isolation barrier (PoE bus → 5 V); it is required when the 5 V rail must be galvanically isolated from the rectified bus *as well as* from the cable, which is overkill for a Class 0 PD.
+
+**Decision: non-isolated buck post-bridge.** Magnetics provide the spec-required 1 500 V cable-to-PD isolation; the buck does not re-isolate.
+
+A `Y2` 1 nF / 2 kV stitching capacitor connects PD-ground to RJ45 shield (and from there to chassis if the Core's enclosure provides one) to drain EMI noise. This is the standard "Bob Smith"–free chassis bond for PoE designs (per `interfaces/ethernet`: *"Bob Smith termination left populated on PoE design… shorts center taps (carrying PoE power) to chassis ground through low-impedance AC path. Do not populate on PoE."*).
+
+### 3.6 Non-isolated buck — MP9486AGN-Z (MPS)
+
+| Attribute | Value |
+|-----------|-------|
+| LCSC | C404013 |
+| Manufacturer | Monolithic Power Systems |
+| Package | SOIC-8-EP (with exposed pad — needs thermal pour) |
+| Stock @ 2026-05-23 | 3 222 |
+| Unit price (1 pc) | $2.91 |
+| Input range | 4.5 V ~ 100 V |
+| Output current | 1 A continuous (Class 0 budget: ~13 W / 5 V = 2.6 A peak demand, but real Core+NFC+LEDs+Beeper combined ≤1 A) |
+| Switch | Built-in HV NMOS, asynchronous (needs external Schottky catch diode) |
+| Switching freq | 1 MHz fixed |
+| Quiescent current | 170 µA |
+| Reference design | MPS EV9486-A-00A; Vout-set R-divider, FB pin = 0.81 V |
+
+**Why MP9486A.** MP9486A is the cleanest 100 V-class non-isolated buck on JLC's catalog with > 1 k stock and a known-good MPS reference design. Alternates considered:
+
+- **MP4570** (MPS, C86311, 81 pcs) — stock too low.
+- **TPS54360** (TI, 60 V class) — input range insufficient (PoE bus can hit 57 V cable + 6 V transient = 63 V seen at buck input briefly).
+- **LMR16006** (TI, 60 V) — same issue.
+
+The 100 V input rating gives full margin over the 57 V PSE max + transient room.
+
+**Output filter / feedback (per MPS EV9486-A-00A reference):**
+
+| Component | Value | LCSC family |
+|-----------|-------|------------|
+| Bootstrap cap (BST → SW) | 100 nF X7R 50 V 0402 | shared-lib `C0402` |
+| Schottky catch diode (SW → GND, cathode SW) | SS34 (40 V/3 A SMA) | C8678 |
+| Output inductor | **47 µH** shielded SMD 1.2 A — pick at impl. (Sumida CDRH8D43NP-470, Cyntec PIE-1264 family, or any JLC C7xxx series 47 µH 1A) | TBD at impl |
+| Output cap | 22 µF X7R 16 V 0805 + 47 µF 10 V SMD electrolytic (D5×5.4) | shared-lib `C0805` + JLC C7xxx |
+| FB R-top (Vout=5 V) | 51.1 kΩ 1% 0402 | shared-lib `R0402` |
+| FB R-bot (FB=0.81 V) | 10 kΩ 1% 0402 | shared-lib `R0402` |
+| EN pin | tie to VIN via 100 kΩ pull-up — enables on PoE bus rise | — |
+
+Inductor and bulk-output caps are picked at implementation time via `jlc_search` constrained by stock + footprint; the design margin is already proven by the MPS reference.
+
+---
+
+## 4. Topology — block diagram
+
+```
+                                            ┌──────────────────────────────────────────────┐
+                                            │ Cable side  (1500 V_rms iso barrier)         │
+                                            │                                              │
+RJ45 plug (cat5e)                            │   ┌──────────────────────────────────────┐  │
+   │                                         │   │ HY931147C — integrated magjack       │  │
+   │  TX± / RX± / spare pairs / shield  ─────┼──▶│  • RJ45                              │  │
+   │                                         │   │  • Internal 1:1 magnetics (PoE-rated │  │
+   │                                         │   │    center taps)                      │  │
+   │                                         │   │  • Link LED (green) + Act LED (yel)  │  │
+   │                                         │   │  • Shield-bond pin                   │  │
+   │                                         │   └──┬───┬──────────────────────────┬────┘  │
+                                            │      │   │                          │       │
+                                            │      │   │                          │       │
+                                            │      │   ▼                          ▼       │
+                                            │      │   PHY-side TX±/RX± ──────► LAN8720A  │
+                                            │      │   (MDI diff pairs, 100Ω,             │
+                                            │      │   short, no copper under mags)       │
+                                            │      │                                       │
+                                            │      ▼                                       │
+                                            │  Power center-taps                           │
+                                            │  Mode A: pins 4/5 vs 7/8 ─► MB10S bridge #1 │
+                                            │  Mode B: pin 1/2 CT vs 3/6 CT ─► bridge #2 │
+                                            │                                              │
+                                            └──┬─────────────────────────────────────┬─────┘
+                                               │  (now post-magnetics: PD ground ref) │
+                                               ▼                                      ▼
+                                          + V_PoE_BUS (37–57 V DC)              PD_GND
+                                               │
+                       ┌───────────────────────┼──────────────────────────────────────┐
+                       │                       │                                      │
+                       ▼                       ▼                                      ▼
+                  SMAJ58A             0.1 µF (DEN, <120 nF)              WS3203 — PD interface
+                  (TVS clamp)          (detection cap on VDD-VSS,         • DEN: 24.9 kΩ → RTN
+                                       per IEEE 802.3 detection budget)  • CLS: 768 Ω → RTN (Class 0)
+                                                                          • Internal hot-swap pass FET
+                                                                          • SS_R: 100 nF
+                                                                          • ILIM: 22 kΩ
+                                                                                │
+                                                                                ▼
+                                                                          V_OUT_PD (switched 37–57 V)
+                                                                                │
+                                                                                ▼
+                                                                          MP9486AGN-Z — buck 100 V→5 V
+                                                                          • BST cap 100 nF
+                                                                          • SW node → 47 µH L → +5V
+                                                                          • SS34 catch diode SW→GND
+                                                                          • C_IN 22 µF/100 V elec + 100 nF
+                                                                          • C_OUT 22 µF X7R + 47 µF elec
+                                                                          • FB divider: 51.1 k / 10 k → 5.00 V
+                                                                          • EN: 100 kΩ pull-up to V_OUT_PD
+                                                                                │
+                                                                                ▼
+                                                                           +5V SELV rail (1 A)
+                                                                                │
+                                            ┌───────────────────────────────────┼────────────┐
+                                            ▼                                   ▼            ▼
+                                       J_POE.+5V (×2)                AMS1117-3.3       LEDs (optional
+                                       (to Core)                        │                power-good)
+                                                                        ▼
+                                                              +3.3 V (LAN8720A VDDIO/VDDA)
+                                                                        │
+                                                                        ├─ ferrite bead ─► VDDA
+                                                                        │   (100 nF + 4.7 µF at pin)
+                                                                        └────────────────► VDDIO
+                                                                            (100 nF + 4.7 µF at pin)
+
+LAN8720A — 25 MHz xtal (XG1SI-111-25M) + 2× 18 pF C0G, RBIAS 12.1 kΩ to GND, VDDCR 470 pF+1 µF
+       ├─ MDI± (TX/RX) ──── back to magjack PHY-side
+       ├─ RMII bus ──── series 10 Ω on RXD0/RXD1/CRS_DV ──► J_POE pins 5–11
+       ├─ MDIO ────── 1.5 kΩ pull-up to +3V3 ────► J_POE pin 12
+       ├─ MDC ────────────────────────────────────► J_POE pin 13
+       ├─ REFCLKO (50 MHz) ──────────────────────► J_POE pin 11
+       └─ nRST ◄────────────────────────────────── J_POE pin 14 (push-pull from Core)
+```
+
+---
+
+## 5. Connector contract — verify against `J_POE` freeze
+
+`libs/attractap-hw-shared/src/connectors/j-poe.ts` is the freeze point. The board imports it and uses `assertWiresAllSignals` to compile-time-prove every required signal is wired. No changes to the contract are needed for this board; pinout is already locked.
+
+| `J_POE` pin | Signal | Board source/sink |
+|-------------|--------|-------------------|
+| 1, 2 | +5V | from `MP9486A.VOUT` |
+| 3, 4, 15 | GND | board PD ground |
+| 5 | RMII_TXD0 | from Core → into PHY TXD0 |
+| 6 | RMII_TXD1 | from Core → into PHY TXD1 |
+| 7 | RMII_TX_EN | from Core → into PHY TXEN |
+| 8 | RMII_RXD0 | from PHY RXD0 → to Core (10 Ω series) |
+| 9 | RMII_RXD1 | from PHY RXD1 → to Core (10 Ω series) |
+| 10 | RMII_CRS_DV | from PHY CRS_DV → to Core (10 Ω series) |
+| 11 | RMII_REF_CLK | from PHY REFCLKO pin 14 → to Core EMAC REFCLK_IN |
+| 12 | MDIO | bidirectional, 1.5 kΩ pull-up to 3V3 on PoE side |
+| 13 | MDC | from Core → into PHY MDC |
+| 14 | nRST | from Core → into PHY nRST (active low, push-pull required) |
+| 16 | NC | reserved |
+
+---
+
+## 6. Layout strategy (4-layer JLC)
+
+### 6.1 Stack-up
+
+| Layer | Thickness | Use |
+|-------|-----------|-----|
+| L1 (top sig) | 0.5 oz | components + MDI diff pairs + RMII traces |
+| L2 (GND) | 1 oz | continuous ground reference, **no cuts** under MDI |
+| L3 (+5 V + V_PoE_BUS pours) | 1 oz | power planes — separate islands for V_PoE_BUS (cable side of bridges) and +5 V SELV (post-buck) |
+| L4 (bot sig) | 0.5 oz | low-speed routing, no MDI, no clock |
+
+Board thickness 1.6 mm (JLC default). Trace impedance reference: 100 Ω differential MDI on L1 over L2-GND, prepreg ~0.2 mm, trace width ~0.16 mm + spacing 0.16 mm (tuned at DRC time).
+
+### 6.2 Critical placement rules
+
+| Region | Rule | Source |
+|--------|------|--------|
+| MDI pairs | < 50 mm length; intra-pair match < 1.3 mm; 3w GND clearance | `interfaces/ethernet` |
+| Magjack (HY931147C) | **No copper under magnetics on any layer** (clear power AND GND planes inside the magjack footprint shadow) | `interfaces/ethernet` |
+| Buck switch node (MP9486A SW pin → L → output cap) | Tight loop, < 5 mm; no clock-sensitive traces nearby | `power/switching.md` (general) |
+| PoE bus pour (V_PoE_BUS) | Wide pour on L3, 2-oz-equivalent via stitching to bridges | thermal budget at ~360 mA |
+| RBIAS resistor (12.1 kΩ) | No traces under, bury in inner layer if possible | LAN8720A schematic checklist |
+| VDDCR cap (470 pF + 1 µF on LAN8720A pin 6) | Directly at pin, vias to L2 GND | LAN8720A schematic checklist |
+| Crystal + load caps | Local ground island for caps, separate from MDI ground | LAN8720A schematic checklist |
+| RJ45 shield bond | 1 nF / 2 kV Y2 cap + 1 MΩ to PD ground; populate 1206 footprint for EMC swapping | `interfaces/ethernet` |
+| RMII clock/data | Series 10 Ω on PHY-driven outputs (RXD0, RXD1, CRS_DV) at PHY side, before via to J_POE | `interfaces/ethernet` RMII |
+| MDIO pull-up | 1.5 kΩ to +3V3 close to PHY MDIO pin | `interfaces/ethernet` RMII |
+| Connector edge | J_POE 2×8 1.27 mm B2B at the SELV-side edge of the board (opposite the RJ45) | board partitioning |
+
+### 6.3 "Isolation barrier" silkscreen line
+
+Even though the topology is non-isolated post-bridge, the **1 500 V cable-to-PD-ground barrier inside the magjack is the legally relevant one**. Silkscreen a clear line on the top layer marking the boundary between:
+
+- **CABLE SIDE**: RJ45 plug + magjack body (everything inside the magjack footprint)
+- **PD SIDE**: everything else (bridges, WS3203, MP9486A, PHY, J_POE)
+
+The line carries the text "PoE 1500 V iso barrier — do not bridge". The magjack itself enforces the creepage internally; the silkscreen is documentation for reviewers and rework.
+
+### 6.4 Mounting + outline
+
+- Outline: 60.0 × 35.0 mm (per `mech-envelope.md` PoE row)
+- 4× M3 mount, ⌀3.2 clearance, copper-free annulus 6 mm, positioned: (3, 3), (57, 3), (3, 32), (57, 32)
+- Max top-component height: 8 mm (RJ45 sits at 13.5 mm but overhangs the board edge — its body extends beyond the 60 mm length but the **height inside the 60 mm footprint** is ≤ 8 mm at the connector face once seated)
+- Max bottom-component height: 1.5 mm
+
+### 6.5 DRC ruleset
+
+- JLC 4-layer ruleset (override the per-board default of 2-layer)
+- Minimum trace: 4 mil
+- Minimum spacing: 4 mil
+- Via: 0.3 mm drill / 0.6 mm pad
+- No solder mask between MDI traces (per JLC 4L spec)
+- BOM tag: every part gets `supplierPartNumbers={{ jlcpcb: [lcsc] }}` so JLC's CPL pipeline auto-matches
+
+---
+
+## 7. tscircuit shared-lib additions (libs/attractap-hw-shared)
+
+The PoE board needs the following new parts wrappers added to `libs/attractap-hw-shared/src/parts/`. All wrappers follow the existing pattern (named export, `jlcSupplier(pn)` helper, `pinLabels` map).
+
+| New file | Wrapper export | Footprint | LCSC | Used by |
+|----------|----------------|-----------|------|---------|
+| `ethernet.tsx` (new) | `Lan8720a` | `qfn24_p0.5_w4_h4_ep2.5` | C17146 | PoE board PHY |
+| `ethernet.tsx` | `Hy931147c` | custom TH magjack footprint (HanRun datasheet) | C91754 | PoE board RJ45 |
+| `ethernet.tsx` | `Crystal25M_5032` | `xtal_smd_5x3.2_2pin` | C20617602 | PoE board PHY clock |
+| `poe.tsx` (new) | `Ws3203` | `tssop14` | C5143001 | PoE board PD interface |
+| `poe.tsx` | `Mp9486a` | `soic8_ep` | C404013 | PoE board buck |
+| `poe.tsx` | `Mb10s` | `mbs_4lead` | C2488 | PoE board bridges (×2) |
+| `poe.tsx` | `Smaj58a` | `sma_do214ac` | C2980408 | PoE board TVS |
+| `poe.tsx` | `Ss34` | `sma_do214ac` | C8678 | PoE board buck catch diode |
+| `passives.tsx` (extend) | `ElecCap_22uF_100V` | `electrolytic_smd_d6.3` | C46550391 | PoE board input bulk |
+
+Add a re-export of both new files from `libs/attractap-hw-shared/src/parts/index.tsx`. Bump `libs/attractap-hw-shared/package.json` minor version (additive — not a connector freeze break). Update `CONNECTORS.md` is not needed (no connector change); update `README.md` parts table.
+
+Each wrapper takes `name`, `pn`, position props (`pcbX`, `pcbY`, `pcbRotation`) per the existing `BasePartProps` contract, and forwards `supplierPartNumbers={{ jlcpcb: [pn] }}`.
+
+---
+
+## 8. Acceptance gate coverage
+
+The ATT-351 acceptance gates:
+
+| Gate | How this design meets it |
+|------|--------------------------|
+| 1. `nx run poe:lint` clean on JLC 4-layer ruleset | tscircuit ERC will pass: every required `J_POE` signal wired via `assertWiresAllSignals`; DRC will pass via JLC 4L override in `tscircuit.config.json` |
+| 2. `nx run poe:export` clean | Gerbers + BOM (LCSC PNs) + CPL emitted by `tscircuit-cli export -f gerbers` |
+| 3. `nx run poe:render` PNGs in PR | PCB + schematic + assembly SVG → PNG via shared `render-png.mjs`; hardware.yml workflow handles the rest |
+| 4. Peer review with isolation-barrier scrutiny | §6.3 silkscreen line + this doc's §3.5 rationale lets the reviewer confirm the iso strategy |
+| 5. Smoke test: PoE injector → +5 V ≥ 1 A, no thermal runaway 24 h | Buck rated 1 A continuous; thermal pour under MP9486A SOIC-8-EP; bench gate, not in this PR |
+| 6. Functional: PHY MDIO read + link LED + Class 0 negotiate | LAN8720A defaults to PHY addr 0x01 on MDIO; HY931147C LEDs hard-wired to PHY; WS3203 detection signature (24.9 kΩ) is 802.3 standard |
+
+Gates 5 and 6 are bench tests after physical fab; this PR ships the design that *enables* them.
+
+---
+
+## 9. Risks & known unknowns
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| MP9486AGN-Z stock (3 222 pcs) drops before fab order | Fab delay or substitution | Alternates documented (TPS54360 if 60 V max is OK, MP4570 if stock allows) |
+| WS3203 NJGW lot variability | Some Chinese PD chips have ±5 % R_CLS tolerance instead of ±1 %; affects classification | Use 1 % R_CLS resistor regardless; verify classify event on bench |
+| HY931147C "With PoE" — verify center-tap DC bias rating from HanRun datasheet at fab time | If DC bias rating < 360 mA, magnetics saturate at Class 0 | Cross-check HanRun datasheet at PR review; alt = HY911105AE (4 821 pcs, also rated) |
+| REFCLK timing — LAN8720A REFCLK Out mode not strictly RMII-compliant | ESP32-P4 EMAC may need serpentine delay on RXD/CRS_DV at Core | Out-of-scope for this board; logged as input to ATT-T6 Core ticket |
+| MB10S package is JLC-tagged through-hole but datasheet shows SMD MBS | Footprint mismatch | Verify via `jlc_get_part C2488` + EasyEDA footprint at impl; swap to MB6F SMD if needed |
+| Si3402-B-GMR (originally spec'd in ticket) not selected | Diverges from ticket text | Documented divergence here; user explicitly accepted single-source JLC constraint over Si3402-B + manual flyback |
+| Class 0 max 13 W; +5 V × 1 A = 5 W consumed by Core + downstream | Power budget OK with 8 W margin; if downstream grows (e.g. PoE feeds NFC LED ring full-on + Core + display backlight) we may exceed | Document budget; if real-world stack exceeds 5 V × 1.5 A, bump buck IC and re-spin |
+
+---
+
+## 10. Next steps
+
+1. **User review of this doc.** Confirm topology + PNs before tscircuit code lands.
+2. Add wrappers to `libs/attractap-hw-shared/src/parts/ethernet.tsx` and `poe.tsx`. Re-export. Bump shared-lib minor version.
+3. Scaffold `apps/attractap/hardware/poe/` from `_placeholder/` template; rewrite `index.tsx` to the topology in §4; add `tscircuit.config.json` with `pcb.drc.preset: jlcpcb4`.
+4. Wire `J_POE` per §5; assert via `assertWiresAllSignals`.
+5. Run `pnpm nx run attractap-hw-poe:lint` locally until clean.
+6. Run `:build`, `:export`, `:render`.
+7. Commit, push, open PR. CI `hardware.yml` produces gerber ZIP + render PNGs.
+8. Post render PNGs back to the Linear ticket per the agent guidance (frontend-style screenshot rule, applied to PCB renders here).

--- a/libs/attractap-hw-shared/package.json
+++ b/libs/attractap-hw-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attraccess/attractap-hw-shared",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/libs/attractap-hw-shared/src/parts/ethernet.tsx
+++ b/libs/attractap-hw-shared/src/parts/ethernet.tsx
@@ -36,7 +36,7 @@ export type Lan8720aProps = BasePartProps;
 export const Lan8720a = ({ name, pn, ...rest }: Lan8720aProps) => (
   <chip
     name={name}
-    footprint="qfn24_p0.5_w4_h4_ep2.5"
+    footprint="qfn24"
     pinLabels={LAN8720A_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
@@ -73,24 +73,30 @@ export type Hy931147cProps = BasePartProps;
 export const Hy931147c = ({ name, pn, ...rest }: Hy931147cProps) => (
   <chip
     name={name}
-    footprint="rj45_magjack_th_hr"
+    footprint="dip20"
     pinLabels={HY931147C_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="HY931147C — PoE-rated RJ45 magjack 10/100, 1500Vrms iso" />
+    <fabricationnotetext text="HY931147C — PoE-rated RJ45 magjack 10/100, 1500Vrms iso (placeholder fp; JLC fetches real magjack)" />
   </chip>
 );
 
 export type Crystal25M_5032_Props = BasePartProps;
 
+const CRYSTAL_5032_PINS = {
+  pin1: ['pin1'],
+  pin2: ['pin2'],
+} as const;
+
 export const Crystal25M_5032 = ({ name, pn, ...rest }: Crystal25M_5032_Props) => (
-  <crystal
+  <chip
     name={name}
-    frequency="25MHz"
-    loadCapacitance="20pF"
-    footprint="xtal_smd_5032_2pin"
+    footprint="dip2"
+    pinLabels={CRYSTAL_5032_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
-  />
+  >
+    <fabricationnotetext text="25 MHz SMD5032 crystal, 20 pF load" />
+  </chip>
 );

--- a/libs/attractap-hw-shared/src/parts/ethernet.tsx
+++ b/libs/attractap-hw-shared/src/parts/ethernet.tsx
@@ -36,36 +36,30 @@ export type Lan8720aProps = BasePartProps;
 export const Lan8720a = ({ name, pn, ...rest }: Lan8720aProps) => (
   <chip
     name={name}
-    footprint="qfn24"
+    footprint="qfn24_w4_h4_p0.5mm"
     pinLabels={LAN8720A_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="LAN8720A 10/100 Ethernet PHY (RMII). Parser fp 'qfn24' is stub — JLC EasyEDA footprint sourced via LCSC PN at fab." />
+    <fabricationnotetext text="LAN8720A 10/100 Ethernet PHY (RMII), QFN-24-EP 4x4mm 0.5mm pitch." />
   </chip>
 );
 
 const HY931147C_PINS = {
-  pin1: ['TX_P'],
-  pin2: ['TX_N'],
-  pin3: ['RX_P'],
-  pin4: ['CT_TX'],
-  pin5: ['CT_RX'],
-  pin6: ['RX_N'],
-  pin7: ['CABLE_3'],
-  pin8: ['CABLE_6'],
-  pin9: ['CABLE_1'],
-  pin10: ['CABLE_2'],
-  pin11: ['CABLE_4_5_A'],
-  pin12: ['CABLE_4_5_B'],
-  pin13: ['CABLE_7_8_A'],
-  pin14: ['CABLE_7_8_B'],
-  pin15: ['LED_LINK_A'],
-  pin16: ['LED_LINK_K'],
-  pin17: ['LED_ACT_A'],
-  pin18: ['LED_ACT_K'],
-  pin19: ['SHIELD_1'],
-  pin20: ['SHIELD_2'],
+  pin1: ['TX_P', 'J1'],
+  pin2: ['TX_N', 'J2'],
+  pin3: ['RX_P', 'J3'],
+  pin4: ['CABLE_4', 'J4'],
+  pin5: ['CABLE_5', 'J5'],
+  pin6: ['RX_N', 'J6'],
+  pin7: ['CABLE_7', 'J7'],
+  pin8: ['CABLE_8', 'J8'],
+  pin9: ['SHIELD_1'],
+  pin10: ['SHIELD_2'],
+  pin11: ['LED_LINK_A'],
+  pin12: ['LED_LINK_K'],
+  pin13: ['LED_ACT_A'],
+  pin14: ['LED_ACT_K'],
 } as const;
 
 export type Hy931147cProps = BasePartProps;
@@ -73,30 +67,56 @@ export type Hy931147cProps = BasePartProps;
 export const Hy931147c = ({ name, pn, ...rest }: Hy931147cProps) => (
   <chip
     name={name}
-    footprint="dip20"
     pinLabels={HY931147C_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
+    footprint={
+      <footprint>
+        <platedhole shape="circle" portHints={['pin1']} pcbX={8.890} pcbY={-5.715} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin2']} pcbX={6.350} pcbY={-4.445} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin3']} pcbX={8.890} pcbY={-3.175} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin4']} pcbX={6.350} pcbY={-1.905} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin5']} pcbX={8.890} pcbY={-0.635} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin6']} pcbX={6.350} pcbY={0.635} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin7']} pcbX={8.890} pcbY={1.905} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin8']} pcbX={6.350} pcbY={3.175} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin9']} pcbX={8.890} pcbY={4.445} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin10']} pcbX={6.350} pcbY={5.715} holeDiameter="0.9mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin11']} pcbX={-4.089} pcbY={-6.629} holeDiameter="1.1mm" outerDiameter="1.8mm" />
+        <platedhole shape="circle" portHints={['pin12']} pcbX={-4.089} pcbY={-4.089} holeDiameter="1.1mm" outerDiameter="1.8mm" />
+        <platedhole shape="circle" portHints={['pin13']} pcbX={-4.089} pcbY={4.089} holeDiameter="1.1mm" outerDiameter="1.8mm" />
+        <platedhole shape="circle" portHints={['pin14']} pcbX={-4.089} pcbY={6.629} holeDiameter="1.1mm" outerDiameter="1.8mm" />
+      </footprint>
+    }
     {...rest}
   >
-    <fabricationnotetext text="HY931147C — PoE-rated RJ45 magjack 10/100, 1500Vrms iso. Parser fp 'dip20' is stub — JLC EasyEDA footprint sourced via LCSC PN at fab." />
+    <fabricationnotetext text="HY931147C PoE RJ45 magjack. Pins 4,5,7,8 = spare-pair direct cable contacts for Mode A PoE." />
   </chip>
 );
 
 export type Crystal25M_5032_Props = BasePartProps;
 
 const CRYSTAL_5032_PINS = {
-  pin1: ['pin1'],
-  pin2: ['pin2'],
+  pin1: ['XOUT'],
+  pin2: ['GND_1'],
+  pin3: ['XIN'],
+  pin4: ['GND_2'],
 } as const;
 
 export const Crystal25M_5032 = ({ name, pn, ...rest }: Crystal25M_5032_Props) => (
   <chip
     name={name}
-    footprint="dip2"
     pinLabels={CRYSTAL_5032_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
+    footprint={
+      <footprint>
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.0} pcbY={1.20} width="1.6mm" height="1.2mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={2.0} pcbY={1.20} width="1.6mm" height="1.2mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={2.0} pcbY={-1.20} width="1.6mm" height="1.2mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.0} pcbY={-1.20} width="1.6mm" height="1.2mm" layer="top" />
+      </footprint>
+    }
     {...rest}
   >
-    <fabricationnotetext text="25 MHz SMD5032 crystal, 20 pF load. Parser fp 'dip2' is stub — JLC EasyEDA footprint sourced via LCSC PN at fab." />
+    <fabricationnotetext text="25 MHz SMD5032-4P crystal, 20 pF load. Pins 1+3 = crystal, pins 2+4 = GND." />
   </chip>
 );

--- a/libs/attractap-hw-shared/src/parts/ethernet.tsx
+++ b/libs/attractap-hw-shared/src/parts/ethernet.tsx
@@ -14,7 +14,7 @@ const LAN8720A_PINS = {
   pin7: ['XTAL2'],
   pin8: ['XTAL1', 'CLKIN'],
   pin9: ['VSS'],
-  pin10: ['VDDIO_NC1'],
+  pin10: ['VDDIO_2'],
   pin11: ['nRST'],
   pin12: ['MDIO'],
   pin13: ['MDC'],
@@ -26,7 +26,7 @@ const LAN8720A_PINS = {
   pin19: ['TXEN'],
   pin20: ['TXD0'],
   pin21: ['TXD1'],
-  pin22: ['VDDIO_NC2'],
+  pin22: ['VDDIO_3'],
   pin23: ['TXP'],
   pin24: ['TXN'],
 } as const;
@@ -41,7 +41,7 @@ export const Lan8720a = ({ name, pn, ...rest }: Lan8720aProps) => (
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="LAN8720A 10/100 Ethernet PHY (RMII)" />
+    <fabricationnotetext text="LAN8720A 10/100 Ethernet PHY (RMII). Parser fp 'qfn24' is stub — JLC EasyEDA footprint sourced via LCSC PN at fab." />
   </chip>
 );
 
@@ -78,7 +78,7 @@ export const Hy931147c = ({ name, pn, ...rest }: Hy931147cProps) => (
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="HY931147C — PoE-rated RJ45 magjack 10/100, 1500Vrms iso (placeholder fp; JLC fetches real magjack)" />
+    <fabricationnotetext text="HY931147C — PoE-rated RJ45 magjack 10/100, 1500Vrms iso. Parser fp 'dip20' is stub — JLC EasyEDA footprint sourced via LCSC PN at fab." />
   </chip>
 );
 
@@ -97,6 +97,6 @@ export const Crystal25M_5032 = ({ name, pn, ...rest }: Crystal25M_5032_Props) =>
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="25 MHz SMD5032 crystal, 20 pF load" />
+    <fabricationnotetext text="25 MHz SMD5032 crystal, 20 pF load. Parser fp 'dip2' is stub — JLC EasyEDA footprint sourced via LCSC PN at fab." />
   </chip>
 );

--- a/libs/attractap-hw-shared/src/parts/ethernet.tsx
+++ b/libs/attractap-hw-shared/src/parts/ethernet.tsx
@@ -1,0 +1,96 @@
+// Typed tscircuit wrappers for the Ethernet IC family used by Attractap V2 PoE
+// FEATURE: hw-shared/ethernet — LAN8720A PHY, HanRun PoE magjack, 25 MHz crystal
+
+import type { BasePartProps } from './types';
+import { jlcSupplier } from './types';
+
+const LAN8720A_PINS = {
+  pin1: ['VDDCR'],
+  pin2: ['VDD2A'],
+  pin3: ['RBIAS'],
+  pin4: ['VDDIO'],
+  pin5: ['LED2', 'nINTSEL'],
+  pin6: ['LED1', 'REGOFF'],
+  pin7: ['XTAL2'],
+  pin8: ['XTAL1', 'CLKIN'],
+  pin9: ['VSS'],
+  pin10: ['VDDIO_NC1'],
+  pin11: ['nRST'],
+  pin12: ['MDIO'],
+  pin13: ['MDC'],
+  pin14: ['RXER'],
+  pin15: ['RXD1', 'PHYAD2'],
+  pin16: ['RXD0', 'PHYAD1'],
+  pin17: ['CRS_DV', 'PHYAD0', 'MODE2'],
+  pin18: ['REFCLKO'],
+  pin19: ['TXEN'],
+  pin20: ['TXD0'],
+  pin21: ['TXD1'],
+  pin22: ['VDDIO_NC2'],
+  pin23: ['TXP'],
+  pin24: ['TXN'],
+} as const;
+
+export type Lan8720aProps = BasePartProps;
+
+export const Lan8720a = ({ name, pn, ...rest }: Lan8720aProps) => (
+  <chip
+    name={name}
+    footprint="qfn24_p0.5_w4_h4_ep2.5"
+    pinLabels={LAN8720A_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="LAN8720A 10/100 Ethernet PHY (RMII)" />
+  </chip>
+);
+
+const HY931147C_PINS = {
+  pin1: ['TX_P'],
+  pin2: ['TX_N'],
+  pin3: ['RX_P'],
+  pin4: ['CT_TX'],
+  pin5: ['CT_RX'],
+  pin6: ['RX_N'],
+  pin7: ['CABLE_3'],
+  pin8: ['CABLE_6'],
+  pin9: ['CABLE_1'],
+  pin10: ['CABLE_2'],
+  pin11: ['CABLE_4_5_A'],
+  pin12: ['CABLE_4_5_B'],
+  pin13: ['CABLE_7_8_A'],
+  pin14: ['CABLE_7_8_B'],
+  pin15: ['LED_LINK_A'],
+  pin16: ['LED_LINK_K'],
+  pin17: ['LED_ACT_A'],
+  pin18: ['LED_ACT_K'],
+  pin19: ['SHIELD_1'],
+  pin20: ['SHIELD_2'],
+} as const;
+
+export type Hy931147cProps = BasePartProps;
+
+export const Hy931147c = ({ name, pn, ...rest }: Hy931147cProps) => (
+  <chip
+    name={name}
+    footprint="rj45_magjack_th_hr"
+    pinLabels={HY931147C_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="HY931147C — PoE-rated RJ45 magjack 10/100, 1500Vrms iso" />
+  </chip>
+);
+
+export type Crystal25M_5032_Props = BasePartProps;
+
+export const Crystal25M_5032 = ({ name, pn, ...rest }: Crystal25M_5032_Props) => (
+  <crystal
+    name={name}
+    frequency="25MHz"
+    loadCapacitance="20pF"
+    footprint="xtal_smd_5032_2pin"
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  />
+);

--- a/libs/attractap-hw-shared/src/parts/ethernet.tsx
+++ b/libs/attractap-hw-shared/src/parts/ethernet.tsx
@@ -54,12 +54,14 @@ const HY931147C_PINS = {
   pin6: ['RX_N', 'J6'],
   pin7: ['CABLE_7', 'J7'],
   pin8: ['CABLE_8', 'J8'],
-  pin9: ['SHIELD_1'],
-  pin10: ['SHIELD_2'],
+  pin9: ['NC9'],
+  pin10: ['NC10'],
   pin11: ['LED_LINK_A'],
   pin12: ['LED_LINK_K'],
   pin13: ['LED_ACT_A'],
   pin14: ['LED_ACT_K'],
+  pin15: ['SHIELD_1'],
+  pin16: ['SHIELD_2'],
 } as const;
 
 export type Hy931147cProps = BasePartProps;
@@ -71,25 +73,29 @@ export const Hy931147c = ({ name, pn, ...rest }: Hy931147cProps) => (
     supplierPartNumbers={jlcSupplier(pn)}
     footprint={
       <footprint>
-        <platedhole shape="circle" portHints={['pin1']} pcbX={8.890} pcbY={-5.715} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin2']} pcbX={6.350} pcbY={-4.445} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin3']} pcbX={8.890} pcbY={-3.175} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin4']} pcbX={6.350} pcbY={-1.905} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin5']} pcbX={8.890} pcbY={-0.635} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin6']} pcbX={6.350} pcbY={0.635} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin7']} pcbX={8.890} pcbY={1.905} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin8']} pcbX={6.350} pcbY={3.175} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin9']} pcbX={8.890} pcbY={4.445} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin10']} pcbX={6.350} pcbY={5.715} holeDiameter="0.9mm" outerDiameter="1.6mm" />
-        <platedhole shape="circle" portHints={['pin11']} pcbX={-4.089} pcbY={-6.629} holeDiameter="1.1mm" outerDiameter="1.8mm" />
-        <platedhole shape="circle" portHints={['pin12']} pcbX={-4.089} pcbY={-4.089} holeDiameter="1.1mm" outerDiameter="1.8mm" />
-        <platedhole shape="circle" portHints={['pin13']} pcbX={-4.089} pcbY={4.089} holeDiameter="1.1mm" outerDiameter="1.8mm" />
-        <platedhole shape="circle" portHints={['pin14']} pcbX={-4.089} pcbY={6.629} holeDiameter="1.1mm" outerDiameter="1.8mm" />
+        <platedhole shape="circle" portHints={['pin1']} pcbX={6.490} pcbY={-5.715} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin2']} pcbX={3.950} pcbY={-4.445} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin3']} pcbX={6.490} pcbY={-3.175} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin4']} pcbX={3.950} pcbY={-1.905} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin5']} pcbX={6.490} pcbY={-0.635} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin6']} pcbX={3.950} pcbY={0.635} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin7']} pcbX={6.490} pcbY={1.905} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin8']} pcbX={3.950} pcbY={3.175} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin9']} pcbX={6.490} pcbY={4.445} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin10']} pcbX={3.950} pcbY={5.715} holeDiameter="0.9mm" outerDiameter="1.5mm" />
+        <platedhole shape="circle" portHints={['pin11']} pcbX={-6.490} pcbY={-6.629} holeDiameter="1.1mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin12']} pcbX={-6.490} pcbY={-4.089} holeDiameter="1.1mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin13']} pcbX={-6.490} pcbY={4.089} holeDiameter="1.1mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin14']} pcbX={-6.490} pcbY={6.629} holeDiameter="1.1mm" outerDiameter="1.6mm" />
+        <platedhole shape="circle" portHints={['pin15']} pcbX={0.648} pcbY={-7.747} holeDiameter="1.6mm" outerDiameter="2.0mm" />
+        <platedhole shape="circle" portHints={['pin16']} pcbX={0.648} pcbY={7.747} holeDiameter="1.6mm" outerDiameter="2.0mm" />
+        <hole shape="circle" pcbX={-2.400} pcbY={-5.700} diameter="1.625mm" />
+        <hole shape="circle" pcbX={-2.400} pcbY={5.700} diameter="1.625mm" />
       </footprint>
     }
     {...rest}
   >
-    <fabricationnotetext text="HY931147C PoE RJ45 magjack. Pins 4,5,7,8 = spare-pair direct cable contacts for Mode A PoE." />
+    <fabricationnotetext text="HY931147C PoE RJ45 magjack. Pins 4,5,7,8 = spare-pair cable contacts (Mode A). Pin15/16 = chassis shield mounting pegs." />
   </chip>
 );
 

--- a/libs/attractap-hw-shared/src/parts/index.tsx
+++ b/libs/attractap-hw-shared/src/parts/index.tsx
@@ -9,3 +9,5 @@ export * from './discrete';
 export * from './buzzer';
 export * from './leds';
 export * from './silk';
+export * from './ethernet';
+export * from './poe';

--- a/libs/attractap-hw-shared/src/parts/passives.tsx
+++ b/libs/attractap-hw-shared/src/parts/passives.tsx
@@ -77,7 +77,7 @@ export const ElecCap_22uF_100V = ({ name, pn, ...rest }: BasePartProps) => (
   <capacitor
     name={name}
     capacitance="22uF"
-    footprint="cap_smd_d6.3_h7.7_p2.5"
+    footprint="1210"
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   />

--- a/libs/attractap-hw-shared/src/parts/passives.tsx
+++ b/libs/attractap-hw-shared/src/parts/passives.tsx
@@ -72,3 +72,13 @@ export const L0603 = ({ name, pn, inductance, ...rest }: InductorWrapperProps) =
     {...rest}
   />
 );
+
+export const ElecCap_22uF_100V = ({ name, pn, ...rest }: BasePartProps) => (
+  <capacitor
+    name={name}
+    capacitance="22uF"
+    footprint="cap_smd_d6.3_h7.7_p2.5"
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  />
+);

--- a/libs/attractap-hw-shared/src/parts/passives.tsx
+++ b/libs/attractap-hw-shared/src/parts/passives.tsx
@@ -77,8 +77,13 @@ export const ElecCap_22uF_100V = ({ name, pn, ...rest }: BasePartProps) => (
   <capacitor
     name={name}
     capacitance="22uF"
-    footprint="1210"
     supplierPartNumbers={jlcSupplier(pn)}
+    footprint={
+      <footprint>
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.67} pcbY={0} width="3.5mm" height="1.2mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={2.67} pcbY={0} width="3.5mm" height="1.2mm" layer="top" />
+      </footprint>
+    }
     {...rest}
   />
 );

--- a/libs/attractap-hw-shared/src/parts/poe.tsx
+++ b/libs/attractap-hw-shared/src/parts/poe.tsx
@@ -30,20 +30,20 @@ export const Ws3203 = ({ name, pn, ...rest }: Ws3203Props) => (
     supplierPartNumbers={jlcSupplier(pn)}
     footprint={
       <footprint>
-        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.85} pcbY={1.95} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin2']} shape="rect" pcbX={-2.85} pcbY={1.30} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin3']} shape="rect" pcbX={-2.85} pcbY={0.65} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.85} pcbY={0.00} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin5']} shape="rect" pcbX={-2.85} pcbY={-0.65} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin6']} shape="rect" pcbX={-2.85} pcbY={-1.30} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin7']} shape="rect" pcbX={-2.85} pcbY={-1.95} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin8']} shape="rect" pcbX={2.85} pcbY={-1.95} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin9']} shape="rect" pcbX={2.85} pcbY={-1.30} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin10']} shape="rect" pcbX={2.85} pcbY={-0.65} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin11']} shape="rect" pcbX={2.85} pcbY={0.00} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin12']} shape="rect" pcbX={2.85} pcbY={0.65} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin13']} shape="rect" pcbX={2.85} pcbY={1.30} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin14']} shape="rect" pcbX={2.85} pcbY={1.95} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.50} pcbY={1.95} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={-2.50} pcbY={1.30} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={-2.50} pcbY={0.65} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.50} pcbY={0.00} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin5']} shape="rect" pcbX={-2.50} pcbY={-0.65} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin6']} shape="rect" pcbX={-2.50} pcbY={-1.30} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin7']} shape="rect" pcbX={-2.50} pcbY={-1.95} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin8']} shape="rect" pcbX={2.50} pcbY={-1.95} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin9']} shape="rect" pcbX={2.50} pcbY={-1.30} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin10']} shape="rect" pcbX={2.50} pcbY={-0.65} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin11']} shape="rect" pcbX={2.50} pcbY={0.00} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin12']} shape="rect" pcbX={2.50} pcbY={0.65} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin13']} shape="rect" pcbX={2.50} pcbY={1.30} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin14']} shape="rect" pcbX={2.50} pcbY={1.95} width="1.40mm" height="0.40mm" layer="top" />
       </footprint>
     }
     {...rest}
@@ -72,14 +72,14 @@ export const Mp9486a = ({ name, pn, ...rest }: Mp9486aProps) => (
     supplierPartNumbers={jlcSupplier(pn)}
     footprint={
       <footprint>
-        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.35} pcbY={1.905} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin2']} shape="rect" pcbX={-2.35} pcbY={0.635} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin3']} shape="rect" pcbX={-2.35} pcbY={-0.635} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.35} pcbY={-1.905} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin5']} shape="rect" pcbX={2.35} pcbY={-1.905} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin6']} shape="rect" pcbX={2.35} pcbY={-0.635} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin7']} shape="rect" pcbX={2.35} pcbY={0.635} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin8']} shape="rect" pcbX={2.35} pcbY={1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.225} pcbY={1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={-2.225} pcbY={0.635} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={-2.225} pcbY={-0.635} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.225} pcbY={-1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin5']} shape="rect" pcbX={2.225} pcbY={-1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin6']} shape="rect" pcbX={2.225} pcbY={-0.635} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin7']} shape="rect" pcbX={2.225} pcbY={0.635} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin8']} shape="rect" pcbX={2.225} pcbY={1.905} width="1.55mm" height="0.60mm" layer="top" />
         <smtpad portHints={['pin4', 'GND']} shape="rect" pcbX={0} pcbY={0} width="2.50mm" height="2.50mm" layer="top" />
       </footprint>
     }

--- a/libs/attractap-hw-shared/src/parts/poe.tsx
+++ b/libs/attractap-hw-shared/src/parts/poe.tsx
@@ -1,0 +1,108 @@
+// Typed tscircuit wrappers for the 802.3af PoE PD-side IC family
+// FEATURE: hw-shared/poe — WS3203 PD interface, MP9486A buck, MB10S bridge, SMAJ58A TVS, SS34 catch
+
+import type { BasePartProps } from './types';
+import { jlcSupplier } from './types';
+
+const WS3203_PINS = {
+  pin1: ['VDD'],
+  pin2: ['RTN'],
+  pin3: ['DEN'],
+  pin4: ['CLS'],
+  pin5: ['T2P'],
+  pin6: ['PG'],
+  pin7: ['GND'],
+  pin8: ['GATE'],
+  pin9: ['VSS_BIAS'],
+  pin10: ['SS_R'],
+  pin11: ['ILIM'],
+  pin12: ['OCS'],
+  pin13: ['BLNK'],
+  pin14: ['VOUT_PD'],
+} as const;
+
+export type Ws3203Props = BasePartProps;
+
+export const Ws3203 = ({ name, pn, ...rest }: Ws3203Props) => (
+  <chip
+    name={name}
+    footprint="tssop14"
+    pinLabels={WS3203_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="WS3203 — 802.3af PD interface (NJGW)" />
+  </chip>
+);
+
+const MP9486A_PINS = {
+  pin1: ['BST'],
+  pin2: ['VIN'],
+  pin3: ['SW'],
+  pin4: ['GND'],
+  pin5: ['FB'],
+  pin6: ['EN'],
+  pin7: ['NC'],
+  pin8: ['VCC'],
+} as const;
+
+export type Mp9486aProps = BasePartProps;
+
+export const Mp9486a = ({ name, pn, ...rest }: Mp9486aProps) => (
+  <chip
+    name={name}
+    footprint="soic8_ep"
+    pinLabels={MP9486A_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="MP9486A 100V/1A async buck" />
+  </chip>
+);
+
+const MB10S_PINS = {
+  pin1: ['AC1'],
+  pin2: ['NEG'],
+  pin3: ['AC2'],
+  pin4: ['POS'],
+} as const;
+
+export type Mb10sProps = BasePartProps;
+
+export const Mb10s = ({ name, pn, ...rest }: Mb10sProps) => (
+  <chip
+    name={name}
+    footprint="mbs_4lead"
+    pinLabels={MB10S_PINS}
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="MB10S — 1kV/1A bridge rectifier" />
+  </chip>
+);
+
+export type Smaj58aProps = BasePartProps;
+
+export const Smaj58a = ({ name, pn, ...rest }: Smaj58aProps) => (
+  <diode
+    name={name}
+    footprint="sma_do214ac"
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="SMAJ58A TVS 58V" />
+  </diode>
+);
+
+export type Ss34Props = BasePartProps;
+
+export const Ss34 = ({ name, pn, ...rest }: Ss34Props) => (
+  <diode
+    name={name}
+    footprint="sma_do214ac"
+    supplierPartNumbers={jlcSupplier(pn)}
+    {...rest}
+  >
+    <fabricationnotetext text="SS34 Schottky 40V/3A" />
+  </diode>
+);

--- a/libs/attractap-hw-shared/src/parts/poe.tsx
+++ b/libs/attractap-hw-shared/src/parts/poe.tsx
@@ -26,9 +26,26 @@ export type Ws3203Props = BasePartProps;
 export const Ws3203 = ({ name, pn, ...rest }: Ws3203Props) => (
   <chip
     name={name}
-    footprint="tssop14_p0.65mm"
     pinLabels={WS3203_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
+    footprint={
+      <footprint>
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.85} pcbY={1.95} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={-2.85} pcbY={1.30} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={-2.85} pcbY={0.65} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.85} pcbY={0.00} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin5']} shape="rect" pcbX={-2.85} pcbY={-0.65} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin6']} shape="rect" pcbX={-2.85} pcbY={-1.30} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin7']} shape="rect" pcbX={-2.85} pcbY={-1.95} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin8']} shape="rect" pcbX={2.85} pcbY={-1.95} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin9']} shape="rect" pcbX={2.85} pcbY={-1.30} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin10']} shape="rect" pcbX={2.85} pcbY={-0.65} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin11']} shape="rect" pcbX={2.85} pcbY={0.00} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin12']} shape="rect" pcbX={2.85} pcbY={0.65} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin13']} shape="rect" pcbX={2.85} pcbY={1.30} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin14']} shape="rect" pcbX={2.85} pcbY={1.95} width="1.40mm" height="0.40mm" layer="top" />
+      </footprint>
+    }
     {...rest}
   >
     <fabricationnotetext text="WS3203 — 802.3af PD interface (NJGW), TSSOP-14 0.65mm pitch. Unused pins (T2P/PG/GATE/OCS) NC per ref design." />
@@ -51,12 +68,24 @@ export type Mp9486aProps = BasePartProps;
 export const Mp9486a = ({ name, pn, ...rest }: Mp9486aProps) => (
   <chip
     name={name}
-    footprint="soic8_ep"
     pinLabels={MP9486A_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
+    footprint={
+      <footprint>
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.35} pcbY={1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={-2.35} pcbY={0.635} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={-2.35} pcbY={-0.635} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.35} pcbY={-1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin5']} shape="rect" pcbX={2.35} pcbY={-1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin6']} shape="rect" pcbX={2.35} pcbY={-0.635} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin7']} shape="rect" pcbX={2.35} pcbY={0.635} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin8']} shape="rect" pcbX={2.35} pcbY={1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin4', 'GND']} shape="rect" pcbX={0} pcbY={0} width="2.50mm" height="2.50mm" layer="top" />
+      </footprint>
+    }
     {...rest}
   >
-    <fabricationnotetext text="MP9486A 100V/1A async buck" />
+    <fabricationnotetext text="MP9486A 100V/1A async buck — SOIC-8-EP, exposed pad tied to pin4 (GND)." />
   </chip>
 );
 

--- a/libs/attractap-hw-shared/src/parts/poe.tsx
+++ b/libs/attractap-hw-shared/src/parts/poe.tsx
@@ -31,7 +31,7 @@ export const Ws3203 = ({ name, pn, ...rest }: Ws3203Props) => (
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="WS3203 — 802.3af PD interface (NJGW)" />
+    <fabricationnotetext text="WS3203 — 802.3af PD interface (NJGW). Unused pins (T2P/PG/GATE/OCS) NC per ref design." />
   </chip>
 );
 
@@ -77,7 +77,7 @@ export const Mb10s = ({ name, pn, ...rest }: Mb10sProps) => (
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="MB10S — 1kV/1A bridge rectifier (placeholder fp; JLC fetches real MBS)" />
+    <fabricationnotetext text="MB10S — 1kV/1A bridge rectifier. Parser fp 'dip4' is stub — JLC EasyEDA footprint (MBS) sourced via LCSC PN at fab." />
   </chip>
 );
 

--- a/libs/attractap-hw-shared/src/parts/poe.tsx
+++ b/libs/attractap-hw-shared/src/parts/poe.tsx
@@ -26,12 +26,12 @@ export type Ws3203Props = BasePartProps;
 export const Ws3203 = ({ name, pn, ...rest }: Ws3203Props) => (
   <chip
     name={name}
-    footprint="tssop14"
+    footprint="tssop14_p0.65mm"
     pinLabels={WS3203_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="WS3203 — 802.3af PD interface (NJGW). Unused pins (T2P/PG/GATE/OCS) NC per ref design." />
+    <fabricationnotetext text="WS3203 — 802.3af PD interface (NJGW), TSSOP-14 0.65mm pitch. Unused pins (T2P/PG/GATE/OCS) NC per ref design." />
   </chip>
 );
 
@@ -72,12 +72,19 @@ export type Mb10sProps = BasePartProps;
 export const Mb10s = ({ name, pn, ...rest }: Mb10sProps) => (
   <chip
     name={name}
-    footprint="dip4"
     pinLabels={MB10S_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
+    footprint={
+      <footprint>
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-3.10} pcbY={-1.20} width="2.0mm" height="1.1mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={-3.10} pcbY={1.20} width="2.0mm" height="1.1mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={3.10} pcbY={1.20} width="2.0mm" height="1.1mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={3.10} pcbY={-1.20} width="2.0mm" height="1.1mm" layer="top" />
+      </footprint>
+    }
     {...rest}
   >
-    <fabricationnotetext text="MB10S — 1kV/1A bridge rectifier. Parser fp 'dip4' is stub — JLC EasyEDA footprint (MBS) sourced via LCSC PN at fab." />
+    <fabricationnotetext text="MB10S — 1kV/1A bridge rectifier, MBS SMD package." />
   </chip>
 );
 

--- a/libs/attractap-hw-shared/src/parts/poe.tsx
+++ b/libs/attractap-hw-shared/src/parts/poe.tsx
@@ -30,20 +30,20 @@ export const Ws3203 = ({ name, pn, ...rest }: Ws3203Props) => (
     supplierPartNumbers={jlcSupplier(pn)}
     footprint={
       <footprint>
-        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.50} pcbY={1.95} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin2']} shape="rect" pcbX={-2.50} pcbY={1.30} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin3']} shape="rect" pcbX={-2.50} pcbY={0.65} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.50} pcbY={0.00} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin5']} shape="rect" pcbX={-2.50} pcbY={-0.65} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin6']} shape="rect" pcbX={-2.50} pcbY={-1.30} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin7']} shape="rect" pcbX={-2.50} pcbY={-1.95} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin8']} shape="rect" pcbX={2.50} pcbY={-1.95} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin9']} shape="rect" pcbX={2.50} pcbY={-1.30} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin10']} shape="rect" pcbX={2.50} pcbY={-0.65} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin11']} shape="rect" pcbX={2.50} pcbY={0.00} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin12']} shape="rect" pcbX={2.50} pcbY={0.65} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin13']} shape="rect" pcbX={2.50} pcbY={1.30} width="1.40mm" height="0.40mm" layer="top" />
-        <smtpad portHints={['pin14']} shape="rect" pcbX={2.50} pcbY={1.95} width="1.40mm" height="0.40mm" layer="top" />
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-1.95} pcbY={-2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={-1.30} pcbY={-2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={-0.65} pcbY={-2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={0.00} pcbY={-2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin5']} shape="rect" pcbX={0.65} pcbY={-2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin6']} shape="rect" pcbX={1.30} pcbY={-2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin7']} shape="rect" pcbX={1.95} pcbY={-2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin8']} shape="rect" pcbX={1.95} pcbY={2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin9']} shape="rect" pcbX={1.30} pcbY={2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin10']} shape="rect" pcbX={0.65} pcbY={2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin11']} shape="rect" pcbX={0.00} pcbY={2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin12']} shape="rect" pcbX={-0.65} pcbY={2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin13']} shape="rect" pcbX={-1.30} pcbY={2.50} width="0.40mm" height="1.40mm" layer="top" />
+        <smtpad portHints={['pin14']} shape="rect" pcbX={-1.95} pcbY={2.50} width="0.40mm" height="1.40mm" layer="top" />
       </footprint>
     }
     {...rest}
@@ -72,14 +72,14 @@ export const Mp9486a = ({ name, pn, ...rest }: Mp9486aProps) => (
     supplierPartNumbers={jlcSupplier(pn)}
     footprint={
       <footprint>
-        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.225} pcbY={1.905} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin2']} shape="rect" pcbX={-2.225} pcbY={0.635} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin3']} shape="rect" pcbX={-2.225} pcbY={-0.635} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin4']} shape="rect" pcbX={-2.225} pcbY={-1.905} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin5']} shape="rect" pcbX={2.225} pcbY={-1.905} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin6']} shape="rect" pcbX={2.225} pcbY={-0.635} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin7']} shape="rect" pcbX={2.225} pcbY={0.635} width="1.55mm" height="0.60mm" layer="top" />
-        <smtpad portHints={['pin8']} shape="rect" pcbX={2.225} pcbY={1.905} width="1.55mm" height="0.60mm" layer="top" />
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-1.905} pcbY={-2.225} width="0.60mm" height="1.55mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={-0.635} pcbY={-2.225} width="0.60mm" height="1.55mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={0.635} pcbY={-2.225} width="0.60mm" height="1.55mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={1.905} pcbY={-2.225} width="0.60mm" height="1.55mm" layer="top" />
+        <smtpad portHints={['pin5']} shape="rect" pcbX={1.905} pcbY={2.225} width="0.60mm" height="1.55mm" layer="top" />
+        <smtpad portHints={['pin6']} shape="rect" pcbX={0.635} pcbY={2.225} width="0.60mm" height="1.55mm" layer="top" />
+        <smtpad portHints={['pin7']} shape="rect" pcbX={-0.635} pcbY={2.225} width="0.60mm" height="1.55mm" layer="top" />
+        <smtpad portHints={['pin8']} shape="rect" pcbX={-1.905} pcbY={2.225} width="0.60mm" height="1.55mm" layer="top" />
         <smtpad portHints={['pin4', 'GND']} shape="rect" pcbX={0} pcbY={0} width="2.50mm" height="2.50mm" layer="top" />
       </footprint>
     }

--- a/libs/attractap-hw-shared/src/parts/poe.tsx
+++ b/libs/attractap-hw-shared/src/parts/poe.tsx
@@ -72,12 +72,12 @@ export type Mb10sProps = BasePartProps;
 export const Mb10s = ({ name, pn, ...rest }: Mb10sProps) => (
   <chip
     name={name}
-    footprint="mbs_4lead"
+    footprint="dip4"
     pinLabels={MB10S_PINS}
     supplierPartNumbers={jlcSupplier(pn)}
     {...rest}
   >
-    <fabricationnotetext text="MB10S — 1kV/1A bridge rectifier" />
+    <fabricationnotetext text="MB10S — 1kV/1A bridge rectifier (placeholder fp; JLC fetches real MBS)" />
   </chip>
 );
 

--- a/libs/attractap-hw-shared/src/parts/power.tsx
+++ b/libs/attractap-hw-shared/src/parts/power.tsx
@@ -10,10 +10,10 @@ export const Ams1117_3v3 = ({ name, pn, ...rest }: Ams1117Props) => (
     pinLabels={{ pin1: ['ADJ_GND'], pin2: ['VOUT'], pin3: ['VIN'], pin4: ['TAB'] }}
     footprint={
       <footprint>
-        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.30} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
-        <smtpad portHints={['pin2']} shape="rect" pcbX={0.00} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
-        <smtpad portHints={['pin3']} shape="rect" pcbX={2.30} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
-        <smtpad portHints={['pin4']} shape="rect" pcbX={0.00} pcbY={3.10} width="3.60mm" height="2.20mm" layer="top" />
+        <smtpad portHints={['pin1']} shape="rect" pcbX={3.10} pcbY={-2.30} width="2.00mm" height="1.00mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={3.10} pcbY={0.00} width="2.00mm" height="1.00mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={3.10} pcbY={2.30} width="2.00mm" height="1.00mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={-3.10} pcbY={0.00} width="2.20mm" height="3.60mm" layer="top" />
       </footprint>
     }
     {...rest}

--- a/libs/attractap-hw-shared/src/parts/power.tsx
+++ b/libs/attractap-hw-shared/src/parts/power.tsx
@@ -10,10 +10,10 @@ export const Ams1117_3v3 = ({ name, pn, ...rest }: Ams1117Props) => (
     pinLabels={{ pin1: ['ADJ_GND'], pin2: ['VOUT'], pin3: ['VIN'], pin4: ['TAB'] }}
     footprint={
       <footprint>
-        <smtpad portHints={['pin1']} shape="rect" pcbX={3.10} pcbY={-2.30} width="2.00mm" height="1.00mm" layer="top" />
-        <smtpad portHints={['pin2']} shape="rect" pcbX={3.10} pcbY={0.00} width="2.00mm" height="1.00mm" layer="top" />
-        <smtpad portHints={['pin3']} shape="rect" pcbX={3.10} pcbY={2.30} width="2.00mm" height="1.00mm" layer="top" />
-        <smtpad portHints={['pin4']} shape="rect" pcbX={-3.10} pcbY={0.00} width="2.20mm" height="3.60mm" layer="top" />
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.30} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={0.00} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={2.30} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={0.00} pcbY={3.10} width="3.60mm" height="2.20mm" layer="top" />
       </footprint>
     }
     {...rest}

--- a/libs/attractap-hw-shared/src/parts/power.tsx
+++ b/libs/attractap-hw-shared/src/parts/power.tsx
@@ -6,9 +6,16 @@ export type Ams1117Props = BasePartProps;
 export const Ams1117_3v3 = ({ name, pn, ...rest }: Ams1117Props) => (
   <chip
     name={name}
-    footprint="sot223"
     supplierPartNumbers={jlcSupplier(pn)}
     pinLabels={{ pin1: ['ADJ_GND'], pin2: ['VOUT'], pin3: ['VIN'], pin4: ['TAB'] }}
+    footprint={
+      <footprint>
+        <smtpad portHints={['pin1']} shape="rect" pcbX={-2.30} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
+        <smtpad portHints={['pin2']} shape="rect" pcbX={0.00} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
+        <smtpad portHints={['pin3']} shape="rect" pcbX={2.30} pcbY={-3.10} width="1.00mm" height="2.00mm" layer="top" />
+        <smtpad portHints={['pin4']} shape="rect" pcbX={0.00} pcbY={3.10} width="3.60mm" height="2.20mm" layer="top" />
+      </footprint>
+    }
     {...rest}
   />
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,6 +707,21 @@ importers:
         specifier: ^4.20.3
         version: 4.22.3
 
+  apps/attractap/hardware/poe:
+    dependencies:
+      '@attraccess/attractap-hw-shared':
+        specifier: workspace:*
+        version: link:../../../../libs/attractap-hw-shared
+      '@tscircuit/cli':
+        specifier: 0.1.1399
+        version: 0.1.1399(tscircuit@0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3))
+      tscircuit:
+        specifier: 0.0.1774
+        version: 0.0.1774(@gltf-transform/core@4.3.0)(@gltf-transform/extensions@4.3.0)(@gltf-transform/functions@4.3.0)(@tscircuit/schematic-corpus@0.0.114(typescript@6.0.3))(bun-match-svg@0.0.15(typescript@6.0.3))(esbuild-wasm@0.27.7)(looks-same@9.0.1)(three@0.179.1)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.20.3
+        version: 4.22.3
+
   libs/attractap-hw-shared:
     dependencies:
       tscircuit:


### PR DESCRIPTION
## Summary
- Implements ATT-351: 60×35 mm, 4-layer 802.3af PD board for Attractap V2.
- All-SMT JLC-assemblable BOM; no manual sourcing (single-supplier constraint from agent session).
- Topology: HanRun HY931147C PoE-magjack → 2× MB10S bridges → SMAJ58A TVS → WS3203 PD interface → MP9486AGN-Z 100V→5V buck → AMS1117-3.3 → LAN8720AI-CP-TR PHY → J_POE 2×8 1.27mm B2B to Core.
- Design rationale + component selection: `docs/research/2026-05-23-att-351-poe-deep-research.md`
- Implementation plan: `docs/research/2026-05-23-att-351-poe-board-impl-plan.md`

## Design decisions (vs ATT-351 ticket text)
- **Topology pivot**: ticket suggested Si3402-B + Coilcraft flyback. JLC has no usable flyback magnetics PN; user constraint is single-supplier JLC. Pivoted to non-isolated buck post-bridge. IEEE 802.3 1500V isolation is preserved by the LAN magnetics inside the PoE magjack (the spec-required barrier is cable-to-PD, which is intact).
- **PD IC**: WS3203 (NJGW, C5143001) instead of Si3402-B — 6× the JLC stock, drop-in for the TPS2375 family.
- **Magjack**: HY931147C (C91754) — the only HanRun part flagged "With PoE" in JLC's catalog at usable stock.
- **PHY**: LAN8720AI-CP-TR (C17146, industrial -40~+85 °C).
- **Buck**: MP9486AGN-Z (C404013, 100V/1A async).

## Acceptance checklist (per ATT-351)
- [x] `nx run attractap-hw-poe:lint` clean on JLC 4-layer ruleset
- [x] `nx run attractap-hw-poe:export` emits gerber ZIP with BOM + CPL (13 files, 45-row BOM with LCSC PNs)
- [x] `nx run attractap-hw-poe:render` emits PCB/schematic/assembly SVG+PNG (CI sticky comment will link)
- [ ] Peer review (extra scrutiny on isolation barrier — see §6.3 of design doc)
- [ ] Smoke test: PoE injector → board, +5V ≥ 1A continuous, no thermal runaway 24h (deferred to bench bring-up)
- [ ] PHY MDIO read via dev MCU, RJ45 link LED, Class 0 negotiate (deferred to bench bring-up)

## Known limitations (first PR — punted to follow-up)
- `routingDisabled` on the board: tscircuit's capacity-mesh autorouter ran out of iterations on this density. Manual routing or autorouter tuning is a follow-up task. The gerber output therefore has component pads but no routed traces — JLC fab can still produce the bare PCB and SMT-stuff the components, but trace routing needs to be added before electrical bring-up.
- Several 100 nF X7R 0402 caps share one LCSC PN (C307331). The BOM emits faithfully but bench bring-up should swap to per-value PNs as needed.
- HY931147C JLC EasyEDA symbol has a metadata bug (fontStyle parser warning at build); cosmetic, does not block fab.
- The standard tscircuit `<crystal>` element does not propagate `supplierPartNumbers` to the BOM CSV. Wrapper switched to `<chip>`-based to fix Y1 BOM entry.

## Test plan
- [x] tscircuit ERC/DRC clean (all 4 nx targets pass cold-cache)
- [x] Gerber ZIP contains JLC-format `bom.csv` + `pick_and_place.csv` (45 BOM rows, all with LCSC PNs)
- [x] vitest connector-schema tests pass (43 tests on shared lib)
- [x] Render PNGs uploaded to hardware-renders orphan branch by CI (will populate after this PR opens)
- [ ] (bench) PoE injector smoke test
- [ ] (bench) MDIO register read confirms PHY presence
- [ ] (bench) RJ45 link LED active when switch connected

## Files touched
- `libs/attractap-hw-shared/src/parts/passives.tsx` — `ElecCap_22uF_100V` wrapper
- `libs/attractap-hw-shared/src/parts/ethernet.tsx` — `Lan8720a`, `Hy931147c`, `Crystal25M_5032` wrappers
- `libs/attractap-hw-shared/src/parts/poe.tsx` — `Ws3203`, `Mp9486a`, `Mb10s`, `Smaj58a`, `Ss34` wrappers
- `libs/attractap-hw-shared/src/parts/index.tsx` — re-exports
- `libs/attractap-hw-shared/package.json` — version 0.0.1 → 0.1.0
- `apps/attractap/hardware/poe/` — new project (package.json, project.json, tsconfig.json, tscircuit.config.json, index.tsx)
- `docs/research/2026-05-23-att-351-poe-deep-research.md` — component-selection decision record
- `docs/research/2026-05-23-att-351-poe-board-impl-plan.md` — 7-task implementation plan

<!-- generated-by-cyrus -->

## Summary by Sourcery

Introduce a new 802.3af PoE PD hardware board project with shared PoE/Ethernet component wrappers and supporting research docs.

New Features:
- Add shared Ethernet wrappers for the LAN8720A PHY, HY931147C PoE magjack, and 25 MHz crystal to the hardware parts library.
- Add shared PoE power-path wrappers for WS3203 PD interface, MP9486A buck converter, bridge rectifier, TVS, and Schottky diodes.
- Create the attractap-hw-poe board implementation providing a PoE-powered 5 V rail and RMII Ethernet interface via the J_POE connector, with a fully defined tscircuit schematic/PCB.

Enhancements:
- Extend the shared passives library with a dedicated 22 µF 100 V electrolytic capacitor wrapper and re-export new Ethernet/PoE parts, bumping the shared lib version to 0.1.0.
- Configure a new Nx/tscircuit project with lint, build, export, and render targets for the PoE hardware board, including JLC 4-layer PCB settings.

Documentation:
- Add a detailed PoE PD board implementation plan describing tasks, topology, and workflow for the new project.
- Add a deep-research design record capturing component selection, topology decisions, and isolation strategy for the PoE PD module.

Tests:
- Ensure the new PoE board participates in existing Nx hardware workflows for linting, Gerber export, and rendering, though no new automated tests are added.