### PR TITLE
fix(ATT-408): use nested plural object for fieldCount EN translation

### DIFF
--- a/apps/frontend/src/app/resources/details/forms/en.json
+++ b/apps/frontend/src/app/resources/details/forms/en.json
@@ -11,8 +11,10 @@
       "takeover": "On takeover",
       "end": "On end"
     },
-    "fieldCount_one": "{{count}} field",
-    "fieldCount_other": "{{count}} fields"
+    "fieldCount": {
+      "one": "{{count}} field",
+      "many": "{{count}} fields"
+    }
   },
   "editor": {
     "createTitle": "Create form",


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes the missing-translation error `Missing translation for key: list.fieldCount` on `/resources/:id/forms`, which rendered as `!!! list.fieldCount !!!` in the form card field counter.

## Root cause

`apps/frontend/src/app/resources/details/forms/en.json` used i18next-style flat plural keys (`fieldCount_one` / `fieldCount_other`). The custom `useTranslations` hook in `libs/plugins-frontend-ui/src/lib/i18n.ts` does not implement i18next pluralization — it expects a nested `{ one, many }` plural object (which `de.json` already uses). Because the lookup is `get(translations, 'list.fieldCount')`, the flat suffix keys were unreachable, so the resolver returned `undefined` and emitted the console error.

## Fix

Convert the EN entry to the same nested `{ one, many }` shape used by DE:

```diff
- "fieldCount_one": "{{count}} field",
- "fieldCount_other": "{{count}} fields"
+ "fieldCount": {
+   "one": "{{count}} field",
+   "many": "{{count}} fields"
+ }
```

## Test plan

- [ ] Visit `/resources/1/forms` in EN — field counter shows `N field` / `N fields` (no `!!!` placeholder, no console error)
- [ ] Switch language to DE — counter shows `N Feld` / `N Felder` (already worked, no regression)

> **Note:** Local browser verification was not possible — the Claude browser extension was not connected in this session. Change is JSON-only and the resolver logic in `libs/plugins-frontend-ui/src/lib/i18n.ts` (`isPluralObject` + `resolvePlural`) is well-defined for this shape, so the fix is high-confidence but please spot-check in a running app.

Closes [ATT-408](https://linear.app/attraccess/issue/ATT-408/missing-translation-for-key-listfieldcount).

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Resolve the missing `list.fieldCount` translation on the resource forms page by providing a proper nested plural translation entry in the English locale file.