### PR TITLE
fix(ATT-384): align sidebar collapsible triggers with flat items

### DIFF
--- a/apps/frontend/src/app/layout/sidebar.tsx
+++ b/apps/frontend/src/app/layout/sidebar.tsx
@@ -215,16 +215,18 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
                   key={group.translationKey} id={group.translationKey}
                 >
                   <AccordionHeading>
-                    <AccordionTrigger>
-                      <span className="flex items-center gap-2">
-                        <group.icon size={16} />
+                    <AccordionTrigger className="px-2 py-2 text-sm font-normal rounded-md">
+                      <span className="flex items-center">
+                        <span className="mr-3 flex items-center">
+                          <group.icon size={16} />
+                        </span>
                         {t('groups.' + group.translationKey + '.label')}
                       </span>
                       <AccordionIndicator />
                     </AccordionTrigger>
                   </AccordionHeading>
                   <AccordionPanel>
-                    <AccordionBody>
+                    <AccordionBody className="px-0 pt-0 pb-0">
                       {group.items.map((item) => (
                         <NavLink
                           key={item.path}
@@ -252,16 +254,18 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
                   className="text-sm"
                 >
                   <AccordionHeading>
-                    <AccordionTrigger>
-                      <span className="flex items-center gap-2">
-                        <group.icon size={16} />
+                    <AccordionTrigger className="px-2 py-2 text-sm font-normal rounded-md">
+                      <span className="flex items-center">
+                        <span className="mr-3 flex items-center">
+                          <group.icon size={16} />
+                        </span>
                         {t('endItems.groups.' + group.translationKey + '.label')}
                       </span>
                       <AccordionIndicator />
                     </AccordionTrigger>
                   </AccordionHeading>
                   <AccordionPanel>
-                    <AccordionBody>
+                    <AccordionBody className="px-0 pt-0 pb-0">
                       {group.items.map((item) => (
                         <NavLink
                           key={item.path}

--- a/apps/frontend/src/app/layout/sidebar.tsx
+++ b/apps/frontend/src/app/layout/sidebar.tsx
@@ -33,13 +33,14 @@ interface NavLinkProps {
   icon: React.ReactNode;
   isExternal?: boolean;
   target?: string;
+  indent?: boolean;
   'data-cy'?: string;
 }
 
-function NavLink({ href, label, icon, isExternal, target, ...rest }: NavLinkProps) {
+function NavLink({ href, label, icon, isExternal, target, indent, ...rest }: NavLinkProps) {
   const resolvedTarget = target ?? (isExternal ? '_blank' : undefined);
-  const className =
-    'flex items-center px-2 py-2 rounded-md text-sm text-default-foreground no-underline hover:bg-default hover:text-default-foreground';
+  const paddingClass = indent ? 'pl-6 pr-2' : 'px-2';
+  const className = `flex items-center ${paddingClass} py-2 rounded-md text-sm text-default-foreground no-underline hover:bg-default hover:text-default-foreground`;
 
   if (isExternal) {
     return (
@@ -234,6 +235,7 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
                           icon={<item.icon size={16} />}
                           label={t('groups.' + group.translationKey + '.items.' + item.translationKey)}
                           data-cy={`sidebar-nav-${item.path?.replace('/', '')}`}
+                          indent
                         />
                       ))}
                     </AccordionBody>
@@ -273,6 +275,7 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
                           icon={<item.icon size={16} />}
                           label={t('endItems.groups.' + group.translationKey + '.items.' + item.translationKey)}
                           isExternal={item.isExternal}
+                          indent
                         />
                       ))}
                     </AccordionBody>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

In the left sidebar the collapsible groups (`System`, `Feedback`) sat at a different horizontal offset than the non-collapsible items, and their child items had no visual indent.

This PR has two parts:

1. **Align triggers with flat items** — `AccordionTrigger` defaulted to `px-4 py-4` and `AccordionBody` to `px-4`, while `NavLink` uses `px-2 py-2`. Override the trigger to `px-2 py-2` and zero the body padding so collapsible group headers share the same left edge as flat items. Wrap the icon in a `mr-3` span to match `NavLink` icon spacing.
2. **Inset child items** — child `NavLink`s rendered inside `AccordionBody` now use `pl-6 pr-2` (via a new `indent` prop on `NavLink`) so they appear slightly indented under their parent group, matching the visual hierarchy requested in the Linear comment.

Linear: [ATT-384](https://linear.app/attraccess/issue/ATT-384/sidebar-collapsible-menu-items-have-wrong-left-offset-vs)

## Test plan

- [x] Local frontend dev server, screenshot expanded state — collapsible group headers share the same left edge as flat items, and child items (`MQTT-Server`, `Plugins`, `Einstellungen`, `Fehler melden`, `Funktion vorschlagen`, …) are inset under their parent
- [x] `pnpm nx run frontend:lint --fix` — no new warnings
- [x] `pnpm nx run frontend:typecheck` — green
- [x] `pnpm nx affected -t lint,typecheck,build,test` (via pre-commit hook) — passed

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->