### PR TITLE
fix(ATT-385): align sidebar footer trailing icons

### DIFF
--- a/apps/frontend/src/app/layout/sidebar.tsx
+++ b/apps/frontend/src/app/layout/sidebar.tsx
@@ -52,7 +52,7 @@ function NavLink({ href, label, icon, isExternal, target, ...rest }: NavLinkProp
       >
         <span className="mr-3">{icon}</span>
         <span className="flex-1">{label}</span>
-        <ExternalLink className="ml-2 h-4 w-4" />
+        <ExternalLink className="ml-2 mr-2 h-4 w-4" />
       </a>
     );
   }
@@ -305,7 +305,7 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
                 <DropdownTrigger
                   aria-label="Settings"
                   data-cy="sidebar-settings-button"
-                  className={buttonVariants({ variant: 'ghost', isIconOnly: true })}
+                  className={`${buttonVariants({ variant: 'ghost', isIconOnly: true })} !inline-flex items-center justify-center`}
                 >
                   <Settings className="h-5 w-5" />
                 </DropdownTrigger>


### PR DESCRIPTION
## Summary
- HeroUI v3's `.dropdown__trigger` applies `inline-block`, which silently overrode the icon-only button's `inline-flex` so the cog glyph rendered flush-left inside its 36px button instead of centered. Re-centered with `!inline-flex items-center justify-center`.
- Documentation row's `<ExternalLink>` had no right margin, so it pushed to the link container's edge while the chevron (controlled by the accordion trigger's `px-4`) sat one column inward. Added matching `mr-2` so all trailing icons share the same right offset.
- All three trailing icons (Documentation external-link, Feedback chevron, profile cog) now sit on the same vertical line at 25px from the sidebar's right edge.

Closes ATT-385.

## Test plan
- [x] Visual verification in headless Chromium at 1440x900: external-link icon, Feedback/System chevrons, and profile cog icon all share the same right edge (x=231 of 256px sidebar).
- [x] `nx run frontend:lint` — pass (1 unrelated warning).
- [x] `nx run frontend:typecheck` — pass.
- [x] `nx run frontend:test` — 82/82 pass.
- [x] `nx run frontend:build` — pass.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Align sidebar footer trailing icons and fix their button alignment.

Bug Fixes:
- Center the sidebar settings icon-only button by overriding conflicting dropdown trigger display styles.
- Align the documentation external-link icon padding so it matches the other trailing icons in the sidebar footer.