### PR TITLE
fix(ATT-391): disable pull-to-refresh on desktop (non-touch) devices

### DIFF
--- a/apps/frontend/src/app/app.tsx
+++ b/apps/frontend/src/app/app.tsx
@@ -1,6 +1,6 @@
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { Unauthorized } from './unauthorized/unauthorized';
-import { PropsWithChildren, useEffect, useMemo } from 'react';
+import { PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { Layout } from './layout/layout';
 import { useAuth } from '../hooks/useAuth';
 import { useAllRoutes } from './routes';
@@ -72,6 +72,24 @@ function useRoutesWithAuthElements(routes: RouteConfig[]) {
   );
 }
 
+function useIsTouchDevice() {
+  const [isTouch, setIsTouch] = useState(() =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(pointer: coarse)').matches
+      : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia('(pointer: coarse)');
+    const handler = (event: MediaQueryListEvent) => setIsTouch(event.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isTouch;
+}
+
 function AppLayout(props: PropsWithChildren) {
   const { isAuthenticated } = useAuth();
   const queryClient = useQueryClient();
@@ -80,6 +98,7 @@ function AppLayout(props: PropsWithChildren) {
   const { t, language } = useTranslations({ de, en });
 
   const { pullToRefreshIsEnabled } = usePtrStore();
+  const isTouchDevice = useIsTouchDevice();
 
   return (
     <PullToRefresh
@@ -92,7 +111,7 @@ function AppLayout(props: PropsWithChildren) {
           <div style={{ fontSize: '24px' }}>↓</div>
         </div>
       }
-      isPullable={pullToRefreshIsEnabled}
+      isPullable={pullToRefreshIsEnabled && isTouchDevice}
     >
       <RouterProvider navigate={navigate}>
         <I18nProvider locale={language}>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes [ATT-391](https://linear.app/attraccess/issue/ATT-391/pull-to-refresh-should-not-be-active-on-desktop) — on desktop, click+drag (and in some cases mere mouse movement after closing a menu) was activating the pull-to-refresh gesture from `react-simple-pull-to-refresh`.

## Approach

Pull-to-refresh is now gated on a `(pointer: coarse)` media query in addition to the existing `pullToRefreshIsEnabled` store flag. The query matches when the user's primary pointing device is coarse (touch), so PTR remains active on phones/tablets and is disabled on mouse-driven desktop browsers. A `matchMedia` `change` listener keeps the value reactive if the primary input changes at runtime (e.g. detachable keyboard).

Implementation: `apps/frontend/src/app/app.tsx`
- New `useIsTouchDevice()` hook
- `isPullable={pullToRefreshIsEnabled && isTouchDevice}`

## Test plan

- [x] `pnpm nx run frontend:typecheck` — pass
- [x] `pnpm nx run frontend:lint` — pass (only the pre-existing unrelated warning)
- [x] `pnpm nx run frontend:test` — 124/124 pass
- [ ] Manual: on desktop, attempt click-drag down on any page → no PTR
- [ ] Manual: on mobile/touch, swipe down from top → PTR still works
- [ ] Manual: open three-dot menu on resource details, close it, move mouse → no PTR

> Browser-based visual verification was attempted but the local `claude-in-chrome` extension was not connected, so the manual checks above are left for the reviewer.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->