### PR TITLE
fix(ATT-390): restore flow canvas height after tabbed-layout redesign

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -383,8 +383,8 @@ function FlowsPageInner() {
   );
 
   return (
-    <div className="h-full w-full flex flex-col min-h-[70vh]">
-      <div className="flex flex-row w-full h-full min-h-[60vh] rounded-lg overflow-hidden border border-gray-200 dark:border-gray-800">
+    <div className="h-full w-full flex flex-col">
+      <div className="flex flex-row w-full flex-1 min-h-0 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-800">
         <NodeCatalogPanel
           ref={nodeCatalogRef}
           resourceId={Number(resourceId)}

--- a/apps/frontend/src/app/resources/details/layout/ResourceTabsLayout.tsx
+++ b/apps/frontend/src/app/resources/details/layout/ResourceTabsLayout.tsx
@@ -171,7 +171,7 @@ function ResourceTabsLayoutInner({ resourceId, children }: { resourceId: number;
   };
 
   return (
-    <div>
+    <div className="flex flex-col h-full min-h-0">
       <PageHeader
         title={resource.name}
         icon={!resource.imageFilename && <ShapesIcon className="w-6 h-6" />}
@@ -222,7 +222,7 @@ function ResourceTabsLayoutInner({ resourceId, children }: { resourceId: number;
         </div>
       </div>
 
-      {children ?? <Outlet />}
+      <div className="flex-1 min-h-0 overflow-auto">{children ?? <Outlet />}</div>
 
       {canManageResources && (
         <>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes [ATT-390](https://linear.app/attraccess/issue/ATT-390/redesign-of-flows-view-fully-broke-it): after the tabbed-layout redesign in #998 the flow canvas no longer rendered — `h-full` inside `FlowsPage` collapsed to 0 because `ResourceTabsLayout`'s root `<div>` had no defined height, leaving React Flow with `height: 0`. The `min-h-[70vh]` / `min-h-[60vh]` band-aids only made the page overflow vertically; they never gave the canvas a real height, so no dots background, no controls, no top-right Panel buttons, and dropped nodes were not visible.

## Changes

- `ResourceTabsLayout`: root is now `flex flex-col h-full min-h-0`, and the `Outlet`/`children` slot is wrapped in `flex-1 min-h-0 overflow-auto`. The page header + tab bar stay anchored at the top, and the content area gets a real, scrollable height it can hand to its children. Other tabs (overview/history/people/groups/maintenance/forms) continue to render normally — they just scroll inside the content wrapper instead of pushing the page below the viewport.
- `FlowsPage`: drops the `min-h-[70vh]` / `min-h-[60vh]` hacks and uses `flex-1 min-h-0` on the canvas row. React Flow now inherits a real height from the layout chain.

## Test plan

- [x] Reproduced the broken state locally (canvas blank, page overflowing).
- [x] After the fix, React Flow wrapper has non-zero height (verified `getBoundingClientRect().height = 449px` at 1280×800).
- [x] Dots background, bottom-left Controls, and top-right Panel buttons all render.
- [x] Clicking a catalog entry adds a visible node to the canvas; the Save button lights up.
- [x] Walked through every other resource sub-tab (overview / history / people / groups / maintenance / forms) — all render correctly with the new sticky-chrome / scrolling-content layout.
- [x] `pnpm nx affected -t lint typecheck test --uncommitted` passes (`frontend` lint/typecheck/124 tests green; the single pre-existing warning is in unrelated code).

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->