### PR TITLE
fix(ATT-387): stack resource filter options vertically

### DIFF
--- a/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx
@@ -25,7 +25,7 @@ export function ResourceFilter(props: Props & Omit<FilterProps, 'onSearchChanged
       {children({ onOpen: open })}
       <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
         <DrawerHeader>{t('drawer.title')}</DrawerHeader>
-        <DrawerBody>
+        <DrawerBody className="flex flex-col gap-4">
           <LabeledSwitch isSelected={filterProps.onlyInUseByMe} onChange={filterProps.onOnlyInUseByMeChanged}>
             {t('drawer.options.onlyInUseByMe')}
           </LabeledSwitch>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

The `/resources` filter drawer rendered all three switch toggles inline, wrapping mid-row (see [ATT-387](https://linear.app/attraccess/issue/ATT-387/resources-page-filter-ui-looks-odd-options-should-each-have)).

This change adds `flex flex-col gap-4` to the filter drawer's `DrawerBody`, matching the convention already used by every other drawer/modal in the app (allowed-signup-domains, two-factor-policy, invite-member, etc.). Each option now occupies its own row.

## Implementation

Single-line change to `apps/frontend/src/app/resourceOverview/toolbar/filter/index.tsx`.

## Verification

- `pnpm nx run frontend:lint` ✓
- `pnpm nx run frontend:typecheck` ✓
- Pre-commit `lint,typecheck,build,test,e2e` for `frontend` ✓
- Browser-verified on desktop (1280×800) and mobile (414×900) — see screenshots in the Linear issue.

Closes [ATT-387](https://linear.app/attraccess/issue/ATT-387/resources-page-filter-ui-looks-odd-options-should-each-have).

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Enhancements:
- Adjust the resource filter drawer body layout so each switch option appears on its own row with vertical spacing.