### PR TITLE
feat(ATT-191): paginate attractap forms with server-held draft state

### DIFF
--- a/apps/api/src/attractap/websockets/websocket.gateway.ts
+++ b/apps/api/src/attractap/websockets/websocket.gateway.ts
@@ -34,7 +34,14 @@ import { ResourceFlowNodeType, ResourceFormAction } from '@attraccess/database-e
 import { ProjectsService } from '../../projects/projects.service';
 import { ResourceFormsService } from '../../resources/forms/forms.service';
 import { FormSubmissionRequestDto } from '../../resources/forms/dto/form-submission-request.dto';
-import { ResourceUsageFormRequestPayload } from './websocket.types';
+import {
+  ResourceUsageFormRequestPayload,
+  ResourceUsageFormGetFieldsPayload,
+  ResourceUsageFormFieldsPayload,
+  ResourceUsageFormSubmitPagePayload,
+  ResourceUsageFormPageResultPayload,
+  FormFieldAnswerValue,
+} from './websocket.types';
 import { MetricsService } from '../../metrics/metrics.service';
 import { MetricsToggleService } from '../../metrics/settings/metrics-toggle.service';
 import { WS_METRICS } from '../../metrics/definitions/tokens';
@@ -442,6 +449,14 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
         await this.handleProjectsOfUserRequest(socket, eventData);
         break;
 
+      case AttractapEventType.RESOURCE_USAGE_FORM_GET_FIELDS:
+        await this.handleResourceUsageFormGetFields(socket, eventData);
+        break;
+
+      case AttractapEventType.RESOURCE_USAGE_FORM_SUBMIT_PAGE:
+        await this.handleResourceUsageFormSubmitPage(socket, eventData);
+        break;
+
       case AttractapEventType.READER_FIRMWARE_UPDATE_REQUIRED:
         // no-op on server; metadata-only event sent by server
         break;
@@ -452,6 +467,8 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
       case AttractapEventType.CARD_AUTHENTICATION_DATA:
       case AttractapEventType.ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO:
       case AttractapEventType.RESOURCE_USAGE_FORM_REQUEST:
+      case AttractapEventType.RESOURCE_USAGE_FORM_FIELDS:
+      case AttractapEventType.RESOURCE_USAGE_FORM_PAGE_RESULT:
         this.logger.error(
           `Received event of type ${eventData.type} from client ${socket.id}, this is a server side only event, clients should not send this event`,
         );
@@ -960,26 +977,55 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
     return true;
   }
 
+  private formDraftKey(resourceId: number, action: ResourceFormAction): string {
+    return `${resourceId}:${action}`;
+  }
+
+  private getFormDraft(
+    socket: AuthenticatedWebSocket,
+    resourceId: number,
+    action: ResourceFormAction,
+  ): Record<number, FormFieldAnswerValue> {
+    return socket.state.formDrafts?.[this.formDraftKey(resourceId, action)] ?? {};
+  }
+
+  private clearFormDraft(socket: AuthenticatedWebSocket, resourceId: number, action: ResourceFormAction): void {
+    if (socket.state.formDrafts) {
+      delete socket.state.formDrafts[this.formDraftKey(resourceId, action)];
+    }
+  }
+
   private async ensureFormsSatisfied({
     socket,
     resourceId,
     action,
-    formSubmissions,
   }: {
     socket: AuthenticatedWebSocket;
     resourceId: number;
     action: ResourceFormAction;
-    formSubmissions?: FormSubmissionRequestDto[];
-  }): Promise<boolean> {
+  }): Promise<FormSubmissionRequestDto[] | null> {
     const forms = await this.resourceFormsService.getFormsForAction(resourceId, action);
     if (!forms.length) {
-      return true;
+      return [];
     }
 
-    const submissionIds = new Set((formSubmissions ?? []).map((submission) => submission.formId));
-    const allProvided = forms.every((form) => submissionIds.has(form.id));
-    if (allProvided) {
-      return true;
+    const draft = this.getFormDraft(socket, resourceId, action);
+    const hasValue = (fieldId: number) => {
+      const value = draft[fieldId];
+      return value !== undefined && value !== null && value !== '';
+    };
+
+    const complete = forms.every((form) =>
+      form.fields.filter((field) => field.isRequired).every((field) => hasValue(field.id)),
+    );
+
+    if (complete) {
+      return forms.map((form) => ({
+        formId: form.id,
+        answers: form.fields
+          .filter((field) => draft[field.id] !== undefined)
+          .map((field) => ({ fieldId: field.id, value: draft[field.id] })),
+      }));
     }
 
     let resourceName: string | undefined;
@@ -995,43 +1041,86 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
       resourceId,
       resourceName,
       action,
-      forms: forms.map((form) => ({
-        id: form.id,
-        name: form.name,
-        fields: form.fields.map((field) => ({
-          id: field.id,
-          name: field.name,
-          description: field.description ?? null,
-          type: field.type,
-          isRequired: field.isRequired,
-          options: field.options ?? null,
-        })),
-      })),
+      forms: forms.map((form) => ({ id: form.id, name: form.name, fieldCount: form.fields.length })),
     };
 
     await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_REQUEST, payload));
-    return false;
+    return null;
+  }
+
+  private async handleResourceUsageFormGetFields(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId, action, formId, offset, limit } = data.payload as ResourceUsageFormGetFieldsPayload;
+
+    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
+      return;
+    }
+
+    const { totalFieldCount, fields } = await this.resourceFormsService.getFieldsWindow(
+      resourceId,
+      formId,
+      offset,
+      limit,
+    );
+
+    const draft = this.getFormDraft(socket, resourceId, action);
+    const payload: ResourceUsageFormFieldsPayload = {
+      resourceId,
+      action,
+      formId,
+      offset,
+      totalFieldCount,
+      fields: fields.map((field) => ({
+        id: field.id,
+        name: field.name,
+        description: field.description ?? null,
+        type: field.type,
+        isRequired: field.isRequired,
+        options: field.options ?? null,
+        value: draft[field.id] ?? null,
+      })),
+    };
+
+    await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_FIELDS, payload));
+  }
+
+  private async handleResourceUsageFormSubmitPage(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId, action, formId, offset, answers } = data.payload as ResourceUsageFormSubmitPagePayload;
+
+    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
+      return;
+    }
+
+    const { valid, errors } = await this.resourceFormsService.validatePageAnswers(resourceId, formId, answers);
+
+    if (valid) {
+      const key = this.formDraftKey(resourceId, action);
+      socket.state.formDrafts ??= {};
+      socket.state.formDrafts[key] ??= {};
+      for (const answer of answers) {
+        socket.state.formDrafts[key][answer.fieldId] = answer.value;
+      }
+    }
+
+    const payload: ResourceUsageFormPageResultPayload = { resourceId, action, formId, offset, valid, errors };
+    await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_PAGE_RESULT, payload));
   }
 
   private async handleStartResourceUsageSession(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId, projectId, formSubmissions } = data.payload as {
+    const { resourceId, projectId } = data.payload as {
       resourceId: number;
       projectId?: number;
-      formSubmissions?: FormSubmissionRequestDto[];
     };
 
     if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
       return;
     }
 
