### PR TITLE
fix(ATT-404): use danger color for resource usage stop button

### DIFF
--- a/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/index.tsx
@@ -130,13 +130,14 @@ export function ActiveSessionDisplay({ resourceId, startTime }: ActiveSessionDis
 
         <ButtonGroup className="w-full">
           <Button
+            variant="danger"
             isPending={endSession.isPending}
             onPress={immediatelyEndSession}
           ><StopCircle className="w-4 h-4" />
             {t('endSession')}
           </Button>
           <Dropdown>
-            <DropdownTrigger className={buttonVariants({ isIconOnly: true })}>
+            <DropdownTrigger className={buttonVariants({ isIconOnly: true, variant: 'danger' })}>
               <ChevronDownIcon />
             </DropdownTrigger>
             <DropdownPopover>


### PR DESCRIPTION
## Summary
- Apply HeroUI `danger` color to the active-session `ButtonGroup` and the chevron `DropdownTrigger` (`buttonVariants({ color: 'danger' })`) so both halves of the end-session control read as destructive.
- Linear: [ATT-404](https://linear.app/attraccess/issue/ATT-404/resource-usage-stop-button-should-be-reddanger-color)
- Closes #1033

## Test plan
- [x] Visual verification in browser with a real active session (screenshots in Linear issue).
- [x] `pnpm nx affected -t lint --uncommitted` — clean.
- [x] `pnpm nx affected -t typecheck --uncommitted` — clean.

<!-- generated-by-cyrus -->