### PR TITLE
fix(ATT-417): stack active usage sessions banner on small screens

### DIFF
--- a/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, AlertContent, AlertTitle, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, Spinner } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertTitle, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, Spinner } from '@heroui/react';
 import { Button } from '../../../components/button';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -209,10 +209,8 @@ export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessi
       <Alert status="warning">
         <AlertContent>
           <AlertTitle>{t('title', { count: activeCount })}</AlertTitle>
-        </AlertContent>
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-2 w-full">
-          <div className="flex flex-1">{t('description', { count: activeCount })}</div>
-          <div className="flex flex-shrink gap-2">
+          <AlertDescription>{t('description', { count: activeCount })}</AlertDescription>
+          <div className="mt-2 flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
             <Button variant="primary" onPress={onShowMySessions}>
               {t('showMine')}
             </Button>
@@ -220,7 +218,7 @@ export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessi
               {t('endAll')}
             </Button>
           </div>
-        </div>
+        </AlertContent>
       </Alert>
 
       <Modal


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes the cramped layout of the **Active Usage Sessions** banner on narrow viewports (see [ATT-417](https://linear.app/attraccess/issue/ATT-417/active-usage-sessions-banner-layout-on-smaller-screens)).

Previously the banner placed `AlertTitle`, the description, and the action buttons in side-by-side flex columns, which caused the description to wrap into a narrow vertical column and the buttons to squeeze on small screens.

Now title, description (via `AlertDescription`), and the button group all live inside `AlertContent`, which stacks them vertically. Buttons stack on mobile and switch to a horizontal row from the `sm` breakpoint.

## Implementation

- Render `AlertTitle`, `AlertDescription`, and the button container inside `AlertContent`
- Button group: `flex flex-col gap-2` on mobile, `sm:flex-row sm:w-auto` from the `sm` breakpoint
- Import `AlertDescription` from `@heroui/react`

## Testing

Verified in browser at three viewports:

- **400×800 (mobile)** — title, description full-width, buttons stacked
- **700×900 (sm)** — buttons inline, description full-width
- **1280×800 (desktop)** — banner uses available width without wrapping awkwardly

Lint and typecheck pass.

---

> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->