### PR TITLE
fix(ATT-395): disable pan in select mode on touch devices

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -305,13 +305,17 @@ function FlowsPageInner() {
   const [flowIsRunning, setFlowIsRunning] = useState(false);
   const [, setFlowExecutionHadError] = useState(false);
 
-  const [interactionMode, setInteractionMode] = useState<'pan' | 'select'>(() => {
+  const isCoarsePointer = useMemo(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-      return 'select';
+      return false;
     }
-    return window.matchMedia('(hover: none) and (pointer: coarse)').matches ? 'pan' : 'select';
-  });
-  const panOnDrag = interactionMode === 'pan' ? true : [1, 2];
+    return window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+  }, []);
+  const [interactionMode, setInteractionMode] = useState<'pan' | 'select'>(() =>
+    isCoarsePointer ? 'pan' : 'select',
+  );
+  // @xyflow/react's mouse-button array in panOnDrag doesn't apply to touch, so for select mode on touch we must disable pan entirely.
+  const panOnDrag = interactionMode === 'pan' ? true : isCoarsePointer ? false : [1, 2];
   const selectionOnDrag = interactionMode === 'select';
 
   const onLiveLog = useCallback(


### PR DESCRIPTION
## Summary

Follow-up to #1020 and #1057 for ATT-395. In select mode on iPad, touch and pen input still panned the canvas while also drawing a selection box at the same time.

**Root cause:** `@xyflow/react` v12's `panOnDrag` mouse-button array (`[1, 2]`) only filters mouse events — single-finger touch events bypass that filter and still pan. Combined with `selectionOnDrag: true`, touch input triggered both pan and selection simultaneously.

**Fix:** On coarse-pointer devices (iPad / touch), set `panOnDrag = false` for select mode so touch can only initiate a selection. Desktop is unchanged: middle/right-click still pans, left-click drags a selection.

## Test plan

- [ ] On iPad, switch the resource flow canvas to **select mode** (box icon).
- [ ] Touch-drag on empty canvas → only a selection box is drawn, the canvas does **not** pan.
- [ ] Apple Pencil drag on empty canvas → only a selection box is drawn.
- [ ] Switch to **pan mode** (hand icon) → touch/pen still pans the canvas.
- [ ] Desktop: in select mode, left-click drag draws a selection box; middle-click drag still pans.

Browser verification of touch behaviour on desktop is unreliable (matchMedia + synthetic touch only approximate the real device), so this needs verification on an actual iPad.

🔗 Linear: [ATT-395](https://linear.app/attraccess/issue/ATT-395/moving-resource-flows-canvas-with-touch-or-pen-on-ios)