### PR TITLE
fix(ATT-420): nest ModalContainer inside ModalBackdrop in end-all-sessions modal

### DIFF
--- a/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/activeUsageSessionsBanner/index.tsx
@@ -225,9 +225,9 @@ export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessi
         isOpen={isModalOpen}
         onOpenChange={(open) => { if (!open && !isEndingAll) setIsModalOpen(false); }}
       >
-        <ModalBackdrop isDismissable={!isEndingAll} />
-        <ModalContainer size="md">
-          <ModalDialog>
+        <ModalBackdrop>
+          <ModalContainer size="md">
+            <ModalDialog>
             {({ close }) => (
               <>
                 <ModalHeader>
@@ -306,8 +306,9 @@ export function ActiveUsageSessionsBanner({ onShowMySessions }: ActiveUsageSessi
                 )}
               </>
             )}
-          </ModalDialog>
-        </ModalContainer>
+            </ModalDialog>
+          </ModalContainer>
+        </ModalBackdrop>
       </Modal>
     </div>
   );


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

The "End all my sessions" confirmation modal opened with an empty black overlay covering the whole screen and the dialog rendered detached in the bottom-left corner instead of centered.

Root cause: HeroUI v3 requires `ModalContainer` to be nested **inside** `ModalBackdrop`. `ActiveUsageSessionsBanner` had the backdrop self-closed with the container as a sibling, so the dialog rendered outside the overlay positioning context.

## Fix

- Nest `ModalContainer` → `ModalDialog` inside `ModalBackdrop`, matching the working pattern in `deleteConfirmationModal`.
- Drop the now-redundant `isDismissable` on the backdrop — dismissal is already gated by `onOpenChange`.

## Test plan

- [x] `nx typecheck frontend`
- [x] `nx test frontend` (141 passed)
- [x] `nx lint frontend` (no new warnings)
- [x] Reproduced the bug locally with two active usage sessions
- [x] Verified fix: modal opens immediately, centered, with backdrop dim
- [x] Confirmed end-all flow completes successfully and toasts

## Screenshots

Before (from issue): off-center, detached dialog with full-screen black overlay.

After: centered modal with backdrop dim, list of active sessions, success toast on completion.

Linear: [ATT-420](https://linear.app/attraccess/issue/ATT-420/end-all-my-sessions-modal-is-broken)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->