### PR TITLE
refactor(frontend): use StandardDrawer for NFC enroll + MQTT create (ATT-360)

### DIFF
--- a/apps/frontend/src/app/attractap/NfcCardList/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/index.tsx
@@ -4,6 +4,9 @@ import {
   AlertDescription,
   AlertTitle,
   Button,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
   Modal,
   ModalBackdrop,
   ModalBody,
@@ -20,6 +23,7 @@ import {
   TableRow,
   cn,
 } from '@heroui/react';
+import { StandardDrawer } from '../../../components/standardDrawer';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AttraccessUser, DateTimeDisplay, useTranslations } from '@attraccess/plugins-frontend-ui';
 import {
@@ -206,13 +210,16 @@ const EnrollNfcCardButton = () => {
 
   const { mutate: enrollNfcCardMutation } = useAttractapServiceEnrollNfcCard();
 
+  const close = useCallback(() => setShow(false), []);
+
   const enrollNfcCard = useCallback(() => {
     if (!readerId) {
       return;
     }
 
     enrollNfcCardMutation({ requestBody: { readerId } });
-  }, [readerId, enrollNfcCardMutation]);
+    close();
+  }, [readerId, enrollNfcCardMutation, close]);
 
   return (
     <>
@@ -220,50 +227,45 @@ const EnrollNfcCardButton = () => {
         <PlusIcon />
         {t('enroll')}
       </Button>
-      <Modal
+      <StandardDrawer
         isOpen={show}
         onOpenChange={(open) => {
-          if (!open) setShow(false);
+          if (!open) close();
         }}
-        data-cy="enroll-nfc-card-modal"
       >
-        <ModalBackdrop>
-          <ModalContainer size="md">
-            <ModalDialog>
-              {({ close }) => (
-                <>
-                  <ModalHeader>
-                    <h1>{t('enrollModal.title')}</h1>
-                  </ModalHeader>
-                  <ModalBody>
-                    <p>{t('enrollModal.description')}</p>
-                    <AttractapSelect
-                      label={t('enrollModal.readerLabel')}
-                      placeholder={t('enrollModal.readerPlaceholder')}
-                      selection={readerId}
-                      onSelectionChange={(readerId) => setReaderId(readerId ?? null)}
-                      data-cy="enroll-nfc-card-modal-reader-select"
-                      requiredCapabilities={{ cardEnrollment: true }}
-                    />
-                  </ModalBody>
-                  <ModalFooter>
-                    <Button onPress={close} data-cy="enroll-nfc-card-modal-cancel-button">
-                      {t('enrollModal.cancel')}
-                    </Button>
-                    <Button
-                      isDisabled={!readerId}
-                      onPress={enrollNfcCard}
-                      data-cy="enroll-nfc-card-modal-enroll-button"
-                    >
-                      {t('enrollModal.enroll')}
-                    </Button>
-                  </ModalFooter>
-                </>
-              )}
-            </ModalDialog>
-          </ModalContainer>
-        </ModalBackdrop>
-      </Modal>
+        <DrawerHeader>
+          <div className="flex w-full items-start justify-between gap-3">
+            <h2 className="text-lg font-semibold">{t('enrollModal.title')}</h2>
+            <Button isIconOnly variant="ghost" aria-label={t('enrollModal.cancel')} onPress={close}>
+              <XIcon size={16} />
+            </Button>
+          </div>
+        </DrawerHeader>
+        <DrawerBody>
+          <p>{t('enrollModal.description')}</p>
+          <AttractapSelect
+            label={t('enrollModal.readerLabel')}
+            placeholder={t('enrollModal.readerPlaceholder')}
+            selection={readerId}
+            onSelectionChange={(readerId) => setReaderId(readerId ?? null)}
+            data-cy="enroll-nfc-card-modal-reader-select"
+            requiredCapabilities={{ cardEnrollment: true }}
+          />
+        </DrawerBody>
+        <DrawerFooter>
+          <Button variant="secondary" onPress={close} data-cy="enroll-nfc-card-modal-cancel-button">
+            {t('enrollModal.cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            isDisabled={!readerId}
+            onPress={enrollNfcCard}
+            data-cy="enroll-nfc-card-modal-enroll-button"
+          >
+            {t('enrollModal.enroll')}
+          </Button>
+        </DrawerFooter>
+      </StandardDrawer>
     </>
   );
 };

--- a/apps/frontend/src/app/mqtt/MqttServersPage.tsx
+++ b/apps/frontend/src/app/mqtt/MqttServersPage.tsx
@@ -1,43 +1,64 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button } from '@heroui/react';
-import { Navigate, useNavigate } from 'react-router-dom';
-import { Plus } from 'lucide-react';
+import { Button, DrawerBody, DrawerHeader } from '@heroui/react';
+import { Navigate } from 'react-router-dom';
+import { Plus, X } from 'lucide-react';
+import { useCallback, useState } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import en from './translations/en.json';
 import de from './translations/de.json';
 import { MqttServerList } from './servers/MqttServerList';
+import { CreateMqttServerForm } from './servers/CreateMqttServerPage';
 import { PageHeader } from '../../components/pageHeader';
+import { StandardDrawer } from '../../components/standardDrawer';
 
 export function MqttServersPage() {
   const { hasPermission } = useAuth();
-  const navigate = useNavigate();
   const { t } = useTranslations({ en, de });
+
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
 
   const canManageMqtt = hasPermission('canManageResources');
 
-  // Redirect if user doesn't have permission
+  const close = useCallback(() => setIsCreateOpen(false), []);
+
   if (!canManageMqtt) {
     return <Navigate to="/" />;
   }
-
-  const handleAddNewServer = () => {
-    navigate('/mqtt/servers/create');
-  };
 
   return (
     <div>
       <PageHeader
         title={t('title')}
         actions={
-          <Button variant="ghost"
-            onPress={handleAddNewServer}
+          <Button
+            variant="ghost"
+            onPress={() => setIsCreateOpen(true)}
             data-cy="mqtt-servers-page-add-new-server-button"
-          ><Plus size={16} />
+          >
+            <Plus size={16} />
             {t('addNewServer')}
           </Button>
         }
       />
       <MqttServerList />
+      <StandardDrawer
+        isOpen={isCreateOpen}
+        onOpenChange={(open) => {
+          if (!open) close();
+        }}
+      >
+        <DrawerHeader>
+          <div className="flex w-full items-start justify-between gap-3">
+            <h2 className="text-lg font-semibold">{t('addNewMqttServer')}</h2>
+            <Button isIconOnly variant="ghost" aria-label={t('close')} onPress={close}>
+              <X size={16} />
+            </Button>
+          </div>
+        </DrawerHeader>
+        <DrawerBody>
+          <CreateMqttServerForm onSuccess={close} onCancel={close} />
+        </DrawerBody>
+      </StandardDrawer>
     </div>
   );
 }

--- a/apps/frontend/src/app/mqtt/index.ts
+++ b/apps/frontend/src/app/mqtt/index.ts
@@ -1,3 +1,2 @@
 export { MqttServersPage } from './MqttServersPage';
-export { CreateMqttServerPage } from './servers/CreateMqttServerPage';
 export { EditMqttServerPage } from './servers/EditMqttServerPage';

--- a/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/CreateMqttServerPage.tsx
@@ -2,13 +2,11 @@ import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { Button, Checkbox, Form, Input, Label, TextField } from "@heroui/react";
 import { Select } from '../../../components/select';
 import { LabeledSwitch } from '../../../components/labeledSwitch';
-import { PageHeader } from '../../../components/pageHeader';
 import { PasswordInput } from '../../../components/PasswordInput';
-import { useNavigate } from 'react-router-dom';
 import { useToastMessage } from '../../../components/toastProvider';
 import en from './translations/create/en.json';
 import de from './translations/create/de.json';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import {
   useMqttServiceMqttServersCreateOne,
   CreateMqttServerDto,
@@ -17,15 +15,14 @@ import {
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
 
-interface CreateMqttServerPageProps {
+interface CreateMqttServerFormProps {
   onSuccess?: (createdServer: MqttServer) => void;
   onCancel?: () => void;
 }
 
-export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>) {
-  const { onSuccess } = props || {};
+export function CreateMqttServerForm(props?: Readonly<CreateMqttServerFormProps>) {
+  const { onSuccess, onCancel } = props || {};
   const { t } = useTranslations({ en, de });
-  const navigate = useNavigate();
   const toast = useToastMessage();
   const queryClient = useQueryClient();
 
@@ -51,11 +48,7 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
       queryClient.invalidateQueries({
         queryKey: [useMqttServiceMqttServersGetAllKey],
       });
-      if (onSuccess) {
-        onSuccess(server);
-      } else {
-        navigate('/mqtt/servers');
-      }
+      onSuccess?.(server);
     },
     onError: (err: Error) => {
       toast.error({
@@ -64,14 +57,6 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
       });
     },
   });
-
-  const handleCancel = useCallback(() => {
-    if (props?.onCancel) {
-      props.onCancel();
-    } else {
-      navigate('/mqtt/servers');
-    }
-  }, [props, navigate]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -226,7 +211,7 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
       </section>
 
       <div className="flex justify-end space-x-3 mt-4 w-full">
-        <Button variant="secondary" onPress={handleCancel} data-cy="create-mqtt-server-form-cancel-button">
+        <Button variant="secondary" onPress={onCancel} data-cy="create-mqtt-server-form-cancel-button">
           {t('cancel')}
         </Button>
         <Button variant="primary"
@@ -238,26 +223,5 @@ export function CreateMqttServerForm(props?: Readonly<CreateMqttServerPageProps>
         </Button>
       </div>
     </Form>
-  );
-}
-
-export function CreateMqttServerPage(props?: Readonly<CreateMqttServerPageProps>) {
-  const navigate = useNavigate();
-
-  const { t } = useTranslations({ en, de });
-
-  const handleCancel = useCallback(() => {
-    if (props?.onCancel) {
-      props.onCancel();
-    } else {
-      navigate('/mqtt/servers');
-    }
-  }, [props, navigate]);
-
-  return (
-    <div className="max-w-7xl mx-auto px-4 py-8" data-cy="create-mqtt-server-page">
-      <PageHeader title={t('addNewMqttServer')} onBack={handleCancel} />
-      <CreateMqttServerForm {...props} onCancel={handleCancel} />
-    </div>
   );
 }

--- a/apps/frontend/src/app/mqtt/translations/de.json
+++ b/apps/frontend/src/app/mqtt/translations/de.json
@@ -1,5 +1,7 @@
 {
   "title": "MQTT Server",
   "addNewServer": "Neuen Server hinzufügen",
+  "addNewMqttServer": "Neuen MQTT Server hinzufügen",
+  "close": "Schließen",
   "back": "Zurück"
-} 
+}

--- a/apps/frontend/src/app/mqtt/translations/en.json
+++ b/apps/frontend/src/app/mqtt/translations/en.json
@@ -1,5 +1,7 @@
 {
   "title": "MQTT Servers",
   "addNewServer": "Add New Server",
+  "addNewMqttServer": "Add New MQTT Server",
+  "close": "Close",
   "back": "Back"
-} 
+}

