### PR TITLE
fix(ATT-413): persist hideEmptyResourceGroups filter to localStorage

### DIFF
--- a/apps/frontend/src/app/resourceOverview/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/index.tsx
@@ -58,6 +58,14 @@ export function ResourceOverview() {
     );
   }, []);
 
+  const setFilterByHideEmptyResourceGroups = useCallback((value: boolean) => {
+    setFilterByHideEmptyResourceGroupsState(value);
+    localStorage.setItem(
+      getLocalStorageFilterKey(PersistedFilterProps.hideEmptyResourceGroups),
+      value === true ? 'true' : 'false'
+    );
+  }, []);
+
   const groupIds = useMemo(() => {
     const ids: Array<number | 'none'> = ['none'];
 
@@ -85,7 +93,7 @@ export function ResourceOverview() {
         onlyWithPermissions={filterByOnlyWithPermissions}
         onOnlyWithPermissionsChanged={setFilterByOnlyWithPermissions}
         hideEmptyResourceGroups={filterByHideEmptyResourceGroups}
-        onHideEmptyResourceGroupsChanged={setFilterByHideEmptyResourceGroupsState}
+        onHideEmptyResourceGroupsChanged={setFilterByHideEmptyResourceGroups}
         highlightSearch={allResources?.data.length === 0}
         highlightFilter={allResources?.data.length === 0}
       />


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

The "hide empty resource groups" toggle on the resource overview was wired directly to its `useState` setter, so toggling it never wrote to localStorage. On refresh, the default `true` re-applied and empty groups vanished again — making the resource list look incomplete after the HeroUI v3 redesign drew attention to the behavior.

Wrap the setter in a `useCallback` that persists the value, matching the pattern already used for `onlyInUseByMe` and `onlyWithPermissions`.

Linear: [ATT-413](https://linear.app/attraccess/issue/ATT-413/since-heroui-v3-redesign-resource-list-is-incomplete)

## Investigation

Reproduced locally with 5 groups (one empty). With default localStorage state (no key written), the filter defaults to `true` and empty groups hide. Toggling the switch in the filter drawer changes the in-memory state, but the localStorage key `resourceOverview.toolbar.filter.hideEmptyResourceGroups` was never set. On reload, the default `true` re-applied and the empty group disappeared again.

After the fix, toggling the switch writes `"true"` / `"false"` to localStorage and the preference survives reload.

## Test plan

- [x] `pnpm nx typecheck frontend`
- [x] `pnpm nx test frontend` (141 passed)
- [x] Manual: log in as dev admin, create an empty group, open filter drawer, toggle "leere Ressourcengruppen ausblenden" off, confirm `localStorage.getItem('resourceOverview.toolbar.filter.hideEmptyResourceGroups') === 'false'`, refresh, confirm empty group still visible.
- [x] Manual: toggle back on, refresh, confirm empty group hides.

---

> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->