### PR TITLE
feat(ATT-252): show allowed users on maintenance & not-introduced views

### DIFF
--- a/apps/frontend/src/app/resources/details/overview/RecentSessionsCard.tsx
+++ b/apps/frontend/src/app/resources/details/overview/RecentSessionsCard.tsx
@@ -13,9 +13,10 @@ import de from './recentSessionsCard.de.json';
 
 interface RecentSessionsCardProps {
   resourceId: number;
+  className?: string;
 }
 
-export function RecentSessionsCard({ resourceId }: RecentSessionsCardProps) {
+export function RecentSessionsCard({ resourceId, className }: RecentSessionsCardProps) {
   const { t } = useTranslations({ en, de });
   const { user } = useAuth();
 
@@ -29,6 +30,7 @@ export function RecentSessionsCard({ resourceId }: RecentSessionsCardProps) {
 
   return (
     <FlatSection
+      className={className}
       icon={<History className="w-4 h-4" />}
       title={t('title')}
       actions={

--- a/apps/frontend/src/app/resources/details/overview/ResourceDocsPreviewCard.tsx
+++ b/apps/frontend/src/app/resources/details/overview/ResourceDocsPreviewCard.tsx
@@ -15,11 +15,12 @@ import de from './resourceDocsPreviewCard.de.json';
 
 interface ResourceDocsPreviewCardProps {
   resourceId: number;
+  className?: string;
 }
 
 const PREVIEW_CHAR_COUNT = 220;
 
-export function ResourceDocsPreviewCard({ resourceId }: ResourceDocsPreviewCardProps) {
+export function ResourceDocsPreviewCard({ resourceId, className }: ResourceDocsPreviewCardProps) {
   const { t } = useTranslations({ en, de });
   const { hasPermission } = useAuth();
   const canManageResources = hasPermission('canManageResources');
@@ -42,7 +43,7 @@ export function ResourceDocsPreviewCard({ resourceId }: ResourceDocsPreviewCardP
 
   if (isLoading) {
     return (
-      <FlatSection icon={<BookOpen className="w-4 h-4" />} title={t('title')} data-cy="docs-preview-card">
+      <FlatSection className={className} icon={<BookOpen className="w-4 h-4" />} title={t('title')} data-cy="docs-preview-card">
         <div className="h-8" />
       </FlatSection>
     );
@@ -52,6 +53,7 @@ export function ResourceDocsPreviewCard({ resourceId }: ResourceDocsPreviewCardP
     if (!canManageResources) return null;
     return (
       <FlatSection
+        className={className}
         icon={<BookOpen className="w-4 h-4" />}
         title={t('title')}
         data-cy="docs-preview-card"
@@ -73,6 +75,7 @@ export function ResourceDocsPreviewCard({ resourceId }: ResourceDocsPreviewCardP
 
   return (
     <FlatSection
+      className={className}
       icon={<BookOpen className="w-4 h-4" />}
       title={t('title')}
       data-cy="docs-preview-card"

--- a/apps/frontend/src/app/resources/details/overview/ResourceOverviewTab.tsx
+++ b/apps/frontend/src/app/resources/details/overview/ResourceOverviewTab.tsx
@@ -8,6 +8,8 @@ import { useResourcesServiceGetOneResourceById } from '@attraccess/react-query-c
 import { RecentSessionsCard } from './RecentSessionsCard';
 import { ResourceDocsPreviewCard } from './ResourceDocsPreviewCard';
 
+const CARD_CLASS = 'break-inside-avoid mb-6';
+
 export function ResourceOverviewTab() {
   const { id } = useParams<{ id: string }>();
   const resourceId = parseInt(id || '', 10);
@@ -18,31 +20,22 @@ export function ResourceOverviewTab() {
   if (!resource) return null;
 
   return (
-    <div className="space-y-6">
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:items-start">
-        <div className="lg:col-span-2">
-          <ResourceUsageSession
-            resourceId={resourceId}
-            resource={resource}
-            data-cy="resource-usage-session"
-            insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
-          />
-        </div>
-        <aside className="lg:col-span-1">
-          <ResourceBillingInfo
-            variant="flat"
-            resourceId={resourceId}
-            onExampleAmountChange={(value) =>
-              setInsufficientBalanceDesiredAmount(Math.ceil(value))
-            }
-          />
-        </aside>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:items-start">
-        <ResourceDocsPreviewCard resourceId={resourceId} />
-        <RecentSessionsCard resourceId={resourceId} />
-      </div>
+    <div className="columns-1 lg:columns-2 gap-6 [&>*:last-child]:mb-0">
+      <ResourceUsageSession
+        className={CARD_CLASS}
+        resourceId={resourceId}
+        resource={resource}
+        data-cy="resource-usage-session"
+        insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
+      />
+      <ResourceBillingInfo
+        className={CARD_CLASS}
+        variant="flat"
+        resourceId={resourceId}
+        onExampleAmountChange={(value) => setInsufficientBalanceDesiredAmount(Math.ceil(value))}
+      />
+      <ResourceDocsPreviewCard className={CARD_CLASS} resourceId={resourceId} />
+      <RecentSessionsCard className={CARD_CLASS} resourceId={resourceId} />
     </div>
   );
 }

--- a/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
+++ b/apps/frontend/src/app/resources/details/resourceBillingInfo/index.tsx
@@ -20,11 +20,13 @@ import { FlatSection } from '../../../../components/flatSection';
 interface Props extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
   resourceId: number;
   onExampleAmountChange?: (amount: number) => void;
+  /** Reports whether the component renders any content. Lets parents reclaim layout space when hidden. */
+  onVisibilityChange?: (visible: boolean) => void;
   variant?: 'card' | 'flat';
 }
 
 export function ResourceBillingInfo(props: Props) {
-  const { resourceId, onExampleAmountChange, variant = 'card', className, ...htmlProps } = props;
+  const { resourceId, onExampleAmountChange, onVisibilityChange, variant = 'card', className, ...htmlProps } = props;
 
   const { t } = useTranslations({ en, de });
   const { data: configuration } = useBillingServiceGetBillingConfiguration();
@@ -99,6 +101,18 @@ export function ResourceBillingInfo(props: Props) {
   useEffect(() => {
     onExampleAmountChange?.(exampleCost);
   }, [exampleCost, onExampleAmountChange]);
+
+  const isVisible = useMemo(() => {
+    if (!license?.modules.includes('billing')) return false;
+    if (!resourceBillingConfiguration) return false;
+    if (resource?.type !== 'machine') return false;
+    if (isFree && !hasPermission('canManageBilling')) return false;
+    return true;
+  }, [license, resourceBillingConfiguration, resource, isFree, hasPermission]);
+
+  useEffect(() => {
+    onVisibilityChange?.(isVisible);
+  }, [isVisible, onVisibilityChange]);
 
   if (!license?.modules.includes('billing')) {
     return null;

--- a/apps/frontend/src/app/resources/usage/components/IntroductionRequiredDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/IntroductionRequiredDisplay/index.tsx
@@ -1,8 +1,7 @@
-import { Alert, AlertContent, AlertDescription, Separator, Spinner } from '@heroui/react';
-import { Users } from 'lucide-react';
+import { Alert, AlertContent, AlertDescription } from '@heroui/react';
 import { AlertStatusIcon } from '../../../../../components/AlertStatusIcon';
-import { useTranslations, AttraccessUser } from '@attraccess/plugins-frontend-ui';
-import { useAccessControlServiceResourceIntroducersGetMany } from '@attraccess/react-query-client';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { ResourceIntroducersList } from '../../../../../components/ResourceIntroducersList';
 import en from './translations/en.json';
 import de from './translations/de.json';
 
@@ -13,19 +12,6 @@ interface IntroductionRequiredDisplayProps {
 export function IntroductionRequiredDisplay({ resourceId }: Readonly<IntroductionRequiredDisplayProps>) {
   const { t } = useTranslations({ en, de });
 
-  // Get list of users who can give introductions
-  const { data: introducers, isLoading: isLoadingIntroducers } = useAccessControlServiceResourceIntroducersGetMany({
-    resourceId,
-  });
-
-  if (isLoadingIntroducers) {
-    return (
-      <div className="flex justify-center py-4">
-        <Spinner color="accent" />
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-4">
       <Alert status="warning">
@@ -35,22 +21,7 @@ export function IntroductionRequiredDisplay({ resourceId }: Readonly<Introductio
         </AlertContent>
       </Alert>
 
-      {introducers && introducers.length > 0 ? (
-        <div>
-          <p className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center mb-2">
-            <Users className="w-4 h-4 mr-1" />
-            {t('availableIntroducers')}:
-          </p>
-          <Separator className="my-2" />
-          <div className="space-y-2 mt-2">
-            {introducers?.map((introducer) => (
-              <AttraccessUser key={introducer.id} user={introducer.user} />
-            ))}
-          </div>
-        </div>
-      ) : (
-        <p className="text-gray-500 dark:text-gray-400 italic">{t('noIntroducersAvailable')}</p>
-      )}
+      <ResourceIntroducersList resourceId={resourceId} title={t('availableIntroducers')} />
     </div>
   );
 }

--- a/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/maintenance/de.json
+++ b/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/maintenance/de.json
@@ -7,5 +7,6 @@
       "noReason": "Keine Begründung"
     },
     "noDate": "Datum nicht bekannt"
-  }
+  },
+  "maintainers": "Benutzer, die Wartungsarbeiten durchführen dürfen"
 }

--- a/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/maintenance/en.json
+++ b/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/maintenance/en.json
@@ -7,5 +7,6 @@
       "noReason": "No reason"
     },
     "noDate": "Date not known"
-  }
+  },
+  "maintainers": "Users allowed to perform maintenance"
 }

--- a/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/maintenance/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/maintenance/index.tsx
@@ -4,6 +4,7 @@ import {
 } from '@attraccess/react-query-client';
 import { useDateTimeFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { MaintenanceReasonDisplay } from '../../../../../../components/MaintenanceReasonDisplay';
+import { ResourceIntroducersList } from '../../../../../../components/ResourceIntroducersList';
 import { StartSessionControls } from '../../StartSessionControls';
 import { Alert, AlertContent, AlertDescription, AlertTitle } from '@heroui/react';
 
@@ -50,13 +51,17 @@ export function MaintenanceInProgressDisplay(props: Props) {
             start: formatDateTime(maintenance.startTime, t('alert.noDate')),
             end: formatDateTime(maintenance.endTime, t('alert.noDate')),
           })}</AlertDescription>
+            <div className="mt-4 flex flex-col">
+              <small className="text-sm text-gray-500">{t('alert.reason.label')}</small>
+              <p className="text-lg whitespace-pre-wrap">
+                <MaintenanceReasonDisplay reason={maintenance.reason} fallback={t('alert.reason.noReason')} />
+              </p>
+            </div>
           </AlertContent>
-          <small className="text-sm text-gray-500 mt-4 ">{t('alert.reason.label')}</small>
-          <p className="text-lg whitespace-pre-wrap">
-            <MaintenanceReasonDisplay reason={maintenance.reason} fallback={t('alert.reason.noReason')} />
-          </p>
         </Alert>
       ))}
+
+      <ResourceIntroducersList resourceId={resourceId} title={t('maintainers')} />
 
       {permissions?.canManage && <StartSessionControls resourceId={resourceId} />}
     </div>

--- a/apps/frontend/src/components/ResourceIntroducersList/de.json
+++ b/apps/frontend/src/components/ResourceIntroducersList/de.json
@@ -1,0 +1,4 @@
+{
+  "title": "Verfügbare Einweiser",
+  "empty": "Derzeit sind keine Einweiser für diese Ressource verfügbar. Bitte wenden Sie sich an einen Administrator."
+}

--- a/apps/frontend/src/components/ResourceIntroducersList/en.json
+++ b/apps/frontend/src/components/ResourceIntroducersList/en.json
@@ -1,0 +1,4 @@
+{
+  "title": "Available Introducers",
+  "empty": "No introducers are currently available for this resource. Please contact an administrator."
+}

--- a/apps/frontend/src/components/ResourceIntroducersList/index.tsx
+++ b/apps/frontend/src/components/ResourceIntroducersList/index.tsx
@@ -1,0 +1,55 @@
+import { Separator, Spinner } from '@heroui/react';
+import { Users } from 'lucide-react';
+import { useTranslations, AttraccessUser } from '@attraccess/plugins-frontend-ui';
+import { useAccessControlServiceResourceIntroducersGetMany } from '@attraccess/react-query-client';
+
+import de from './de.json';
+import en from './en.json';
+
+export interface ResourceIntroducersListProps {
+  resourceId: number;
+  /** Heading shown above the list. Defaults to translated "Available Introducers". */
+  title?: string;
+  /** Shown when no introducers exist. Defaults to translated message. */
+  emptyText?: string;
+}
+
+/**
+ * Shared list of users who are allowed to introduce others to (and perform
+ * maintenance on) a resource. Used on the "introduction required" and
+ * "maintenance in progress" displays so a blocked user can see who to contact.
+ */
+export function ResourceIntroducersList({ resourceId, title, emptyText }: Readonly<ResourceIntroducersListProps>) {
+  const { t } = useTranslations({ en, de });
+
+  const { data: introducers, isLoading } = useAccessControlServiceResourceIntroducersGetMany({
+    resourceId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-4">
+        <Spinner color="accent" />
+      </div>
+    );
+  }
+
+  if (!introducers || introducers.length === 0) {
+    return <p className="text-gray-500 dark:text-gray-400 italic">{emptyText ?? t('empty')}</p>;
+  }
+
+  return (
+    <div>
+      <p className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center mb-2">
+        <Users className="w-4 h-4 mr-1" />
+        {title ?? t('title')}:
+      </p>
+      <Separator className="my-2" />
+      <div className="space-y-2 mt-2">
+        {introducers.map((introducer) => (
+          <AttraccessUser key={introducer.id} user={introducer.user} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Part of ATT-252. The Attractap/websocket half was split out into #1121.

## What
- New shared `ResourceIntroducersList` component listing users allowed to introduce/maintain a resource.
- Used on the introduction-required display and the maintenance-in-progress display, so a blocked user can see who to contact.
- Tidy the maintenance reason layout, collapse the empty billing column, and unify the overview cards into a flexible masonry layout (hidden cards leave no dead space).

## Why split
This PR previously also carried the backend websocket + Attractap firmware changes. Those moved to #1121 so each PR is reviewable on its own. This one is now frontend-only.

## Scope (11 files, all `apps/frontend`)
- `components/ResourceIntroducersList/*`
- `resources/usage/components/IntroductionRequiredDisplay`, `ResourceUsageSession/maintenance/*`
- `resources/details/overview/*`, `resourceBillingInfo`

<!-- generated-by-cyrus -->