### PR TITLE
fix(ATT-389): mobile horizontal scroll for resource groups table

### DIFF
--- a/apps/frontend/src/app/resources/groups/index.tsx
+++ b/apps/frontend/src/app/resources/groups/index.tsx
@@ -8,6 +8,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
 } from '@heroui/react';
 import {
   ResourceGroup,
@@ -122,75 +123,77 @@ export function ManageResourceGroups({
 
   const renderTable = () => (
     <Table data-cy="resource-groups-list">
-      <TableContent aria-label={t('table.ariaLabel')}>
-        <TableHeader>
-          <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
-          <TableColumn>{t('columns.assigned')}</TableColumn>
-          <TableColumn>{t('columns.actions')}</TableColumn>
-        </TableHeader>
-        <TableBody
-          items={visibleGroups}
-          renderEmptyState={() => <EmptyState message={emptyMessage} />}
-        >
-          {(group) => {
-            const isAssigned = assignedIds.has(group.id);
-            const dotClass = isAssigned ? 'bg-success' : 'bg-default-300';
-            const ringClass = isAssigned ? 'ring-success/30' : 'ring-default-300/30';
-            const toggleLabel = t(isAssigned ? 'row.toggleOff' : 'row.toggleOn', {
-              resource: resourceName,
-              group: group.name,
-            });
-            return (
-              <TableRow
-                key={group.id}
-                id={group.id}
-                data-cy={`resource-group-row-${group.id}`}
-                data-assigned={isAssigned ? 'true' : 'false'}
-              >
-                <TableCell>
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span
-                      aria-hidden
-                      className={`inline-block w-2.5 h-2.5 rounded-full ring-2 shrink-0 ${dotClass} ${ringClass}`}
-                    />
-                    <div className="min-w-0">
-                      <p className="truncate" title={group.name}>
-                        {group.name}
-                      </p>
-                      {group.description ? (
-                        <p className="text-xs text-default-500 truncate max-w-md" title={group.description}>
-                          {group.description}
+      <TableScrollContainer>
+        <TableContent aria-label={t('table.ariaLabel')}>
+          <TableHeader>
+            <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
+            <TableColumn>{t('columns.assigned')}</TableColumn>
+            <TableColumn>{t('columns.actions')}</TableColumn>
+          </TableHeader>
+          <TableBody
+            items={visibleGroups}
+            renderEmptyState={() => <EmptyState message={emptyMessage} />}
+          >
+            {(group) => {
+              const isAssigned = assignedIds.has(group.id);
+              const dotClass = isAssigned ? 'bg-success' : 'bg-default-300';
+              const ringClass = isAssigned ? 'ring-success/30' : 'ring-default-300/30';
+              const toggleLabel = t(isAssigned ? 'row.toggleOff' : 'row.toggleOn', {
+                resource: resourceName,
+                group: group.name,
+              });
+              return (
+                <TableRow
+                  key={group.id}
+                  id={group.id}
+                  data-cy={`resource-group-row-${group.id}`}
+                  data-assigned={isAssigned ? 'true' : 'false'}
+                >
+                  <TableCell>
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span
+                        aria-hidden
+                        className={`inline-block w-2.5 h-2.5 rounded-full ring-2 shrink-0 ${dotClass} ${ringClass}`}
+                      />
+                      <div className="min-w-0">
+                        <p className="truncate" title={group.name}>
+                          {group.name}
                         </p>
-                      ) : null}
+                        {group.description ? (
+                          <p className="text-xs text-default-500 truncate max-w-md" title={group.description}>
+                            {group.description}
+                          </p>
+                        ) : null}
+                      </div>
                     </div>
-                  </div>
-                </TableCell>
-                <TableCell>
-                  <LabeledSwitch
-                    size="sm"
-                    isSelected={isAssigned}
-                    isDisabled={pendingGroupIds.has(group.id)}
-                    onChange={() => handleToggle(group)}
-                    aria-label={toggleLabel}
-                    data-cy={`resource-group-row-${group.id}-switch`}
-                  />
-                </TableCell>
-                <TableCell>
-                  <Link
-                    href={`/resource-groups/${group.id}`}
-                    className="text-xs inline-flex items-center gap-0.5"
-                    data-cy={`resource-group-row-${group.id}-open`}
-                    aria-label={`${t('row.openGroup')}: ${group.name}`}
-                  >
-                    {t('row.openGroup')}
-                    <ChevronRightIcon size={14} />
-                  </Link>
-                </TableCell>
-              </TableRow>
-            );
-          }}
-        </TableBody>
-      </TableContent>
+                  </TableCell>
+                  <TableCell>
+                    <LabeledSwitch
+                      size="sm"
+                      isSelected={isAssigned}
+                      isDisabled={pendingGroupIds.has(group.id)}
+                      onChange={() => handleToggle(group)}
+                      aria-label={toggleLabel}
+                      data-cy={`resource-group-row-${group.id}-switch`}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Link
+                      href={`/resource-groups/${group.id}`}
+                      className="text-xs inline-flex items-center gap-0.5"
+                      data-cy={`resource-group-row-${group.id}-open`}
+                      aria-label={`${t('row.openGroup')}: ${group.name}`}
+                    >
+                      {t('row.openGroup')}
+                      <ChevronRightIcon size={14} />
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              );
+            }}
+          </TableBody>
+        </TableContent>
+      </TableScrollContainer>
     </Table>
   );
 


### PR DESCRIPTION
Assignee: @jappyjan ([Jan Jaap](https://linear.app/attraccess/issue/ATT-389/redesign-of-resource-groups-list-made-it-useless))

## Summary

Follow-up to #1007. On narrow viewports the HeroUI v3 Table clipped the **Assigned** and **Actions** columns because `Table` (the root) applies `overflow-clip` and never renders a scroll container unless `Table.ScrollContainer` is opted into.

This wraps `TableContent` in `TableScrollContainer`, which adds the `overflow-x-auto` slot, so the table scrolls horizontally when its columns are wider than the viewport instead of hiding them.

## Verification

Reproduced and verified at 375×812 (mobile) with 8 groups including one long name. The page itself does not overflow; the table area scrolls horizontally to expose toggles + open links.

| Default (Name visible) | Scrolled right (Assigned + Actions) |
| --- | --- |
| see attached screenshot below | see attached screenshot below |

Measured: outer page width 375 / no overflow; `.table__scroll-container` clientWidth 335 / scrollWidth 623.

Quality checks: `nx run frontend:typecheck` ✓, `nx run frontend:lint` ✓ (no new warnings).

Linear: [ATT-389](https://linear.app/attraccess/issue/ATT-389/redesign-of-resource-groups-list-made-it-useless)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->