### PR TITLE
fix(ATT-411): include full end day in CSV export date range

### DIFF
--- a/apps/frontend/src/app/csv-export/date-range-section/compute-range.test.ts
+++ b/apps/frontend/src/app/csv-export/date-range-section/compute-range.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { CalendarDate, getLocalTimeZone } from '@internationalized/date';
+import { rangeToDateBounds } from './compute-range';
+
+describe('rangeToDateBounds', () => {
+  it('uses end-of-day for the end bound so usages on the end day are included', () => {
+    const range = {
+      start: new CalendarDate(2026, 5, 1),
+      end: new CalendarDate(2026, 5, 30),
+    };
+
+    const { start, end } = rangeToDateBounds(range, new Date(0));
+
+    const tz = getLocalTimeZone();
+    const expectedStart = new CalendarDate(2026, 5, 1).toDate(tz);
+    const expectedEndDay = new CalendarDate(2026, 5, 30).toDate(tz);
+
+    expect(start.getTime()).toBe(expectedStart.getTime());
+    expect(end.getFullYear()).toBe(expectedEndDay.getFullYear());
+    expect(end.getMonth()).toBe(expectedEndDay.getMonth());
+    expect(end.getDate()).toBe(expectedEndDay.getDate());
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+    expect(end.getSeconds()).toBe(59);
+    expect(end.getMilliseconds()).toBe(999);
+  });
+
+  it('makes a single-day range cover the entire day', () => {
+    const today = new CalendarDate(2026, 5, 25);
+    const range = { start: today, end: today };
+
+    const { start, end } = rangeToDateBounds(range, new Date(0));
+
+    expect(end.getTime() - start.getTime()).toBe(24 * 60 * 60 * 1000 - 1);
+  });
+
+  it('falls back to provided fallback date when range is null', () => {
+    const fallback = new Date('2026-05-25T10:00:00');
+    const { start, end } = rangeToDateBounds(null, fallback);
+
+    expect(start.getTime()).toBe(fallback.getTime());
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+  });
+});

--- a/apps/frontend/src/app/csv-export/date-range-section/compute-range.ts
+++ b/apps/frontend/src/app/csv-export/date-range-section/compute-range.ts
@@ -65,3 +65,20 @@ export function daysBetween(range: RangeValue<DateValue> | null | undefined): nu
   const diff = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
   return diff;
 }
+
+export interface DateBounds {
+  start: Date;
+  end: Date;
+}
+
+export function rangeToDateBounds(
+  range: RangeValue<DateValue> | null | undefined,
+  fallback: Date,
+): DateBounds {
+  const tz = getLocalTimeZone();
+  const start = range?.start?.toDate(tz) ?? fallback;
+  const endRaw = range?.end?.toDate(tz) ?? fallback;
+  const end = new Date(endRaw);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}

--- a/apps/frontend/src/app/csv-export/export-type-section/billing-transactions-card.tsx
+++ b/apps/frontend/src/app/csv-export/export-type-section/billing-transactions-card.tsx
@@ -2,9 +2,10 @@
 // FEATURE: CSV export — step 2 of new export flow
 import { DateValue, RangeValue } from '@heroui/react';
 import { useAnalyticsServiceGetBillingTransactionsInDateRange } from '@attraccess/react-query-client';
-import { getLocalTimeZone } from '@internationalized/date';
 import { CreditCardIcon } from 'lucide-react';
+import { useMemo } from 'react';
 import { ExportTypeCard } from './export-type-card';
