### PR TITLE
fix(ATT-392): auth rate limit behind reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,13 @@ ATTRACCESS_URL=http://localhost:3000
 # than what your users use to access attraccess (most setups wont need this)
 #ATTRACCESS_PUBLIC_INTERNET_URL=https://public.domain.com
 
+# Reverse proxy: number of trusted proxy hops between the client and Attraccess, so auth
+# rate limiting uses the real client IP instead of the proxy IP. Unset (default) trusts no
+# proxy. Use 1 behind a single reverse proxy (nginx/Traefik/Caddy), 2 behind a CDN + proxy.
+# Advanced: a comma-separated list of trusted proxy IPs/CIDRs, or one of loopback, linklocal,
+# uniquelocal. Setting this larger than your real proxy chain lets clients spoof their IP.
+#TRUST_PROXY=1
+
 SMTP_SERVICE=SMTP
 SMTP_HOST=localhost
 SMTP_PORT=1025

--- a/apps/api/src/config/app.config.ts
+++ b/apps/api/src/config/app.config.ts
@@ -50,6 +50,7 @@ const AppEnvSchema = z
     SSL_GENERATE_SELF_SIGNED_CERTIFICATES: z.coerce.boolean().default(false),
     SSL_KEY_FILE: z.string().optional(),
     SSL_CERT_FILE: z.string().optional(),
