### PR TITLE
fix(ATT-395): pan/select mode toggle for flow canvas (touch fix)

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/de.json
+++ b/apps/frontend/src/app/resources/details/flows/de.json
@@ -5,7 +5,9 @@
     "export": "Exportieren",
     "import": "Importieren",
     "addNode": "Knoten hinzufügen",
-    "variables": "Variablen"
+    "variables": "Variablen",
+    "modePan": "Canvas verschieben",
+    "modeSelect": "Auswählen"
   },
   "export": {
     "success": {

--- a/apps/frontend/src/app/resources/details/flows/en.json
+++ b/apps/frontend/src/app/resources/details/flows/en.json
@@ -5,7 +5,9 @@
     "export": "Export",
     "import": "Import",
     "addNode": "Add node",
-    "variables": "Variables"
+    "variables": "Variables",
+    "modePan": "Pan canvas",
+    "modeSelect": "Select"
   },
   "export": {
     "success": {

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { Background, BackgroundVariant, Controls, ReactFlow, Node, Panel, Edge, useReactFlow, SelectionMode } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
+import { ButtonGroup } from '@heroui/react';
 import {
   ApiError,
   ResourceFlowEdgeDto,
@@ -17,8 +18,10 @@ import { usePtrStore } from '../../../../stores/ptr.store';
 import Dagre from '@dagrejs/dagre';
 import { Button } from '@heroui/react';
 import {
+  BoxSelectIcon,
   Braces as BracesIcon,
   DownloadIcon,
+  HandIcon,
   LayoutGridIcon,
   LogsIcon,
   PlusIcon,
@@ -302,6 +305,15 @@ function FlowsPageInner() {
   const [flowIsRunning, setFlowIsRunning] = useState(false);
   const [, setFlowExecutionHadError] = useState(false);
 
+  const [interactionMode, setInteractionMode] = useState<'pan' | 'select'>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return 'select';
+    }
+    return window.matchMedia('(hover: none) and (pointer: coarse)').matches ? 'pan' : 'select';
+  });
+  const panOnDrag = interactionMode === 'pan' ? true : [1, 2];
+  const selectionOnDrag = interactionMode === 'select';
+
   const onLiveLog = useCallback(
     (log: ResourceFlowLog) => {
       if (log.type === 'node.processing.failed') {
@@ -405,8 +417,8 @@ function FlowsPageInner() {
             onConnect={onConnect}
             onDrop={onDropNode}
             onDragOver={onDragOver}
-            selectionOnDrag
-            panOnDrag={[1, 2]}
+            selectionOnDrag={selectionOnDrag}
+            panOnDrag={panOnDrag}
             selectionMode={SelectionMode.Partial}
             deleteKeyCode={['Backspace', 'Delete']}
             multiSelectionKeyCode="Shift"
@@ -418,6 +430,29 @@ function FlowsPageInner() {
           >
             <Controls />
             <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
+
+            <Panel position="top-left">
+              <ButtonGroup>
+                <Button
+                  isIconOnly
+                  variant={interactionMode === 'pan' ? 'primary' : 'ghost'}
+                  onPress={() => setInteractionMode('pan')}
+                  aria-label={t('actions.modePan')}
+                  aria-pressed={interactionMode === 'pan'}
+                >
+                  <HandIcon />
+                </Button>
+                <Button
+                  isIconOnly
+                  variant={interactionMode === 'select' ? 'primary' : 'ghost'}
+                  onPress={() => setInteractionMode('select')}
+                  aria-label={t('actions.modeSelect')}
+                  aria-pressed={interactionMode === 'select'}
+                >
+                  <BoxSelectIcon />
+                </Button>
+              </ButtonGroup>
+            </Panel>
 
             <Panel position="top-right" className="flex flex-row flex-wrap gap-2">
               <Button


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
Fixes [ATT-395](https://linear.app/attraccess/issue/ATT-395/moving-resource-flows-canvas-with-touch-or-pen-on-ios). On iOS, single-finger/pen drag on the resource flow canvas hit `selectionOnDrag` (button 0) instead of panning, so the canvas appeared stuck with a selection rectangle.

Adds an explicit pan/select mode toggle (HeroUI `ButtonGroup`) in the canvas' top-left panel:

- **Pan mode**: `panOnDrag={true}`, `selectionOnDrag={false}` — single touch or left-drag pans.
- **Select mode**: `panOnDrag={[1, 2]}`, `selectionOnDrag={true}` — left-drag draws a selection rectangle, middle/right-drag pans (existing desktop UX).

Default is derived from `matchMedia('(hover: none) and (pointer: coarse)')`: pan on touch devices, select on hover/mouse devices. Shift-multiselect and keyboard shortcuts are unaffected.

## Test plan
- [x] `nx run frontend:typecheck`
- [x] `nx run frontend:lint`
- [x] `nx run frontend:test` (132 passed)
- [x] Verified in agent-browser: toggle switches active mode and ReactFlow prop wiring.
- [ ] Manual iOS verification: single-finger drag pans in pan mode; toggle to select mode produces selection rectangle.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->