### PR TITLE
fix(ci): unbreak main — exclude hardware projects from nightly + release

### DIFF
--- a/.github/workflows/docker-nightly-latest.yml
+++ b/.github/workflows/docker-nightly-latest.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Lint all projects
-        run: pnpm nx run-many --target=lint --parallel=5
+        run: pnpm nx run-many --target=lint --parallel=5 --exclude=tag:scope:hardware
 
   typecheck:
     runs-on: ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Typecheck all projects
-        run: pnpm nx run-many --target=typecheck --parallel=5
+        run: pnpm nx run-many --target=typecheck --parallel=5 --exclude=tag:scope:hardware
 
   test:
     runs-on: ubuntu-latest
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Test all projects
-        run: pnpm nx run-many --target=test,e2e --parallel=5
+        run: pnpm nx run-many --target=test,e2e --parallel=5 --exclude=tag:scope:hardware
 
   build:
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
       - name: Build all projects
         env:
           NODE_ENV: production
-        run: pnpm nx run-many --target=build --parallel=5
+        run: pnpm nx run-many --target=build --parallel=5 --exclude=tag:scope:hardware
 
   containerize:
     needs: [lint, typecheck, test, build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Lint all projects
-        run: pnpm nx run-many --target=lint --parallel=5
+        run: pnpm nx run-many --target=lint --parallel=5 --exclude=tag:scope:hardware
 
   typecheck:
     runs-on: ubuntu-latest
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Typecheck all projects
-        run: pnpm nx run-many --target=typecheck --parallel=5
+        run: pnpm nx run-many --target=typecheck --parallel=5 --exclude=tag:scope:hardware
 
   test:
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Test all projects
-        run: pnpm nx run-many --target=test,e2e --parallel=5
+        run: pnpm nx run-many --target=test,e2e --parallel=5 --exclude=tag:scope:hardware
 
   build:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
       - name: Build all projects
         env:
           NODE_ENV: production
-        run: pnpm nx run-many --target=build --parallel=5
+        run: pnpm nx run-many --target=build --parallel=5 --exclude=tag:scope:hardware
 
   containerize:
     needs: [lint, typecheck, test, build]


### PR DESCRIPTION
## Summary
- Main CI broken: `Docker Nightly Latest (Main Branch)` build job fails on every push since ATT-348 + ATT-350 merged the first tscircuit-based hardware projects (`attractap-hw-beeper`, `attractap-hw-nfc`).
- Root cause: `nx run-many --target=build` in nightly + release workflows runs with `NODE_ENV=production`, which triggers an upstream tscircuit-cli regression — `TypeError: jsxDEV2 is not a function` — when it tries to export the board `index.tsx` files. Reproduced locally: build passes without `NODE_ENV`, fails identically with `NODE_ENV=production`.
- Hotfix: align `docker-nightly-latest.yml` + `release.yml` with the existing `pull-requests.yml` convention by adding `--exclude=tag:scope:hardware` to all `nx run-many` invocations (lint / typecheck / test / build). Hardware boards are already built in their dedicated `hardware.yml` workflow (path-gated on `apps/attractap/hardware/**`), so excluding them from the docker pipeline restores main CI without dropping any verification coverage.

## Test plan
- [x] Reproduced failure locally: `NODE_ENV=production pnpm exec tscircuit-cli export apps/attractap/hardware/beeper/index.tsx -f circuit-json …` errors with `TypeError: jsxDEV2 is not a function`. Same command without `NODE_ENV` succeeds.
- [x] `pnpm nx show projects --with-target=build --exclude=tag:scope:hardware` returns the 12 deployable projects (no `attractap-hw-beeper` / `attractap-hw-nfc`).
- [x] Local pre-commit hook ran `lint, typecheck, build, test, e2e` across 16 projects — all pass.
- [ ] Watch the next `Docker Nightly Latest (Main Branch)` run on `main` after merge — expect green.
- [ ] Hardware boards continue to be verified by the `Hardware` workflow on hardware-touching PRs.

## Follow-up
- The upstream tscircuit JSX-runtime issue under `NODE_ENV=production` should be reported / pinned in a tracking ticket so we can re-include hardware projects in unified pipelines later if desired. Not in scope for this hotfix.

## Summary by Sourcery

Exclude hardware-tagged projects from nightly and release Nx pipelines to restore passing CI builds without affecting other services.

CI:
- Update docker nightly workflow to skip lint, typecheck, test, and build targets for hardware-scoped projects.
- Update release workflow to exclude hardware-scoped projects from lint, typecheck, test, and build stages.