### PR TITLE
fix(ATT-409): make form validation errors visible with bold red + warning glyph

### DIFF
--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.de.json
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.de.json
@@ -11,7 +11,8 @@
       }
     },
     "name": {
-      "label": "Name"
+      "label": "Name",
+      "required": "Name ist erforderlich"
     },
     "description": {
       "label": "Beschreibung"

--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.en.json
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.en.json
@@ -11,7 +11,8 @@
       }
     },
     "name": {
-      "label": "Name"
+      "label": "Name",
+      "required": "Name is required"
     },
     "description": {
       "label": "Description"

--- a/apps/frontend/src/app/resources/editModal/tabs/shared.tsx
+++ b/apps/frontend/src/app/resources/editModal/tabs/shared.tsx
@@ -21,7 +21,7 @@ export function SharedDataTab(props: EditorTabProps & Props) {
       >
         <Label>{t('inputs.name.label')}</Label>
         <Input required className="w-full" />
-        {!formData.name && <FieldError />}
+        {!formData.name && <FieldError>{t('inputs.name.required')}</FieldError>}
       </TextField>
       <TextField
         value={formData.description}

--- a/apps/frontend/src/app/resources/forms/components/ResourceFormsModal.tsx
+++ b/apps/frontend/src/app/resources/forms/components/ResourceFormsModal.tsx
@@ -272,12 +272,20 @@ function renderTextInput(
 ) {
   if (options.multiline) {
     return (
-      <TextArea
-        value={(value as string) ?? ''}
-        placeholder={options.placeholder ?? ''}
-        onChange={(e) => onChange(e.target.value)}
-        aria-invalid={Boolean(error)}
-      />
+      <div className="space-y-1">
+        <TextArea
+          value={(value as string) ?? ''}
+          placeholder={options.placeholder ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          aria-invalid={Boolean(error)}
+        />
+        {error && (
+          <p className="flex items-start gap-1 text-sm font-medium text-danger">
+            <span aria-hidden="true">⚠</span>
+            <span>{error}</span>
+          </p>
+        )}
+      </div>
     );
   }
 
@@ -327,7 +335,12 @@ function renderBooleanInput(
         />
         <span className="text-xs text-default-500">{t('modal.booleanYes')}</span>
       </div>
-      {error && <p className="text-xs text-danger-500">{error}</p>}
+      {error && (
+        <p className="flex items-start gap-1 text-sm font-medium text-danger">
+          <span aria-hidden="true">⚠</span>
+          <span>{error}</span>
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -21,4 +21,14 @@ body,
   overflow: hidden;
 }
 
+/* Expressive form validation errors: larger, bolder, with leading warning glyph */
+.field-error[data-visible="true"] {
+  @apply text-sm font-medium flex items-start gap-1;
+}
+
+.field-error[data-visible="true"]::before {
+  content: "⚠";
+  @apply text-base leading-none;
+}
+
 /* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Form validation errors across the app were rendered in HeroUI's default light-gray `text-xs`, making them easy to miss (see the original bug screenshot on the `ResourceFormsModal` boolean field).

- Globally override `.field-error[data-visible="true"]` in `styles.css` to `text-sm font-medium` with a leading ⚠ glyph. This catches every HeroUI `FieldError` (used in `ResourceFormsModal`, `ResourceGroupUpsertModal`, `DocumentationEditor`, `UploadPluginModal`, `ResourceEditModal`, `PasswordInput`, `UsernameInput`, `PasswordField`) without per-callsite churn.
- Match the same styling on the `ResourceFormsModal` boolean branch (which used a custom `<p>` instead of `FieldError`).
- Fix the `ResourceFormsModal` multiline text branch: it called `aria-invalid` but never rendered the error string. Now shows the matching red error block.
- Fix `ResourceEditModal` shared tab: empty `<FieldError />` now contains `inputs.name.required` text (EN/DE translations added).

Resolves [ATT-409](https://linear.app/attraccess/issue/ATT-409/resource-forms-form-error-state-not-very-expressive).

## Verification

Logged in, opened a resource with a required `PreFlight` form containing a required boolean and a multiline text field, and submitted with the boolean unchecked. The error `Dieses Feld muss aktiviert sein` now renders in vivid red with the ⚠ prefix. Also verified the `ResourceEditModal` name-required path — `⚠ Name ist erforderlich` shows clearly below the input. Screenshots posted in the Linear issue thread.

- `pnpm nx affected --uncommitted --target=lint --max-warnings=0` — pass (only pre-existing warning in `flows/node/editor/property-input/index.tsx`, untouched here)
- `pnpm nx affected --uncommitted --target=typecheck` — pass
- `pnpm nx affected --uncommitted --target=test` — 132/132 pass

## Test plan

- [ ] Open a resource that requires a form before start; click submit with required fields empty → confirm error text is large red with ⚠ glyph
- [ ] Open `Ressource erstellen` modal; submit empty → confirm `⚠ Name ist erforderlich`
- [ ] Open `Ressourcen-Gruppe` upsert modal; submit empty → confirm name FieldError styling
- [ ] Open `Plugin hochladen`; submit without file → confirm invalid-file error
- [ ] Open `Dokumentation bearbeiten`; submit markdown/URL form empty → confirm error styling
- [ ] Light + dark theme: error color stays vivid

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->