### PR TITLE
fix(ATT-395): move pan/select toggle into top-right toolbar

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -431,7 +431,7 @@ function FlowsPageInner() {
             <Controls />
             <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
 
-            <Panel position="top-left">
+            <Panel position="top-left" className="hidden md:block">
               <ButtonGroup>
                 <Button
                   isIconOnly

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -431,7 +431,7 @@ function FlowsPageInner() {
             <Controls />
             <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
 
-            <Panel position="top-left" className="hidden md:block">
+            <Panel position="top-right" className="flex flex-row flex-wrap gap-2">
               <ButtonGroup>
                 <Button
                   isIconOnly
@@ -452,9 +452,6 @@ function FlowsPageInner() {
                   <BoxSelectIcon />
                 </Button>
               </ButtonGroup>
-            </Panel>
-
-            <Panel position="top-right" className="flex flex-row flex-wrap gap-2">
               <Button
                 isIconOnly
                 isPending={isSaving}


### PR DESCRIPTION
## Summary

- Move the pan/select mode toggle from a separate top-left Panel into the existing top-right toolbar so it stays accessible on phones (previously hidden under `md:` due to overlap).
- Toolbar's `flex-wrap` lets the ButtonGroup wrap onto a second row on narrow viewports rather than colliding with Save/Import/etc.
- Includes the prior fix (toggle hidden under `md`) which is now obsolete since the toggle is part of the responsive toolbar.

Follow-up to merged PR #1020.

## Test plan

- [x] Frontend typecheck passes.
- [x] Verified in browser at 1280px (desktop): toggle appears first in top-right toolbar.
- [x] Verified in emulated iPhone 14 (390px): toolbar wraps, toggle remains visible; tapping the hand icon switches pan/select state.
- [ ] Verify on a real touch device that the default mode is still `pan` (matchMedia `(hover: none) and (pointer: coarse)` returns false under Chrome's `set device` emulation, so the emulator boots in `select` — real iPhone should still default to `pan`).

<!-- generated-by-cyrus -->