--- a/apps/frontend/src/app/routes/index.tsx
+++ b/apps/frontend/src/app/routes/index.tsx
@@ -2,7 +2,7 @@ import { Navigate } from 'react-router-dom';
 import { ResourceDetails } from '../resources/details/resourceDetails';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { Spinner } from '@heroui/react';
-import { MqttServersPage, CreateMqttServerPage, EditMqttServerPage } from '../mqtt';
+import { MqttServersPage, EditMqttServerPage } from '../mqtt';
 import { SSOProvidersPage } from '../sso/SSOProvidersPage';
 import { UserManagementPage } from '../user-management';
 import { usePluginStore } from 'react-pluggable';
@@ -116,11 +116,6 @@ const coreRoutes: RouteConfig[] = [
   {
     path: '/mqtt/servers',
     element: <MqttServersPage />,
-    authRequired: 'canManageResources',
-  },
-  {
-    path: '/mqtt/servers/create',
-    element: <CreateMqttServerPage />,
     authRequired: 'canManageResources',
   },
   {


### PR DESCRIPTION
## Summary
- Converts the NFC card **Enroll** dialog (`apps/frontend/src/app/attractap/NfcCardList/index.tsx`) from a HeroUI `Modal` to the shared `StandardDrawer` pattern (DrawerHeader / DrawerBody / DrawerFooter), matching usage-notes and grant-person.
- Converts the **MQTT → Add New Server** flow from a dedicated routed page (`/mqtt/servers/create`) to a `StandardDrawer` opened in place from `MqttServersPage`.
- Drops the `/mqtt/servers/create` route, the `CreateMqttServerPage` wrapper, and its index export.
- `CreateMqttServerForm` is kept (still consumed by the flow editor's MQTT-server property input). Cancel/success are now caller-provided callbacks — no implicit `navigate('/mqtt/servers')` fallback.
- Adds `addNewMqttServer` + `close` i18n keys to the mqtt namespace (EN + DE).

Covers two of the four sub-items in ATT-360. The other two (People & Permissions add-person dialogs and Resource detail usage-notes) already shipped under ATT-370 and ATT-367.

## Test plan
- [x] `pnpm nx run frontend:typecheck` — green
- [x] `pnpm nx run frontend:lint --max-warnings=0` — only a pre-existing warning in `property-input/index.tsx:59` (unrelated to this PR; present on the base branch as well)
- [x] `pnpm nx run frontend:test` — 11 files / 76 tests pass
- [x] Manual: open Drawer from MQTT Servers → URL stays on `/mqtt/servers`, drawer renders header + form sections + Cancel / Create Server, close (X) and Cancel dismiss
- [x] Manual: open Drawer from NFC Cards → Enroll → renders header + reader select + Cancel / Enroll, close dismisses

### Screenshots
**MQTT → Add New Server drawer (opens in place on `/mqtt/servers`):**
![MQTT create drawer](https://uploads.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/1986ecf0-c059-4523-ba74-4e1e0fa2086f/65538cc1-3396-4a5a-a7a0-cd1f85b97851)

**NFC Cards → Enroll drawer:**
![NFC enroll drawer](https://uploads.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/66def623-1364-4917-a9e4-840aad3a57ba/26ad86e7-a33a-4b8c-b458-32746dba6cb4)

Closes ATT-360.

<!-- generated-by-cyrus -->