+    TRUST_PROXY: z.string().optional(),
   })
   .refine(
     (config) => {

--- a/apps/api/src/main.bootstrap.ts
+++ b/apps/api/src/main.bootstrap.ts
@@ -19,6 +19,7 @@ import { StorageConfigType } from './config/storage.config';
 import cookieParser from 'cookie-parser';
 import { SqliteReadonlyFilter } from './exceptions/sqlite-readonly.filter';
 import { SettingsService } from './settings/settings.service';
+import { isValidTrustProxyValue, resolveTrustProxySetting } from './trust-proxy';
 
 async function generateSelfSignedCertificates(storageDir: string, domain: string) {
   const ca = await createCA({
@@ -94,6 +95,26 @@ export async function bootstrap() {
     httpsOptions,
   });
   bootstrapLogger.log('Main application instance created.');
+
+  // Behind a reverse proxy, X-Forwarded-For only reflects the real client IP when Express is told
+  // how many proxy hops to trust. Without this, auth rate limiting buckets every request under the
+  // proxy IP. Opt-in via TRUST_PROXY (default off) so a misconfiguration can never be self-spoofed.
+  const trustProxyRaw = appConfig.TRUST_PROXY;
+  const trustProxyValid = isValidTrustProxyValue(trustProxyRaw);
+  if (trustProxyRaw && !trustProxyValid) {
+    bootstrapLogger.warn(
+      `Invalid TRUST_PROXY value "${trustProxyRaw}"; trusting no proxy. ` +
+        'Use a hop count (e.g. "1"), "true"/"false", or a comma-separated list of IPs/CIDRs/presets (loopback, linklocal, uniquelocal).',
+    );
+  }
+  const trustProxy = trustProxyValid ? resolveTrustProxySetting(trustProxyRaw) : false;
+  try {
+    app.set('trust proxy', trustProxy);
+    bootstrapLogger.log(`Express "trust proxy" set to: ${JSON.stringify(trustProxy)}`);
+  } catch (error) {
+    bootstrapLogger.error(`Failed to apply TRUST_PROXY "${trustProxyRaw}"; trusting no proxy.`, error as Error);
+    app.set('trust proxy', false);
+  }
 
   app.useGlobalFilters(new SqliteReadonlyFilter(app.get(HttpAdapterHost)));
 

--- a/apps/api/src/trust-proxy.spec.ts
+++ b/apps/api/src/trust-proxy.spec.ts
@@ -1,0 +1,96 @@
+// Unit tests for TRUST_PROXY env parsing and validation helpers
+// FEATURE: Auth rate limiting — real client IP behind reverse proxy
+import { isValidTrustProxyValue, resolveTrustProxySetting } from './trust-proxy';
+
+describe('resolveTrustProxySetting', () => {
+  it('treats empty / nullish as off (false)', () => {
+    expect(resolveTrustProxySetting('')).toBe(false);
+    expect(resolveTrustProxySetting('   ')).toBe(false);
+    expect(resolveTrustProxySetting(null)).toBe(false);
+    expect(resolveTrustProxySetting(undefined)).toBe(false);
+  });
+
+  it('treats explicit off keywords as false', () => {
+    expect(resolveTrustProxySetting('false')).toBe(false);
+    expect(resolveTrustProxySetting('off')).toBe(false);
+    expect(resolveTrustProxySetting('none')).toBe(false);
+    expect(resolveTrustProxySetting('no')).toBe(false);
+    expect(resolveTrustProxySetting('OFF')).toBe(false);
+    expect(resolveTrustProxySetting('False')).toBe(false);
+  });
+
+  it('maps "true" to boolean true', () => {
+    expect(resolveTrustProxySetting('true')).toBe(true);
+    expect(resolveTrustProxySetting('TRUE')).toBe(true);
+  });
+
+  it('maps integer strings to hop counts', () => {
+    expect(resolveTrustProxySetting('0')).toBe(0);
+    expect(resolveTrustProxySetting('1')).toBe(1);
+    expect(resolveTrustProxySetting('2')).toBe(2);
+    expect(resolveTrustProxySetting('10')).toBe(10);
+    expect(resolveTrustProxySetting('  3  ')).toBe(3);
+  });
+
+  it('passes IP / CIDR / preset lists through as strings', () => {
+    expect(resolveTrustProxySetting('127.0.0.1')).toBe('127.0.0.1');
+    expect(resolveTrustProxySetting('10.0.0.0/8')).toBe('10.0.0.0/8');
+    expect(resolveTrustProxySetting('loopback')).toBe('loopback');
+    expect(resolveTrustProxySetting(' uniquelocal, 10.0.0.0/8 ')).toBe('uniquelocal, 10.0.0.0/8');
+  });
+});
+
+describe('isValidTrustProxyValue', () => {
+  it('accepts empty (reset to default)', () => {
+    expect(isValidTrustProxyValue('')).toBe(true);
+    expect(isValidTrustProxyValue('   ')).toBe(true);
+    expect(isValidTrustProxyValue(null)).toBe(true);
+    expect(isValidTrustProxyValue(undefined)).toBe(true);
+  });
+
+  it('accepts boolean and off keywords', () => {
+    for (const value of ['true', 'false', 'off', 'none', 'no', 'OFF']) {
+      expect(isValidTrustProxyValue(value)).toBe(true);
+    }
+  });
+
+  it('accepts non-negative integer hop counts', () => {
+    for (const value of ['0', '1', '2', '99']) {
+      expect(isValidTrustProxyValue(value)).toBe(true);
+    }
+  });
+
+  it('accepts valid IPv4 / IPv6 addresses and CIDR ranges', () => {
+    for (const value of ['127.0.0.1', '::1', '10.0.0.0/8', '172.16.0.0/12', '2001:db8::/32']) {
+      expect(isValidTrustProxyValue(value)).toBe(true);
+    }
+  });
+
+  it('accepts named presets', () => {
+    for (const value of ['loopback', 'linklocal', 'uniquelocal', 'LOOPBACK']) {
+      expect(isValidTrustProxyValue(value)).toBe(true);
+    }
+  });
+
+  it('accepts comma-separated mixed lists', () => {
+    expect(isValidTrustProxyValue('loopback, 10.0.0.0/8, 192.168.0.1')).toBe(true);
+    expect(isValidTrustProxyValue('uniquelocal,127.0.0.1')).toBe(true);
+  });
+
+  it('rejects malformed values', () => {
+    for (const value of [
+      'abc',
+      '999.999.0.0',
+      '10.0.0.0/99',
+      '2001:db8::/200',
+      '10.0.0.0/8/9',
+      '10.0.0.0/',
+      '-1',
+      '1.5',
+      'loopback,,10.0.0.0/8',
+      '10.0.0.0/abc',
+    ]) {
+      expect(isValidTrustProxyValue(value)).toBe(false);
+    }
+  });
+});

--- a/apps/api/src/trust-proxy.ts
+++ b/apps/api/src/trust-proxy.ts
@@ -1,0 +1,64 @@
+// Parses and validates the TRUST_PROXY env var into an Express trust-proxy value
+// FEATURE: Auth rate limiting — real client IP behind reverse proxy
+import { isIP } from 'net';
+
+export type TrustProxySetting = boolean | number | string;
+
+const TRUST_PROXY_PRESETS = new Set(['loopback', 'linklocal', 'uniquelocal']);
+
+export function resolveTrustProxySetting(raw: string | null | undefined): TrustProxySetting {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed === '') {
+    return false;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower === 'false' || lower === 'off' || lower === 'none' || lower === 'no') {
+    return false;
+  }
+  if (lower === 'true') {
+    return true;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  return trimmed;
+}
+
+export function isValidTrustProxyValue(raw: string | null | undefined): boolean {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed === '') {
+    return true;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower === 'true' || lower === 'false' || lower === 'off' || lower === 'none' || lower === 'no') {
+    return true;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return true;
+  }
+  return trimmed.split(',').every((token) => isValidTrustProxyEntry(token.trim()));
+}
+
+function isValidTrustProxyEntry(entry: string): boolean {
+  if (entry === '') {
+    return false;
+  }
+  if (TRUST_PROXY_PRESETS.has(entry.toLowerCase())) {
+    return true;
+  }
+  const parts = entry.split('/');
+  if (parts.length > 2) {
+    return false;
+  }
+  const version = isIP(parts[0]);
+  if (version === 0) {
+    return false;
+  }
+  if (parts.length === 1) {
+    return true;
+  }
+  if (!/^\d+$/.test(parts[1])) {
+    return false;
+  }
+  return Number(parts[1]) <= (version === 4 ? 32 : 128);
+}

--- a/apps/api/src/users-and-auth/rate-limiting/auth-rate-limit.integration.spec.ts
+++ b/apps/api/src/users-and-auth/rate-limiting/auth-rate-limit.integration.spec.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, INestApplication, Module, Post, UnauthorizedException, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Module, Post, UnauthorizedException, UseInterceptors } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { Reflector } from '@nestjs/core';
 import request from 'supertest';
 import { BruteForceProtectionService } from './brute-force.service';
@@ -48,31 +49,94 @@ const policy = {
 class FakeModule {}
 
 describe('AuthRateLimitInterceptor (HTTP integration)', () => {
-  let app: INestApplication;
+  let app: NestExpressApplication;
   let bruteForce: BruteForceProtectionService;
 
-  beforeAll(async () => {
+  async function init(trustProxy: boolean | number | string): Promise<void> {
     const moduleRef = await Test.createTestingModule({ imports: [FakeModule] }).compile();
-    app = moduleRef.createNestApplication();
+    app = moduleRef.createNestApplication<NestExpressApplication>();
+    app.set('trust proxy', trustProxy);
     await app.init();
     bruteForce = app.get(BruteForceProtectionService);
+  }
+
+  afterEach(async () => {
+    await app?.close();
   });
 
-  afterAll(async () => {
-    await app.close();
-  });
-
-  it('returns 429 with Retry-After after threshold and recovers after recordSuccess', async () => {
+  const hammerToLockout = async (headers: Record<string, string> = {}) => {
     for (let i = 0; i < policy.maxAttempts; i += 1) {
-      const res = await request(app.getHttpServer()).post('/register').send({ fail: true });
+      const res = await request(app.getHttpServer()).post('/register').set(headers).send({ fail: true });
       expect(res.status).toBe(401);
     }
-    const blocked = await request(app.getHttpServer()).post('/register').send({});
-    expect(blocked.status).toBe(429);
-    expect(blocked.headers['retry-after']).toBeDefined();
-    expect(Number(blocked.headers['retry-after'])).toBeGreaterThan(0);
-    await bruteForce.recordSuccess('register', '::ffff:127.0.0.1', null);
-    const after = await request(app.getHttpServer()).post('/register').send({});
-    expect(after.status).toBe(201);
+  };
+
+  describe('without trust proxy (default)', () => {
+    beforeEach(() => init(false));
+
+    it('returns 429 with Retry-After after threshold and recovers after recordSuccess', async () => {
+      await hammerToLockout();
+      const blocked = await request(app.getHttpServer()).post('/register').send({});
+      expect(blocked.status).toBe(429);
+      expect(blocked.headers['retry-after']).toBeDefined();
+      expect(Number(blocked.headers['retry-after'])).toBeGreaterThan(0);
+
+      await bruteForce.recordSuccess('register', '::ffff:127.0.0.1', null);
+      const after = await request(app.getHttpServer()).post('/register').send({});
+      expect(after.status).toBe(201);
+    });
+
+    it('ignores spoofed X-Forwarded-For: distinct fake client IPs share the proxy socket bucket', async () => {
+      await hammerToLockout({ 'X-Forwarded-For': '203.0.113.1' });
+
+      const spoofedDifferentClient = await request(app.getHttpServer())
+        .post('/register')
+        .set('X-Forwarded-For', '203.0.113.99')
+        .send({});
+
+      expect(spoofedDifferentClient.status).toBe(429);
+    });
+  });
+
+  describe('with trust proxy = 1 (single reverse proxy)', () => {
+    beforeEach(() => init(1));
+
+    it('buckets by the real client IP from X-Forwarded-For', async () => {
+      const clientA = '203.0.113.1';
+      const clientB = '203.0.113.2';
+
+      await hammerToLockout({ 'X-Forwarded-For': clientA });
+
+      const blockedA = await request(app.getHttpServer()).post('/register').set('X-Forwarded-For', clientA).send({});
+      expect(blockedA.status).toBe(429);
+      expect(blockedA.headers['retry-after']).toBeDefined();
+
+      const allowedB = await request(app.getHttpServer()).post('/register').set('X-Forwarded-For', clientB).send({});
+      expect(allowedB.status).toBe(201);
+    });
+  });
+
+  describe('with trust proxy = 2 (CDN in front of reverse proxy)', () => {
+    beforeEach(() => init(2));
+
+    it('buckets by the leftmost client across two trusted hops', async () => {
+      const proxy = '198.51.100.7';
+      const clientA = '203.0.113.1';
+      const clientB = '203.0.113.2';
+
+      await hammerToLockout({ 'X-Forwarded-For': `${clientA}, ${proxy}` });
+
+      const blockedA = await request(app.getHttpServer())
+        .post('/register')
+        .set('X-Forwarded-For', `${clientA}, ${proxy}`)
+        .send({});
+      expect(blockedA.status).toBe(429);
+
+      const allowedB = await request(app.getHttpServer())
+        .post('/register')
+        .set('X-Forwarded-For', `${clientB}, ${proxy}`)
+        .send({});
+      expect(allowedB.status).toBe(201);
+    });
   });
 });

--- a/apps/api/src/users-and-auth/rate-limiting/login.rate-limit.guard.spec.ts
+++ b/apps/api/src/users-and-auth/rate-limiting/login.rate-limit.guard.spec.ts
@@ -1,0 +1,38 @@
+import { resolveIp } from './login.rate-limit.guard';
+import { Request } from 'express';
+
+describe('resolveIp', () => {
+  const createRequest = (overrides?: Partial<Request>): Request =>
+    ({
+      ip: '203.0.113.42',
+      headers: {} as Request['headers'],
+      socket: { remoteAddress: '198.51.100.7' } as Request['socket'],
+      ...overrides,
+    } as Request);
+
+  it('returns request.ip, which Express derives via the "trust proxy" setting', () => {
+    expect(resolveIp(createRequest({ ip: '203.0.113.42' }))).toBe('203.0.113.42');
+  });
+
+  it('does NOT trust client-supplied forwarding headers itself (defers entirely to Express)', () => {
+    const req = createRequest({
+      ip: '172.20.0.6',
+      headers: {
+        'x-forwarded-for': '1.2.3.4',
+        'x-real-ip': '5.6.7.8',
+        'cf-connecting-ip': '9.10.11.12',
+      } as Request['headers'],
+    });
+    expect(resolveIp(req)).toBe('172.20.0.6');
+  });
+
+  it('falls back to socket.remoteAddress when request.ip is missing', () => {
+    const req = createRequest({ ip: undefined, socket: { remoteAddress: '198.51.100.7' } as Request['socket'] });
+    expect(resolveIp(req)).toBe('198.51.100.7');
+  });
+
+  it('returns "unknown" when neither request.ip nor socket address is available', () => {
+    const req = createRequest({ ip: undefined, socket: { remoteAddress: undefined } as Request['socket'] });
+    expect(resolveIp(req)).toBe('unknown');
+  });
+});

--- a/apps/api/src/users-and-auth/rate-limiting/login.rate-limit.guard.ts
+++ b/apps/api/src/users-and-auth/rate-limiting/login.rate-limit.guard.ts
@@ -121,12 +121,7 @@ async function observableToPromise(observable: Observable<boolean>): Promise<boo
 }
 
 export function resolveIp(request: Request): string {
-  return (
-    request.ip ||
-    (request.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ||
-    request.socket?.remoteAddress ||
-    'unknown'
-  );
+  return request.ip || request.socket?.remoteAddress || 'unknown';
 }
 
 export function sanitizeUsername(value: unknown): string | null {

--- a/docs/de/installation/environment-variables.md
+++ b/docs/de/installation/environment-variables.md
@@ -18,6 +18,10 @@ Alle Konfigurationsoptionen für Attraccess, die über Umgebungsvariablen gesetz
 | `LOG_LEVELS` | `error,warn,log` | Kommagetrennte Protokollebenen: `error`, `warn`, `log`, `debug`, `verbose` |
 | `LICENSE_KEY` | – | Lizenzschlüssel für Attraccess |
 | `TZ` | – | Zeitzone, z.B. `Europe/Berlin` |
+| `TRUST_PROXY` | – | Anzahl vertrauenswürdiger Reverse-Proxy-Hops, damit das Auth-Rate-Limiting die echte Client-IP verwendet. `1` = einzelner Proxy (nginx/Traefik/Caddy), `2` = CDN + Proxy, oder eine kommagetrennte Liste vertrauenswürdiger Proxy-IPs/CIDRs (bzw. `loopback`, `linklocal`, `uniquelocal`). Nicht gesetzt = keinem Proxy vertrauen. |
+
+> [!NOTE]
+> `TRUST_PROXY` ist **standardmäßig deaktiviert**. Hinter einem Reverse Proxy scheint sonst jede Anfrage von der Proxy-IP zu kommen, sodass das Auth-Rate-Limiting alle Benutzer gemeinsam drosselt statt des eigentlichen Angreifers. Setzen Sie den Wert passend zu Ihrer Proxy-Kette (meist `1`). Mehr Hops zu vertrauen als tatsächlich existieren, erlaubt Clients das Fälschen ihrer IP — siehe [Sicherheit](settings/security.md#reverse-proxies-und-die-echte-client-ip). Wird nach einem Neustart wirksam.
 
 ## Speicher
 

--- a/docs/de/settings/security.md
+++ b/docs/de/settings/security.md
@@ -68,6 +68,22 @@ Antworten bei Ausloesung:
 
 Erfolgreicher Login oder Admin-Unlock entsperrt das Konto. Admin-Unlock erfolgt ueber die Benutzerverwaltung.
 
+### Reverse Proxies und die echte Client-IP
+
+Die Drosselung pro IP funktioniert nur, wenn Attraccess die **echte Client-IP** sieht. Laeuft die Anwendung hinter einem Reverse Proxy (nginx, Traefik, Caddy, einem CDN oder dem mitgelieferten Docker-Stack), kommt die Verbindung vom Proxy — ohne Konfiguration scheint daher jede Anfrage von der Proxy-IP zu stammen. Ein einzelner Angreifer wuerde so alle Benutzer drosseln, und das Audit-Log zeigt fuer alle die Proxy-IP.
+
+Setzen Sie die Umgebungsvariable `TRUST_PROXY` auf die Anzahl vertrauenswuerdiger Proxy-Hops zwischen Client und Attraccess. Die Client-IP wird dann aus dem vom Proxy gesetzten `X-Forwarded-For`-Header gelesen:
+
+| Deployment | `TRUST_PROXY` |
+|------------|---------------|
+| Kein Reverse Proxy (direkt) | nicht gesetzt (Standard) |
+| Einzelner Reverse Proxy (nginx/Traefik/Caddy) | `1` |
+| CDN vor einem Reverse Proxy | `2` |
+| Nur bestimmte vertrauenswuerdige Proxies | kommagetrennte IPs/CIDRs, z.B. `10.0.0.0/8, 172.16.0.0/12`, oder `uniquelocal` |
+
+> [!WARNING]
+> Vertrauen Sie nur so vielen Hops, wie tatsaechlich existieren. Vertraut `TRUST_PROXY` mehr Hops als Ihre reale Proxy-Kette, koennen Clients `X-Forwarded-For` faelschen, ihre scheinbare IP rotieren und das Rate-Limiting umgehen. Nicht gesetzt vertraut Attraccess keinen Weiterleitungs-Headern (sicherer Standard). Aenderungen werden nach einem Neustart wirksam.
+
 ## Format des Anmelde-Audit-Logs
 
 Jeder Anmeldeversuch erzeugt eine einzeilige, leerzeichengetrennte Log-Zeile im `AuthAudit`-Kontext. Feldnamen und Reihenfolge sind stabil und fail2ban-tauglich.

--- a/docs/en/installation/environment-variables.md
+++ b/docs/en/installation/environment-variables.md
@@ -18,6 +18,10 @@ All configuration options for Attraccess that can be set via environment variabl
 | `LOG_LEVELS` | `error,warn,log` | Comma-separated log levels: `error`, `warn`, `log`, `debug`, `verbose` |
 | `LICENSE_KEY` | – | Attraccess license key |
 | `TZ` | – | Time zone, e.g. `Europe/Berlin` |
+| `TRUST_PROXY` | – | Trusted reverse-proxy hops so auth rate limiting uses the real client IP. `1` = single proxy (nginx/Traefik/Caddy), `2` = CDN + proxy, or a comma-separated list of trusted proxy IPs/CIDRs (or `loopback`, `linklocal`, `uniquelocal`). Unset = trust no proxy. |
+
+> [!NOTE]
+> `TRUST_PROXY` is **off by default**. Behind a reverse proxy, every request otherwise appears to come from the proxy IP, so auth rate limiting throttles all users together instead of the real attacker. Set it to match your proxy chain (usually `1`). Trusting more hops than actually exist lets clients spoof their IP — see [Security](settings/security.md#reverse-proxies-and-the-real-client-ip). Takes effect after a restart.
 
 ## Storage
 

--- a/docs/en/settings/security.md
+++ b/docs/en/settings/security.md
@@ -68,6 +68,22 @@ Rate limit triggers:
 
 A successful login or admin unlock clears the lockout. Admin unlock is available via the user management UI.
 
+### Reverse proxies and the real client IP
+
+Per-IP throttling only works if Attraccess sees the **real client IP**. When it runs behind a reverse proxy (nginx, Traefik, Caddy, a CDN, or the bundled Docker stack), the connection arrives from the proxy, so without configuration every request looks like it comes from the proxy IP. One abusive client would then rate-limit everyone, and the audit log shows the proxy IP for all users.
+
+Set the `TRUST_PROXY` environment variable to the number of trusted proxy hops between the client and Attraccess. The client IP is then taken from the `X-Forwarded-For` header added by your proxy:
+
+| Deployment | `TRUST_PROXY` |
+|------------|---------------|
+| No reverse proxy (direct) | unset (default) |
+| Single reverse proxy (nginx/Traefik/Caddy) | `1` |
+| CDN in front of a reverse proxy | `2` |
+| Specific trusted proxies only | comma-separated IPs/CIDRs, e.g. `10.0.0.0/8, 172.16.0.0/12`, or `uniquelocal` |
+
+> [!WARNING]
+> Trust only as many hops as actually exist in your deployment. If `TRUST_PROXY` trusts more hops than your real proxy chain, clients can forge `X-Forwarded-For` to rotate their apparent IP and evade rate limiting entirely. When unset, Attraccess trusts no forwarding headers (safe default). Changes take effect after a restart.
+
 ## Auth Audit Log Format
 
 Every auth attempt produces a single-line, space-separated log record under the `AuthAudit` logger context. Field names and order are stable so the log is fail2ban-friendly.


### PR DESCRIPTION
## Summary
- Behind a reverse proxy, Express saw the **proxy IP** for every request, so auth rate limiting bucketed all users under one IP (global throttle). `resolveIp`'s `X-Forwarded-For` fallback was dead code because `request.ip` is always truthy without `trust proxy` configured.
- Add a **`TRUST_PROXY`** env var (hop count, `true`/`false`, or comma-separated IP/CIDR/preset list) applied via `app.set('trust proxy', …)` at bootstrap. **Default off** (current behavior) — opt-in. Invalid values warn and fall back to off; a bad value cannot brick boot (try/catch).
- `resolveIp` now defers to `request.ip` (Express derives the real client IP from `X-Forwarded-For` only for **trusted hops**) instead of trusting client-supplied headers, which would be spoofable. The same `resolveIp` feeds the audit log, so fail2ban also bans the real client IP once `TRUST_PROXY` is set.
- Env var (not a DB/UI setting) by design: a system-critical security knob shouldn't be able to lock an admin out of the UI.

## Why default off
Trusting proxy headers when not actually behind a trusted proxy lets a client spoof `X-Forwarded-For` to rotate its apparent IP and evade rate limiting. Admins opt in to match their real proxy chain (usually `TRUST_PROXY=1`).

## Test plan
- [x] `trust-proxy.spec.ts` (12) — parse + validate: hop counts, `true`/`false`/`off`, IPv4/IPv6, CIDR, presets, malformed rejects
- [x] `login.rate-limit.guard.spec.ts` (4) — `request.ip` preferred, forwarding headers ignored, socket fallback, `unknown`
- [x] `auth-rate-limit.integration.spec.ts` (4) — trust off = shared/spoof-safe bucket (the bug), trust=1 single hop → real client, trust=2 CDN+proxy → leftmost client
- [x] Full api suite green · lint · build (typecheck)
- [ ] Manual: deploy behind proxy with `TRUST_PROXY=1`, confirm audit log shows real client IPs and per-client throttling

## Docs
`.env.example`, en/de `installation/environment-variables.md`, en/de `settings/security.md` (new "Reverse proxies and the real client IP" section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)