-    if (
-      !(await this.ensureFormsSatisfied({
-        socket,
-        resourceId,
-        action: ResourceFormAction.START,
-        formSubmissions,
-      }))
-    ) {
+    const formSubmissions = await this.ensureFormsSatisfied({
+      socket,
+      resourceId,
+      action: ResourceFormAction.START,
+    });
+    if (formSubmissions === null) {
       return;
     }
 
@@ -1045,6 +1134,7 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     try {
       await this.resourceUsageService.startSession(resourceId, user, { projectId, formSubmissions });
+      this.clearFormDraft(socket, resourceId, ResourceFormAction.START);
       await socket.sendMessage(new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { success: true }));
     } catch (error) {
       if (error instanceof ResourceInUseError) {
@@ -1071,23 +1161,20 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
   }
 
   private async handleStopResourceUsageSession(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId, formSubmissions } = data.payload as {
+    const { resourceId } = data.payload as {
       resourceId: number;
-      formSubmissions?: FormSubmissionRequestDto[];
     };
 
     if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
       return;
     }
 
-    if (
-      !(await this.ensureFormsSatisfied({
-        socket,
-        resourceId,
-        action: ResourceFormAction.END,
-        formSubmissions,
-      }))
-    ) {
+    const formSubmissions = await this.ensureFormsSatisfied({
+      socket,
+      resourceId,
+      action: ResourceFormAction.END,
+    });
+    if (formSubmissions === null) {
       return;
     }
 
@@ -1101,6 +1188,7 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     try {
       await this.resourceUsageService.endSession(resourceId, user, { formSubmissions });
+      this.clearFormDraft(socket, resourceId, ResourceFormAction.END);
       await socket.sendMessage(new AttractapEvent(AttractapEventType.STOP_RESOURCE_USAGE_SESSION, { success: true }));
     } catch (error) {
       this.logger.error(`Failed to stop resource usage session: ${error.message}`);

--- a/apps/api/src/attractap/websockets/websocket.types.ts
+++ b/apps/api/src/attractap/websockets/websocket.types.ts
@@ -33,6 +33,10 @@ export enum AttractapEventType {
   BILLING_REQUEST_TOPUP = 'BILLING_REQUEST_TOPUP',
   PROJECTS_OF_USER = 'PROJECTS_OF_USER',
   RESOURCE_USAGE_FORM_REQUEST = 'RESOURCE_USAGE_FORM_REQUEST',
+  RESOURCE_USAGE_FORM_GET_FIELDS = 'RESOURCE_USAGE_FORM_GET_FIELDS',
+  RESOURCE_USAGE_FORM_FIELDS = 'RESOURCE_USAGE_FORM_FIELDS',
+  RESOURCE_USAGE_FORM_SUBMIT_PAGE = 'RESOURCE_USAGE_FORM_SUBMIT_PAGE',
+  RESOURCE_USAGE_FORM_PAGE_RESULT = 'RESOURCE_USAGE_FORM_PAGE_RESULT',
 }
 
 export interface ResourceThumbnailDescriptorPayload {
@@ -81,6 +85,7 @@ export interface AuthenticatedWebSocket extends Omit<WebSocket, 'send'> {
       fd?: number;
       lastLoggedPct?: number;
     } | null;
+    formDrafts?: Record<string, Record<number, FormFieldAnswerValue>>;
   };
 }
 
@@ -108,6 +113,8 @@ export interface FirmwareUpdateResponse {
   bytes_received_before_timeout?: number;
 }
 
+export type FormFieldAnswerValue = string | number | boolean;
+
 export interface ResourceUsageFormFieldPayload {
   id: number;
   name: string;
@@ -115,18 +122,57 @@ export interface ResourceUsageFormFieldPayload {
   type: string;
   isRequired: boolean;
   options: Record<string, unknown> | string[] | null;
+  value?: FormFieldAnswerValue | null;
 }
 
-export interface ResourceUsageFormPayload {
+export interface ResourceUsageFormMetaPayload {
   id: number;
   name: string;
-  description?: string | null;
-  fields: ResourceUsageFormFieldPayload[];
+  fieldCount: number;
 }
 
 export interface ResourceUsageFormRequestPayload {
   resourceId: number;
   resourceName?: string;
   action: ResourceFormAction;
-  forms: ResourceUsageFormPayload[];
+  forms: ResourceUsageFormMetaPayload[];
+}
+
+export interface ResourceUsageFormGetFieldsPayload {
+  resourceId: number;
+  action: ResourceFormAction;
+  formId: number;
+  offset: number;
+  limit: number;
+}
+
+export interface ResourceUsageFormFieldsPayload {
+  resourceId: number;
+  action: ResourceFormAction;
+  formId: number;
+  offset: number;
+  totalFieldCount: number;
+  fields: ResourceUsageFormFieldPayload[];
+}
+
+export interface ResourceUsageFormSubmitPagePayload {
+  resourceId: number;
+  action: ResourceFormAction;
+  formId: number;
+  offset: number;
+  answers: { fieldId: number; value: FormFieldAnswerValue }[];
+}
+
+export interface ResourceUsageFormPageErrorPayload {
+  fieldId: number;
+  message: string;
+}
+
+export interface ResourceUsageFormPageResultPayload {
+  resourceId: number;
+  action: ResourceFormAction;
+  formId: number;
+  offset: number;
+  valid: boolean;
+  errors: ResourceUsageFormPageErrorPayload[];
 }

--- a/apps/api/src/resources/forms/forms.service.spec.ts
+++ b/apps/api/src/resources/forms/forms.service.spec.ts
@@ -1,0 +1,108 @@
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Form, FormField, FormFieldType, FormSubmission, Resource, ResourceFormAction } from '@attraccess/database-entities';
+import { ResourceFormsService } from './forms.service';
+
+const makeField = (overrides: Partial<FormField>): FormField =>
+  ({
+    id: 1,
+    formId: 1,
+    name: 'Field',
+    type: FormFieldType.TEXT,
+    isRequired: false,
+    description: null,
+    options: null,
+    ...overrides,
+  }) as FormField;
+
+describe('ResourceFormsService pagination + per-field validation', () => {
+  let service: ResourceFormsService;
+  const formRepo = { find: jest.fn(), findOne: jest.fn() };
+  const resourceRepo = { findOne: jest.fn() };
+
+  const form: Form = {
+    id: 7,
+    name: 'Safety',
+    resourceId: 5,
+    isRequiredOnResourceUsageStart: true,
+    isRequiredOnResourceUsageTakeOver: false,
+    isRequiredOnResourceUsageEnd: false,
+    fields: [
+      makeField({ id: 11, name: 'Name', type: FormFieldType.TEXT, isRequired: true }),
+      makeField({ id: 12, name: 'Age', type: FormFieldType.NUMBER, isRequired: false }),
+      makeField({ id: 13, name: 'Confirm', type: FormFieldType.BOOLEAN, isRequired: true }),
+      makeField({ id: 14, name: 'Color', type: FormFieldType.SELECT, isRequired: true, options: ['red', 'blue'] }),
+    ],
+  } as Form;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    resourceRepo.findOne.mockResolvedValue({ id: 5 } as Resource);
+    formRepo.findOne.mockResolvedValue(form);
+    formRepo.find.mockResolvedValue([form]);
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ResourceFormsService,
+        { provide: getRepositoryToken(Form), useValue: formRepo },
+        { provide: getRepositoryToken(FormField), useValue: { find: jest.fn() } },
+        { provide: getRepositoryToken(FormSubmission), useValue: { save: jest.fn() } },
+        { provide: getRepositoryToken(Resource), useValue: resourceRepo },
+      ],
+    }).compile();
+
+    service = moduleRef.get(ResourceFormsService);
+  });
+
+  it('returns form metadata with field counts', async () => {
+    const meta = await service.getFormMetaForAction(5, ResourceFormAction.START);
+    expect(meta).toEqual([{ id: 7, name: 'Safety', fieldCount: 4 }]);
+  });
+
+  it('returns a windowed slice of fields ordered by id with total count', async () => {
+    const page = await service.getFieldsWindow(5, 7, 1, 1);
+    expect(page.totalFieldCount).toBe(4);
+    expect(page.fields).toHaveLength(1);
+    expect(page.fields[0].id).toBe(12);
+  });
+
+  it('accepts a valid single-field answer', async () => {
+    const result = await service.validatePageAnswers(5, 7, [{ fieldId: 11, value: 'Alice' }]);
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it('rejects an empty required field', async () => {
+    const result = await service.validatePageAnswers(5, 7, [{ fieldId: 11, value: '' }]);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].fieldId).toBe(11);
+  });
+
+  it('rejects a non-numeric number field', async () => {
+    const result = await service.validatePageAnswers(5, 7, [{ fieldId: 12, value: 'abc' }]);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].fieldId).toBe(12);
+  });
+
+  it('rejects an unchecked required boolean', async () => {
+    const result = await service.validatePageAnswers(5, 7, [{ fieldId: 13, value: false }]);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].fieldId).toBe(13);
+  });
+
+  it('rejects a select value outside the configured options', async () => {
+    const result = await service.validatePageAnswers(5, 7, [{ fieldId: 14, value: 'green' }]);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].fieldId).toBe(14);
+  });
+
+  it('accepts an in-range select value', async () => {
+    const result = await service.validatePageAnswers(5, 7, [{ fieldId: 14, value: 'blue' }]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags an unknown field id', async () => {
+    const result = await service.validatePageAnswers(5, 7, [{ fieldId: 999, value: 'x' }]);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].fieldId).toBe(999);
+  });
+});

--- a/apps/api/src/resources/forms/forms.service.ts
+++ b/apps/api/src/resources/forms/forms.service.ts
@@ -153,6 +153,55 @@ export class ResourceFormsService {
     return forms.map((form) => this.mapFormResponse(form));
   }
 
