### PR TITLE
fix(ATT-383): add CogIcon to resource group settings button

### DIFF
--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
@@ -10,7 +10,7 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { filenameToUrl } from '../../../api';
 import { StatusChip } from './statusChip';
-import { ChevronRightIcon, ShapesIcon } from 'lucide-react';
+import { ChevronRightIcon, CogIcon, ShapesIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useAuth } from '../../../hooks/useAuth';
 import { useDebounce } from '../../../hooks/useDebounce';
@@ -126,7 +126,9 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
             onPress={() => navigate(`/resource-groups/${groupId}`)}
             isIconOnly
             aria-label={t('actions.openGroupSettings')}
-          />
+          >
+            <CogIcon />
+          </Button>
         )}
       </Card.Header>
 


### PR DESCRIPTION
## Summary

- Resources page: the action button at the top-right of each group card rendered as an empty blue circle (no icon, no label).
- Root cause: `Button` had `isIconOnly` + `aria-label` but no child icon. Self-closing tag in `apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx:125-130`.
- Fix: import `CogIcon` from `lucide-react` and render it as the button's child. Matches the existing settings icon used in the sidebar (`apps/frontend/src/app/layout/sidebarItems.tsx`) and maintenance management.

## Test plan

- [x] Pre-commit hook ran lint, typecheck, build, test for `frontend` — all green
- [x] Frontend dev server starts and serves `/resources` (HTTP 200)
- [ ] Visual verification via browser was blocked: claude-in-chrome MCP not connected and local API dev server fails to boot (missing `AUTH_SESSION_SECRET` env). Diff is mechanically trivial and mirrors a working pattern used elsewhere (sidebar `CogIcon`), but the rendered button could not be screenshot-confirmed in this session.

Closes ATT-383.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Render a Cog icon inside the resource group settings button so the icon-only action is no longer an empty circle.