+import { rangeToDateBounds } from '../date-range-section/compute-range';
 
 interface Props {
   range: RangeValue<DateValue> | null;
@@ -16,8 +17,11 @@ export function BillingTransactionsCard(props: Props) {
   const { range, onPress, t } = props;
 
   const hasRange = Boolean(range?.start && range?.end);
-  const start = range?.start ? range.start.toDate(getLocalTimeZone()).toISOString() : '';
-  const end = range?.end ? range.end.toDate(getLocalTimeZone()).toISOString() : '';
+  const { start, end } = useMemo(() => {
+    if (!hasRange) return { start: '', end: '' };
+    const bounds = rangeToDateBounds(range, new Date());
+    return { start: bounds.start.toISOString(), end: bounds.end.toISOString() };
+  }, [range, hasRange]);
 
   const { data, status } = useAnalyticsServiceGetBillingTransactionsInDateRange(
     { start, end },

--- a/apps/frontend/src/app/csv-export/export-type-section/resource-usage-card.tsx
+++ b/apps/frontend/src/app/csv-export/export-type-section/resource-usage-card.tsx
@@ -2,9 +2,10 @@
 // FEATURE: CSV export — step 2 of new export flow
 import { DateValue, RangeValue } from '@heroui/react';
 import { useAnalyticsServiceGetResourceUsageHoursInDateRange } from '@attraccess/react-query-client';
-import { getLocalTimeZone } from '@internationalized/date';
 import { DatabaseIcon } from 'lucide-react';
+import { useMemo } from 'react';
 import { ExportTypeCard } from './export-type-card';
+import { rangeToDateBounds } from '../date-range-section/compute-range';
 
 interface Props {
   range: RangeValue<DateValue> | null;
@@ -16,8 +17,11 @@ export function ResourceUsageCard(props: Props) {
   const { range, onPress, t } = props;
 
   const hasRange = Boolean(range?.start && range?.end);
-  const start = range?.start ? range.start.toDate(getLocalTimeZone()).toISOString() : '';
-  const end = range?.end ? range.end.toDate(getLocalTimeZone()).toISOString() : '';
+  const { start, end } = useMemo(() => {
+    if (!hasRange) return { start: '', end: '' };
+    const bounds = rangeToDateBounds(range, new Date());
+    return { start: bounds.start.toISOString(), end: bounds.end.toISOString() };
+  }, [range, hasRange]);
 
   const { data, status } = useAnalyticsServiceGetResourceUsageHoursInDateRange(
     { start, end },

--- a/apps/frontend/src/app/csv-export/index.tsx
+++ b/apps/frontend/src/app/csv-export/index.tsx
@@ -12,9 +12,8 @@ import {
   RangeValue,
 } from '@heroui/react';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { getLocalTimeZone } from '@internationalized/date';
 import { DateRangeSection } from './date-range-section';
-import { computeRange, Preset } from './date-range-section/compute-range';
+import { computeRange, Preset, rangeToDateBounds } from './date-range-section/compute-range';
 import { SelectedRangePill } from './date-range-section/selected-range-pill';
 import { ExportTypeKey, ExportTypeSection } from './export-type-section';
 import { ResourceUsageExport } from './resource-usage';
@@ -54,8 +53,10 @@ export function CsvExport() {
     return null;
   }, [activeExportKey]);
 
-  const startDate = dateRange?.start?.toDate(getLocalTimeZone()) ?? now.current;
-  const endDate = dateRange?.end?.toDate(getLocalTimeZone()) ?? now.current;
+  const { start: startDate, end: endDate } = useMemo(
+    () => rangeToDateBounds(dateRange, now.current),
+    [dateRange],
+  );
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 md:px-6 lg:px-8 py-6 flex flex-col gap-6">


### PR DESCRIPTION
## Summary
- CSV export date pickers returned local-midnight (00:00) for the end bound. Backend `Between(start, end)` is inclusive on both ends, so any usage on the end day after 00:00 was excluded. `today` / `yesterday` presets produced empty windows entirely.
- New `rangeToDateBounds` helper shifts the end bound to `23:59:59.999` local. Reused by the CSV export entry point, the resource-usage card, and the billing-transactions card so the row-count preview matches the actual export.
- Added vitest covering end-of-day shift, single-day range, and null-range fallback.

Closes ATT-411.

## Test plan
- [x] `pnpm nx typecheck frontend`
- [x] `pnpm nx lint frontend` (no new warnings)
- [x] `pnpm nx test frontend compute-range` (3/3)
- [x] full precommit (`lint`, `typecheck`, `build`, `test`, `e2e`) — 135/135 unit tests
- [x] Browser verified at `/csv-export`: with usage on 2026-05-25, "Gestern" preview shows 2 rows (was 0), "Letzte 7 Tage" shows 3 rows

<!-- generated-by-cyrus -->