### PR TITLE
fix(ATT-394): wrap password-policy diff table in TableContent

### DIFF
--- a/apps/frontend/src/app/settings/password-policy/ConfirmDiffModal.tsx
+++ b/apps/frontend/src/app/settings/password-policy/ConfirmDiffModal.tsx
@@ -11,6 +11,7 @@ import {
   TableBody,
   TableCell,
   TableColumn,
+  TableContent,
   TableHeader,
   TableRow,
 } from '@heroui/react';
@@ -48,24 +49,26 @@ export function ConfirmDiffModal({ isOpen, diff, isConfirming, onClose, onConfir
                 <p className="text-sm text-default-500">{t('diff.noChanges')}</p>
               ) : (
                 <Table aria-label="changes" data-testid="policy-diff-table">
-                  <TableHeader>
-                    <TableColumn isRowHeader>{t('diff.field')}</TableColumn>
-                    <TableColumn>{t('diff.before')}</TableColumn>
-                    <TableColumn>{t('diff.after')}</TableColumn>
-                  </TableHeader>
-                  <TableBody>
-                    {diff.map((row) => (
-                      <TableRow key={row.field}>
-                        <TableCell className="font-medium">{row.field}</TableCell>
-                        <TableCell>
-                          <code>{row.before}</code>
-                        </TableCell>
-                        <TableCell>
-                          <code className="text-success-600">{row.after}</code>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
+                  <TableContent>
+                    <TableHeader>
+                      <TableColumn isRowHeader>{t('diff.field')}</TableColumn>
+                      <TableColumn>{t('diff.before')}</TableColumn>
+                      <TableColumn>{t('diff.after')}</TableColumn>
+                    </TableHeader>
+                    <TableBody>
+                      {diff.map((row) => (
+                        <TableRow key={row.field}>
+                          <TableCell className="font-medium">{row.field}</TableCell>
+                          <TableCell>
+                            <code>{row.before}</code>
+                          </TableCell>
+                          <TableCell>
+                            <code className="text-success-600">{row.after}</code>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </TableContent>
                 </Table>
               )}
             </ModalBody>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Saving the global password policy crashed the entire React tree and left a blank page.

Root cause: `ConfirmDiffModal.tsx` rendered `<Table><TableHeader/><TableBody/></Table>` directly. HeroUI v3 requires a `<TableContent>` wrapper between `<Table>` and its header/body — without it React Aria throws `cannot be rendered outside a collection`, which propagates past the error boundary and unmounts the page.

Fix: wrap the diff table in `<TableContent>` (same pattern already used in `OverridesSection.tsx`).

## Test plan

- [x] Reproduced the blank page on `att-394` before the fix (Vite dev server, admin user, click save) — React error in console: `cannot be rendered outside a collection`
- [x] After fix: confirm dialog renders, save persists, toast shows, value reflected in subsequent GET
- [x] `nx run frontend:typecheck`
- [x] `nx run frontend:lint` (only pre-existing warning unrelated)

Linear: [ATT-394](https://linear.app/attraccess/issue/ATT-394/saving-password-policy-is-broken-and-results-in-black-page)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->