### PR TITLE
fix(ATT-396): show clear state in usage history scope toggle

### DIFF
--- a/apps/frontend/src/app/resources/usage/components/HistoryHeader/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryHeader/index.tsx
@@ -1,9 +1,6 @@
 import { memo } from 'react';
-import { Checkbox } from '@heroui/react';
-import { History, Users } from 'lucide-react';
-import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import en from './translations/en';
-import de from './translations/de';
+import { History } from 'lucide-react';
+import { ShowAllUsersToggle } from '../ShowAllUsersToggle';
 
 interface HistoryHeaderProps {
   title: string;
@@ -14,8 +11,6 @@ interface HistoryHeaderProps {
 
 export const HistoryHeader = memo(
   ({ title, showAllUsers, setShowAllUsers, canManageResources }: HistoryHeaderProps) => {
-    const { t } = useTranslations({ en, de });
-
     return (
       <div className="flex items-center justify-between gap-x-4 gap-y-4 flex-wrap">
         <div className="flex items-center">
@@ -23,12 +18,7 @@ export const HistoryHeader = memo(
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
         </div>
         {canManageResources && (
-          <div className="flex items-center">
-            <Checkbox isSelected={showAllUsers} onChange={setShowAllUsers} />
-            <span className="ml-2 text-sm flex items-center">
-              <Users className="w-4 h-4 mr-1" /> {t('showAllUsers')}
-            </span>
-          </div>
+          <ShowAllUsersToggle showAllUsers={showAllUsers} setShowAllUsers={setShowAllUsers} />
         )}
       </div>
     );

--- a/apps/frontend/src/app/resources/usage/components/HistoryHeader/translations/de.ts
+++ b/apps/frontend/src/app/resources/usage/components/HistoryHeader/translations/de.ts
@@ -1,4 +1,0 @@
-export default {
-  usageHistory: 'Nutzungsverlauf',
-  showAllUsers: 'Alle Benutzer anzeigen',
-};

--- a/apps/frontend/src/app/resources/usage/components/HistoryHeader/translations/en.ts
+++ b/apps/frontend/src/app/resources/usage/components/HistoryHeader/translations/en.ts
@@ -1,4 +1,0 @@
-export default {
-  usageHistory: 'Usage History',
-  showAllUsers: 'Show all users',
-};

--- a/apps/frontend/src/app/resources/usage/components/ShowAllUsersToggle/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ShowAllUsersToggle/index.tsx
@@ -1,0 +1,35 @@
+import { memo } from 'react';
+import { User, Users } from 'lucide-react';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { LabeledSwitch } from '../../../../../components/labeledSwitch';
+import en from './translations/en';
+import de from './translations/de';
+
+interface ShowAllUsersToggleProps {
+  showAllUsers: boolean;
+  setShowAllUsers: (value: boolean) => void;
+}
+
+export const ShowAllUsersToggle = memo(({ showAllUsers, setShowAllUsers }: ShowAllUsersToggleProps) => {
+  const { t } = useTranslations({ en, de });
+
+  const Icon = showAllUsers ? Users : User;
+  const label = showAllUsers ? t('showingAllUsers') : t('showingOnlyMe');
+
+  return (
+    <LabeledSwitch
+      size="sm"
+      isSelected={showAllUsers}
+      onChange={setShowAllUsers}
+      aria-label={t('ariaLabel')}
+      data-cy="show-all-users-toggle"
+    >
+      <span className="flex items-center gap-1 text-sm">
+        <Icon className="w-4 h-4" />
+        {label}
+      </span>
+    </LabeledSwitch>
+  );
+});
+
+ShowAllUsersToggle.displayName = 'ShowAllUsersToggle';

--- a/apps/frontend/src/app/resources/usage/components/ShowAllUsersToggle/translations/de.ts
+++ b/apps/frontend/src/app/resources/usage/components/ShowAllUsersToggle/translations/de.ts
@@ -1,0 +1,5 @@
+export default {
+  showingAllUsers: 'Anzeige: Alle Benutzer',
+  showingOnlyMe: 'Anzeige: Nur ich',
+  ariaLabel: 'Zwischen eigenen Sitzungen und Sitzungen aller Benutzer umschalten',
+};

--- a/apps/frontend/src/app/resources/usage/components/ShowAllUsersToggle/translations/en.ts
+++ b/apps/frontend/src/app/resources/usage/components/ShowAllUsersToggle/translations/en.ts
@@ -1,0 +1,5 @@
+export default {
+  showingAllUsers: 'Showing: All users',
+  showingOnlyMe: 'Showing: Only me',
+  ariaLabel: 'Toggle between showing only your sessions or sessions of all users',
+};

--- a/apps/frontend/src/app/resources/usage/resourceUsageHistory.tsx
+++ b/apps/frontend/src/app/resources/usage/resourceUsageHistory.tsx
@@ -1,8 +1,7 @@
 import { HTMLAttributes, useCallback, useRef, useState } from 'react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useAuth } from '../../../hooks/useAuth';
-import { Checkbox } from '@heroui/react';
-import { History, Users } from 'lucide-react';
+import { History } from 'lucide-react';
 import {
   ResourceUsage,
   useResourcesServiceResourceUsageUpdateSessionProject,
@@ -10,14 +9,13 @@ import {
 } from '@attraccess/react-query-client';
 import { HistoryTable } from './components/HistoryTable';
 import { UsageNotesModal } from './components/UsageNotesModal';
+import { ShowAllUsersToggle } from './components/ShowAllUsersToggle';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToastMessage } from '../../../components/toastProvider';
 import en from './translations/resourceUsageHistory.en';
 import de from './translations/resourceUsageHistory.de';
 import historyTableEn from './components/HistoryTable/utils/translations/en.json';
 import historyTableDe from './components/HistoryTable/utils/translations/de.json';
-import historyHeaderEn from './components/HistoryHeader/translations/en';
-import historyHeaderDe from './components/HistoryHeader/translations/de';
 import { FlatSection } from '../../../components/flatSection';
 
 type ResourceUsageHistoryProps = Omit<HTMLAttributes<HTMLElement>, 'children'> & {
@@ -28,7 +26,6 @@ type ResourceUsageHistoryProps = Omit<HTMLAttributes<HTMLElement>, 'children'> &
 export function ResourceUsageHistory({ resourceId, hideHeader, ...rest }: ResourceUsageHistoryProps) {
   const { t } = useTranslations({ en, de });
   const { t: tHistoryTable } = useTranslations({ en: historyTableEn, de: historyTableDe });
-  const { t: tHistoryHeader } = useTranslations({ en: historyHeaderEn, de: historyHeaderDe });
   const { hasPermission } = useAuth();
   const canManageResources = hasPermission('canManageResources');
   const queryClient = useQueryClient();
@@ -136,12 +133,7 @@ export function ResourceUsageHistory({ resourceId, hideHeader, ...rest }: Resour
   );
 
   const showAllUsersToggle = canManageResources ? (
-    <div className="flex items-center">
-      <Checkbox isSelected={showAllUsers} onChange={setShowAllUsers} />
-      <span className="ml-2 text-sm flex items-center">
-        <Users className="w-4 h-4 mr-1" /> {tHistoryHeader('showAllUsers')}
-      </span>
-    </div>
+    <ShowAllUsersToggle showAllUsers={showAllUsers} setShowAllUsers={setShowAllUsers} />
   ) : undefined;
 
   const table = (


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Resource Usage History had a checkbox to toggle between "only my sessions" and "all users", but the checkbox state was nearly invisible — admins could not tell at a glance which scope they were viewing without scanning the table rows for foreign usernames.

Replace it with a labeled HeroUI Switch whose label flips between **"Showing: Only me"** and **"Showing: All users"**, paired with a `User` / `Users` icon. The colored switch thumb plus dynamic copy make the current scope obvious without inspecting data.

Extracted into a dedicated `ShowAllUsersToggle` component with its own translations; removed the now-dead `HistoryHeader/translations` duplicates.

Screenshots posted to the Linear issue.

## Linear

Closes [ATT-396](https://linear.app/attraccess/issue/ATT-396/resource-usage-history-show-all-users-toggle-bad-uiux)

## Test plan

- [x] Typecheck passes (`nx typecheck frontend`)
- [x] Lint passes (`nx lint frontend`)
- [x] Manual browser verification of both states in DE + EN
- [x] Switch thumb + label + icon all reflect state

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->