### PR TITLE
fix(ATT-388): pin cdxgen SBOM to CycloneDX 1.6 for DependencyTrack

### DIFF
--- a/.github/workflows/dependency-track.yml
+++ b/.github/workflows/dependency-track.yml
@@ -31,7 +31,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate SBOM
-        run: pnpm exec cdxgen -o bom.json .
+        run: pnpm exec cdxgen --spec-version 1.6 -o bom.json .
 
       - name: Determine project version
         id: version


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

`DependencyTrack SBOM` workflow has failed on every run since 2026-04-18. Root cause: `@cyclonedx/cdxgen` 12.3.x now defaults to emitting `specVersion: "1.7"`, but the self-hosted Dependency-Track server (4.14.0 at `api.dependencytrack.apps.janjaap.de`) only supports CycloneDX up to 1.6 and rejects the upload with `HTTP 400`.

The `DependencyTrack/gh-upload-sbom@v3` action swallows the response body, which is why the failures showed only `Failed response status code:400` with no detail.

## Fix

Pass `--spec-version 1.6` to `cdxgen` so the generated `bom.json` matches the server's max supported spec version.

## Verification

Locally regenerated the SBOM with the new flag — confirmed `specVersion: "1.6"` and the same ~3769 components / ~5.5 MB as before (size matches the last successful run on Apr 18, ruling out the upload size limit as a factor).

Live verification will happen on merge to `main`, since the API key is only available to CI.

Linear: [ATT-388](https://linear.app/attraccess/issue/ATT-388/dependencytrack-github-action-failing-constantly)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->

## Summary by Sourcery

Build:
- Update the Dependency-Track workflow to invoke cdxgen with --spec-version 1.6 when generating bom.json.