### PR TITLE
fix(ATT-397): resource tabs use mobile picker on <sm screens

### DIFF
--- a/apps/frontend/src/app/resources/details/health-state/index.tsx
+++ b/apps/frontend/src/app/resources/details/health-state/index.tsx
@@ -55,7 +55,7 @@ export function ResourceHealthWarning({ resourceId }: Props) {
   }
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 mb-6">
       {summary.unhealthyEntries.map((entry: ResourceHealthStateDto) => {
         const identifierLabel =
           entry.identifier && entry.identifier.length > 0

--- a/apps/frontend/src/app/resources/details/layout/ResourceTabsLayout.tsx
+++ b/apps/frontend/src/app/resources/details/layout/ResourceTabsLayout.tsx
@@ -163,8 +163,6 @@ function ResourceTabsLayoutInner({ resourceId, children }: { resourceId: number;
     },
   ];
 
-  const useMobilePicker = tabs.length > 5;
-
   const navigateToTab = (key: ResourceTabKey) => {
     const next = tabs.find((tab) => tab.key === key);
     if (next) navigate(`/resources/${resourceId}${next.path ? '/' + next.path : ''}`);
@@ -189,19 +187,17 @@ function ResourceTabsLayoutInner({ resourceId, children }: { resourceId: number;
       </div>
 
       <div className="mb-6">
-        {useMobilePicker ? (
-          <div className="sm:hidden">
-            <Select
-              aria-label={t('tabs.mobilePickerLabel')}
-              value={activeTabKey}
-              onChange={(key) => navigateToTab(key as ResourceTabKey)}
-              items={tabs.map((tab) => ({ key: tab.key, label: t(tab.translationKey) }))}
-              data-cy="resource-tabs-mobile-picker"
-            />
-          </div>
-        ) : null}
+        <div className="sm:hidden">
+          <Select
+            aria-label={t('tabs.mobilePickerLabel')}
+            value={activeTabKey}
+            onChange={(key) => navigateToTab(key as ResourceTabKey)}
+            items={tabs.map((tab) => ({ key: tab.key, label: t(tab.translationKey) }))}
+            data-cy="resource-tabs-mobile-picker"
+          />
+        </div>
 
-        <div className={useMobilePicker ? 'hidden sm:block' : ''}>
+        <div className="hidden sm:block">
           <Tabs
             aria-label={t('tabs.mobilePickerLabel')}
             selectedKey={activeTabKey}

--- a/apps/frontend/src/app/resources/details/layout/ResourceTabsLayout.tsx
+++ b/apps/frontend/src/app/resources/details/layout/ResourceTabsLayout.tsx
@@ -180,13 +180,12 @@ function ResourceTabsLayoutInner({ resourceId, children }: { resourceId: number;
         actions={overflowActions}
         maxVisibleActions={0}
         moreActionsLabel={t('actions.moreLabel')}
+        noMargin
       />
 
-      <div className="mb-6">
-        <ResourceHealthWarning resourceId={resourceId} />
-      </div>
+      <ResourceHealthWarning resourceId={resourceId} />
 
-      <div className="mb-6">
+      <div className="mt-4 mb-4">
         <div className="sm:hidden">
           <Select
             aria-label={t('tabs.mobilePickerLabel')}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Resource details tab strip overflowed narrow mobile viewports and pushed
the page horizontally, clipping stat cards and content (ATT-397).

The mobile picker was already implemented but only kicked in for users with
more than 5 tabs. Users with 4 visible tabs (introducer + maintenance
manager, no canManageResources) still got the overflowing HeroUI `Tabs`
row.

Fix: drop the `tabs.length > 5` gate so any `sm`-and-below viewport renders
the Select picker, and the Tabs row only renders from `sm` and up.

## Linear

[ATT-397](https://linear.app/attraccess/issue/ATT-397/resource-details-tabs-are-not-mobile-friendly-and-break-page-layout)

## Test plan

- [x] Manual: iPhone 12 viewport (390×844) — Übersicht/Wartung/Verlauf — no horizontal overflow, picker fits, stat cards fully visible
- [x] Manual: 768×900 viewport — tab strip still renders normally
- [x] `pnpm nx typecheck frontend`
- [x] `pnpm nx lint frontend`

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->