### PR TITLE
fix(frontend): account page multi-column grid (ATT-379)

### DIFF
--- a/apps/frontend/src/app/account/index.tsx
+++ b/apps/frontend/src/app/account/index.tsx
@@ -48,7 +48,7 @@ export default function AccountPage() {
     <div>
       <PageHeader title={t('title')} backTo="/" />
 
-      <div className="w-full max-w-2xl flex flex-col gap-8">
+      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
         <FlatSection icon={<UserIcon size={16} />} title={t('sections.profile')}>
           <div className="flex flex-col gap-6">
             <EmailForm />


### PR DESCRIPTION
## Summary
- Replace single-row flex-wrap layout on `/account` with the same responsive grid used by user-management details (`grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 items-start`).
- Drop `max-w-md` on each card, switch to `w-full` so cards fill their grid cell.
- Profile, Security, and Danger Zone now use horizontal space on desktop; Danger Zone naturally wraps to the next row at the 2-column breakpoint.

Closes [ATT-379](https://linear.app/attraccess/issue/ATT-379/account-page-switch-to-multi-column-grid-p1-follow-up).

## Test plan
- [x] sm (500px) — single column, sections stack.
- [x] md (900px) — two columns, Danger Zone wraps to row 2.
- [x] xl (1440px) — three columns side-by-side.
- [x] `pnpm nx run frontend:typecheck` — pass.
- [x] `pnpm nx run frontend:lint` — pass (only pre-existing warning).
- [x] `pnpm nx run frontend:test` — 76 pass.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Switch the account page layout to a responsive multi-column grid for profile, security, and danger zone sections.

Enhancements:
- Replace the flex-wrap layout on the account page with a responsive CSS grid matching the user-management details layout.
- Update account page cards to span the full width of their grid cells for better use of horizontal space.