### PR TITLE
fix(ATT-422): wrap Attractap Table in TableScrollContainer

### DIFF
--- a/apps/frontend/src/app/attractap/AttractapList/index.tsx
+++ b/apps/frontend/src/app/attractap/AttractapList/index.tsx
@@ -182,28 +182,30 @@ export function AttractapList() {
                             {firmwareUpdateChip(reader)}
                           </TableCell>
                           <TableCell className="whitespace-nowrap">{formatDateTime(reader.lastConnection)}</TableCell>
-                          <TableCell className="flex-row flex">
-                            <Button
-                              variant="ghost"
-                              onPress={() => setOpenedReaderEditor(reader.id)}
-                              data-cy={`attractap-list-edit-reader-button-${reader.id}`}
-                            >
-                              <PencilIcon className="w-4 h-4" />
-                              {t('table.actions.editReader')}
-                            </Button>
+                          <TableCell>
+                            <div className="flex flex-row gap-2">
+                              <Button
+                                variant="ghost"
+                                onPress={() => setOpenedReaderEditor(reader.id)}
+                                data-cy={`attractap-list-edit-reader-button-${reader.id}`}
+                              >
+                                <PencilIcon className="w-4 h-4" />
+                                {t('table.actions.editReader')}
+                              </Button>
 
-                            <AttractapDeleteModal readerId={reader.id}>
-                              {(onOpen) => (
-                                <Button
-                                  variant="danger-soft"
-                                  onPress={onOpen}
-                                  data-cy={`attractap-list-delete-reader-button-${reader.id}`}
-                                >
-                                  <Trash2Icon className="w-4 h-4" />
-                                  {t('table.actions.deleteReader')}
-                                </Button>
-                              )}
-                            </AttractapDeleteModal>
+                              <AttractapDeleteModal readerId={reader.id}>
+                                {(onOpen) => (
+                                  <Button
+                                    variant="danger-soft"
+                                    onPress={onOpen}
+                                    data-cy={`attractap-list-delete-reader-button-${reader.id}`}
+                                  >
+                                    <Trash2Icon className="w-4 h-4" />
+                                    {t('table.actions.deleteReader')}
+                                  </Button>
+                                )}
+                              </AttractapDeleteModal>
+                            </div>
                           </TableCell>
                         </TableRow>
                       )}

