### PR TITLE
refactor(frontend): unwrap Card from account, resource detail, settings (ATT-359)

### DIFF
--- a/apps/frontend/src/app/account/index.tsx
+++ b/apps/frontend/src/app/account/index.tsx
@@ -1,5 +1,5 @@
 import { PageHeader } from '../../components/pageHeader';
-import { Button, Card, DrawerBody, DrawerFooter, DrawerHeader, useOverlayState } from '@heroui/react';
+import { Button, DrawerBody, DrawerFooter, DrawerHeader, useOverlayState } from '@heroui/react';
 import { StandardDrawer } from '../../components/standardDrawer';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
@@ -46,38 +46,40 @@ export default function AccountPage() {
     <div>
       <PageHeader title={t('title')} backTo="/" />
 
-      <div className="flex flex-row flex-wrap gap-4">
-        <Card className="max-w-md">
-          <Card.Header>
-            <PageHeader title={t('sections.profile')} noMargin />
-          </Card.Header>
-          <Card.Content className="flex flex-col gap-6">
-            <EmailForm />
-            <UsernameForm />
-          </Card.Content>
-        </Card>
+      <div className="flex flex-col gap-8">
+        <section className="w-full max-w-md flex flex-col gap-6">
+          <header className="border-b border-divider pb-2">
+            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+              {t('sections.profile')}
+            </h3>
+          </header>
+          <EmailForm />
+          <UsernameForm />
+        </section>
 
-        <Card className="max-w-md">
-          <Card.Header>
-            <PageHeader title={t('sections.security')} noMargin />
-          </Card.Header>
-          <Card.Content className="flex flex-col gap-6">
-            {me && <SetPasswordForm userId={me.id} username={me.username} />}
-            {me && <TwoFactorCard />}
-          </Card.Content>
-        </Card>
+        <section className="w-full max-w-md flex flex-col gap-6">
+          <header className="border-b border-divider pb-2">
+            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+              {t('sections.security')}
+            </h3>
+          </header>
+          {me && <SetPasswordForm userId={me.id} username={me.username} />}
+          {me && <TwoFactorCard />}
+        </section>
 
-        <Card className="max-w-md">
-          <Card.Header>
-            <PageHeader title={t('sections.dangerZone')} noMargin />
-          </Card.Header>
-          <Card.Content className="flex flex-col gap-4">
-            <p className="text-sm text-default-500">{t('deleteAccount.description')}</p>
+        <section className="w-full max-w-md flex flex-col gap-4">
+          <header className="border-b border-divider pb-2">
+            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+              {t('sections.dangerZone')}
+            </h3>
+          </header>
+          <p className="text-sm text-default-500">{t('deleteAccount.description')}</p>
+          <div>
             <Button variant="danger-soft" onPress={open} data-cy="delete-account-open-modal">
               {t('deleteAccount.actions.request')}
             </Button>
-          </Card.Content>
-        </Card>
+          </div>
+        </section>
       </div>
 
       <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>

--- a/apps/frontend/src/app/account/index.tsx
+++ b/apps/frontend/src/app/account/index.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from '../../components/pageHeader';
 import { Button, DrawerBody, DrawerFooter, DrawerHeader, useOverlayState } from '@heroui/react';
+import { AlertTriangleIcon, ShieldIcon, UserIcon } from 'lucide-react';
 import { StandardDrawer } from '../../components/standardDrawer';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
@@ -11,6 +12,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { TwoFactorCard } from './two-factor';
 import { useUsersServiceRequestDeleteAccount, ApiError } from '@attraccess/react-query-client';
 import { useToastMessage } from '../../components/toastProvider';
+import { FlatSection } from '../resources/details/flatSection';
 import API_ERROR_TRANSLATIONS_EN from '../../global-translations/api-errors.en.json';
 import API_ERROR_TRANSLATIONS_DE from '../../global-translations/api-errors.de.json';
 
@@ -46,40 +48,31 @@ export default function AccountPage() {
     <div>
       <PageHeader title={t('title')} backTo="/" />
 
-      <div className="flex flex-col gap-8">
-        <section className="w-full max-w-md flex flex-col gap-6">
-          <header className="border-b border-divider pb-2">
-            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-              {t('sections.profile')}
-            </h3>
-          </header>
-          <EmailForm />
-          <UsernameForm />
-        </section>
-
-        <section className="w-full max-w-md flex flex-col gap-6">
-          <header className="border-b border-divider pb-2">
-            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-              {t('sections.security')}
-            </h3>
-          </header>
-          {me && <SetPasswordForm userId={me.id} username={me.username} />}
-          {me && <TwoFactorCard />}
-        </section>
-
-        <section className="w-full max-w-md flex flex-col gap-4">
-          <header className="border-b border-divider pb-2">
-            <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-              {t('sections.dangerZone')}
-            </h3>
-          </header>
-          <p className="text-sm text-default-500">{t('deleteAccount.description')}</p>
-          <div>
-            <Button variant="danger-soft" onPress={open} data-cy="delete-account-open-modal">
-              {t('deleteAccount.actions.request')}
-            </Button>
+      <div className="w-full max-w-2xl flex flex-col gap-8">
+        <FlatSection icon={<UserIcon size={16} />} title={t('sections.profile')}>
+          <div className="flex flex-col gap-6">
+            <EmailForm />
+            <UsernameForm />
           </div>
-        </section>
+        </FlatSection>
+
+        <FlatSection icon={<ShieldIcon size={16} />} title={t('sections.security')}>
+          <div className="flex flex-col gap-6">
+            {me && <SetPasswordForm userId={me.id} username={me.username} />}
+            {me && <TwoFactorCard />}
+          </div>
+        </FlatSection>
+
+        <FlatSection icon={<AlertTriangleIcon size={16} className="text-danger" />} title={t('sections.dangerZone')}>
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-default-500">{t('deleteAccount.description')}</p>
+            <div>
+              <Button variant="danger" onPress={open} data-cy="delete-account-open-modal">
+                {t('deleteAccount.actions.request')}
+              </Button>
+            </div>
+          </div>
+        </FlatSection>
       </div>
 
       <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>

--- a/apps/frontend/src/app/account/index.tsx
+++ b/apps/frontend/src/app/account/index.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { TwoFactorCard } from './two-factor';
 import { useUsersServiceRequestDeleteAccount, ApiError } from '@attraccess/react-query-client';
 import { useToastMessage } from '../../components/toastProvider';
-import { FlatSection } from '../resources/details/flatSection';
+import { FlatSection } from '../../components/flatSection';
 import API_ERROR_TRANSLATIONS_EN from '../../global-translations/api-errors.en.json';
 import API_ERROR_TRANSLATIONS_DE from '../../global-translations/api-errors.de.json';
 

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -14,7 +14,7 @@ import { MarkDoneModal } from './mark-done';
 import { CheckCircleIcon, CogIcon, ConstructionIcon, ExternalLinkIcon, PlusIcon } from 'lucide-react';
 import { useNow } from '../../../../hooks/useNow';
 import { EmptyState } from '../../../../components/emptyState';
-import { FlatSection } from '../flatSection';
+import { FlatSection } from '../../../../components/flatSection';
 
 interface Props extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
   resourceId: number;

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -100,7 +100,13 @@ export function MaintenanceManagement(props: Props) {
       </LabeledSwitch>
       <ResourceMaintenanceUpsertModal resourceId={resourceId}>
         {(open) => (
-          <Button variant="primary" size="sm" isIconOnly onPress={open} aria-label={t('actions.create.label')}>
+          <Button
+            variant="primary"
+            size="sm"
+            isIconOnly
+            onPress={open}
+            aria-label={t('actions.create.label')}
+          >
             <PlusIcon className="w-4 h-4" />
           </Button>
         )}

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/de.json
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/de.json
@@ -22,5 +22,8 @@
   },
   "exampleResultingBalance": {
     "label": "Resultierendes Guthaben"
+  },
+  "actions": {
+    "edit": "Abrechnung bearbeiten"
   }
 }

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/en.json
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/en.json
@@ -22,5 +22,8 @@
   },
   "exampleResultingBalance": {
     "label": "Resulting balance"
+  },
+  "actions": {
+    "edit": "Edit billing"
   }
 }

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -187,8 +187,14 @@ export function ResourceBillingInfo(props: Props) {
             minutes: exampleMinutes,
           })}
         </dd>
