### PR TITLE
fix(ATT-405): preserve Button size and content when isPending

### DIFF
--- a/apps/frontend/src/components/button/index.tsx
+++ b/apps/frontend/src/components/button/index.tsx
@@ -1,4 +1,4 @@
-// Button wrapper that auto-renders a Spinner while isPending is true
+// Button wrapper overlaying a Spinner while isPending without resizing
 // FEATURE: UI primitive ensuring pending mutations show a loading indicator
 import { Button as HeroButton, type ButtonProps as HeroButtonProps, Spinner } from '@heroui/react';
 
@@ -8,15 +8,22 @@ export function Button(props: ButtonProps) {
   const { children, ...rest } = props;
   return (
     <HeroButton {...rest}>
-      {(renderProps) =>
-        renderProps.isPending ? (
-          <Spinner color="current" />
-        ) : typeof children === 'function' ? (
-          children(renderProps)
-        ) : (
-          children
-        )
-      }
+      {(renderProps) => (
+        <>
+          <span
+            className="inline-flex items-center gap-2"
+            style={{ visibility: renderProps.isPending ? 'hidden' : undefined }}
+            aria-hidden={renderProps.isPending || undefined}
+          >
+            {typeof children === 'function' ? children(renderProps) : children}
+          </span>
+          {renderProps.isPending && (
+            <span className="absolute inset-0 flex items-center justify-center">
+              <Spinner color="current" size="sm" />
+            </span>
+          )}
+        </>
+      )}
     </HeroButton>
   );
 }


### PR DESCRIPTION
Assignee: @janjaapdejong ([Jan Jaap](https://linear.app/attraccess/profiles/janjaapdejong))

## Summary

Follow-up to #1043. Wrapping every pending Button still made it shrink and lose its label because the wrapper replaced children with the Spinner — causing layout shift and confusing UX about what the button was for.

This change keeps the original children mounted inside a span that turns `visibility: hidden` while `isPending`, and overlays the Spinner with `absolute inset-0`. Width, height and surrounding flow stay identical between idle and pending states; the spinner sits centered on top of the reserved space.

Verified locally on a temporary `/__button-demo` route with idle/pending side-by-side rows (text-only, icon-only, icon+text). All three variants kept identical dimensions.

Linear: [ATT-405](https://linear.app/attraccess/issue/ATT-405/long-flow-runs-cause-usage-startstop-button-to-freeze)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->