### PR TITLE
fix(auth): normalize IPv4-mapped IPv6 in resolveIp to unblock nightly builds

### DIFF
--- a/apps/api/src/users-and-auth/rate-limiting/login.rate-limit.guard.spec.ts
+++ b/apps/api/src/users-and-auth/rate-limiting/login.rate-limit.guard.spec.ts
@@ -35,4 +35,9 @@ describe('resolveIp', () => {
     const req = createRequest({ ip: undefined, socket: { remoteAddress: undefined } as Request['socket'] });
     expect(resolveIp(req)).toBe('unknown');
   });
+
+  it('collapses IPv4-mapped IPv6 addresses to their IPv4 form so each client gets one bucket', () => {
+    expect(resolveIp(createRequest({ ip: '::ffff:127.0.0.1' }))).toBe('127.0.0.1');
+    expect(resolveIp(createRequest({ ip: '::ffff:203.0.113.42' }))).toBe('203.0.113.42');
+  });
 });

--- a/apps/api/src/users-and-auth/rate-limiting/login.rate-limit.guard.ts
+++ b/apps/api/src/users-and-auth/rate-limiting/login.rate-limit.guard.ts
@@ -121,7 +121,8 @@ async function observableToPromise(observable: Observable<boolean>): Promise<boo
 }
 
 export function resolveIp(request: Request): string {
-  return request.ip || request.socket?.remoteAddress || 'unknown';
+  const raw = request.ip || request.socket?.remoteAddress || 'unknown';
+  return raw.startsWith('::ffff:') ? raw.slice(7) : raw;
 }
 
 export function sanitizeUsername(value: unknown): string | null {


### PR DESCRIPTION
## Summary
- The auth-rate-limit integration test (`auth-rate-limit.integration.spec.ts:86`) flakes on CI because `request.ip` is `::ffff:127.0.0.1` on the runner but `127.0.0.1` locally. `bruteForce.recordSuccess('register', '127.0.0.1', null)` clears the wrong bucket, the next POST stays `429`, and the test fails with `Expected 201, Received 429`.
- Every nightly Docker build since 2026-05-25T23:24 failed for this reason, so the `attraccess/attraccess:nightly-latest` image used by Coolify never received the ATT-405 spinner wrapper fix or anything merged after it.
- Collapse the `::ffff:` IPv4-mapped IPv6 prefix in `resolveIp` so each client gets exactly one rate-limit bucket regardless of which representation Express hands us. Fixes the test deterministically and prevents an attacker from getting two buckets per IP.

## Test plan
- [x] `pnpm nx test api --testFile=login.rate-limit.guard.spec.ts` (5/5 pass, includes new IPv4-mapped IPv6 case)
- [x] `pnpm nx test api --testFile=auth-rate-limit.integration.spec.ts` (4/4 pass)
- [x] Full `pnpm nx test api` (983/983 pass)

<!-- generated-by-cyrus -->