--- a/apps/frontend/src/app/attractap/AttractapList/index.tsx
+++ b/apps/frontend/src/app/attractap/AttractapList/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card, Chip, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import { Alert, AlertContent, AlertDescription, AlertTitle, Button, Card, Chip, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, TableScrollContainer } from '@heroui/react';
 import { ArrowRightIcon, CpuIcon, LogsIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 import { EmptyState } from '../../../components/emptyState';
@@ -159,54 +159,57 @@ export function AttractapList() {
               />
             </Card.Header>
             <Card.Content>
-              <Table
-                data-cy={`attractap-list-table-${tableIndex === 0 ? 'active' : 'stale'}`}
-              >
-                <TableContent aria-label={`${tableIndex === 0 ? 'active' : 'stale'} attractaps`}>
-                <TableHeader>
-                  <TableColumn isRowHeader>{t('table.columns.name')}</TableColumn>
-                  <TableColumn>{t('table.columns.type')}</TableColumn>
-                  <TableColumn>{t('table.columns.lastConnection')}</TableColumn>
-                  <TableColumn>{t('table.columns.actions')}</TableColumn>
-                </TableHeader>
-                <TableBody
-                  items={readers ?? []}
-                  renderEmptyState={() => <EmptyState />}
-                >
-                  {(reader) => (
-                    <TableRow key={reader.id} id={reader.id} className={tableIndex === 1 ? 'border-l-8 border-l-warning' : ''}>
-                      <TableCell>{reader.name}</TableCell>
-                      <TableCell className="whitespace-nowrap">
-                        {reader.firmware.name} ({reader.firmware.variant})
-                        <br />
-                        {firmwareUpdateChip(reader)}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap">{formatDateTime(reader.lastConnection)}</TableCell>
-                      <TableCell className="flex-row flex">
-                        <Button variant="ghost"
-
-                          onPress={() => setOpenedReaderEditor(reader.id)}
-                          data-cy={`attractap-list-edit-reader-button-${reader.id}`}
-                        ><PencilIcon className="w-4 h-4" />
-                          {t('table.actions.editReader')}
-                        </Button>
-
-                        <AttractapDeleteModal readerId={reader.id}>
-                          {(onOpen) => (
-                            <Button variant="danger-soft"
-
-                              onPress={onOpen}
-                              data-cy={`attractap-list-delete-reader-button-${reader.id}`}
-                            ><Trash2Icon className="w-4 h-4" />
-                              {t('table.actions.deleteReader')}
+              <Table data-cy={`attractap-list-table-${tableIndex === 0 ? 'active' : 'stale'}`}>
+                <TableScrollContainer>
+                  <TableContent aria-label={`${tableIndex === 0 ? 'active' : 'stale'} attractaps`}>
+                    <TableHeader>
+                      <TableColumn isRowHeader>{t('table.columns.name')}</TableColumn>
+                      <TableColumn>{t('table.columns.type')}</TableColumn>
+                      <TableColumn>{t('table.columns.lastConnection')}</TableColumn>
+                      <TableColumn>{t('table.columns.actions')}</TableColumn>
+                    </TableHeader>
+                    <TableBody items={readers ?? []} renderEmptyState={() => <EmptyState />}>
+                      {(reader) => (
+                        <TableRow
+                          key={reader.id}
+                          id={reader.id}
+                          className={tableIndex === 1 ? 'border-l-8 border-l-warning' : ''}
+                        >
+                          <TableCell>{reader.name}</TableCell>
+                          <TableCell className="whitespace-nowrap">
+                            {reader.firmware.name} ({reader.firmware.variant})
+                            <br />
+                            {firmwareUpdateChip(reader)}
+                          </TableCell>
+                          <TableCell className="whitespace-nowrap">{formatDateTime(reader.lastConnection)}</TableCell>
+                          <TableCell className="flex-row flex">
+                            <Button
+                              variant="ghost"
+                              onPress={() => setOpenedReaderEditor(reader.id)}
+                              data-cy={`attractap-list-edit-reader-button-${reader.id}`}
+                            >
+                              <PencilIcon className="w-4 h-4" />
+                              {t('table.actions.editReader')}
                             </Button>
-                          )}
-                        </AttractapDeleteModal>
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-                </TableContent>
+
+                            <AttractapDeleteModal readerId={reader.id}>
+                              {(onOpen) => (
+                                <Button
+                                  variant="danger-soft"
+                                  onPress={onOpen}
+                                  data-cy={`attractap-list-delete-reader-button-${reader.id}`}
+                                >
+                                  <Trash2Icon className="w-4 h-4" />
+                                  {t('table.actions.deleteReader')}
+                                </Button>
+                              )}
+                            </AttractapDeleteModal>
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  </TableContent>
+                </TableScrollContainer>
               </Table>
             </Card.Content>
           </Card>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes the weird gray bar visible at the bottom of the cards on the Attractap management page (ATT-422). HeroUI v3's `Table` requires `Table.ScrollContainer` between `Table` and `Table.Content`. Without it, the `.table-root` wrapper's `bg-surface-secondary` + `pb-1` padding shows through as a gray strip below the content. Matches the existing working pattern in `apps/frontend/src/app/resources/groups/index.tsx`.

## Changes

- `apps/frontend/src/app/attractap/AttractapList/index.tsx` — wrap `<TableContent>` in `<TableScrollContainer>` and tidy indentation while there.

## Verification

- `nx typecheck frontend` — passes
- `nx lint frontend` — passes (only pre-existing unrelated warning)
- `nx test frontend` — 141/141 pass
- Precommit hook (`nx affected lint,typecheck,build,test,e2e`) — passes
- Browser screenshot — not captured: the API would not boot inside the agent runtime due to long webpack build. The structural fix is verified against the HeroUI v3 docs and the sibling working component (`resources/groups/index.tsx`).

Closes ATT-422.

Linear: https://linear.app/attraccess/issue/ATT-422/attractap-table-has-weird-gray-bar

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->