### PR TITLE
fix(ATT-389): replace groups switch with action button + optimistic update

### DIFF
--- a/apps/frontend/src/app/resources/groups/de.json
+++ b/apps/frontend/src/app/resources/groups/de.json
@@ -20,6 +20,8 @@
   "row": {
     "toggleOn": "{{resource}} zur Gruppe {{group}} hinzufügen",
     "toggleOff": "{{resource}} aus der Gruppe {{group}} entfernen",
+    "add": "Hinzufügen",
+    "remove": "Entfernen",
     "openGroup": "öffnen"
   },
   "newGroup": "Neue Gruppe",

--- a/apps/frontend/src/app/resources/groups/en.json
+++ b/apps/frontend/src/app/resources/groups/en.json
@@ -20,6 +20,8 @@
   "row": {
     "toggleOn": "Add {{resource}} to {{group}}",
     "toggleOff": "Remove {{resource}} from {{group}}",
+    "add": "Add",
+    "remove": "Remove",
     "openGroup": "open"
   },
   "newGroup": "New group",

--- a/apps/frontend/src/app/resources/groups/index.tsx
+++ b/apps/frontend/src/app/resources/groups/index.tsx
@@ -1,5 +1,6 @@
 import { HTMLAttributes, useCallback, useMemo, useState } from 'react';
 import {
+  Button,
   Link,
   Table,
   TableBody,
@@ -11,6 +12,7 @@ import {
   TableScrollContainer,
 } from '@heroui/react';
 import {
+  Resource,
   ResourceGroup,
   useResourcesServiceGetAllResourcesKey,
   useResourcesServiceGetOneResourceById,
@@ -20,13 +22,12 @@ import {
   useResourcesServiceResourceGroupsRemoveResource,
 } from '@attraccess/react-query-client';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { ChevronRightIcon, GroupIcon } from 'lucide-react';
+import { ChevronRightIcon, GroupIcon, MinusIcon, PlusIcon } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import en from './en.json';
 import de from './de.json';
 import { EmptyState } from '../../../components/emptyState';
 import { FlatSection } from '../../../components/flatSection';
-import { LabeledSwitch } from '../../../components/labeledSwitch';
 import { useToastMessage } from '../../../components/toastProvider';
 import { ResourceGroupUpsertModal } from '../../resource-groups/upsertModal/resourceGroupUpsertModal';
 import { GroupsToolbar } from './GroupsToolbar';
@@ -83,6 +84,16 @@ export function ManageResourceGroups({
     async (group: ResourceGroup) => {
       const wasAssigned = assignedIds.has(group.id);
       markPending(group.id, true);
+
+      const resourceKey = UseResourcesServiceGetOneResourceByIdKeyFn({ id: resourceId });
+      const previous = queryClient.getQueryData<Resource>(resourceKey);
+      if (previous) {
+        const nextGroups = wasAssigned
+          ? (previous.groups ?? []).filter((g) => g.id !== group.id)
+          : [...(previous.groups ?? []), group];
+        queryClient.setQueryData<Resource>(resourceKey, { ...previous, groups: nextGroups });
+      }
+
       try {
         if (wasAssigned) {
           await removeResourceFromGroup({ groupId: group.id, resourceId });
@@ -91,12 +102,23 @@ export function ManageResourceGroups({
         }
         invalidateAll();
       } catch {
+        if (previous) queryClient.setQueryData<Resource>(resourceKey, previous);
         toast.error({ title: t('errors.toggleFailed') });
       } finally {
         markPending(group.id, false);
       }
     },
-    [addResourceToGroup, removeResourceFromGroup, assignedIds, invalidateAll, markPending, resourceId, toast, t],
+    [
+      addResourceToGroup,
+      removeResourceFromGroup,
+      assignedIds,
+      invalidateAll,
+      markPending,
+      queryClient,
+      resourceId,
+      toast,
+      t,
+    ],
   );
 
   const onGroupCreated = useCallback(
@@ -138,10 +160,12 @@ export function ManageResourceGroups({
               const isAssigned = assignedIds.has(group.id);
               const dotClass = isAssigned ? 'bg-success' : 'bg-default-300';
               const ringClass = isAssigned ? 'ring-success/30' : 'ring-default-300/30';
-              const toggleLabel = t(isAssigned ? 'row.toggleOff' : 'row.toggleOn', {
+              const actionLabel = t(isAssigned ? 'row.toggleOff' : 'row.toggleOn', {
                 resource: resourceName,
                 group: group.name,
               });
+              const buttonLabel = t(isAssigned ? 'row.remove' : 'row.add');
+              const isPending = pendingGroupIds.has(group.id);
               return (
                 <TableRow
                   key={group.id}
@@ -168,14 +192,18 @@ export function ManageResourceGroups({
                     </div>
                   </TableCell>
                   <TableCell>
-                    <LabeledSwitch
+                    <Button
                       size="sm"
-                      isSelected={isAssigned}
-                      isDisabled={pendingGroupIds.has(group.id)}
-                      onChange={() => handleToggle(group)}
-                      aria-label={toggleLabel}
-                      data-cy={`resource-group-row-${group.id}-switch`}
-                    />
+                      variant={isAssigned ? 'danger-soft' : 'primary'}
+                      isDisabled={isPending}
+                      isPending={isPending}
+                      onPress={() => handleToggle(group)}
+                      aria-label={actionLabel}
+                      data-cy={`resource-group-row-${group.id}-toggle`}
+                    >
+                      {isPending ? null : isAssigned ? <MinusIcon size={14} /> : <PlusIcon size={14} />}
+                      {buttonLabel}
+                    </Button>
                   </TableCell>
                   <TableCell>
                     <Link

--- a/apps/frontend/src/app/resources/groups/index.tsx
+++ b/apps/frontend/src/app/resources/groups/index.tsx
@@ -154,6 +154,7 @@ export function ManageResourceGroups({
           </TableHeader>
           <TableBody
             items={visibleGroups}
+            dependencies={[assignedIds, pendingGroupIds]}
             renderEmptyState={() => <EmptyState message={emptyMessage} />}
           >
             {(group) => {


### PR DESCRIPTION
## Summary

Follow-up to ATT-389. Two reported bugs on the redesigned resource groups tab:

1. Toggling the per-row Switch produced no visible state change.
2. The row stayed in the current filter view (Assigned / Available) after the assignment flipped — the resource query had not refetched before the filter recomputed.

Both stem from the same root cause: the Switch was bound to `assignedIds`, which is derived from `resource.groups`, but `resource.groups` only updates on the next refetch after `invalidateQueries`. There was no intermediate state, so the UI looked frozen until the network round-trip finished.

## Changes

- `apps/frontend/src/app/resources/groups/index.tsx`
  - Swap `LabeledSwitch` for a HeroUI `Button`. State is now spelled out:
    - Unassigned → `variant="primary"` solid, `+` icon, label "Add".
    - Assigned → `variant="danger-soft"`, `-` icon, label "Remove".
    - Mutation in flight → `isPending` spinner, disabled.
  - Optimistically patch the single-resource query cache via `queryClient.setQueryData` before awaiting the mutation. `assignedIds` updates synchronously, which propagates through `visibleGroups`/`counts` `useMemo`s, so the row leaves the Assigned/Available list immediately. Rollback to the previous cache on error. The post-success `invalidateAll()` is kept as the source-of-truth refresh.
- `apps/frontend/src/app/resources/groups/en.json` & `de.json`
  - Add `row.add` / `row.remove` (existing `toggleOn` / `toggleOff` keys are reused as aria-labels).

## Verification

- `pnpm nx run frontend:typecheck` ✓
- `pnpm nx run frontend:lint` ✓ (only a pre-existing warning in an unrelated file)
- `pnpm nx run frontend:test` ✓ 132/132

Local browser validation was blocked this session (Claude-in-Chrome extension not connected), so I have not captured before/after screenshots. The change is small and the logic is covered by the existing helper tests, but please give the Assigned / Available / All filters a click-through before merging.

## Test plan

- [ ] Open a resource → Groups tab, default filter "All": each row shows status dot + button. Buttons read "Add" or "Remove" matching the dot color.
- [ ] Click "Add" on an available group → button shows spinner briefly, then row flips to "Remove" + green dot, the Assigned count in the toolbar increments.
- [ ] Switch to "Available" filter → clicking "Add" removes the row from the list immediately (without waiting for refetch).
- [ ] Switch to "Assigned" filter → clicking "Remove" removes the row from the list immediately.
- [ ] Simulate a backend error → row reverts to its previous state and the toast appears.

<!-- generated-by-cyrus -->