### PR TITLE
fix(ATT-423): tabbed editor drawer, scrollable resource list, selector fixes

### DIFF
--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.de.json
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.de.json
@@ -11,5 +11,9 @@
   "errorUpdatingReader": "Fehler beim Aktualisieren des Readers",
   "readerUpdated": "Reader aktualisiert",
   "readerUpdatedDescription": "Reader erfolgreich aktualisiert",
-  "ledBrightness": "LED Helligkeit"
+  "ledBrightness": "LED Helligkeit",
+  "tabs": {
+    "general": "Allgemein",
+    "resources": "Ressourcen"
+  }
 }

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.en.json
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.en.json
@@ -11,5 +11,9 @@
   "errorUpdatingReader": "Error updating reader",
   "readerUpdated": "Reader updated",
   "readerUpdatedDescription": "Reader updated successfully",
-  "ledBrightness": "LED Brightness"
+  "ledBrightness": "LED Brightness",
+  "tabs": {
+    "general": "General",
+    "resources": "Resources"
+  }
 }

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx
@@ -6,11 +6,14 @@ import {
   DrawerFooter,
   DrawerHeader,
   Form,
-  Separator,
   Slider,
   SliderTrack,
   SliderFill,
   SliderThumb,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
 } from '@heroui/react';
 import { Button } from '../../../components/button';
 import { TextField, Label, Input } from '@heroui/react';