-        <dt>{t('exampleResultingBalance.label')}</dt>
-        <dd className={cn(valueClass, exampleResultingBalance < 0 ? 'text-danger' : 'text-success')}>
+        <dt className="font-medium">{t('exampleResultingBalance.label')}</dt>
+        <dd
+          className={cn(
+            valueClass,
+            'font-semibold text-base',
+            exampleResultingBalance < 0 ? 'text-danger' : 'text-success',
+          )}
+        >
           {t('billingValue', {
             credits: formatNumber(exampleResultingBalance),
             currency: configuration.currency,
@@ -201,7 +207,14 @@ export function ResourceBillingInfo(props: Props) {
   const editorAction = (
     <ResourceBillingInfoEditor resourceId={resourceId}>
       {(onOpen) => (
-        <Button variant="primary" isIconOnly onPress={onOpen}><Edit2Icon size={12} /></Button>
+        <Button
+          variant="primary"
+          isIconOnly
+          onPress={onOpen}
+          aria-label={t('actions.edit')}
+        >
+          <Edit2Icon size={12} />
+        </Button>
       )}
     </ResourceBillingInfoEditor>
   );

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -15,7 +15,7 @@ import { ResourceBillingInfoEditor } from './editor';
 import { Fragment, HTMLAttributes, useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../../../../hooks/useAuth';
 import { dbCurrencyToUserCurrency } from '@attraccess/shared';
-import { FlatSection } from '../flatSection';
+import { FlatSection } from '../../../../components/flatSection';
 
 interface Props extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
   resourceId: number;

--- a/apps/frontend/src/app/resources/details/resourceDetails.de.json
+++ b/apps/frontend/src/app/resources/details/resourceDetails.de.json
@@ -14,6 +14,7 @@
     "edit": "Bearbeiten",
     "delete": "Löschen",
     "documentation": "Dokumentation",
-    "maintenance": "Wartung"
+    "maintenance": "Wartung",
+    "more": "Weitere Aktionen"
   }
 }

--- a/apps/frontend/src/app/resources/details/resourceDetails.en.json
+++ b/apps/frontend/src/app/resources/details/resourceDetails.en.json
@@ -14,6 +14,7 @@
     "edit": "Edit",
     "delete": "Delete",
     "documentation": "Documentation",
-    "maintenance": "Maintenance"
+    "maintenance": "Maintenance",
+    "more": "More actions"
   }
 }

--- a/apps/frontend/src/app/resources/details/resourceDetails.tsx
+++ b/apps/frontend/src/app/resources/details/resourceDetails.tsx
@@ -200,7 +200,6 @@ function ResourceDetailsComponent() {
             resource={resource}
             data-cy="resource-usage-session"
             insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
-            className="border-l-4 border-l-primary shadow-medium"
           />
 
           <ResourceUsageHistory resourceId={resourceId} data-cy="resource-usage-history" />

--- a/apps/frontend/src/app/resources/details/resourceDetails.tsx
+++ b/apps/frontend/src/app/resources/details/resourceDetails.tsx
@@ -1,8 +1,27 @@
 import { useParams, useNavigate } from 'react-router-dom';
-import { Button, Spinner, useOverlayState } from '@heroui/react';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownPopover,
+  DropdownTrigger,
+  Spinner,
+  useOverlayState,
+} from '@heroui/react';
 import { useAuth } from '../../../hooks/useAuth';
 import { useToastMessage } from '../../../components/toastProvider';
-import { ArrowLeft, BookOpen, ListChecks, PenSquareIcon, ShapesIcon, Trash, WorkflowIcon, WrenchIcon } from 'lucide-react';
+import {
+  ArrowLeft,
+  BookOpen,
+  ListChecks,
+  MoreVerticalIcon,
+  PenSquareIcon,
+  ShapesIcon,
+  Trash,
+  WorkflowIcon,
+  WrenchIcon,
+} from 'lucide-react';
 
 import { ResourceUsageSession } from '../usage/resourceUsageSession';
 import { ResourceUsageHistory } from '../usage/resourceUsageHistory';
@@ -130,10 +149,8 @@ function ResourceDetailsComponent() {
           <>
             <DocumentationModal resourceId={resourceId}>
               {(onOpenDocumentation) => (
-                <Button variant="ghost"
-                  onPress={onOpenDocumentation}
-                  data-cy="documentation-button"
-                ><BookOpen className="w-4 h-4" />
+                <Button variant="outline" size="sm" onPress={onOpenDocumentation} data-cy="documentation-button">
+                  <BookOpen className="w-4 h-4" />
                   {t('actions.documentation')}
                 </Button>
               )}
@@ -141,48 +158,70 @@ function ResourceDetailsComponent() {
 
             {canManageResources && (
               <>
-                <ResourceQrCode resourceId={resourceId} variant="ghost" buttonIconSize={16} />
+                <ResourceQrCode resourceId={resourceId} variant="outline" buttonIconSize={16} />
 
-                <Button variant="ghost"
+                <Button
+                  variant="outline"
+                  size="sm"
                   onPress={() => navigate(`/resources/${resourceId}/flows`)}
                   data-cy="flows-button"
-                ><WorkflowIcon className="w-4 h-4" />
+                >
+                  <WorkflowIcon className="w-4 h-4" />
                   {t('navItems.flows')}
                 </Button>
 
-                <Button variant="ghost"
+                <Button
+                  variant="outline"
+                  size="sm"
                   onPress={() => navigate(`/resources/${resourceId}/forms`)}
                   data-cy="forms-button"
-                ><ListChecks className="w-4 h-4" />
+                >
+                  <ListChecks className="w-4 h-4" />
                   {t('navItems.forms')}
                 </Button>
 
                 {maintenancePermissions?.canManage && (
-                  <Button variant="ghost"
+                  <Button
+                    variant="outline"
+                    size="sm"
                     onPress={() => navigate(`/resources/${resourceId}/maintenance`)}
                     data-cy="maintenance-button"
-                  ><WrenchIcon className="w-4 h-4" />
+                  >
+                    <WrenchIcon className="w-4 h-4" />
                     {t('actions.maintenance')}
                   </Button>
                 )}
 
                 <ResourceEditModal resourceId={resourceId} closeOnSuccess>
                   {(onOpen) => (
-                    <Button variant="ghost"
-                      onPress={onOpen}
-                      data-cy="edit-resource-button"
-                    ><PenSquareIcon className="w-4 h-4" />
+                    <Button variant="outline" size="sm" onPress={onOpen} data-cy="edit-resource-button">
+                      <PenSquareIcon className="w-4 h-4" />
                       {t('actions.edit')}
                     </Button>
                   )}
                 </ResourceEditModal>
 
-                <Button variant="danger-soft"
-                  onPress={open}
-                  data-cy="delete-resource-button"
-                ><Trash className="w-4 h-4" />
-                  {t('actions.delete')}
-                </Button>
+                <Dropdown>
+                  <DropdownTrigger aria-label={t('actions.more')}>
+                    <Button variant="outline" size="sm" isIconOnly aria-label={t('actions.more')}>
+                      <MoreVerticalIcon className="w-4 h-4" />
+                    </Button>
+                  </DropdownTrigger>
+                  <DropdownPopover>
+                    <DropdownMenu aria-label={t('actions.more')}>
+                      <DropdownItem
+                        key="delete"
+                        id="delete"
+                        onPress={open}
+                        data-cy="delete-resource-button"
+                        className="text-danger"
+                      >
+                        <Trash className="w-4 h-4 inline mr-2" />
+                        {t('actions.delete')}
+                      </DropdownItem>
+                    </DropdownMenu>
+                  </DropdownPopover>
+                </Dropdown>
               </>
             )}
           </>

--- a/apps/frontend/src/app/resources/groups/index.tsx
+++ b/apps/frontend/src/app/resources/groups/index.tsx
@@ -16,7 +16,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import en from './en.json';
 import de from './de.json';
 import { ResourceGroupUpsertModal } from '../../resource-groups/upsertModal/resourceGroupUpsertModal';
-import { FlatSection } from '../details/flatSection';
+import { FlatSection } from '../../../components/flatSection';
 
 type ManageResourceGroupsProps = Omit<HTMLAttributes<HTMLElement>, 'children'> & {
   resourceId: number;

--- a/apps/frontend/src/app/resources/groups/index.tsx
+++ b/apps/frontend/src/app/resources/groups/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { HTMLAttributes, useCallback, useMemo, useState } from 'react';
 import {
   ResourceGroup,
   useResourcesServiceGetAllResourcesKey,
@@ -8,24 +8,24 @@ import {
   useResourcesServiceResourceGroupsGetMany,
   useResourcesServiceResourceGroupsRemoveResource,
 } from '@attraccess/react-query-client';
-import { Button, Card, CardProps, Checkbox, Link, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import { Button, Checkbox, Link, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
 import { EmptyState } from '../../../components/emptyState';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { GroupIcon, PlusIcon } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { PageHeader } from '../../../components/pageHeader';
 import en from './en.json';
 import de from './de.json';
 import { ResourceGroupUpsertModal } from '../../resource-groups/upsertModal/resourceGroupUpsertModal';
+import { FlatSection } from '../details/flatSection';
 
-interface ManageResourceGroupsProps {
+type ManageResourceGroupsProps = Omit<HTMLAttributes<HTMLElement>, 'children'> & {
   resourceId: number;
-}
+};
 
 export function ManageResourceGroups({
   resourceId,
-  ...cardProps
-}: Readonly<ManageResourceGroupsProps & Omit<CardProps, 'children'>>) {
+  ...rest
+}: Readonly<ManageResourceGroupsProps>) {
   const { t } = useTranslations({ de, en });
   const queryClient = useQueryClient();
 
@@ -107,44 +107,35 @@ export function ManageResourceGroups({
     [handleGroupClick],
   );
 
+  const actions = (
+    <ResourceGroupUpsertModal onUpserted={onGroupCreated}>
+      {(onOpen: () => void) => (
+        <Button
+          variant="secondary"
+          size="sm"
+          onPress={onOpen}
+          data-cy="toolbar-open-create-resource-group-modal-button"
+        >
+          <PlusIcon size={16} />
+          {t('addGroup')}
+        </Button>
+      )}
+    </ResourceGroupUpsertModal>
+  );
+
   return (
-    <Card {...cardProps}>
-      <Card.Header>
-        <PageHeader
-          title={t('title')}
-          subtitle={t('subtitle')}
-          icon={<GroupIcon />}
-          noMargin
-          actions={
-            <ResourceGroupUpsertModal onUpserted={onGroupCreated}>
-              {(onOpen: () => void) => (
-                <Button variant="secondary"
-
-                  onPress={onOpen}
-
-                  data-cy="toolbar-open-create-resource-group-modal-button"
-                ><PlusIcon size={18} />
-                  {t('addGroup')}
-                </Button>
-              )}
-            </ResourceGroupUpsertModal>
-          }
-        />
-      </Card.Header>
-      <Card.Content>
-        <Table>
-          <TableContent aria-label={t('table.ariaLabel')}>
+    <FlatSection icon={<GroupIcon className="w-4 h-4" />} title={t('title')} actions={actions} {...rest}>
+      <Table>
+        <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
             <TableColumn isRowHeader>{t('columns.group')}</TableColumn>
             <TableColumn>{t('columns.actions')}</TableColumn>
           </TableHeader>
-          <TableBody
-            items={currentPage}
-            renderEmptyState={() => <EmptyState />}
-          >
+          <TableBody items={currentPage} renderEmptyState={() => <EmptyState />}>
             {(group) => (
               <TableRow
-                key={group.id} id={group.id}
+                key={group.id}
+                id={group.id}
                 className={isAdded(group) ? 'border-l-8 border-l-success' : 'border-l-8 border-l-danger'}
               >
                 <TableCell className="w-full">{group.name}</TableCell>
@@ -156,16 +147,13 @@ export function ManageResourceGroups({
                     aria-label={group.name}
                     isSelected={isAdded(group)}
                   />
-                  <Link href={`/resource-groups/${group.id}`}>
-                    {t('actions.openGroup')}
-                  </Link>
+                  <Link href={`/resource-groups/${group.id}`}>{t('actions.openGroup')}</Link>
                 </TableCell>
               </TableRow>
             )}
           </TableBody>
-          </TableContent>
-        </Table>
-      </Card.Content>
-    </Card>
+        </TableContent>
+      </Table>
+    </FlatSection>
   );
 }

--- a/apps/frontend/src/app/resources/groups/index.tsx
+++ b/apps/frontend/src/app/resources/groups/index.tsx
@@ -111,7 +111,7 @@ export function ManageResourceGroups({
     <ResourceGroupUpsertModal onUpserted={onGroupCreated}>
       {(onOpen: () => void) => (
         <Button
-          variant="secondary"
+          variant="primary"
           size="sm"
           onPress={onOpen}
           data-cy="toolbar-open-create-resource-group-modal-button"
@@ -125,35 +125,39 @@ export function ManageResourceGroups({
 
   return (
     <FlatSection icon={<GroupIcon className="w-4 h-4" />} title={t('title')} actions={actions} {...rest}>
-      <Table>
-        <TableContent aria-label={t('table.ariaLabel')}>
-          <TableHeader>
-            <TableColumn isRowHeader>{t('columns.group')}</TableColumn>
-            <TableColumn>{t('columns.actions')}</TableColumn>
-          </TableHeader>
-          <TableBody items={currentPage} renderEmptyState={() => <EmptyState />}>
-            {(group) => (
-              <TableRow
-                key={group.id}
-                id={group.id}
-                className={isAdded(group) ? 'border-l-8 border-l-success' : 'border-l-8 border-l-danger'}
-              >
-                <TableCell className="w-full">{group.name}</TableCell>
-                <TableCell className="text-right flex items-center gap-2">
-                  <Checkbox
-                    onChange={() => {
-                      handleGroupClick(group);
-                    }}
-                    aria-label={group.name}
-                    isSelected={isAdded(group)}
-                  />
-                  <Link href={`/resource-groups/${group.id}`}>{t('actions.openGroup')}</Link>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </TableContent>
-      </Table>
+      {currentPage.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <Table>
+          <TableContent aria-label={t('table.ariaLabel')}>
+            <TableHeader>
+              <TableColumn isRowHeader>{t('columns.group')}</TableColumn>
+              <TableColumn>{t('columns.actions')}</TableColumn>
+            </TableHeader>
+            <TableBody items={currentPage}>
+              {(group) => (
+                <TableRow
+                  key={group.id}
+                  id={group.id}
+                  className={isAdded(group) ? 'border-l-8 border-l-success' : 'border-l-8 border-l-danger'}
+                >
+                  <TableCell className="w-full">{group.name}</TableCell>
+                  <TableCell className="text-right flex items-center gap-2">
+                    <Checkbox
+                      onChange={() => {
+                        handleGroupClick(group);
+                      }}
+                      aria-label={group.name}
+                      isSelected={isAdded(group)}
+                    />
+                    <Link href={`/resource-groups/${group.id}`}>{t('actions.openGroup')}</Link>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </TableContent>
+        </Table>
+      )}
     </FlatSection>
   );
 }

--- a/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/index.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import { Card, Spinner } from '@heroui/react';
+import { HTMLAttributes, useMemo } from 'react';
+import { Spinner } from '@heroui/react';
 import { Clock } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useAuth } from '../../../../../hooks/useAuth';
@@ -17,13 +17,12 @@ import {
 import en from './translations/en.json';
 import de from './translations/de.json';
 import { MaintenanceInProgressDisplay } from './maintenance';
+import { FlatSection } from '../../../details/flatSection';
 
-type ResourceUsageSessionProps = {
+type ResourceUsageSessionProps = Omit<HTMLAttributes<HTMLElement>, 'children' | 'resource'> & {
   resourceId: number;
   resource: Resource;
   insufficientBalanceDesiredAmount?: number;
-  className?: string;
-  [key: string]: unknown;
 };
 
 export function ResourceUsageSession({
@@ -36,7 +35,6 @@ export function ResourceUsageSession({
   const { hasPermission, user } = useAuth();
   const canManageResources = hasPermission('canManageResources');
 
-  // Check if user has completed the introduction
   const { data: access, isLoading: isLoadingIntroStatus } = useResourcesServiceResourceUsageCanControl(
     { resourceId },
     undefined,
@@ -45,12 +43,10 @@ export function ResourceUsageSession({
     },
   );
 
-  // Get list of users who can give introductions
   const { data: introducers, isLoading: isLoadingIntroducers } = useAccessControlServiceResourceIntroducersGetMany({
     resourceId,
   });
 
-  // Get active session
   const { data: activeSessionResponse, isLoading: isLoadingSession } = useResourcesServiceResourceUsageGetActiveSession(
     { resourceId },
     undefined,
@@ -67,7 +63,6 @@ export function ResourceUsageSession({
     return introducers?.some((introducer) => introducer.userId === user?.id);
   }, [introducers, user]);
 
-  // Users with canManageResources permission can always start a session
   const canStartSession = canManageResources || access?.canControl || isIntroducer;
 
   const { data: activeMaintenances } = useResourceMaintenancesServiceFindMaintenances({
@@ -85,12 +80,9 @@ export function ResourceUsageSession({
     }
 
     if (activeSession) {
-      // Check if the active session belongs to the current user
       if (activeSession.userId === user?.id) {
-        // Current user's active session: Show timer and End button
         return <ActiveSessionDisplay resourceId={resourceId} startTime={activeSession.startTime} />;
       } else {
-        // Active session belongs to another user: Show info message
         return <OtherUserSessionDisplay resourceId={resourceId} />;
       }
     }
@@ -112,14 +104,8 @@ export function ResourceUsageSession({
   };
 
   return (
-    <Card {...rest}>
-      <Card.Header>
-        <div className="flex items-center">
-          <Clock className="w-5 h-5 mr-2" />
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{t('title.' + resource.type)}: </h3>
-        </div>
-      </Card.Header>
-      <Card.Content>{renderContent()}</Card.Content>
-    </Card>
+    <FlatSection icon={<Clock className="w-4 h-4" />} title={t('title.' + resource.type)} {...rest}>
+      {renderContent()}
+    </FlatSection>
   );
 }

--- a/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/index.tsx
@@ -17,7 +17,7 @@ import {
 import en from './translations/en.json';
 import de from './translations/de.json';
 import { MaintenanceInProgressDisplay } from './maintenance';
-import { FlatSection } from '../../../details/flatSection';
+import { FlatSection } from '../../../../../components/flatSection';
 
 type ResourceUsageSessionProps = Omit<HTMLAttributes<HTMLElement>, 'children' | 'resource'> & {
   resourceId: number;

--- a/apps/frontend/src/app/resources/usage/resourceUsageHistory.tsx
+++ b/apps/frontend/src/app/resources/usage/resourceUsageHistory.tsx
@@ -18,7 +18,7 @@ import historyTableEn from './components/HistoryTable/utils/translations/en.json
 import historyTableDe from './components/HistoryTable/utils/translations/de.json';
 import historyHeaderEn from './components/HistoryHeader/translations/en';
 import historyHeaderDe from './components/HistoryHeader/translations/de';
-import { FlatSection } from '../details/flatSection';
+import { FlatSection } from '../../../components/flatSection';
 
 type ResourceUsageHistoryProps = Omit<HTMLAttributes<HTMLElement>, 'children'> & {
   resourceId: number;

--- a/apps/frontend/src/app/resources/usage/resourceUsageHistory.tsx
+++ b/apps/frontend/src/app/resources/usage/resourceUsageHistory.tsx
@@ -1,14 +1,14 @@
-import { useCallback, useRef, useState } from 'react';
+import { HTMLAttributes, useCallback, useRef, useState } from 'react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useAuth } from '../../../hooks/useAuth';
-import { Card } from '@heroui/react';
+import { Checkbox } from '@heroui/react';
+import { History, Users } from 'lucide-react';
 import {
   ResourceUsage,
   useResourcesServiceResourceUsageUpdateSessionProject,
   UseResourcesServiceResourceUsageGetHistoryKeyFn,
 } from '@attraccess/react-query-client';
 import { HistoryTable } from './components/HistoryTable';
-import { HistoryHeader } from './components/HistoryHeader';
 import { UsageNotesModal } from './components/UsageNotesModal';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -16,17 +16,18 @@ import en from './translations/resourceUsageHistory.en';
 import de from './translations/resourceUsageHistory.de';
 import historyTableEn from './components/HistoryTable/utils/translations/en.json';
 import historyTableDe from './components/HistoryTable/utils/translations/de.json';
+import historyHeaderEn from './components/HistoryHeader/translations/en';
+import historyHeaderDe from './components/HistoryHeader/translations/de';
+import { FlatSection } from '../details/flatSection';
 
-type ResourceUsageHistoryProps = {
+type ResourceUsageHistoryProps = Omit<HTMLAttributes<HTMLElement>, 'children'> & {
   resourceId: number;
-  className?: string;
-  [key: string]: unknown;
 };
 
-// Main component
 export function ResourceUsageHistory({ resourceId, ...rest }: ResourceUsageHistoryProps) {
   const { t } = useTranslations({ en, de });
   const { t: tHistoryTable } = useTranslations({ en: historyTableEn, de: historyTableDe });
+  const { t: tHistoryHeader } = useTranslations({ en: historyHeaderEn, de: historyHeaderDe });
   const { hasPermission } = useAuth();
   const canManageResources = hasPermission('canManageResources');
   const queryClient = useQueryClient();
@@ -133,29 +134,32 @@ export function ResourceUsageHistory({ resourceId, ...rest }: ResourceUsageHisto
     [resourceId, resolveProjectId, updateSessionProject],
   );
 
-  return (
-    <Card {...rest}>
-      <Card.Header className="flex justify-between items-center">
-        <HistoryHeader
-          title={t('usageHistory')}
-          showAllUsers={showAllUsers}
-          setShowAllUsers={setShowAllUsers}
-          canManageResources={canManageResources}
-        />
-      </Card.Header>
+  const showAllUsersToggle = canManageResources ? (
+    <div className="flex items-center">
+      <Checkbox isSelected={showAllUsers} onChange={setShowAllUsers} />
+      <span className="ml-2 text-sm flex items-center">
+        <Users className="w-4 h-4 mr-1" /> {tHistoryHeader('showAllUsers')}
+      </span>
+    </div>
+  ) : undefined;
 
-      <Card.Content>
-        <HistoryTable
-          resourceId={resourceId}
-          showAllUsers={showAllUsers}
-          canManageResources={canManageResources}
-          onSessionClick={handleSessionClick}
-          projectPlaceholder={projectPlaceholder}
-          resolveProjectId={resolveProjectId}
-          updatingSessionIds={updatingSessionIds}
-          onProjectChange={handleProjectChange}
-        />
-      </Card.Content>
+  return (
+    <FlatSection
+      icon={<History className="w-4 h-4" />}
+      title={t('usageHistory')}
+      actions={showAllUsersToggle}
+      {...rest}
+    >
+      <HistoryTable
+        resourceId={resourceId}
+        showAllUsers={showAllUsers}
+        canManageResources={canManageResources}
+        onSessionClick={handleSessionClick}
+        projectPlaceholder={projectPlaceholder}
+        resolveProjectId={resolveProjectId}
+        updatingSessionIds={updatingSessionIds}
+        onProjectChange={handleProjectChange}
+      />
 
       <UsageNotesModal
         isOpen={isModalOpen}
@@ -167,6 +171,6 @@ export function ResourceUsageHistory({ resourceId, ...rest }: ResourceUsageHisto
         updatingSessionIds={updatingSessionIds}
         onProjectChange={handleProjectChange}
       />
-    </Card>
+    </FlatSection>
   );
 }

--- a/apps/frontend/src/app/settings/cards/AppSettingsCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/AppSettingsCard/index.tsx
@@ -1,5 +1,5 @@
 import { Chip, cn } from '@heroui/react';
-import { CheckIcon, XIcon } from 'lucide-react';
+import { CheckIcon, GlobeIcon, XIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { AppSettingsForm } from '../../forms/AppSettingsForm';
 import en from './en.json';
@@ -40,9 +40,10 @@ export function AppSettingsCard({ variant, onNext, className }: AppSettingsCardP
       data-cy="app-settings-section"
     >
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-          {t('title')}
-        </h3>
+        <div className="flex items-center gap-2 text-default-700">
+          <GlobeIcon size={18} />
+          <h3 className="text-sm uppercase tracking-wide font-semibold">{t('title')}</h3>
+        </div>
         {licenseChip}
       </div>
       <AppSettingsForm variant={variant} endpoint="settings" onNext={onNext} />

--- a/apps/frontend/src/app/settings/cards/AuthRateLimitCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/AuthRateLimitCard/index.tsx
@@ -1,21 +1,32 @@
-import { Card } from '@heroui/react';
+import { cn } from '@heroui/react';
 import { ShieldAlertIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { PageHeader } from '../../../../components/pageHeader';
 import { AuthRateLimitForm } from '../../forms/AuthRateLimitForm';
 import en from './en.json';
 import de from './de.json';
 
-export function AuthRateLimitCard() {
+export type AuthRateLimitCardProps = {
+  className?: string;
+};
+
+export function AuthRateLimitCard({ className }: AuthRateLimitCardProps = {}) {
   const { t } = useTranslations({ en, de });
   return (
-    <Card className="flex-1 min-w-[300px]">
-      <Card.Header>
-        <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<ShieldAlertIcon size={18} />} noMargin />
-      </Card.Header>
-      <Card.Content className="flex flex-col gap-4">
-        <AuthRateLimitForm />
-      </Card.Content>
-    </Card>
+    <section
+      className={cn(
+        'w-full flex flex-col gap-4 rounded-large border border-default-200 bg-default-50 p-6',
+        className,
+      )}
+      data-cy="auth-rate-limit-settings-section"
+    >
+      <div className="flex items-center gap-2">
+        <ShieldAlertIcon size={18} className="text-default-700" />
+        <div className="flex flex-col">
+          <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">{t('title')}</h3>
+          <p className="text-xs text-default-500">{t('subtitle')}</p>
+        </div>
+      </div>
+      <AuthRateLimitForm />
+    </section>
   );
 }

--- a/apps/frontend/src/app/settings/cards/MetricsSettingsCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/MetricsSettingsCard/index.tsx
@@ -1,5 +1,5 @@
 import { Chip, cn } from '@heroui/react';
-import { CheckIcon, XIcon } from 'lucide-react';
+import { ActivityIcon, CheckIcon, XIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { MetricsSettingsForm } from '../../forms/MetricsSettingsForm';
 import { useSettingsServiceGetMetricsSettings } from '@attraccess/react-query-client';
@@ -34,9 +34,10 @@ export function MetricsSettingsCard({ className }: MetricsSettingsCardProps = {}
       data-cy="metrics-settings-section"
     >
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-          {t('title')}
-        </h3>
+        <div className="flex items-center gap-2 text-default-700">
+          <ActivityIcon size={18} />
+          <h3 className="text-sm uppercase tracking-wide font-semibold">{t('title')}</h3>
+        </div>
         {statusChip}
       </div>
       <MetricsSettingsForm />

--- a/apps/frontend/src/app/settings/cards/PasswordPolicyCard/de.json
+++ b/apps/frontend/src/app/settings/cards/PasswordPolicyCard/de.json
@@ -1,5 +1,17 @@
 {
   "title": "Passwortrichtlinie",
   "subtitle": "Regeln für zulässige Passwörter, mit optionalen rollenspezifischen Übersteuerungen.",
-  "openButton": "Passwortrichtlinie öffnen"
+  "openButton": "Passwortrichtlinie öffnen",
+  "loading": "Aktuelle Richtlinie wird geladen…",
+  "summary": {
+    "minLength": "Mind. {{count}} Zeichen",
+    "requireUppercase": "Großbuchstaben",
+    "requireLowercase": "Kleinbuchstaben",
+    "requireDigit": "Ziffer",
+    "requireSpecial": "Sonderzeichen",
+    "zxcvbn": "Stärke ≥ {{score}}",
+    "hibp": "Leak-Prüfung",
+    "history": "Letzte {{count}} nicht wiederverwendbar",
+    "rotation": "Wechsel alle {{days}}d"
+  }
 }

--- a/apps/frontend/src/app/settings/cards/PasswordPolicyCard/en.json
+++ b/apps/frontend/src/app/settings/cards/PasswordPolicyCard/en.json
@@ -1,5 +1,17 @@
 {
   "title": "Password Policy",
   "subtitle": "Rules for what counts as an acceptable password, with optional per-role overrides.",
-  "openButton": "Open password policy"
+  "openButton": "Open password policy",
+  "loading": "Loading current policy…",
+  "summary": {
+    "minLength": "Min {{count}} chars",
+    "requireUppercase": "A-Z required",
+    "requireLowercase": "a-z required",
+    "requireDigit": "0-9 required",
+    "requireSpecial": "Symbol required",
+    "zxcvbn": "Strength ≥ {{score}}",
+    "hibp": "Breach check",
+    "history": "No reuse of last {{count}}",
+    "rotation": "Rotate every {{days}}d"
+  }
 }

--- a/apps/frontend/src/app/settings/cards/PasswordPolicyCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/PasswordPolicyCard/index.tsx
@@ -1,7 +1,11 @@
-import { Button, cn } from '@heroui/react';
+import { Button, Chip, cn, Spinner } from '@heroui/react';
 import { useNavigate } from 'react-router-dom';
 import { ShieldCheckIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import {
+  PasswordPolicyDto,
+  usePasswordPolicyAdminServiceGetAdminPasswordPolicy,
+} from '@attraccess/react-query-client';
 import en from './en.json';
 import de from './de.json';
 
@@ -9,9 +13,25 @@ export type PasswordPolicyCardProps = {
   className?: string;
 };
 
+function policyChips(policy: PasswordPolicyDto, t: (key: string, vars?: Record<string, string | number>) => string): string[] {
+  const chips: string[] = [];
+  chips.push(t('summary.minLength', { count: policy.minLength }));
+  if (policy.requireUppercase) chips.push(t('summary.requireUppercase'));
+  if (policy.requireLowercase) chips.push(t('summary.requireLowercase'));
+  if (policy.requireDigit) chips.push(t('summary.requireDigit'));
+  if (policy.requireSpecial) chips.push(t('summary.requireSpecial'));
+  if (policy.minZxcvbnScore > 0) chips.push(t('summary.zxcvbn', { score: policy.minZxcvbnScore }));
+  if (policy.checkHIBP) chips.push(t('summary.hibp'));
+  if (policy.historySize > 0) chips.push(t('summary.history', { count: policy.historySize }));
+  if (policy.rotationDays > 0) chips.push(t('summary.rotation', { days: policy.rotationDays }));
+  return chips;
+}
+
 export function PasswordPolicyCard({ className }: PasswordPolicyCardProps = {}) {
   const { t } = useTranslations({ en, de });
   const navigate = useNavigate();
+  const { data: policy, isLoading } = usePasswordPolicyAdminServiceGetAdminPasswordPolicy();
+
   return (
     <section
       className={cn(
@@ -27,6 +47,24 @@ export function PasswordPolicyCard({ className }: PasswordPolicyCardProps = {}) 
           <p className="text-xs text-default-500">{t('subtitle')}</p>
         </div>
       </div>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-sm text-default-500">
+          <Spinner size="sm" />
+          {t('loading')}
+        </div>
+      )}
+
+      {policy && (
+        <div className="flex flex-wrap gap-1.5">
+          {policyChips(policy, t).map((chip) => (
+            <Chip key={chip} variant="soft" color="default">
+              {chip}
+            </Chip>
+          ))}
+        </div>
+      )}
+
       <div>
         <Button variant="primary" onPress={() => navigate('/settings/security/password-policy')}>
           {t('openButton')}

--- a/apps/frontend/src/app/settings/cards/PasswordPolicyCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/PasswordPolicyCard/index.tsx
@@ -1,24 +1,37 @@
-import { Button, Card } from '@heroui/react';
+import { Button, cn } from '@heroui/react';
 import { useNavigate } from 'react-router-dom';
 import { ShieldCheckIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { PageHeader } from '../../../../components/pageHeader';
 import en from './en.json';
 import de from './de.json';
 
-export function PasswordPolicyCard() {
+export type PasswordPolicyCardProps = {
+  className?: string;
+};
+
+export function PasswordPolicyCard({ className }: PasswordPolicyCardProps = {}) {
   const { t } = useTranslations({ en, de });
   const navigate = useNavigate();
   return (
-    <Card className="flex-1 min-w-[300px]">
-      <Card.Header>
-        <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<ShieldCheckIcon size={18} />} noMargin />
-      </Card.Header>
-      <Card.Content>
+    <section
+      className={cn(
+        'w-full flex flex-col gap-4 rounded-large border border-default-200 bg-default-50 p-6',
+        className,
+      )}
+      data-cy="password-policy-settings-section"
+    >
+      <div className="flex items-center gap-2">
+        <ShieldCheckIcon size={18} className="text-default-700" />
+        <div className="flex flex-col">
+          <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">{t('title')}</h3>
+          <p className="text-xs text-default-500">{t('subtitle')}</p>
+        </div>
+      </div>
+      <div>
         <Button variant="primary" onPress={() => navigate('/settings/security/password-policy')}>
           {t('openButton')}
         </Button>
-      </Card.Content>
-    </Card>
+      </div>
+    </section>
   );
 }

--- a/apps/frontend/src/app/settings/cards/SmtpSettingsCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/SmtpSettingsCard/index.tsx
@@ -1,5 +1,5 @@
 import { Chip, cn } from '@heroui/react';
-import { CheckIcon, XIcon } from 'lucide-react';
+import { CheckIcon, MailIcon, XIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { SmtpSettingsForm } from '../../forms/SmtpSettingsForm';
 import en from './en.json';
@@ -40,9 +40,10 @@ export function SmtpSettingsCard({ variant, onNext, className }: SmtpSettingsCar
       data-cy="smtp-settings-section"
     >
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-          {t('title')}
-        </h3>
+        <div className="flex items-center gap-2 text-default-700">
+          <MailIcon size={18} />
+          <h3 className="text-sm uppercase tracking-wide font-semibold">{t('title')}</h3>
+        </div>
         {passwordChip}
       </div>
       <SmtpSettingsForm variant={variant} endpoint="settings" onNext={onNext} />

--- a/apps/frontend/src/app/settings/forms/AuthRateLimitForm/index.tsx
+++ b/apps/frontend/src/app/settings/forms/AuthRateLimitForm/index.tsx
@@ -9,6 +9,7 @@ import {
   Separator,
   Spinner,
 } from '@heroui/react';
+import { HelpCircleIcon } from 'lucide-react';
 import { LabeledSwitch } from '../../../../components/labeledSwitch';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -61,7 +62,14 @@ function NumberRow({
 }) {
   return (
     <div className="flex flex-col gap-1" data-testid={dataTestid}>
-      <span className="text-sm font-medium">{label}</span>
+      <div className="flex items-center gap-1.5">
+        <span className="text-sm font-medium">{label}</span>
+        {description && (
+          <span title={description} aria-label={description}>
+            <HelpCircleIcon size={14} className="text-default-400 cursor-help" />
+          </span>
+        )}
+      </div>
       <NumberField value={value} onChange={onChange} minValue={minValue} step={step} isDisabled={isDisabled}>
         <NumberFieldGroup>
           <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
@@ -69,7 +77,6 @@ function NumberRow({
           <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
         </NumberFieldGroup>
       </NumberField>
-      {description && <span className="text-xs text-default-500">{description}</span>}
     </div>
   );
 }
@@ -121,27 +128,29 @@ export function AuthRateLimitForm() {
   return (
     <div className="flex flex-col gap-4">
       <p className="text-sm text-default-500">{t('description')}</p>
-      <NumberRow
-        label={t('fields.maxAttempts.label')}
-        description={t('fields.maxAttempts.description')}
-        value={form.maxAttempts}
-        onChange={(value) => setForm({ ...form, maxAttempts: value })}
-        dataTestid="rate-limit-max-attempts"
-      />
-      <NumberRow
-        label={t('fields.windowSeconds.label')}
-        description={t('fields.windowSeconds.description')}
-        value={form.windowSeconds}
-        onChange={(value) => setForm({ ...form, windowSeconds: value })}
-        dataTestid="rate-limit-window-seconds"
-      />
-      <NumberRow
-        label={t('fields.lockoutDurationSeconds.label')}
-        description={t('fields.lockoutDurationSeconds.description')}
-        value={form.lockoutDurationSeconds}
-        onChange={(value) => setForm({ ...form, lockoutDurationSeconds: value })}
-        dataTestid="rate-limit-lockout-duration"
-      />
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <NumberRow
+          label={t('fields.maxAttempts.label')}
+          description={t('fields.maxAttempts.description')}
+          value={form.maxAttempts}
+          onChange={(value) => setForm({ ...form, maxAttempts: value })}
+          dataTestid="rate-limit-max-attempts"
+        />
+        <NumberRow
+          label={t('fields.windowSeconds.label')}
+          description={t('fields.windowSeconds.description')}
+          value={form.windowSeconds}
+          onChange={(value) => setForm({ ...form, windowSeconds: value })}
+          dataTestid="rate-limit-window-seconds"
+        />
+        <NumberRow
+          label={t('fields.lockoutDurationSeconds.label')}
+          description={t('fields.lockoutDurationSeconds.description')}
+          value={form.lockoutDurationSeconds}
+          onChange={(value) => setForm({ ...form, lockoutDurationSeconds: value })}
+          dataTestid="rate-limit-lockout-duration"
+        />
+      </div>
       <Separator />
       <LabeledSwitch
         isSelected={form.exponentialBackoff}

--- a/apps/frontend/src/components/PasswordField/PasswordField.tsx
+++ b/apps/frontend/src/components/PasswordField/PasswordField.tsx
@@ -131,10 +131,11 @@ export function PasswordField(props: PasswordFieldProps) {
 
       {showGenerator && (
         <Button
-          variant="secondary"
+          variant="outline"
           onPress={handleGenerate}
           data-cy={cy('generate-password-button')}
           type="button"
+          fullWidth
         >
           <Wand2 className="h-4 w-4" />
           {t('generate')}

--- a/apps/frontend/src/components/emptyState.tsx
+++ b/apps/frontend/src/components/emptyState.tsx
@@ -18,9 +18,9 @@ export function EmptyState(props: Props) {
   });
 
   return (
-    <div className="flex flex-col justify-center items-center py-12 px-4 gap-3">
-      <MehIcon size={56} className="text-default-300" />
-      <p className="text-default-500">{message ?? t('message')}</p>
+    <div className="flex flex-col justify-center items-center py-6 px-4 gap-2">
+      <MehIcon size={36} className="text-default-300" />
+      <p className="text-sm text-default-500">{message ?? t('message')}</p>
     </div>
   );
 }

--- a/apps/frontend/src/components/flatSection.tsx
+++ b/apps/frontend/src/components/flatSection.tsx
@@ -1,5 +1,5 @@
-// Shared flat sidebar section wrapper for icon, title, actions, body
-// FEATURE: Resource details visual hierarchy (ATT-289 secondary sidebar chrome)
+// Shared section wrapper rendering icon, uppercase title, optional actions, body
+// FEATURE: Cross-page visual hierarchy after Card-wrapper removal (ATT-359)
 import { cn } from '@heroui/react';
 import { HTMLAttributes, ReactNode } from 'react';
 

--- a/docs/superpowers/specs/2026-05-23-att-359-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-23-att-359-ui-fixes-design.md
@@ -1,0 +1,69 @@
+# ATT-359 follow-up: UI/UX fixes after Card unwrap
+
+Date: 2026-05-23
+Linear: ATT-359
+Source PR: #981 (merged) — Card components unwrapped from Account, Resource detail, Settings.
+
+## Context
+
+Removing the v3 Card wrappers exposed pre-existing UX debt: weak section hierarchy, inconsistent action affordances, unbalanced layouts. This spec captures fixes grouped into four independent phases. Each phase ships as its own PR.
+
+Color critique skipped per user direction.
+
+## User decisions
+
+- **Multi-save buttons retained.** Per-field save UX stays on Account page.
+- **Empty-state smiley retained.** Compress padding only; keep MehIcon illustration.
+- **Action strip on Resource detail → Button row (Option B).** Restyle as button group; no behavior change (each still navigates). Delete moves to overflow `⋯` menu.
+- **Rate-limit help text → info tooltip on label.** Compresses card vertically.
+
+## P1 — Account page (`apps/frontend/src/app/account/index.tsx`)
+
+- Widen page container max-width to match Settings page.
+- Strengthen section headers (uppercase label + thin top border or larger font weight).
+- `Generate strong password` → real Button variant, not chip.
+- Danger Zone `Delete account` → stronger destructive style (bordered red).
+- `Two-factor authentication` heading → uppercase to match peers.
+
+## P2 — Settings + System cards (`apps/frontend/src/app/settings/`)
+
+- Balance Application + Email column heights (pack denser or allow stack on narrower viewports).
+- All section headers get an icon (Application, Email currently lack).
+- Group `Use TLS` toggle with related fields.
+- Auth Rate Limiting numeric fields → horizontal row (max attempts / window / lockout).
+- Drop NumberField steppers on seconds fields → plain numeric input.
+- Per-field help text → `i` tooltip on label.
+- Password Policy card → summary line of current policy values + Edit button.
+
+## P3 — Resource detail (`apps/frontend/src/app/resources/details/resourceDetails.tsx`)
+
+- Action strip → button row (option B), no tab-strip styling.
+- Delete action → overflow `⋯` menu, removes accident risk next to Edit.
+- Empty states: compress vertical padding, keep MehIcon.
+- Pencil-edit affordance consistent across panels (Billing already uses it).
+- Highlight `Resulting balance` row (bold + larger).
+- Label `Include past` / `+` / external-link icons in Maintenance side panel.
+- Resource type icon: resize larger or drop entirely.
+- `Add person` and `Add Group` use same affordance (both dropdown or both modal trigger).
+- Hide Groups table header row when zero entries.
+
+## P4 — Cross-cutting design tokens
+
+- Unify button radius scale.
+- Shared `<EmptyState>` component refinement (compressed default).
+- Shared `<SectionHeader>` component (icon optional, uppercase label, top divider).
+- aria-label audit on all icon-only buttons (eye reveal, pencil, external link).
+- Unified grid system across Account, Settings, Resource detail.
+
+## Out of scope
+
+- Color collision fixes (user accepted current palette).
+- New features.
+- Backend changes.
+
+## Verification
+
+Each phase PR includes:
+- `pnpm -r typecheck && pnpm -r lint`
+- Real-browser screenshot before/after of every changed screen
+- Screenshot comment on the Linear issue


### PR DESCRIPTION
## Summary

Drops v3 Card wrappers on the 6 sections flagged in the ATT-280 QA pass (continues the pattern from ATT-289 / ATT-294 / ATT-301):

- **/account** — Profile / Security / Danger zone become flat sections with uppercase header + divider.
- **/resources/:id** — `ResourceUsageSession`, `ResourceUsageHistory`, and `ManageResourceGroups` now use the shared `FlatSection` from ATT-289. Also drops the accent left border + shadow on the Usage Session card.
- **/settings** — `AuthRateLimitCard` and `PasswordPolicyCard` switch from `Card` to the rounded section pattern already used by App / SMTP / Metrics cards on the same page.

Forwards `HTMLAttributes` consistently on the three resource-detail components (drops `CardProps` and `[key: string]: unknown` index signatures). `HistoryHeader`'s inline toggle moves into `FlatSection`'s `actions` slot; `HistoryHeader` itself stays — still used by `projectUsageHistory`.

Linear issue: [ATT-359](https://linear.app/attraccess/issue/ATT-359/unwrap-remaining-v3-card-wrappers-on-multiple-pages)

## Follow-up UI fixes (post-review pass)

Five more commits added in response to design-review feedback on the unwrapped screens. Color critiques skipped per user direction.

- **P1 Account hierarchy** (`3d288915`) — widen container to `max-w-2xl`, use `FlatSection` w/ icons for Profile / Security / Danger zone, promote Delete to solid `danger`, change Generate Password to full-width outline.
- **P2 Settings cards** (`c2fc55ee`) — header icons on App / SMTP / Metrics, horizontal 3-col grid for Auth Rate Limit numerics + `?` tooltip help, current password policy shown as chip summary.
- **P3 Resource detail** (`bad11700`) — action strip switched from ghost to outline buttons, Delete collapsed into `⋯` overflow menu, Resulting balance bolded, Add Group matches Add Person (primary), Groups table header hidden when empty, EmptyState padding tightened (smiley retained per user request).
- **P4 Design tokens** (`68435769`) — `FlatSection` hoisted from `app/resources/details/` to shared `components/` since Account, Resource detail, Resource usage, and Groups all use it now.
- Spec for the phased fixes: `docs/superpowers/specs/2026-05-23-att-359-ui-fixes-design.md` (`7fe51907`).

## Test plan

- [x] `nx run frontend:typecheck` passes
- [x] `nx run frontend:lint` clean on edited files (one pre-existing warning in `flows/node/editor/property-input/index.tsx` is unrelated)
- [x] `nx affected` full check (lint + typecheck + build + test) passes
- [x] Browser-verified at 1280×900 — before/after screenshots posted to the Linear issue
- [ ] Reviewer sanity-check: maintenance + billing flat sections on `/resources/:id` still read right alongside the now-flattened Usage Session/History blocks

<!-- generated-by-cyrus -->