### PR TITLE
fix(ATT-412): distinct SumUp Credentials/Configuration card titles

### DIFF
--- a/apps/frontend/src/app/billing/administration/sumup/configuration/currency/de.json
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/currency/de.json
@@ -1,22 +1,7 @@
 {
   "title": "Konfiguration",
   "subtitle": "Konfigurieren Sie Attraccess für SumUp",
-  "status": {
-    "enabled": {
-      "title": "Aktiviert"
-    },
-    "disabled": {
-      "title": "Deaktiviert"
-    },
-    "loading": {
-      "title": "Wird geladen..."
-    }
-  },
   "inputs": {
-    "apiKey": {
-      "label": "API-Schlüssel",
-      "description": "Sie können Ihren API-Schlüssel in der SumUp-Konsole finden."
-    },
     "currency": {
       "label": "Währung",
       "description": "Wählen Sie die Währung für die Zahlungen"

--- a/apps/frontend/src/app/billing/administration/sumup/configuration/currency/en.json
+++ b/apps/frontend/src/app/billing/administration/sumup/configuration/currency/en.json
@@ -1,22 +1,7 @@
 {
-  "title": "Credentials",
-  "subtitle": "Connect Attraccess to your SumUp account to enable digital payments.",
-  "status": {
-    "enabled": {
-      "title": "Enabled"
-    },
-    "disabled": {
-      "title": "Disabled"
-    },
-    "loading": {
-      "title": "Loading..."
-    }
-  },
+  "title": "Configuration",
+  "subtitle": "Configure Attraccess for SumUp",
   "inputs": {
-    "apiKey": {
-      "label": "API Key",
-      "description": "You can find your API key in the SumUp console."
-    },
     "currency": {
       "label": "Currency",
       "description": "Select the currency for payments"
@@ -27,8 +12,8 @@
   },
   "success": {
     "toast": {
-      "title": "Credentials updated",
-      "description": "Credentials were updated successfully"
+      "title": "Configuration updated",
+      "description": "Configuration was updated successfully"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Currency card on the SumUp admin page reused the API Key card's translations, so both sections rendered with the identical "Credentials" title in English.
- Replaces `currency/en.json` title/subtitle/toast with the configuration copy the DE locale already used, and drops the unused `status`/`inputs.apiKey` keys from both locales so each translation file matches the component it backs.

## Test plan
- [x] Sign in to the local app, switch to English, open `/billing/administration/sumup` → left card shows "Credentials", right card shows "Configuration".
- [x] Repeat in German → "Zugangsdaten" + "Konfiguration".
- [x] `nx typecheck frontend` passes (lint warning seen is pre-existing in resources/flows/property-input).

Closes ATT-412

<!-- generated-by-cyrus -->