+  async getFormMetaForAction(
+    resourceId: number,
+    action: ResourceFormAction,
+  ): Promise<{ id: number; name: string; fieldCount: number }[]> {
+    await this.ensureResourceExists(resourceId);
+    const forms = await this.getFormsByAction(resourceId, action);
+    return forms.map((form) => ({ id: form.id, name: form.name, fieldCount: (form.fields ?? []).length }));
+  }
+
+  async getFieldsWindow(
+    resourceId: number,
+    formId: number,
+    offset: number,
+    limit: number,
+  ): Promise<{ totalFieldCount: number; fields: FormFieldResponseDto[] }> {
+    await this.ensureResourceExists(resourceId);
+    const form = await this.getFormOrThrow(resourceId, formId);
+    const fields = (form.fields ?? []).sort((a, b) => a.id - b.id);
+    const safeOffset = Math.max(0, offset);
+    const safeLimit = Math.max(1, limit);
+    const window = fields.slice(safeOffset, safeOffset + safeLimit).map((field) => this.mapFieldResponse(field));
+    return { totalFieldCount: fields.length, fields: window };
+  }
+
+  async validatePageAnswers(
+    resourceId: number,
+    formId: number,
+    answers: { fieldId: number; value: unknown }[],
+  ): Promise<{ valid: boolean; errors: { fieldId: number; message: string }[] }> {
+    await this.ensureResourceExists(resourceId);
+    const form = await this.getFormOrThrow(resourceId, formId);
+    const errors: { fieldId: number; message: string }[] = [];
+
+    for (const answer of answers) {
+      const field = form.fields?.find((item) => item.id === answer.fieldId);
+      if (!field) {
+        errors.push({ fieldId: answer.fieldId, message: `Unknown field #${answer.fieldId}.` });
+        continue;
+      }
+      try {
+        this.validateFieldAnswer(form, field, answer.value);
+      } catch (error) {
+        errors.push({ fieldId: field.id, message: (error as Error).message });
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
   async saveRequiredSubmissions(options: {
     resourceId: number;
     action: ResourceFormAction;
@@ -283,29 +332,43 @@ export class ResourceFormsService {
 
     for (const field of form.fields ?? []) {
       const answer = submission.answers.find((item) => item.fieldId === field.id);
-
-      // For boolean fields, check if it's required and must be true
-      if (field.type === 'boolean' && field.isRequired) {
-        const boolValue = answer?.value === true || answer?.value === 'true';
-        if (!boolValue) {
-          throw new BadRequestException(`Field "${field.name}" must be checked on form "${form.name}".`);
-        }
-      }
-
-      if (!answer || answer.value === undefined || answer.value === null || answer.value === '') {
-        if (field.isRequired) {
-          throw new BadRequestException(`Field "${field.name}" is required on form "${form.name}".`);
-        }
+      const value = this.validateFieldAnswer(form, field, answer?.value);
+      if (value === undefined) {
         continue;
       }
-
-      data[field.id.toString()] = {
-        value: parseFieldValue(field.type, answer.value, field.options),
-        fieldDefinition: field,
-      };
+      data[field.id.toString()] = { value, fieldDefinition: field };
     }
 
     return data;
+  }
+
+  private validateFieldAnswer(form: Form, field: FormField, rawValue: unknown): string | undefined {
+    if (field.type === 'boolean' && field.isRequired) {
+      const boolValue = rawValue === true || rawValue === 'true';
+      if (!boolValue) {
+        throw new BadRequestException(`Field "${field.name}" must be checked on form "${form.name}".`);
+      }
+    }
+
+    if (rawValue === undefined || rawValue === null || rawValue === '') {
+      if (field.isRequired) {
+        throw new BadRequestException(`Field "${field.name}" is required on form "${form.name}".`);
+      }
+      return undefined;
+    }
+
+    return parseFieldValue(field.type, rawValue, field.options);
+  }
+
+  private mapFieldResponse(field: FormField): FormFieldResponseDto {
+    const fieldDto = new FormFieldResponseDto();
+    fieldDto.id = field.id;
+    fieldDto.name = field.name;
+    fieldDto.type = field.type;
+    fieldDto.isRequired = field.isRequired;
+    fieldDto.description = field.description;
+    fieldDto.options = field.options;
+    return fieldDto;
   }
 
   private mapFormResponse(form: Form): FormResponseDto {
@@ -318,16 +381,7 @@ export class ResourceFormsService {
     response.isRequiredOnResourceUsageTakeOver = form.isRequiredOnResourceUsageTakeOver;
     response.isRequiredOnResourceUsageEnd = form.isRequiredOnResourceUsageEnd;
     response.resourceId = form.resourceId;
-    response.fields = (form.fields ?? []).map((field) => {
-      const fieldDto = new FormFieldResponseDto();
-      fieldDto.id = field.id;
-      fieldDto.name = field.name;
-      fieldDto.type = field.type;
-      fieldDto.isRequired = field.isRequired;
-      fieldDto.description = field.description;
-      fieldDto.options = field.options;
-      return fieldDto;
-    });
+    response.fields = (form.fields ?? []).map((field) => this.mapFieldResponse(field));
 
     return response;
   }

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.5"'
+	-D FIRMWARE_VERSION='"1.3.3"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.2"'
+	-D FIRMWARE_VERSION='"1.3.3"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.4"'
+	-D FIRMWARE_VERSION='"1.3.5"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.3"'
+	-D FIRMWARE_VERSION='"1.3.4"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/api/api.cpp
+++ b/apps/attractap/firmware/src/api/api.cpp
@@ -202,6 +202,14 @@ void API::processIncomingMessage(const char *buf, size_t len)
     {
         this->onResourceUsageFormRequest(inboundDoc["data"].as<JsonObject>());
     }
+    else if (strcmp(eventType, "RESOURCE_USAGE_FORM_FIELDS") == 0)
+    {
+        this->onResourceUsageFormFields(inboundDoc["data"].as<JsonObject>());
+    }
+    else if (strcmp(eventType, "RESOURCE_USAGE_FORM_PAGE_RESULT") == 0)
+    {
+        this->onResourceUsageFormPageResult(inboundDoc["data"].as<JsonObject>());
+    }
     else
     {
         logger.error((String("Unknown event type: ") + eventType).c_str());
@@ -887,7 +895,7 @@ void API::setCardAuthenticationDetailsResponseCallback(std::function<void(CardAu
     this->cardAuthenticationDetailsResponseCallback = callback;
 }
 
-void API::startResourceUsageSession(uint32_t resourceId, uint32_t projectId, const FormSubmissionList *formSubmissions)
+void API::startResourceUsageSession(uint32_t resourceId, uint32_t projectId)
 {
     this->logger.info("Starting resource usage session");
     JsonDocument doc;
@@ -897,18 +905,40 @@ void API::startResourceUsageSession(uint32_t resourceId, uint32_t projectId, con
     {
         payload["projectId"] = projectId;
     }
-    this->serializeFormSubmissions(payload, formSubmissions);
     this->sendMessage("START_RESOURCE_USAGE_SESSION", payload);
 }
 
-void API::stopResourceUsageSession(uint32_t resourceId, const FormSubmissionList *formSubmissions)
+void API::stopResourceUsageSession(uint32_t resourceId)
 {
     this->logger.info("Stopping resource usage session");
     JsonDocument doc;
     JsonObject payload = doc.to<JsonObject>();
     payload["resourceId"] = resourceId;
-    this->serializeFormSubmissions(payload, formSubmissions);
     this->sendMessage("STOP_RESOURCE_USAGE_SESSION", payload);
+}
+
+void API::requestFormFields(uint32_t resourceId, ResourceUsageFormActionType action, uint32_t formId, uint32_t offset, uint32_t limit)
+{
+    JsonDocument doc;
+    JsonObject payload = doc.to<JsonObject>();
+    payload["resourceId"] = resourceId;
+    payload["action"] = API::formActionToString(action);
+    payload["formId"] = formId;
+    payload["offset"] = offset;
+    payload["limit"] = limit;
+    this->sendMessage("RESOURCE_USAGE_FORM_GET_FIELDS", payload);
+}
+
+void API::submitFormPage(uint32_t resourceId, ResourceUsageFormActionType action, const FormPageSubmission &page)
+{
+    JsonDocument doc;
+    JsonObject payload = doc.to<JsonObject>();
+    payload["resourceId"] = resourceId;
+    payload["action"] = API::formActionToString(action);
+    payload["formId"] = page.formId;
+    payload["offset"] = page.offset;
+    this->serializeFormPageSubmission(payload, page);
+    this->sendMessage("RESOURCE_USAGE_FORM_SUBMIT_PAGE", payload);
 }
 
 void API::lockDoor(uint32_t resourceId)
@@ -1053,6 +1083,16 @@ void API::setResourceFormsRequestCallback(std::function<void(const ResourceUsage
     this->resourceFormsRequestCallback = callback;
 }
 
+void API::setResourceFormFieldsCallback(std::function<void(const ResourceUsageFormFieldsPage &)> callback)
+{
+    this->resourceFormFieldsCallback = callback;
+}
+
+void API::setResourceFormPageResultCallback(std::function<void(const ResourceUsageFormPageResult &)> callback)
+{
+    this->resourceFormPageResultCallback = callback;
+}
+
 void API::onProjectsOfUserResponse(JsonObject data)
 {
     this->logger.info("Received projects of user response");
@@ -1135,20 +1175,18 @@ void API::onResourceUsageFormRequest(JsonObject data)
     }
 
     ResourceUsageFormRequest &request = this->resourceFormsRequestScratch;
-    request.resourceId = 0;
-    request.resourceName = "";
-    request.action = ResourceUsageFormActionType::UNKNOWN;
-    request.formCount = 0;
-    for (uint8_t i = 0; i < MAX_FORMS_PER_REQUEST; ++i)
-    {
-        this->resetResourceUsageForm(request.forms[i]);
-    }
     request.resourceId = payload["resourceId"].is<uint32_t>() ? payload["resourceId"].as<uint32_t>() : 0;
+    request.resourceName = "";
     if (payload["resourceName"].is<const char *>())
     {
         request.resourceName = payload["resourceName"].as<const char *>();
     }
     request.action = this->parseFormAction(payload["action"].as<const char *>());
+    request.formCount = 0;
+    for (uint8_t i = 0; i < MAX_FORMS_PER_REQUEST; ++i)
+    {
+        request.forms[i] = ResourceUsageFormMeta{};
+    }
 
     JsonArray forms = payload["forms"].as<JsonArray>();
     uint8_t formIndex = 0;
@@ -1161,48 +1199,143 @@ void API::onResourceUsageFormRequest(JsonObject data)
                 this->logger.info("Form request truncated due to MAX_FORMS_PER_REQUEST");
                 break;
             }
-
-            ResourceUsageForm &form = request.forms[formIndex];
+            ResourceUsageFormMeta &form = request.forms[formIndex];
             form.id = formObj["id"].is<uint32_t>() ? formObj["id"].as<uint32_t>() : 0;
-            if (formObj["name"].is<const char *>())
-            {
-                form.name = formObj["name"].as<const char *>();
-            }
-
-            JsonArray fields = formObj["fields"].as<JsonArray>();
-            uint8_t fieldIndex = 0;
-            if (!fields.isNull())
-            {
-                for (JsonObject fieldObj : fields)
-                {
-                    if (fieldIndex >= MAX_FORM_FIELDS_PER_FORM)
-                    {
-                        this->logger.info("Field list truncated due to MAX_FORM_FIELDS_PER_FORM");
-                        break;
-                    }
-                    ResourceUsageFormField &field = form.fields[fieldIndex];
-                    field.id = fieldObj["id"].is<uint32_t>() ? fieldObj["id"].as<uint32_t>() : 0;
-                    if (fieldObj["name"].is<const char *>())
-                    {
-                        field.name = fieldObj["name"].as<const char *>();
-                    }
-                    if (fieldObj["description"].is<const char *>())
-                    {
-                        field.description = fieldObj["description"].as<const char *>();
-                    }
-                    field.isRequired = fieldObj["isRequired"].is<bool>() ? fieldObj["isRequired"].as<bool>() : false;
-                    field.type = this->parseFormFieldType(fieldObj["type"].as<const char *>());
-                    this->parseFormFieldOptions(field, fieldObj["options"]);
-                    fieldIndex++;
-                }
-            }
-            form.fieldCount = fieldIndex;
+            form.name = formObj["name"].is<const char *>() ? formObj["name"].as<const char *>() : "";
+            form.fieldCount = formObj["fieldCount"].is<uint32_t>() ? formObj["fieldCount"].as<uint32_t>() : 0;
             formIndex++;
         }
     }
     request.formCount = formIndex;
 
     this->resourceFormsRequestCallback(request);
+}
+
+void API::onResourceUsageFormFields(JsonObject data)
+{
+    if (!this->resourceFormFieldsCallback)
+    {
+        this->logger.info("Received RESOURCE_USAGE_FORM_FIELDS but no callback is registered");
+        return;
+    }
+
+    JsonObject payload = data["payload"].as<JsonObject>();
+    if (payload.isNull())
+    {
+        this->logger.error("RESOURCE_USAGE_FORM_FIELDS missing payload");
+        return;
+    }
+
+    ResourceUsageFormFieldsPage &page = this->resourceFormFieldsScratch;
+    page.resourceId = payload["resourceId"].is<uint32_t>() ? payload["resourceId"].as<uint32_t>() : 0;
+    page.action = this->parseFormAction(payload["action"].as<const char *>());
+    page.formId = payload["formId"].is<uint32_t>() ? payload["formId"].as<uint32_t>() : 0;
+    page.offset = payload["offset"].is<uint32_t>() ? payload["offset"].as<uint32_t>() : 0;
+    page.totalFieldCount = payload["totalFieldCount"].is<uint32_t>() ? payload["totalFieldCount"].as<uint32_t>() : 0;
+    page.fieldCount = 0;
+    for (uint8_t i = 0; i < MAX_FORM_PAGE_FIELDS; ++i)
+    {
+        this->resetResourceUsageFormField(page.fields[i]);
+    }
+
+    JsonArray fields = payload["fields"].as<JsonArray>();
+    uint8_t fieldIndex = 0;
+    if (!fields.isNull())
+    {
+        for (JsonObject fieldObj : fields)
+        {
+            if (fieldIndex >= MAX_FORM_PAGE_FIELDS)
+            {
+                this->logger.info("Field page truncated due to MAX_FORM_PAGE_FIELDS");
+                break;
+            }
+            ResourceUsageFormField &field = page.fields[fieldIndex];
+            field.id = fieldObj["id"].is<uint32_t>() ? fieldObj["id"].as<uint32_t>() : 0;
+            if (fieldObj["name"].is<const char *>())
+            {
+                field.name = fieldObj["name"].as<const char *>();
+            }
+            if (fieldObj["description"].is<const char *>())
+            {
+                field.description = fieldObj["description"].as<const char *>();
+            }
+            field.isRequired = fieldObj["isRequired"].is<bool>() ? fieldObj["isRequired"].as<bool>() : false;
+            field.type = this->parseFormFieldType(fieldObj["type"].as<const char *>());
+            this->parseFormFieldOptions(field, fieldObj["options"]);
+
+            JsonVariantConst valueVariant = fieldObj["value"];
+            field.hasValue = false;
+            field.value = "";
+            if (!valueVariant.isNull())
+            {
+                field.hasValue = true;
+                if (valueVariant.is<bool>())
+                {
+                    field.value = valueVariant.as<bool>() ? "true" : "false";
+                }
+                else if (valueVariant.is<const char *>())
+                {
+                    field.value = valueVariant.as<const char *>();
+                }
+                else if (valueVariant.is<double>())
+                {
+                    field.value = String(valueVariant.as<double>());
+                }
+                else
+                {
+                    field.hasValue = false;
+                }
+            }
+            fieldIndex++;
+        }
+    }
+    page.fieldCount = fieldIndex;
+
+    this->resourceFormFieldsCallback(page);
+}
+
+void API::onResourceUsageFormPageResult(JsonObject data)
+{
+    if (!this->resourceFormPageResultCallback)
+    {
+        this->logger.info("Received RESOURCE_USAGE_FORM_PAGE_RESULT but no callback is registered");
+        return;
+    }
+
+    JsonObject payload = data["payload"].as<JsonObject>();
+    if (payload.isNull())
+    {
+        this->logger.error("RESOURCE_USAGE_FORM_PAGE_RESULT missing payload");
+        return;
+    }
+
+    ResourceUsageFormPageResult &result = this->resourceFormPageResultScratch;
+    result.resourceId = payload["resourceId"].is<uint32_t>() ? payload["resourceId"].as<uint32_t>() : 0;
+    result.action = this->parseFormAction(payload["action"].as<const char *>());
+    result.formId = payload["formId"].is<uint32_t>() ? payload["formId"].as<uint32_t>() : 0;
+    result.offset = payload["offset"].is<uint32_t>() ? payload["offset"].as<uint32_t>() : 0;
+    result.valid = payload["valid"].is<bool>() ? payload["valid"].as<bool>() : false;
+    result.errorCount = 0;
+
+    JsonArray errors = payload["errors"].as<JsonArray>();
+    uint8_t errorIndex = 0;
+    if (!errors.isNull())
+    {
+        for (JsonObject errorObj : errors)
+        {
+            if (errorIndex >= MAX_FORM_PAGE_ERRORS)
+            {
+                break;
+            }
+            ResourceUsageFormPageResult::Error &error = result.errors[errorIndex];
+            error.fieldId = errorObj["fieldId"].is<uint32_t>() ? errorObj["fieldId"].as<uint32_t>() : 0;
+            error.message = errorObj["message"].is<const char *>() ? errorObj["message"].as<const char *>() : "";
+            errorIndex++;
+        }
+    }
+    result.errorCount = errorIndex;
+
+    this->resourceFormPageResultCallback(result);
 }
 
 API::ResourceUsageFormActionType API::parseFormAction(const char *action)
@@ -1224,6 +1357,21 @@ API::ResourceUsageFormActionType API::parseFormAction(const char *action)
         return ResourceUsageFormActionType::TAKEOVER;
     }
     return ResourceUsageFormActionType::UNKNOWN;
+}
+
+const char *API::formActionToString(ResourceUsageFormActionType action)
+{
+    switch (action)
+    {
+    case ResourceUsageFormActionType::START:
+        return "start";
+    case ResourceUsageFormActionType::END:
+        return "end";
+    case ResourceUsageFormActionType::TAKEOVER:
+        return "takeover";
+    default:
+        return "";
+    }
 }
 
 API::ResourceUsageFormFieldType API::parseFormFieldType(const char *type)
@@ -1364,17 +1512,6 @@ void API::parseFormFieldOptions(ResourceUsageFormField &field, JsonVariantConst 
     }
 }
 
-void API::resetResourceUsageForm(ResourceUsageForm &form)
-{
-    form.id = 0;
-    form.name = "";
-    form.fieldCount = 0;
-    for (uint8_t i = 0; i < MAX_FORM_FIELDS_PER_FORM; ++i)
-    {
-        this->resetResourceUsageFormField(form.fields[i]);
-    }
-}
-
 void API::resetResourceUsageFormField(ResourceUsageFormField &field)
 {
     field.id = 0;
@@ -1383,48 +1520,34 @@ void API::resetResourceUsageFormField(ResourceUsageFormField &field)
     field.name = "";
     field.description = "";
     field.options = ResourceUsageFormFieldOptions{};
+    field.hasValue = false;
+    field.value = "";
 }
 
-void API::serializeFormSubmissions(JsonObject payload, const FormSubmissionList *formSubmissions)
+void API::serializeFormPageSubmission(JsonObject payload, const FormPageSubmission &page)
 {
-    if (!formSubmissions || formSubmissions->submissionCount == 0)
+    JsonArray answers = payload.createNestedArray("answers");
+    for (uint8_t j = 0; j < page.answerCount; ++j)
     {
-        return;
-    }
-
-    JsonArray submissions = payload.createNestedArray("formSubmissions");
-    for (uint8_t i = 0; i < formSubmissions->submissionCount; ++i)
-    {
-        const FormSubmission &submission = formSubmissions->submissions[i];
-        if (submission.formId == 0)
+        const FormSubmissionAnswer &answer = page.answers[j];
+        if (answer.fieldId == 0)
         {
             continue;
         }
-        JsonObject submissionObj = submissions.createNestedObject();
-        submissionObj["formId"] = submission.formId;
-        JsonArray answers = submissionObj.createNestedArray("answers");
-        for (uint8_t j = 0; j < submission.answerCount; ++j)
+        JsonObject answerObj = answers.createNestedObject();
+        answerObj["fieldId"] = answer.fieldId;
+        switch (answer.type)
         {
-            const FormSubmissionAnswer &answer = submission.answers[j];
-            if (answer.fieldId == 0)
-            {
-                continue;
-            }
-            JsonObject answerObj = answers.createNestedObject();
-            answerObj["fieldId"] = answer.fieldId;
-            switch (answer.type)
-            {
-            case FormSubmissionAnswer::ValueType::NUMBER:
-                answerObj["value"] = answer.numberValue;
-                break;
-            case FormSubmissionAnswer::ValueType::BOOLEAN:
-                answerObj["value"] = answer.boolValue;
-                break;
-            case FormSubmissionAnswer::ValueType::STRING:
-            default:
-                answerObj["value"] = answer.stringValue.c_str();
-                break;
-            }
+        case FormSubmissionAnswer::ValueType::NUMBER:
+            answerObj["value"] = answer.numberValue;
+            break;
+        case FormSubmissionAnswer::ValueType::BOOLEAN:
+            answerObj["value"] = answer.boolValue;
+            break;
+        case FormSubmissionAnswer::ValueType::STRING:
+        default:
+            answerObj["value"] = answer.stringValue.c_str();
+            break;
         }
     }
 }

--- a/apps/attractap/firmware/src/api/api.hpp
+++ b/apps/attractap/firmware/src/api/api.hpp
@@ -26,10 +26,9 @@ public:
     static constexpr size_t MAX_FLOW_BUTTON_LABEL_LEN = 32;
     static constexpr size_t MAX_FLOW_BUTTON_ID_LEN = 48;
     static constexpr size_t MAX_PROJECTS_PER_PAGE = 4;
-    static constexpr size_t MAX_FORMS_PER_REQUEST = 1;
-    static constexpr size_t MAX_FORM_FIELDS_PER_FORM = 16;
-    static constexpr size_t MAX_FORM_SUBMISSIONS = MAX_FORMS_PER_REQUEST;
-    static constexpr size_t MAX_FORM_FIELD_ANSWERS = MAX_FORM_FIELDS_PER_FORM;
+    static constexpr size_t MAX_FORMS_PER_REQUEST = 4;
+    static constexpr size_t MAX_FORM_PAGE_FIELDS = 1;
+    static constexpr size_t MAX_FORM_PAGE_ERRORS = MAX_FORM_PAGE_FIELDS;
     static constexpr size_t MAX_SELECT_OPTIONS = 12;
     struct FlowButton
     {
@@ -126,14 +125,15 @@ public:
         String name;
         String description;
         ResourceUsageFormFieldOptions options;
+        bool hasValue = false;
+        String value;
     };
 
-    struct ResourceUsageForm
+    struct ResourceUsageFormMeta
     {
         uint32_t id = 0;
         String name;
-        uint8_t fieldCount = 0;
-        ResourceUsageFormField fields[MAX_FORM_FIELDS_PER_FORM];
+        uint32_t fieldCount = 0;
     };
 
     struct ResourceUsageFormRequest
@@ -142,7 +142,18 @@ public:
         ResourceUsageFormActionType action = ResourceUsageFormActionType::UNKNOWN;
         String resourceName;
         uint8_t formCount = 0;
-        ResourceUsageForm forms[MAX_FORMS_PER_REQUEST];
+        ResourceUsageFormMeta forms[MAX_FORMS_PER_REQUEST];
+    };
+
+    struct ResourceUsageFormFieldsPage
+    {
+        uint32_t resourceId = 0;
+        ResourceUsageFormActionType action = ResourceUsageFormActionType::UNKNOWN;
+        uint32_t formId = 0;
+        uint32_t offset = 0;
+        uint32_t totalFieldCount = 0;
+        uint8_t fieldCount = 0;
+        ResourceUsageFormField fields[MAX_FORM_PAGE_FIELDS];
     };
 
     struct FormSubmissionAnswer
@@ -159,17 +170,27 @@ public:
         bool boolValue = false;
     };
 
-    struct FormSubmission
+    struct FormPageSubmission
     {
         uint32_t formId = 0;
+        uint32_t offset = 0;
         uint8_t answerCount = 0;
-        FormSubmissionAnswer answers[MAX_FORM_FIELD_ANSWERS];
+        FormSubmissionAnswer answers[MAX_FORM_PAGE_FIELDS];
     };
 
-    struct FormSubmissionList
+    struct ResourceUsageFormPageResult
     {
-        uint8_t submissionCount = 0;
-        FormSubmission submissions[MAX_FORM_SUBMISSIONS];
+        uint32_t resourceId = 0;
+        ResourceUsageFormActionType action = ResourceUsageFormActionType::UNKNOWN;
+        uint32_t formId = 0;
+        uint32_t offset = 0;
+        bool valid = false;
+        uint8_t errorCount = 0;
+        struct Error
+        {
+            uint32_t fieldId = 0;
+            String message;
+        } errors[MAX_FORM_PAGE_ERRORS];
     };
 
     void setResourceListUpdateCallback(std::function<void(const ResourceList &)> callback);
@@ -194,8 +215,10 @@ public:
     void sendEnrollNewCardAvailableKeyNo(uint8_t *uid, uint8_t uidLength, uint8_t keyNo);
     void sendEnrollNewCard(bool success);
 
-    void startResourceUsageSession(uint32_t resourceId, uint32_t projectId = 0, const FormSubmissionList *formSubmissions = nullptr);
-    void stopResourceUsageSession(uint32_t resourceId, const FormSubmissionList *formSubmissions = nullptr);
+    void startResourceUsageSession(uint32_t resourceId, uint32_t projectId = 0);
+    void stopResourceUsageSession(uint32_t resourceId);
+    void requestFormFields(uint32_t resourceId, ResourceUsageFormActionType action, uint32_t formId, uint32_t offset, uint32_t limit);
+    void submitFormPage(uint32_t resourceId, ResourceUsageFormActionType action, const FormPageSubmission &page);
     void lockDoor(uint32_t resourceId);
     void unlockDoor(uint32_t resourceId);
     void unlatchDoor(uint32_t resourceId);
@@ -220,8 +243,12 @@ public:
     void requestProjectsOfUser(uint32_t page);
     void setProjectsOfUserResponseCallback(std::function<void(const ProjectsOfUserResponse &)> callback);
     void setResourceFormsRequestCallback(std::function<void(const ResourceUsageFormRequest &)> callback);
-    // Get reference to the form request scratch buffer for deferred copy
+    void setResourceFormFieldsCallback(std::function<void(const ResourceUsageFormFieldsPage &)> callback);
+    void setResourceFormPageResultCallback(std::function<void(const ResourceUsageFormPageResult &)> callback);
+    // Get references to the form scratch buffers for deferred copy
     const ResourceUsageFormRequest &getFormRequestScratch() const { return resourceFormsRequestScratch; }
+    const ResourceUsageFormFieldsPage &getFormFieldsScratch() const { return resourceFormFieldsScratch; }
+    const ResourceUsageFormPageResult &getFormPageResultScratch() const { return resourceFormPageResultScratch; }
 
 private:
     Logger logger;
@@ -260,7 +287,11 @@ private:
 
     ProjectsOfUserResponse projectsOfUserResponseScratch;
     ResourceUsageFormRequest resourceFormsRequestScratch;
+    ResourceUsageFormFieldsPage resourceFormFieldsScratch;
+    ResourceUsageFormPageResult resourceFormPageResultScratch;
     std::function<void(const ResourceUsageFormRequest &)> resourceFormsRequestCallback;
+    std::function<void(const ResourceUsageFormFieldsPage &)> resourceFormFieldsCallback;
+    std::function<void(const ResourceUsageFormPageResult &)> resourceFormPageResultCallback;
 
     void onRegistrationData(JsonObject data);
     void onUnauthorized(JsonObject data);
@@ -271,12 +302,14 @@ private:
     void onProjectsOfUserResponse(JsonObject data);
     void onCardAuthenticationDetailsResponse(JsonObject data);
     void onResourceUsageFormRequest(JsonObject data);
+    void onResourceUsageFormFields(JsonObject data);
+    void onResourceUsageFormPageResult(JsonObject data);
     ResourceUsageFormActionType parseFormAction(const char *action);
+    static const char *formActionToString(ResourceUsageFormActionType action);
     ResourceUsageFormFieldType parseFormFieldType(const char *type);
     void parseFormFieldOptions(ResourceUsageFormField &field, JsonVariantConst options);
-    void resetResourceUsageForm(ResourceUsageForm &form);
     void resetResourceUsageFormField(ResourceUsageFormField &field);
-    void serializeFormSubmissions(JsonObject payload, const FormSubmissionList *formSubmissions);
+    void serializeFormPageSubmission(JsonObject payload, const FormPageSubmission &page);
 
     std::function<void(String username)> enrollNewCardGetAvailableKeyNoCallback;
     std::function<void(uint8_t keyNo, String key)> enrollNewCardCallback;

--- a/apps/attractap/firmware/src/application/application.cpp
+++ b/apps/attractap/firmware/src/application/application.cpp
@@ -264,10 +264,12 @@ void Application::setup() {
       [this](uint32_t projectId, const String &projectName) {
         this->handleProjectSelection(projectId, projectName);
       });
-  Display::resourceDetailsScreen.setFormsSubmitCallback(
-      [this](const API::FormSubmissionList &submissions) {
-        this->handleFormsSubmit(submissions);
+  Display::resourceDetailsScreen.setFormPageNextCallback(
+      [this](const API::FormPageSubmission &page) {
+        this->handleFormPageNext(page);
       });
+  Display::resourceDetailsScreen.setFormPageBackCallback(
+      [this]() { this->handleFormPageBack(); });
   Display::resourceDetailsScreen.setFormsCancelCallback(
       [this]() { this->handleFormsCancel(); });
 
@@ -346,6 +348,38 @@ void Application::setup() {
                 // stack/heap)
                 self->pendingFormRequest = self->api.getFormRequestScratch();
                 self->handleFormsRequest(self->pendingFormRequest);
+              }
+            },
+            this);
+      });
+
+  this->api.setResourceFormFieldsCallback(
+      [this](const API::ResourceUsageFormFieldsPage &page) {
+        (void)page; // The data is in api.getFormFieldsScratch()
+        this->pendingFormFieldsReady = true;
+        lv_async_call(
+            [](void *u) {
+              auto *self = static_cast<Application *>(u);
+              if (self && self->pendingFormFieldsReady) {
+                self->pendingFormFieldsReady = false;
+                self->pendingFormFields = self->api.getFormFieldsScratch();
+                self->handleFormFields(self->pendingFormFields);
+              }
+            },
+            this);
+      });
+
+  this->api.setResourceFormPageResultCallback(
+      [this](const API::ResourceUsageFormPageResult &result) {
+        (void)result; // The data is in api.getFormPageResultScratch()
+        this->pendingFormPageResultReady = true;
+        lv_async_call(
+            [](void *u) {
+              auto *self = static_cast<Application *>(u);
+              if (self && self->pendingFormPageResultReady) {
+                self->pendingFormPageResultReady = false;
+                self->pendingFormPageResult = self->api.getFormPageResultScratch();
+                self->handleFormPageResult(self->pendingFormPageResult);
               }
             },
             this);
@@ -980,36 +1014,153 @@ void Application::handleProjectSelection(uint32_t projectId,
 
 void Application::handleFormsRequest(
     const API::ResourceUsageFormRequest &request) {
-  // Note: 'request' is already a reference to this->pendingFormRequest from the
-  // callback, so we don't need to copy it again. Just set the flag and show the
-  // modal.
-  (void)request; // Suppress unused parameter warning; we use pendingFormRequest
-                 // directly
+  // 'request' aliases this->pendingFormRequest (filled by the callback).
+  (void)request;
   this->hasPendingFormRequest = true;
+  this->formCursorFormIdx = 0;
+  this->formCursorOffset = 0;
   Display::resourceDetailsScreen.hideActionProgress();
-  // Pass the stored copy since showFormsModal stores a pointer
   Display::resourceDetailsScreen.showFormsModal(this->pendingFormRequest);
+  this->requestCurrentFormField();
 }
 
-void Application::handleFormsSubmit(
-    const API::FormSubmissionList &submissions) {
-  if (this->pendingActionType == PENDING_ACTION_NONE) {
-    this->handleFormsCancel();
+uint32_t Application::totalFormFields() const {
+  uint32_t total = 0;
+  for (uint8_t i = 0;
+       i < this->pendingFormRequest.formCount && i < API::MAX_FORMS_PER_REQUEST;
+       ++i) {
+    total += this->pendingFormRequest.forms[i].fieldCount;
+  }
+  return total;
+}
+
+uint32_t Application::globalFormFieldNumber() const {
+  uint32_t number = 0;
+  for (uint8_t i = 0;
+       i < this->formCursorFormIdx && i < API::MAX_FORMS_PER_REQUEST; ++i) {
+    number += this->pendingFormRequest.forms[i].fieldCount;
+  }
+  return number + this->formCursorOffset + 1;
+}
+
+bool Application::isLastFormField() const {
+  // Last when no later field exists in this or any subsequent form.
+  if (this->formCursorFormIdx >= this->pendingFormRequest.formCount) {
+    return true;
+  }
+  if (this->formCursorOffset + 1 <
+      this->pendingFormRequest.forms[this->formCursorFormIdx].fieldCount) {
+    return false;
+  }
+  for (uint8_t i = this->formCursorFormIdx + 1;
+       i < this->pendingFormRequest.formCount && i < API::MAX_FORMS_PER_REQUEST;
+       ++i) {
+    if (this->pendingFormRequest.forms[i].fieldCount > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void Application::requestCurrentFormField() {
+  // Skip forms that carry no fields, finish when the cursor runs past the end.
+  while (this->formCursorFormIdx < this->pendingFormRequest.formCount &&
+         this->pendingFormRequest.forms[this->formCursorFormIdx].fieldCount ==
+             0) {
+    this->formCursorFormIdx++;
+    this->formCursorOffset = 0;
+  }
+  if (this->formCursorFormIdx >= this->pendingFormRequest.formCount) {
+    this->finishFormFlow();
     return;
   }
+  const API::ResourceUsageFormMeta &form =
+      this->pendingFormRequest.forms[this->formCursorFormIdx];
+  this->api.requestFormFields(this->pendingFormRequest.resourceId,
+                              this->pendingFormRequest.action, form.id,
+                              this->formCursorOffset, API::MAX_FORM_PAGE_FIELDS);
+}
 
-  this->formSubmissionBuffer = submissions;
+void Application::advanceFormCursor() {
+  this->formCursorOffset += API::MAX_FORM_PAGE_FIELDS;
+  if (this->formCursorFormIdx < this->pendingFormRequest.formCount &&
+      this->formCursorOffset >=
+          this->pendingFormRequest.forms[this->formCursorFormIdx].fieldCount) {
+    this->formCursorFormIdx++;
+    this->formCursorOffset = 0;
+  }
+}
+
+void Application::retreatFormCursor() {
+  if (this->formCursorOffset > 0) {
+    this->formCursorOffset--;
+  } else {
+    if (this->formCursorFormIdx == 0) {
+      return;
+    }
+    int16_t idx = static_cast<int16_t>(this->formCursorFormIdx) - 1;
+    while (idx >= 0 && this->pendingFormRequest.forms[idx].fieldCount == 0) {
+      idx--;
+    }
+    if (idx < 0) {
+      return;
+    }
+    this->formCursorFormIdx = static_cast<uint8_t>(idx);
+    this->formCursorOffset = this->pendingFormRequest.forms[idx].fieldCount - 1;
+  }
+  this->requestCurrentFormField();
+}
+
+void Application::handleFormFields(const API::ResourceUsageFormFieldsPage &page) {
+  if (!this->hasPendingFormRequest) {
+    return;
+  }
+  bool canGoBack = this->globalFormFieldNumber() > 1;
+  Display::resourceDetailsScreen.renderFormField(
+      page, canGoBack, this->isLastFormField(), this->globalFormFieldNumber(),
+      this->totalFormFields());
+}
+
+void Application::handleFormPageNext(const API::FormPageSubmission &page) {
+  if (!this->hasPendingFormRequest) {
+    return;
+  }
+  this->api.submitFormPage(this->pendingFormRequest.resourceId,
+                           this->pendingFormRequest.action, page);
+}
+
+void Application::handleFormPageResult(
+    const API::ResourceUsageFormPageResult &result) {
+  if (!this->hasPendingFormRequest) {
+    return;
+  }
+  if (result.valid) {
+    this->advanceFormCursor();
+    this->requestCurrentFormField();
+  } else {
+    Display::resourceDetailsScreen.showFormPageErrors(result);
+  }
+}
+
+void Application::handleFormPageBack() {
+  if (!this->hasPendingFormRequest) {
+    return;
+  }
+  this->retreatFormCursor();
+}
+
+void Application::finishFormFlow() {
   this->hasPendingFormRequest = false;
   Display::resourceDetailsScreen.hideFormsModal();
   Display::resourceDetailsScreen.showActionProgress("Sende Formular");
 
   if (this->pendingActionType == PENDING_ACTION_START_SESSION) {
     this->api.startResourceUsageSession(this->pendingActionResourceId,
-                                        this->pendingActionProjectId,
-                                        &this->formSubmissionBuffer);
+                                        this->pendingActionProjectId);
   } else if (this->pendingActionType == PENDING_ACTION_STOP_SESSION) {
-    this->api.stopResourceUsageSession(this->pendingActionResourceId,
-                                       &this->formSubmissionBuffer);
+    this->api.stopResourceUsageSession(this->pendingActionResourceId);
+  } else {
+    this->handleFormsCancel();
   }
 }
 
@@ -1019,6 +1170,8 @@ void Application::handleFormsCancel() {
   }
   this->hasPendingFormRequest = false;
   this->pendingActionType = PENDING_ACTION_NONE;
+  this->formCursorFormIdx = 0;
+  this->formCursorOffset = 0;
   Display::resourceDetailsScreen.hideFormsModal();
   Display::resourceDetailsScreen.hideActionProgress();
   this->endActionPause();
@@ -1171,6 +1324,10 @@ void Application::resetSessionOnDisconnect() {
   this->pendingActionProjectId = 0;
   this->hasPendingFormRequest = false;
   this->pendingFormRequestReady = false;
+  this->pendingFormFieldsReady = false;
+  this->pendingFormPageResultReady = false;
+  this->formCursorFormIdx = 0;
+  this->formCursorOffset = 0;
 
   this->clearProjectSelection();
   this->currentProjectsUser = "";

--- a/apps/attractap/firmware/src/application/application.hpp
+++ b/apps/attractap/firmware/src/application/application.hpp
@@ -166,10 +166,15 @@ private:
     uint32_t pendingActionResourceId = 0;
     uint32_t pendingActionProjectId = 0;
     bool hasPendingFormRequest = false;
-    // Flag set by websocket callback when a form request arrives; processed by main loop
+    // Flags set by websocket callbacks when form events arrive; processed by LVGL thread
     volatile bool pendingFormRequestReady = false;
+    volatile bool pendingFormFieldsReady = false;
+    volatile bool pendingFormPageResultReady = false;
     API::ResourceUsageFormRequest pendingFormRequest;
-    API::FormSubmissionList formSubmissionBuffer;
+    API::ResourceUsageFormFieldsPage pendingFormFields;
+    API::ResourceUsageFormPageResult pendingFormPageResult;
+    uint8_t formCursorFormIdx = 0;
+    uint32_t formCursorOffset = 0;
 
     void selectResource(const API::ResourceBrief &resource);
 
@@ -177,8 +182,18 @@ private:
     void clearProjectSelection();
     void handleProjectSelection(uint32_t projectId, const String &projectName);
     void handleFormsRequest(const API::ResourceUsageFormRequest &request);
-    void handleFormsSubmit(const API::FormSubmissionList &submissions);
+    void handleFormFields(const API::ResourceUsageFormFieldsPage &page);
+    void handleFormPageResult(const API::ResourceUsageFormPageResult &result);
+    void handleFormPageNext(const API::FormPageSubmission &page);
+    void handleFormPageBack();
     void handleFormsCancel();
+    void requestCurrentFormField();
+    void advanceFormCursor();
+    void retreatFormCursor();
+    void finishFormFlow();
+    uint32_t totalFormFields() const;
+    uint32_t globalFormFieldNumber() const;
+    bool isLastFormField() const;
     void onActionResult(const String &eventType);
 #endif
 

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
@@ -1545,41 +1545,41 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_remove_flag(footer, LV_OBJ_FLAG_SCROLLABLE);
    lv_obj_set_width(footer, lv_pct(100));
    lv_obj_set_height(footer, LV_SIZE_CONTENT);
-   lv_obj_set_flex_flow(footer, LV_FLEX_FLOW_ROW);
-   lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+   lv_obj_set_flex_flow(footer, LV_FLEX_FLOW_ROW_WRAP);
+   lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
    lv_obj_set_style_pad_top(footer, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_set_style_pad_column(footer, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_column(footer, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_row(footer, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
 
    lv_obj_t *backBtn = lv_button_create(footer);
    this->formsBackButton = backBtn;
    lv_obj_set_width(backBtn, LV_SIZE_CONTENT);
    lv_obj_set_height(backBtn, LV_SIZE_CONTENT);
-   lv_label_set_text(lv_label_create(backBtn), "Zurueck");
+   lv_obj_set_style_pad_all(backBtn, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_t *backLabel = lv_label_create(backBtn);
+   lv_label_set_text(backLabel, "Zurueck");
+   lv_obj_set_align(backLabel, LV_ALIGN_CENTER);
    lv_obj_add_event_cb(backBtn, &ResourceDetailsScreen::onFormsBack, LV_EVENT_CLICKED, this);
 
-   lv_obj_t *rightGroup = lv_obj_create(footer);
-   lv_obj_remove_style_all(rightGroup);
-   lv_obj_remove_flag(rightGroup, LV_OBJ_FLAG_SCROLLABLE);
-   lv_obj_set_width(rightGroup, LV_SIZE_CONTENT);
-   lv_obj_set_height(rightGroup, LV_SIZE_CONTENT);
-   lv_obj_set_flex_flow(rightGroup, LV_FLEX_FLOW_ROW);
-   lv_obj_set_flex_align(rightGroup, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-   lv_obj_set_style_pad_column(rightGroup, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
-
-   lv_obj_t *cancelBtn = lv_button_create(rightGroup);
+   lv_obj_t *cancelBtn = lv_button_create(footer);
    lv_obj_set_width(cancelBtn, LV_SIZE_CONTENT);
    lv_obj_set_height(cancelBtn, LV_SIZE_CONTENT);
-   lv_label_set_text(lv_label_create(cancelBtn), "Abbrechen");
+   lv_obj_set_style_pad_all(cancelBtn, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_t *cancelLabel = lv_label_create(cancelBtn);
+   lv_label_set_text(cancelLabel, "Abbrechen");
+   lv_obj_set_align(cancelLabel, LV_ALIGN_CENTER);
    lv_obj_add_event_cb(cancelBtn, &ResourceDetailsScreen::onFormsCancel, LV_EVENT_CLICKED, this);
 
-   lv_obj_t *nextBtn = lv_button_create(rightGroup);
+   lv_obj_t *nextBtn = lv_button_create(footer);
    this->formsNextButton = nextBtn;
    lv_obj_set_width(nextBtn, LV_SIZE_CONTENT);
    lv_obj_set_height(nextBtn, LV_SIZE_CONTENT);
+   lv_obj_set_style_pad_all(nextBtn, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_bg_color(nextBtn, lv_color_hex(0x10B981), LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_bg_opa(nextBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
    this->formsNextLabel = lv_label_create(nextBtn);
    lv_label_set_text(this->formsNextLabel, "Weiter");
+   lv_obj_set_align(this->formsNextLabel, LV_ALIGN_CENTER);
    lv_obj_add_event_cb(nextBtn, &ResourceDetailsScreen::onFormsNext, LV_EVENT_CLICKED, this);
 
    this->formsKeyboard = lv_keyboard_create(overlay);

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
@@ -613,14 +613,19 @@ void ResourceDetailsScreen::destroy()
    this->formsModalContent = nullptr;
    this->formsModalList = nullptr;
    this->formsModalErrorLabel = nullptr;
+   this->formsModalProgressLabel = nullptr;
    this->formsKeyboard = nullptr;
+   this->formsBackButton = nullptr;
+   this->formsNextButton = nullptr;
+   this->formsNextLabel = nullptr;
    this->elapsedTime = nullptr;
    this->sessionTimeoutIndicator = nullptr;
    this->noIntroductionPanel = nullptr;
    this->introducersListLabel = nullptr;
    this->actionOverlayLabel = nullptr;
    this->successToast = nullptr;
-   this->formsModalRequest = nullptr;
+   this->formsModalMeta = nullptr;
+   this->formsModalPage = nullptr;
    this->formFieldWidgetCount = 0;
 }
 
@@ -654,8 +659,15 @@ void ResourceDetailsScreen::resetFormsModalState()
    this->formsModalContent = nullptr;
    this->formsModalList = nullptr;
    this->formsModalErrorLabel = nullptr;
+   this->formsModalProgressLabel = nullptr;
    this->formsKeyboard = nullptr;
-   this->formsModalRequest = nullptr;
+   this->formsBackButton = nullptr;
+   this->formsNextButton = nullptr;
+   this->formsNextLabel = nullptr;
+   this->formsModalMeta = nullptr;
+   this->formsModalPage = nullptr;
+   this->formsCanGoBack = false;
+   this->formsIsLastField = false;
    this->formFieldWidgetCount = 0;
 }
 
@@ -1026,9 +1038,14 @@ void ResourceDetailsScreen::setProjectSelectionCallback(std::function<void(uint3
    this->projectSelectionCallback = callback;
 }
 
-void ResourceDetailsScreen::setFormsSubmitCallback(std::function<void(const API::FormSubmissionList &)> callback)
+void ResourceDetailsScreen::setFormPageNextCallback(std::function<void(const API::FormPageSubmission &)> callback)
 {
-   this->formsSubmitCallback = callback;
+   this->formPageNextCallback = callback;
+}
+
+void ResourceDetailsScreen::setFormPageBackCallback(std::function<void()> callback)
+{
+   this->formPageBackCallback = callback;
 }
 
 void ResourceDetailsScreen::setFormsCancelCallback(std::function<void()> callback)
@@ -1055,21 +1072,97 @@ void ResourceDetailsScreen::setSelectedProject(uint32_t projectId, const char *p
    }
 }
 
-void ResourceDetailsScreen::showFormsModal(const API::ResourceUsageFormRequest &request)
+void ResourceDetailsScreen::showFormsModal(const API::ResourceUsageFormRequest &meta)
 {
-   this->formsModalRequest = &request;
+   this->formsModalMeta = &meta;
+   this->formsModalPage = nullptr;
+   this->formFieldWidgetCount = 0;
    this->ensureFormsModal();
-   this->rebuildFormsModal();
-   if (this->formsModalContent)
+
+   if (this->formsModalList)
    {
-      lv_obj_scroll_to_y(this->formsModalContent, 0, LV_ANIM_OFF);
+      lv_obj_clean(this->formsModalList);
+      lv_obj_t *loading = lv_label_create(this->formsModalList);
+      lv_label_set_text(loading, "Laden...");
+      lv_obj_set_style_text_color(loading, lv_color_hex(0xE5E7EB), LV_PART_MAIN | LV_STATE_DEFAULT);
    }
+   if (this->formsModalErrorLabel)
+   {
+      lv_label_set_text(this->formsModalErrorLabel, "");
+   }
+   if (this->formsModalProgressLabel)
+   {
+      lv_label_set_text(this->formsModalProgressLabel, "");
+   }
+   if (this->formsBackButton)
+   {
+      lv_obj_add_state(this->formsBackButton, LV_STATE_DISABLED);
+   }
+
    this->hideFormsKeyboard();
    if (this->formsModalOverlay)
    {
       lv_obj_clear_flag(this->formsModalOverlay, LV_OBJ_FLAG_HIDDEN);
    }
    this->updateFormsModalLayoutForKeyboard(false);
+}
+
+void ResourceDetailsScreen::renderFormField(const API::ResourceUsageFormFieldsPage &page, bool canGoBack, bool isLast, uint32_t fieldNumber, uint32_t totalFields)
+{
+   this->formsModalPage = &page;
+   this->formsCanGoBack = canGoBack;
+   this->formsIsLastField = isLast;
+   this->ensureFormsModal();
+
+   if (this->formsModalProgressLabel)
+   {
+      String progress = "Feld " + String(fieldNumber) + " / " + String(totalFields);
+      lv_label_set_text(this->formsModalProgressLabel, progress.c_str());
+   }
+
+   this->buildCurrentFormField();
+
+   if (this->formsBackButton)
+   {
+      if (canGoBack)
+      {
+         lv_obj_clear_state(this->formsBackButton, LV_STATE_DISABLED);
+      }
+      else
+      {
+         lv_obj_add_state(this->formsBackButton, LV_STATE_DISABLED);
+      }
+   }
+   if (this->formsNextLabel)
+   {
+      lv_label_set_text(this->formsNextLabel, isLast ? "Absenden" : "Weiter");
+   }
+
+   if (this->formsModalContent)
+   {
+      lv_obj_scroll_to_y(this->formsModalContent, 0, LV_ANIM_OFF);
+   }
+   this->hideFormsKeyboard();
+   this->updateFormsModalLayoutForKeyboard(false);
+}
+
+void ResourceDetailsScreen::showFormPageErrors(const API::ResourceUsageFormPageResult &result)
+{
+   this->clearFormFieldErrors();
+   bool shown = false;
+   for (uint8_t i = 0; i < result.errorCount; ++i)
+   {
+      FormFieldWidget *widget = this->findFieldWidget(result.formId, result.errors[i].fieldId);
+      if (widget && widget->errorLabel)
+      {
+         lv_label_set_text(widget->errorLabel, result.errors[i].message.c_str());
+         shown = true;
+      }
+   }
+   if (this->formsModalErrorLabel)
+   {
+      lv_label_set_text(this->formsModalErrorLabel, shown ? "Bitte Eingabe korrigieren." : "Eingabe ungueltig.");
+   }
 }
 
 void ResourceDetailsScreen::hideFormsModal()
@@ -1426,6 +1519,11 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_set_scroll_dir(content, LV_DIR_VER);
    lv_obj_set_flex_grow(content, 1);
 
+   this->formsModalProgressLabel = lv_label_create(content);
+   lv_label_set_text(this->formsModalProgressLabel, "");
+   lv_obj_set_style_text_color(this->formsModalProgressLabel, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_font(this->formsModalProgressLabel, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+
    this->formsModalErrorLabel = lv_label_create(content);
    lv_label_set_text(this->formsModalErrorLabel, "");
    lv_obj_set_style_text_color(this->formsModalErrorLabel, lv_color_hex(0xF31260), LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -1448,23 +1546,41 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_set_width(footer, lv_pct(100));
    lv_obj_set_height(footer, LV_SIZE_CONTENT);
    lv_obj_set_flex_flow(footer, LV_FLEX_FLOW_ROW);
-   lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+   lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
    lv_obj_set_style_pad_top(footer, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_pad_column(footer, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-   lv_obj_t *cancelBtn = lv_button_create(footer);
+   lv_obj_t *backBtn = lv_button_create(footer);
+   this->formsBackButton = backBtn;
+   lv_obj_set_width(backBtn, LV_SIZE_CONTENT);
+   lv_obj_set_height(backBtn, LV_SIZE_CONTENT);
+   lv_label_set_text(lv_label_create(backBtn), "Zurueck");
+   lv_obj_add_event_cb(backBtn, &ResourceDetailsScreen::onFormsBack, LV_EVENT_CLICKED, this);
+
+   lv_obj_t *rightGroup = lv_obj_create(footer);
+   lv_obj_remove_style_all(rightGroup);
+   lv_obj_remove_flag(rightGroup, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_width(rightGroup, LV_SIZE_CONTENT);
+   lv_obj_set_height(rightGroup, LV_SIZE_CONTENT);
+   lv_obj_set_flex_flow(rightGroup, LV_FLEX_FLOW_ROW);
+   lv_obj_set_flex_align(rightGroup, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+   lv_obj_set_style_pad_column(rightGroup, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   lv_obj_t *cancelBtn = lv_button_create(rightGroup);
    lv_obj_set_width(cancelBtn, LV_SIZE_CONTENT);
    lv_obj_set_height(cancelBtn, LV_SIZE_CONTENT);
    lv_label_set_text(lv_label_create(cancelBtn), "Abbrechen");
    lv_obj_add_event_cb(cancelBtn, &ResourceDetailsScreen::onFormsCancel, LV_EVENT_CLICKED, this);
 
-   lv_obj_t *submitBtn = lv_button_create(footer);
-   lv_obj_set_width(submitBtn, LV_SIZE_CONTENT);
-   lv_obj_set_height(submitBtn, LV_SIZE_CONTENT);
-   lv_obj_set_style_bg_color(submitBtn, lv_color_hex(0x10B981), LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_set_style_bg_opa(submitBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_label_set_text(lv_label_create(submitBtn), "Absenden");
-   lv_obj_add_event_cb(submitBtn, &ResourceDetailsScreen::onFormsSubmit, LV_EVENT_CLICKED, this);
+   lv_obj_t *nextBtn = lv_button_create(rightGroup);
+   this->formsNextButton = nextBtn;
+   lv_obj_set_width(nextBtn, LV_SIZE_CONTENT);
+   lv_obj_set_height(nextBtn, LV_SIZE_CONTENT);
+   lv_obj_set_style_bg_color(nextBtn, lv_color_hex(0x10B981), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(nextBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+   this->formsNextLabel = lv_label_create(nextBtn);
+   lv_label_set_text(this->formsNextLabel, "Weiter");
+   lv_obj_add_event_cb(nextBtn, &ResourceDetailsScreen::onFormsNext, LV_EVENT_CLICKED, this);
 
    this->formsKeyboard = lv_keyboard_create(overlay);
    lv_obj_set_width(this->formsKeyboard, lv_pct(100));
@@ -1472,7 +1588,7 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_add_event_cb(this->formsKeyboard, &ResourceDetailsScreen::onFormsKeyboardEvent, LV_EVENT_ALL, this);
 }
 
-void ResourceDetailsScreen::rebuildFormsModal()
+void ResourceDetailsScreen::buildCurrentFormField()
 {
    if (!this->formsModalList)
    {
@@ -1487,27 +1603,45 @@ void ResourceDetailsScreen::rebuildFormsModal()
       lv_label_set_text(this->formsModalErrorLabel, "");
    }
 
+   if (!this->formsModalPage || this->formsModalPage->fieldCount == 0)
+   {
+      return;
+   }
+
    String pageTitle = "Bitte Formular ausfuellen";
    String resourceName = "";
 
-   if (this->formsModalRequest)
+   if (this->formsModalMeta)
    {
-      if (this->formsModalRequest->action == API::ResourceUsageFormActionType::START)
+      if (this->formsModalMeta->action == API::ResourceUsageFormActionType::START)
       {
          pageTitle = "Bitte vor dem Start ausfuellen";
       }
-      else if (this->formsModalRequest->action == API::ResourceUsageFormActionType::END)
+      else if (this->formsModalMeta->action == API::ResourceUsageFormActionType::END)
       {
          pageTitle = "Bitte vor dem Ende ausfuellen";
       }
-      else if (this->formsModalRequest->action == API::ResourceUsageFormActionType::TAKEOVER)
+      else if (this->formsModalMeta->action == API::ResourceUsageFormActionType::TAKEOVER)
       {
          pageTitle = "Bitte vor der Uebernahme ausfuellen";
       }
 
-      if (this->formsModalRequest->resourceName.length() > 0)
+      if (this->formsModalMeta->resourceName.length() > 0)
       {
-         resourceName = this->formsModalRequest->resourceName;
+         resourceName = this->formsModalMeta->resourceName;
+      }
+   }
+
+   String formName = "";
+   if (this->formsModalMeta)
+   {
+      for (uint8_t i = 0; i < this->formsModalMeta->formCount && i < API::MAX_FORMS_PER_REQUEST; ++i)
+      {
+         if (this->formsModalMeta->forms[i].id == this->formsModalPage->formId)
+         {
+            formName = this->formsModalMeta->forms[i].name;
+            break;
+         }
       }
    }
 
@@ -1522,11 +1656,7 @@ void ResourceDetailsScreen::rebuildFormsModal()
    lv_obj_set_style_width(resourceNameLabel, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_label_set_long_mode(resourceNameLabel, LV_LABEL_LONG_WRAP);
 
-   if (!this->formsModalRequest)
-      return;
-   for (uint8_t i = 0; i < this->formsModalRequest->formCount && i < API::MAX_FORMS_PER_REQUEST; ++i)
    {
-      const API::ResourceUsageForm &form = this->formsModalRequest->forms[i];
       lv_obj_t *formCard = lv_obj_create(this->formsModalList);
       lv_obj_remove_style_all(formCard);
       lv_obj_remove_flag(formCard, LV_OBJ_FLAG_SCROLLABLE);
@@ -1541,15 +1671,14 @@ void ResourceDetailsScreen::rebuildFormsModal()
       lv_obj_set_flex_align(formCard, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
 
       lv_obj_t *formTitle = lv_label_create(formCard);
-      lv_label_set_text(formTitle, form.name.c_str());
+      lv_label_set_text(formTitle, formName.c_str());
       lv_obj_set_style_text_font(formTitle, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
       lv_obj_set_style_text_color(formTitle, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
       lv_label_set_long_mode(formTitle, LV_LABEL_LONG_WRAP);
       lv_obj_set_style_width(formTitle, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
 
-      for (uint8_t f = 0; f < form.fieldCount && this->formFieldWidgetCount < API::MAX_FORMS_PER_REQUEST * API::MAX_FORM_FIELDS_PER_FORM; ++f)
       {
-         const API::ResourceUsageFormField &field = form.fields[f];
+         const API::ResourceUsageFormField &field = this->formsModalPage->fields[0];
          lv_obj_t *fieldContainer = lv_obj_create(formCard);
          lv_obj_remove_style_all(fieldContainer);
          lv_obj_remove_flag(fieldContainer, LV_OBJ_FLAG_SCROLLABLE);
@@ -1582,7 +1711,7 @@ void ResourceDetailsScreen::rebuildFormsModal()
 
          FormFieldWidget &widget = this->formFieldWidgets[this->formFieldWidgetCount++];
          widget.widgetIndex = this->formFieldWidgetCount - 1;
-         widget.formId = form.id;
+         widget.formId = this->formsModalPage->formId;
          widget.fieldId = field.id;
          widget.type = field.type;
          widget.isRequired = field.isRequired;
@@ -1596,6 +1725,10 @@ void ResourceDetailsScreen::rebuildFormsModal()
          {
             lv_obj_t *sw = lv_switch_create(fieldContainer);
             widget.input = sw;
+            if (field.hasValue && field.value == "true")
+            {
+               lv_obj_add_state(sw, LV_STATE_CHECKED);
+            }
             if (field.options.boolean.trueLabel.length() > 0 || field.options.boolean.falseLabel.length() > 0)
             {
                String boolLabels = field.options.boolean.trueLabel.length() ? field.options.boolean.trueLabel : "An";
@@ -1667,6 +1800,18 @@ void ResourceDetailsScreen::rebuildFormsModal()
 
                   lv_obj_add_event_cb(optBtn, &ResourceDetailsScreen::onSelectOptionClick, LV_EVENT_CLICKED, &evtData);
                }
+               if (field.hasValue && field.value.length() > 0)
+               {
+                  for (uint8_t optIndex = 0; optIndex < field.options.select.count; ++optIndex)
+                  {
+                     if (field.options.select.values[optIndex] == field.value)
+                     {
+                        widget.selectedOptionIndex = static_cast<uint8_t>(optIndex + 1);
+                        break;
+                     }
+                  }
+                  this->updateSelectButtonStyles(widget);
+               }
                this->updateSelectOptionLayout(widget);
             }
          }
@@ -1674,6 +1819,10 @@ void ResourceDetailsScreen::rebuildFormsModal()
          {
             lv_obj_t *ta = lv_textarea_create(fieldContainer);
             widget.input = ta;
+            if (field.hasValue && field.value.length() > 0)
+            {
+               lv_textarea_set_text(ta, field.value.c_str());
+            }
             lv_obj_set_width(ta, lv_pct(100));
             lv_obj_set_style_bg_color(ta, lv_color_hex(0x374151), LV_PART_MAIN | LV_STATE_DEFAULT);
             lv_obj_set_style_text_color(ta, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -1705,38 +1854,22 @@ void ResourceDetailsScreen::rebuildFormsModal()
    lv_obj_update_layout(this->formsModalList);
 }
 
-bool ResourceDetailsScreen::collectFormSubmissions(API::FormSubmissionList &outSubmissions)
+bool ResourceDetailsScreen::collectCurrentField(API::FormPageSubmission &outPage)
 {
-   outSubmissions.submissionCount = 0;
    this->clearFormFieldErrors();
 
-   if (!this->formsModalRequest)
+   if (!this->formsModalPage)
       return false;
-   for (uint8_t i = 0; i < this->formsModalRequest->formCount && i < API::MAX_FORM_SUBMISSIONS; ++i)
-   {
-      API::FormSubmission &submission = outSubmissions.submissions[outSubmissions.submissionCount++];
-      submission.formId = this->formsModalRequest->forms[i].id;
-      submission.answerCount = 0;
-   }
+
+   outPage.formId = this->formsModalPage->formId;
+   outPage.offset = this->formsModalPage->offset;
+   outPage.answerCount = 0;
 
    bool hasErrors = false;
 
-   for (uint16_t i = 0; i < this->formFieldWidgetCount; ++i)
+   for (uint16_t i = 0; i < this->formFieldWidgetCount && i < API::MAX_FORM_PAGE_FIELDS; ++i)
    {
       FormFieldWidget &widget = this->formFieldWidgets[i];
-      API::FormSubmission *submission = nullptr;
-      for (uint8_t s = 0; s < outSubmissions.submissionCount; ++s)
-      {
-         if (outSubmissions.submissions[s].formId == widget.formId)
-         {
-            submission = &outSubmissions.submissions[s];
-            break;
-         }
-      }
-      if (!submission)
-      {
-         continue;
-      }
 
       auto setError = [&](const char *msg)
       {
@@ -1756,11 +1889,7 @@ bool ResourceDetailsScreen::collectFormSubmissions(API::FormSubmissionList &outS
             setError("Pflichtfeld");
             continue;
          }
-         if (submission->answerCount >= API::MAX_FORM_FIELD_ANSWERS)
-         {
-            continue;
-         }
-         API::FormSubmissionAnswer &answer = submission->answers[submission->answerCount++];
+         API::FormSubmissionAnswer &answer = outPage.answers[outPage.answerCount++];
          answer.fieldId = widget.fieldId;
          answer.type = API::FormSubmissionAnswer::ValueType::BOOLEAN;
          answer.boolValue = isChecked;
@@ -1784,15 +1913,10 @@ bool ResourceDetailsScreen::collectFormSubmissions(API::FormSubmissionList &outS
             setError(SELECT_FIELD_INVALID);
             continue;
          }
-         String selectedValue = widget.definition->options.select.values[valueIndex];
-         if (submission->answerCount >= API::MAX_FORM_FIELD_ANSWERS)
-         {
-            continue;
-         }
-         API::FormSubmissionAnswer &answer = submission->answers[submission->answerCount++];
+         API::FormSubmissionAnswer &answer = outPage.answers[outPage.answerCount++];
          answer.fieldId = widget.fieldId;
          answer.type = API::FormSubmissionAnswer::ValueType::STRING;
-         answer.stringValue = selectedValue;
+         answer.stringValue = widget.definition->options.select.values[valueIndex];
          continue;
       }
 
@@ -1809,12 +1933,7 @@ bool ResourceDetailsScreen::collectFormSubmissions(API::FormSubmissionList &outS
          continue;
       }
 
-      if (submission->answerCount >= API::MAX_FORM_FIELD_ANSWERS)
-      {
-         continue;
-      }
-
-      API::FormSubmissionAnswer &answer = submission->answers[submission->answerCount++];
+      API::FormSubmissionAnswer &answer = outPage.answers[outPage.answerCount++];
       answer.fieldId = widget.fieldId;
 
       if (widget.type == API::ResourceUsageFormFieldType::NUMBER)
@@ -1927,7 +2046,7 @@ void ResourceDetailsScreen::showKeyboardForWidget(FormFieldWidget &widget, lv_ob
    this->updateFormsModalLayoutForKeyboard(true);
 }
 
-void ResourceDetailsScreen::onFormsSubmit(lv_event_t *e)
+void ResourceDetailsScreen::onFormsNext(lv_event_t *e)
 {
    if (lv_event_get_code(e) != LV_EVENT_CLICKED)
    {
@@ -1938,14 +2057,35 @@ void ResourceDetailsScreen::onFormsSubmit(lv_event_t *e)
    {
       return;
    }
-   API::FormSubmissionList &submissions = self->formSubmissionScratch;
-   if (!self->collectFormSubmissions(submissions))
+   API::FormPageSubmission &page = self->formPageScratch;
+   if (!self->collectCurrentField(page))
    {
       return;
    }
-   if (self->formsSubmitCallback)
+   if (self->formPageNextCallback)
    {
-      self->formsSubmitCallback(submissions);
+      self->formPageNextCallback(page);
+   }
+}
+
+void ResourceDetailsScreen::onFormsBack(lv_event_t *e)
+{
+   if (lv_event_get_code(e) != LV_EVENT_CLICKED)
+   {
+      return;
+   }
+   auto *self = static_cast<ResourceDetailsScreen *>(lv_event_get_user_data(e));
+   if (!self)
+   {
+      return;
+   }
+   if (!self->formsCanGoBack)
+   {
+      return;
+   }
+   if (self->formPageBackCallback)
+   {
+      self->formPageBackCallback();
    }
 }
 

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
@@ -61,9 +61,12 @@ public:
     void setProjectsPageRequestCallback(std::function<void(uint32_t)> callback);
     void setProjectSelectionCallback(std::function<void(uint32_t, const String &)> callback);
     void setSelectedProject(uint32_t projectId, const char *projectName);
-    void showFormsModal(const API::ResourceUsageFormRequest &request);
+    void showFormsModal(const API::ResourceUsageFormRequest &meta);
+    void renderFormField(const API::ResourceUsageFormFieldsPage &page, bool canGoBack, bool isLast, uint32_t fieldNumber, uint32_t totalFields);
+    void showFormPageErrors(const API::ResourceUsageFormPageResult &result);
     void hideFormsModal();
-    void setFormsSubmitCallback(std::function<void(const API::FormSubmissionList &)> callback);
+    void setFormPageNextCallback(std::function<void(const API::FormPageSubmission &)> callback);
+    void setFormPageBackCallback(std::function<void()> callback);
     void setFormsCancelCallback(std::function<void()> callback);
 
     // UI helpers for async actions
@@ -124,8 +127,15 @@ private:
     lv_obj_t *formsModalContent = nullptr;
     lv_obj_t *formsModalList = nullptr;
     lv_obj_t *formsModalErrorLabel = nullptr;
+    lv_obj_t *formsModalProgressLabel = nullptr;
     lv_obj_t *formsKeyboard = nullptr;
-    const API::ResourceUsageFormRequest *formsModalRequest = nullptr;
+    lv_obj_t *formsBackButton = nullptr;
+    lv_obj_t *formsNextButton = nullptr;
+    lv_obj_t *formsNextLabel = nullptr;
+    const API::ResourceUsageFormRequest *formsModalMeta = nullptr;
+    const API::ResourceUsageFormFieldsPage *formsModalPage = nullptr;
+    bool formsCanGoBack = false;
+    bool formsIsLastField = false;
     struct SelectOptionEventData
     {
         ResourceDetailsScreen *self;
@@ -149,10 +159,11 @@ private:
         uint8_t selectOptionEventCount = 0;
     };
 
-    FormFieldWidget formFieldWidgets[API::MAX_FORMS_PER_REQUEST * API::MAX_FORM_FIELDS_PER_FORM];
+    FormFieldWidget formFieldWidgets[API::MAX_FORM_PAGE_FIELDS];
     uint16_t formFieldWidgetCount = 0;
-    API::FormSubmissionList formSubmissionScratch;
-    std::function<void(const API::FormSubmissionList &)> formsSubmitCallback;
+    API::FormPageSubmission formPageScratch;
+    std::function<void(const API::FormPageSubmission &)> formPageNextCallback;
+    std::function<void()> formPageBackCallback;
     std::function<void()> formsCancelCallback;
 
     void updateElapsedTimeDisplay();
@@ -177,7 +188,8 @@ private:
     static void onProjectListItemDelete(lv_event_t *e);
     static void onProjectsPrevPage(lv_event_t *e);
     static void onProjectsNextPage(lv_event_t *e);
-    static void onFormsSubmit(lv_event_t *e);
+    static void onFormsNext(lv_event_t *e);
+    static void onFormsBack(lv_event_t *e);
     static void onFormsCancel(lv_event_t *e);
     static void onFormFieldFocus(lv_event_t *e);
     static void onFormsKeyboardEvent(lv_event_t *e);
@@ -211,8 +223,8 @@ private:
     void showProjectsLoading();
     void updateProjectsPaginationControls();
     void ensureFormsModal();
-    void rebuildFormsModal();
-    bool collectFormSubmissions(API::FormSubmissionList &outSubmissions);
+    void buildCurrentFormField();
+    bool collectCurrentField(API::FormPageSubmission &outPage);
     FormFieldWidget *findFieldWidget(uint32_t formId, uint32_t fieldId);
     FormFieldWidget *findFieldWidgetByObject(lv_obj_t *object);
     void clearFormFieldErrors();


### PR DESCRIPTION
## Summary
Closes ATT-191. Reworks NFC reader (attractap) forms from "fetch the whole form, hold all fields in RAM, submit everything at once" to a **paginated, one-field-at-a-time** protocol with **server-held draft state**. Removes the hard 16-field cap and flattens reader memory to O(1) per form.

Decisions locked with @jappy on the issue:
- **Draft state**: server holds answers per session (in-memory on the socket), keyed by `resourceId:action`.
- **Pagination**: reader-driven cursor — one field per page (`offset`/`limit`).
- **Validation**: per-field on each page submit; reader must fix before advancing.

## Protocol
| Event | Dir | Payload |
|---|---|---|
| `RESOURCE_USAGE_FORM_REQUEST` | S→R | now **metadata only**: `forms:[{id,name,fieldCount}]` |
| `RESOURCE_USAGE_FORM_GET_FIELDS` | R→S | `{formId, offset, limit}` |
| `RESOURCE_USAGE_FORM_FIELDS` | S→R | one-field window + draft `value` prefill + `totalFieldCount` |
| `RESOURCE_USAGE_FORM_SUBMIT_PAGE` | R→S | `{formId, offset, answers}` |
| `RESOURCE_USAGE_FORM_PAGE_RESULT` | S→R | `{valid, errors:[{fieldId,message}]}` |

`START`/`STOP_RESOURCE_USAGE_SESSION` no longer carry answers — the server reconstructs the submission from the completed draft, validates fully, persists, and clears the draft.

## Server (`apps/api`)
- New event types + payloads in `websocket.types.ts`; draft store on `socket.state.formDrafts`.
- `websocket.gateway.ts`: get-fields window, submit-page (per-field validation), page-result; `ensureFormsSatisfied` rebuilt around the draft.
- `forms.service.ts`: `getFormMetaForAction`, `getFieldsWindow`, `validatePageAnswers`; shared single-field validator (`validateFieldAnswer`) reused by full submission.
- New `forms.service.spec.ts` (9 cases). Full suite green; lint + typecheck clean.

## Firmware (`apps/attractap`)
- Fixed 16-field buffer removed — only one field in RAM (`MAX_FORM_PAGE_FIELDS=1`); field count now unbounded.
- Single-field render, footer **Zurück / Abbrechen / Weiter** (last field → **Absenden**), progress "Feld X / Y", keyboard for text/number, no scroll.
- Application drives the cursor: request → submit → on valid advance / on invalid show error & stay; Back re-fetches the prior field prefilled from draft.
- Firmware version bumped 1.3.2 → **1.3.3** for OTA rollout.
- All 4 board variants build clean.

## Test status
- Server: full Jest suite + new spec green; lint + typecheck clean.
- Firmware: all envs compile.
- **Hardware test in progress** with @jappy on a real reader (paginated flow, validation block, back-nav prefill, OTA update). Not yet hardware-verified end-to-end.

<!-- generated-by-cyrus -->