### PR TITLE
fix(ATT-410): two-column layout for docs + recent sessions on overview

### DIFF
--- a/apps/frontend/src/app/resources/details/overview/ResourceOverviewTab.tsx
+++ b/apps/frontend/src/app/resources/details/overview/ResourceOverviewTab.tsx
@@ -39,9 +39,10 @@ export function ResourceOverviewTab() {
         </aside>
       </div>
 
-      <ResourceDocsPreviewCard resourceId={resourceId} />
-
-      <RecentSessionsCard resourceId={resourceId} />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:items-start">
+        <ResourceDocsPreviewCard resourceId={resourceId} />
+        <RecentSessionsCard resourceId={resourceId} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Resource details overview tab rendered the Documentation preview and Recent Sessions cards as two stacked full-width sections, leaving a lot of dead space next to them on wide screens.

This wraps both cards in a responsive `grid-cols-1 lg:grid-cols-2` layout so they sit side-by-side on screens ≥ 1024 px and stack on tablet/mobile.

- Touches only `apps/frontend/src/app/resources/details/overview/ResourceOverviewTab.tsx` (3 LOC).
- Mirrors the breakpoint already used by the Session/Billing row above.
- Mobile/tablet layout unchanged — cards stack vertically below `lg`.

## Test plan

- [x] `pnpm nx affected -t lint --uncommitted` — clean (1 pre-existing unrelated warning).
- [x] `pnpm nx affected -t test --uncommitted` — 132 / 132 frontend tests pass.
- [x] Manual browser verification with seeded resource + 3 sessions on `localhost:4204`:
  - Desktop (1280-wide): docs preview and recent sessions render side-by-side.
  - Mobile (390-wide): cards stack vertically.

Linear: [ATT-410](https://linear.app/attraccess/issue/ATT-410/resource-documentation-preview-and-recent-history-should-be-multi)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->