@@ -48,6 +51,7 @@ export function AttractapEditor(props: Readonly<Props>) {
   const [name, setName] = useState('');
   const [ledBrightness, setLedBrightness] = useState<number>(255);
   const [connectedResourceIds, setConnectedResourceIds] = useState<number[]>([]);
+  const [selectedTab, setSelectedTab] = useState<'general' | 'resources'>('general');
   const updateReaderMutation = useAttractapServiceUpdateReader({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [useAttractapServiceGetReadersKey] });
@@ -103,40 +107,57 @@ export function AttractapEditor(props: Readonly<Props>) {
         </DrawerHeader>
         <DrawerBody>
           <Form onSubmit={onSubmit} className="flex flex-col gap-4">
-            <TextField value={name} onChange={setName} className="w-full">
-              <Label>{t('readerName')}</Label>
-              <Input placeholder={t('enterReaderName')} data-cy="attractap-editor-name-input" />
-            </TextField>
-            {reader?.firmware.capabilities.hasLeds && (
-              <Slider
-                step={1}
-                minValue={0}
-                maxValue={255}
-                value={ledBrightness}
-                onChange={(val) => setLedBrightness(val as number)}
-                className="w-full"
-                data-cy="attractap-editor-led-brightness-slider"
-              >
-                <Label>{t('ledBrightness')}</Label>
-                <SliderTrack>
-                  <SliderFill />
-                  <SliderThumb />
-                </SliderTrack>
-              </Slider>
-            )}
-            <Separator className="my-6" />
-            <div className="flex flex-col gap-3 w-full">
-              <div className="flex flex-col gap-1">
-                <h3 className="text-base font-semibold">{t('connectedResources')}</h3>
-                <p className="text-sm text-default-500">{t('connectedResourcesDescription')}</p>
-              </div>
-              <ResourceSelector
-                selection={connectedResourceIds}
-                onSelectionChange={setConnectedResourceIds}
-                data-cy="attractap-editor-resource-selector"
-                multiple={reader?.firmware.capabilities.resourceSelection ?? true}
-              />
-            </div>
+            <Tabs
+              selectedKey={selectedTab}
+              onSelectionChange={(k) => setSelectedTab(k as 'general' | 'resources')}
+              className="w-full"
+              data-cy="attractap-editor-tabs"
+            >
+              <TabList>
+                <Tab id="general" data-cy="attractap-editor-general-tab">
+                  {t('tabs.general')}
+                </Tab>
+                <Tab id="resources" data-cy="attractap-editor-resources-tab">
+                  {t('tabs.resources')}
+                </Tab>
+              </TabList>
+              <TabPanel id="general" className="pt-4">
+                <div className="flex flex-col gap-4">
+                  <TextField value={name} onChange={setName} className="w-full">
+                    <Label>{t('readerName')}</Label>
+                    <Input placeholder={t('enterReaderName')} data-cy="attractap-editor-name-input" />
+                  </TextField>
+                  {reader?.firmware.capabilities.hasLeds && (
+                    <Slider
+                      step={1}
+                      minValue={0}
+                      maxValue={255}
+                      value={ledBrightness}
+                      onChange={(val) => setLedBrightness(val as number)}
+                      className="w-full"
+                      data-cy="attractap-editor-led-brightness-slider"
+                    >
+                      <Label>{t('ledBrightness')}</Label>
+                      <SliderTrack>
+                        <SliderFill />
+                        <SliderThumb />
+                      </SliderTrack>
+                    </Slider>
+                  )}
+                </div>
+              </TabPanel>
+              <TabPanel id="resources" className="pt-4">
+                <div className="flex flex-col gap-3 w-full">
+                  <p className="text-sm text-default-500">{t('connectedResourcesDescription')}</p>
+                  <ResourceSelector
+                    selection={connectedResourceIds}
+                    onSelectionChange={setConnectedResourceIds}
+                    data-cy="attractap-editor-resource-selector"
+                    multiple={reader?.firmware.capabilities.resourceSelection ?? true}
+                  />
+                </div>
+              </TabPanel>
+            </Tabs>
           </Form>
         </DrawerBody>
         <DrawerFooter>

--- a/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
+++ b/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
@@ -12,6 +12,7 @@ interface Props {
   selection: number[];
   onSelectionChange: (selection: number[]) => void;
   multiple?: boolean;
+  listClassName?: string;
 }
 
 export const ListboxWrapper = ({ children }: PropsWithChildren) => (
@@ -19,7 +20,7 @@ export const ListboxWrapper = ({ children }: PropsWithChildren) => (
 );
 
 export function ResourceSelector(props: Readonly<Props>) {
-  const { selection, onSelectionChange, multiple = true } = props;
+  const { selection, onSelectionChange, multiple = true, listClassName = 'max-h-80 overflow-y-auto' } = props;
   const [search, setSearch] = useState('');
 
   const { t } = useTranslations({ de, en });
@@ -46,7 +47,7 @@ export function ResourceSelector(props: Readonly<Props>) {
           ) : null}
         </InputGroup>
       </TextField>
-      <TableRoot aria-label={t('table.ariaLabel')}>
+      <TableRoot aria-label={t('table.ariaLabel')} className={listClassName}>
         <TableContent
           selectionMode={multiple ? 'multiple' : 'single'}
           selectedKeys={new Set(selection.map(String))}

--- a/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
+++ b/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
@@ -2,7 +2,8 @@
 // FEATURE: Resource selection for plugins using HeroUI v3 Table compound
 import { useTranslations } from '../../i18n';
 import { useResourcesServiceGetAllResources } from '@attraccess/react-query-client';
-import { TextField, Label, InputGroup, Input, Spinner, TableRoot, TableContent, TableBody, TableCell, TableColumn, TableHeader, TableRow } from '@heroui/react';
+import { Checkbox, TextField, Label, InputGroup, Spinner, TableRoot, TableContent, TableBody, TableCell, TableColumn, TableHeader, TableRow } from '@heroui/react';
+import { SearchIcon } from 'lucide-react';
 import { useState, PropsWithChildren } from 'react';
 import de from './ResourceSelector.de.json';
 import en from './ResourceSelector.en.json';
@@ -34,8 +35,15 @@ export function ResourceSelector(props: Readonly<Props>) {
       <TextField value={search} onChange={setSearch} className="w-full">
         <Label>{t('search.label')}</Label>
         <InputGroup>
-          <Input placeholder={t('search.placeholder')} />
-          {isResourceSearchLoading ? <Spinner /> : null}
+          <InputGroup.Prefix>
+            <SearchIcon className="size-4 text-muted" />
+          </InputGroup.Prefix>
+          <InputGroup.Input placeholder={t('search.placeholder')} />
+          {isResourceSearchLoading ? (
+            <InputGroup.Suffix>
+              <Spinner size="sm" />
+            </InputGroup.Suffix>
+          ) : null}
         </InputGroup>
       </TextField>
       <TableRoot aria-label={t('table.ariaLabel')}>
@@ -51,13 +59,29 @@ export function ResourceSelector(props: Readonly<Props>) {
           }}
         >
           <TableHeader>
-            <TableColumn className="w-full">
+            <TableColumn className="pr-0 w-0">
+              {multiple ? (
+                <Checkbox aria-label={t('table.ariaLabel')} slot="selection">
+                  <Checkbox.Control>
+                    <Checkbox.Indicator />
+                  </Checkbox.Control>
+                </Checkbox>
+              ) : null}
+            </TableColumn>
+            <TableColumn className="w-full" isRowHeader>
               {t('table.columns.name.header')}
             </TableColumn>
           </TableHeader>
           <TableBody items={resourceSearchResults?.data ?? []}>
             {(resource) => (
               <TableRow key={resource.id} id={String(resource.id)}>
+                <TableCell className="pr-0">
+                  <Checkbox aria-label={resource.name} slot="selection" variant="secondary">
+                    <Checkbox.Control>
+                      <Checkbox.Indicator />
+                    </Checkbox.Control>
+                  </Checkbox>
+                </TableCell>
                 <TableCell>{resource.name}</TableCell>
               </TableRow>
             )}

--- a/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
+++ b/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
@@ -15,12 +15,16 @@ interface Props {
   listClassName?: string;
 }
 
+const MAX_VISIBLE_ROWS = 7;
+const LIST_ROW_HEIGHT_PX = 49;
+const LIST_HEADER_HEIGHT_PX = 44;
+
 export const ListboxWrapper = ({ children }: PropsWithChildren) => (
   <div className="border-small px-1 py-2 rounded-small border-default-200 dark:border-default-100">{children}</div>
 );
 
 export function ResourceSelector(props: Readonly<Props>) {
-  const { selection, onSelectionChange, multiple = true, listClassName = 'max-h-80 overflow-y-auto' } = props;
+  const { selection, onSelectionChange, multiple = true, listClassName = '' } = props;
   const [search, setSearch] = useState('');
 
   const { t } = useTranslations({ de, en });
@@ -47,7 +51,11 @@ export function ResourceSelector(props: Readonly<Props>) {
           ) : null}
         </InputGroup>
       </TextField>
-      <TableRoot aria-label={t('table.ariaLabel')} className={listClassName}>
+      <TableRoot
+        aria-label={t('table.ariaLabel')}
+        className={listClassName}
+        style={{ maxHeight: LIST_HEADER_HEIGHT_PX + MAX_VISIBLE_ROWS * LIST_ROW_HEIGHT_PX, overflowY: 'auto' }}
+      >
         <TableContent
           selectionMode={multiple ? 'multiple' : 'single'}
           selectedKeys={new Set(selection.map(String))}


### PR DESCRIPTION
Assignee: [Jan Jaap](https://linear.app/attraccess/profiles/jappyjan)

## Summary

UI/UX fixes to the Attractap reader editor ([ATT-423](https://linear.app/attraccess/issue/ATT-423/attractap-editor-has-terrible-uiux)):

1. **Search input layout** — `<Input>` and `<Spinner>` were rendered as bare children of `<InputGroup>`. HeroUI v3 requires the compound subcomponents `InputGroup.Prefix` / `InputGroup.Input` / `InputGroup.Suffix`, so the input was collapsing to a single column. Switched to the compound API with a search icon prefix and the spinner in the suffix.
2. **Selection visibility** — the table relied solely on React Aria's row-selection background, which is barely visible in dark theme. Added a checkbox column with `slot="selection"` (the v3 idiom for multi-select tables) so selected vs unselected rows are immediately distinguishable.
3. **Scrollable resource list** — the `ResourceSelector` list is now capped at a fixed max height (`max-h-80`, overridable via a new `listClassName` prop) with its own scrollbar, so it scrolls independently instead of growing the whole drawer.
4. **Tabbed editor drawer** — the editor drawer is split into *General* (name + LED brightness) and *Resources* (search + selectable list) tabs for a leaner UI. Header and footer stay pinned while only the active panel's content scrolls.

Patched files:
- `libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx`
- `apps/frontend/src/app/attractap/AttractapEditor/AttractapEditor.tsx` (+ `.de.json` / `.en.json`)

## Test plan

- [x] Lint + typecheck + build + test pass on affected projects (`plugins-frontend-ui`, `frontend`)
- [x] Verified in a real browser (desktop + mobile, DE locale) — tabs switch correctly, resource list scrolls independently with drawer header/footer pinned, search input renders full-width, checkbox selection state is clear. Screenshots posted on the Linear issue.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
