### PR TITLE
fix(ATT-421): stack unhealthy resource banner contents on mobile

### DIFF
--- a/apps/frontend/src/app/resources/details/health-state/index.tsx
+++ b/apps/frontend/src/app/resources/details/health-state/index.tsx
@@ -64,40 +64,38 @@ export function ResourceHealthWarning({ resourceId }: Props) {
             : t('alert.identifier.default');
 
         return (
-          <Alert status="danger"
-            key={entry.id}
-          >
+          <Alert status="danger" key={entry.id}>
             <AlertContent>
               <AlertTitle>{t('alert.title')}</AlertTitle>
               <AlertDescription>{t('alert.description')}</AlertDescription>
-            </AlertContent>
-            <div className="flex flex-col gap-1 mt-2 text-sm">
-              <div>
-                <span className="text-gray-500 mr-1">{t('alert.identifier.label')}:</span>
-                <span className="font-medium">{identifierLabel}</span>
-              </div>
-              <div>
-                <span className="text-gray-500 mr-1">{t('alert.reason.label')}:</span>
-                <span className="whitespace-pre-wrap">
-                  {entry.reason && entry.reason.length > 0 ? entry.reason : t('alert.reason.noReason')}
-                </span>
-              </div>
-              <div>
-                <span className="text-gray-500 mr-1">{t('alert.lastSeen')}:</span>
-                <span>{formatDateTime(entry.lastReportedAt, '')}</span>
+              <div className="flex flex-col gap-1 mt-2 text-sm w-full">
+                <div>
+                  <span className="text-gray-500 mr-1">{t('alert.identifier.label')}:</span>
+                  <span className="font-medium">{identifierLabel}</span>
+                </div>
+                <div>
+                  <span className="text-gray-500 mr-1">{t('alert.reason.label')}:</span>
+                  <span className="whitespace-pre-wrap">
+                    {entry.reason && entry.reason.length > 0 ? entry.reason : t('alert.reason.noReason')}
+                  </span>
+                </div>
+                <div>
+                  <span className="text-gray-500 mr-1">{t('alert.lastSeen')}:</span>
+                  <span>{formatDateTime(entry.lastReportedAt, '')}</span>
+                </div>
               </div>
               {canManage && (
-                <div className="mt-2">
-                  <Button variant="danger-soft"
-
-                    onPress={() => handleClear(entry.id)}
-                    isPending={clearEntry.isPending}
-                  ><CheckCircleIcon size={16} />
-                    {t('actions.markHealthy')}
-                  </Button>
-                </div>
+                <Button
+                  className="mt-3 self-start"
+                  variant="danger-soft"
+                  onPress={() => handleClear(entry.id)}
+                  isPending={clearEntry.isPending}
+                >
+                  <CheckCircleIcon size={16} />
+                  {t('actions.markHealthy')}
+                </Button>
               )}
-            </div>
+            </AlertContent>
           </Alert>
         );
       })}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

The unhealthy resource banner placed its metadata block (Source / Reason / Last reported) and the "Mark as healthy" button as direct children of `<Alert>`, so HeroUI's row-flex layout squeezed the title and description into a narrow column on mobile. Move metadata + action button inside `<AlertContent>` so all rows stack vertically and span the full width.

Linear: [ATT-421](https://linear.app/attraccess/issue/ATT-421/unhealthy-resource-banner-is-not-well-layouted-on-mobile)

## Test plan

- [x] Verified mobile layout (iPhone 16 Pro viewport) — banner stacks cleanly, no narrow title column
- [x] Verified desktop layout (1440×900) — banner spans full width, no regression
- [x] `pnpm nx run frontend:lint` clean
- [x] `pnpm nx run frontend:typecheck` clean
- [x] `pnpm nx run frontend:test` — 141 tests pass

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->