### PR TITLE
fix(ATT-416): show Timeout label on wait-for-MQTT flow node

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/node/editor/property-input/index.tsx
@@ -243,17 +243,14 @@ export function PropertyInput<TValue>(props: Props<TValue>) {
       return (
         <NumberField
           isRequired={isRequired}
-          aria-label={
-            !hideLabel
-              ? t('nodes.' + nodeType + '.config.' + name + '.label')
-              : t('nodes.' + nodeType + '.config.' + name + '.label')
-          }
+          aria-label={t('nodes.' + nodeType + '.config.' + name + '.label')}
           value={Number(parsedValue)}
           defaultValue={schema.default ? Number(schema.default) : undefined}
           onChange={(newValue) => setValue(newValue as TValue)}
           minValue={schema.exclusiveMinimum !== undefined ? schema.exclusiveMinimum + 1 : undefined}
           maxValue={schema.maximum}
         >
+          {!hideLabel && <Label>{t('nodes.' + nodeType + '.config.' + name + '.label')}</Label>}
           <NumberFieldGroup>
             <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
             <NumberFieldInput />


### PR DESCRIPTION
## Summary
- `PropertyInput`'s `NumberField` branch only set `aria-label`, so numeric flow-node config fields had no visible caption.
- Added `<Label>` inside `<NumberField>` when `hideLabel` is false, matching the existing pattern in `TextField`, `Select`, and `MetricsSettingsForm`.
- Also affects every other numeric flow-node config (wait duration, lifetime-signal timeout, billing amounts), all of which now show their label.

Closes ATT-416.

## Test plan
- [x] `pnpm nx affected --target=lint,typecheck,build,test` — green
- [x] Manual: opened "Auf MQTT-Nachricht warten" editor; `Timeout (Sekunden) *` label now renders above the input.

![after-fix](https://uploads.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/3edd36e9-12b8-4671-9911-8cdda1ee8f20/e3af2ccc-a963-4313-9f3f-9c22af8b1a14)

<!-- generated-by-cyrus -->