### PR TITLE
fix(ATT-418): enlarge flow log payload viewer

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/logViewer/index.tsx
@@ -109,7 +109,12 @@ export function LogViewer(props: Props) {
                         <AccordionHeading><AccordionTrigger>{log.title}</AccordionTrigger></AccordionHeading>
                         <AccordionPanel><AccordionBody>
                           {log.payload && (
-                            <TextArea readOnly value={JSON.stringify(JSON.parse(log.payload), null, 2)} />
+                            <TextArea
+                              readOnly
+                              rows={16}
+                              className="font-mono text-sm w-full"
+                              value={JSON.stringify(JSON.parse(log.payload), null, 2)}
+                            />
                           )}
                         </AccordionBody></AccordionPanel>
                       </AccordionItem>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

The payload JSON inside the Flow Logs drawer rendered in a default-sized `TextArea` (≈ 2-3 visible rows), so even small log payloads required scrolling a tiny box to read. This bumps the viewer to 16 rows, switches to a monospace font, and stretches it to the full drawer width so structured JSON is readable at a glance.

- Linear: [ATT-418](https://linear.app/attraccess/issue/ATT-418/flow-node-log-viewer-payload)

## Changes

- `apps/frontend/src/app/resources/details/flows/logViewer/index.tsx` — `TextArea` now uses `rows={16}` and `font-mono text-sm w-full`.

## Verification

- Logged in as a seeded admin, opened the Flow Logs drawer for a resource flow with a seeded payload, and confirmed the JSON renders in a tall monospace block.

Before (from issue): payload cramped to a tiny scrollable box.
After: payload fills the drawer, 16 rows tall, monospace.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->