### PR TITLE
feat(ATT-440): add Conversation, ConversationParticipant, and Message entities with migration

### DIFF
--- a/apps/api/src/database/migrations/1779400000000-messaging.ts
+++ b/apps/api/src/database/migrations/1779400000000-messaging.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Messaging1779400000000 implements MigrationInterface {
+  name = 'Messaging1779400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "conversation" (
+        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        "createdAt" datetime NOT NULL DEFAULT (datetime('now')),
+        "updatedAt" datetime NOT NULL DEFAULT (datetime('now'))
+      )`,
+    );
+
+    await queryRunner.query(
+      `CREATE TABLE "conversation_participant" (
+        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        "conversationId" integer NOT NULL,
+        "userId" integer NOT NULL,
+        "lastReadAt" datetime,
+        CONSTRAINT "FK_conversation_participant_conversation" FOREIGN KEY ("conversationId") REFERENCES "conversation" ("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_conversation_participant_user" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE
+      )`,
+    );
+
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_conversation_participant_conversation_user" ON "conversation_participant" ("conversationId", "userId")`,
+    );
+
+    await queryRunner.query(
+      `CREATE TABLE "message" (
+        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        "conversationId" integer NOT NULL,
+        "senderId" integer NOT NULL,
+        "content" text NOT NULL,
+        "referenceType" text,
+        "referenceId" integer,
+        "referenceLabel" text,
+        "referenceUrl" text,
+        "createdAt" datetime NOT NULL DEFAULT (datetime('now')),
+        CONSTRAINT "FK_message_conversation" FOREIGN KEY ("conversationId") REFERENCES "conversation" ("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_message_sender" FOREIGN KEY ("senderId") REFERENCES "user" ("id") ON DELETE CASCADE
+      )`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_message_conversation_created" ON "message" ("conversationId", "createdAt")`,
+    );
+
+    await queryRunner.query(`CREATE INDEX "IDX_message_sender" ON "message" ("senderId")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_message_sender"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_message_conversation_created"`);
+    await queryRunner.query(`DROP TABLE "message"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_conversation_participant_conversation_user"`);
+    await queryRunner.query(`DROP TABLE "conversation_participant"`);
+    await queryRunner.query(`DROP TABLE "conversation"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -113,3 +113,4 @@ export * from './1778000000000-flow-variables';
 export * from './1779000000000-password-policy';
 export * from './1779100000000-password-history';
 export * from './1779380000000-password-policy-slice-c';
+export * from './1779400000000-messaging';

--- a/apps/api/src/e2e/migrations-down.e2e.spec.ts
+++ b/apps/api/src/e2e/migrations-down.e2e.spec.ts
@@ -9,6 +9,8 @@ import {
   BillingTransaction,
   BillingTransactionItem,
   BillingTransactionStatus,
+  Conversation,
+  ConversationParticipant,
   EmailTemplate,
   EmailTemplateType,
   Form,
@@ -16,6 +18,7 @@ import {
   FormFieldType,
   FormSubmission,
   IntroductionHistoryAction,
+  Message,
   MqttServer,
   NFCCard,
   PasswordHistory,
@@ -174,6 +177,9 @@ const seedDatabase = async (dataSource: DataSource) => {
   const passwordHistoryRepo = dataSource.getRepository(PasswordHistory);
   const passwordPolicyOverrideRepo = dataSource.getRepository(PasswordPolicyOverride);
   const passwordPolicyAuditRepo = dataSource.getRepository(PasswordPolicyAudit);
+  const conversationRepo = dataSource.getRepository(Conversation);
+  const conversationParticipantRepo = dataSource.getRepository(ConversationParticipant);
+  const messageRepo = dataSource.getRepository(Message);
 
   const resourceGroup = await ensureEntity(resourceGroupRepo, () => ({
     name: `Seed Group ${seedTag}`,
@@ -513,6 +519,24 @@ const seedDatabase = async (dataSource: DataSource) => {
     before: JSON.stringify({ minLength: 12 }),
     after: JSON.stringify({ minLength: 16 }),
     changedFields: JSON.stringify(['minLength']),
+  }));
+
+  const conversation = await ensureEntity(conversationRepo, () => ({}));
+
+  await ensureEntity(conversationParticipantRepo, () => ({
+    conversationId: conversation.id,
+    userId: primaryUser.id,
+    lastReadAt: null,
+  }));
+
+  await ensureEntity(messageRepo, () => ({
+    conversationId: conversation.id,
+    senderId: primaryUser.id,
+    content: 'Seed message',
+    referenceType: null,
+    referenceId: null,
+    referenceLabel: null,
+    referenceUrl: null,
   }));
 };
 

--- a/libs/database-entities/src/lib/entities-index.ts
+++ b/libs/database-entities/src/lib/entities-index.ts
@@ -88,6 +88,9 @@ import {
   PasswordPolicyAudit,
   PasswordPolicyAuditEvent,
 } from './entities/password-policy-audit.entity';
+import { Conversation } from './entities/conversation.entity';
+import { ConversationParticipant } from './entities/conversation-participant.entity';
+import { Message, MessageReferenceType } from './entities/message.entity';
 
 // Export all entities individually
 export {
@@ -177,6 +180,10 @@ export {
   PASSWORD_POLICY_ROLES,
   PasswordPolicyAudit,
   PasswordPolicyAuditEvent,
+  Conversation,
+  ConversationParticipant,
+  Message,
+  MessageReferenceType,
 };
 
 // Export the entities object
@@ -221,4 +228,7 @@ export const entities = {
   PasswordHistory,
   PasswordPolicyOverride,
   PasswordPolicyAudit,
+  Conversation,
+  ConversationParticipant,
+  Message,
 };

--- a/libs/database-entities/src/lib/entities/conversation-participant.entity.ts
+++ b/libs/database-entities/src/lib/entities/conversation-participant.entity.ts
@@ -1,0 +1,38 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, Index } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from './user.entity';
+import { Conversation } from './conversation.entity';
+
+@Entity()
+@Index(['conversationId', 'userId'], { unique: true })
+export class ConversationParticipant {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ description: 'The unique identifier of the participant entry', example: 1 })
+  id!: number;
+
+  @Column({ type: 'integer' })
+  @ApiProperty({ description: 'The ID of the conversation this participant belongs to', example: 1 })
+  conversationId!: number;
+
+  @Column({ type: 'integer' })
+  @ApiProperty({ description: 'The ID of the participating user', example: 1 })
+  userId!: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  @ApiProperty({
+    description: 'When this participant last read the conversation',
+    example: '2025-01-18T12:30:00.000Z',
+    nullable: true,
+  })
+  lastReadAt!: Date | null;
+
+  @ManyToOne(() => Conversation, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'conversationId' })
+  @ApiProperty({ description: 'The conversation this participant belongs to', type: () => Conversation })
+  conversation!: Conversation;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  @ApiProperty({ description: 'The participating user', type: () => User })
+  user!: User;
+}

--- a/libs/database-entities/src/lib/entities/conversation.entity.ts
+++ b/libs/database-entities/src/lib/entities/conversation.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity()
+export class Conversation {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ description: 'The unique identifier of the conversation', example: 1 })
+  id!: number;
+
+  @CreateDateColumn()
+  @ApiProperty({
+    description: 'When this conversation was created',
+    example: '2025-01-18T12:00:00.000Z',
+  })
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  @ApiProperty({
+    description: 'When this conversation was last updated',
+    example: '2025-01-18T12:30:00.000Z',
+  })
+  updatedAt!: Date;
+}

--- a/libs/database-entities/src/lib/entities/message.entity.ts
+++ b/libs/database-entities/src/lib/entities/message.entity.ts
@@ -1,0 +1,80 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, Index, CreateDateColumn } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from './user.entity';
+import { Conversation } from './conversation.entity';
+
+export enum MessageReferenceType {
+  RESOURCE = 'RESOURCE',
+  ACTIVITY = 'ACTIVITY',
+}
+
+@Entity()
+@Index(['conversationId', 'createdAt'])
+@Index(['senderId'])
+export class Message {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ description: 'The unique identifier of the message', example: 1 })
+  id!: number;
+
+  @Column({ type: 'integer' })
+  @ApiProperty({ description: 'The ID of the conversation this message belongs to', example: 1 })
+  conversationId!: number;
+
+  @Column({ type: 'integer' })
+  @ApiProperty({ description: 'The ID of the user who sent this message', example: 1 })
+  senderId!: number;
+
+  @Column({ type: 'text' })
+  @ApiProperty({ description: 'The text content of the message', example: 'Hello there' })
+  content!: string;
+
+  @Column({ type: 'text', nullable: true, enum: MessageReferenceType })
+  @ApiProperty({
+    description: 'Optional type of context this message references',
+    enum: MessageReferenceType,
+    example: MessageReferenceType.RESOURCE,
+    nullable: true,
+  })
+  referenceType!: MessageReferenceType | null;
+
+  @Column({ type: 'integer', nullable: true })
+  @ApiProperty({
+    description: 'Optional ID of the referenced entity, scoped by referenceType',
+    example: 1,
+    nullable: true,
+  })
+  referenceId!: number | null;
+
+  @Column({ type: 'text', nullable: true })
+  @ApiProperty({
+    description: 'Optional cached label of the referenced entity for rendering',
+    example: 'Laser Cutter',
+    nullable: true,
+  })
+  referenceLabel!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  @ApiProperty({
+    description: 'Optional cached URL of the referenced entity for rendering',
+    example: '/resources/1',
+    nullable: true,
+  })
+  referenceUrl!: string | null;
+
+  @CreateDateColumn()
+  @ApiProperty({
+    description: 'When this message was created',
+    example: '2025-01-18T12:00:00.000Z',
+  })
+  createdAt!: Date;
+
+  @ManyToOne(() => Conversation, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'conversationId' })
+  @ApiProperty({ description: 'The conversation this message belongs to', type: () => Conversation })
+  conversation!: Conversation;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'senderId' })
+  @ApiProperty({ description: 'The user who sent this message', type: () => User })
+  sender!: User;
+}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds the persistence layer for **people-to-people** messaging (Phase 1). A conversation is a 1:1 thread between two people, keyed by participants — not organized around a resource. A message may optionally *reference* a resource/activity for context, but always lives in the people conversation.

### Entities (`libs/database-entities/src/lib/entities/`)
- **`Conversation`** — `id`, `@CreateDateColumn`, `@UpdateDateColumn`. Participant-keyed, no `resourceId`.
- **`ConversationParticipant`** — `id`, `conversationId` + `@ManyToOne Conversation` (onDelete CASCADE), `userId` + `@ManyToOne User` (onDelete CASCADE), nullable `lastReadAt`. Unique compound index `(conversationId, userId)` to find an existing 1:1 by participant pair.
- **`Message`** — `id`, `conversationId` + `@ManyToOne Conversation` (CASCADE), `senderId` + `@ManyToOne User`, `content` text, `@CreateDateColumn`. Optional context reference: nullable `referenceType` (enum `RESOURCE` | `ACTIVITY`, extensible) + nullable `referenceId` + cached `referenceLabel`/`referenceUrl` for rendering. Indices `(conversationId, createdAt)` and `(senderId)`.

All three exported from `entities-index.ts` (individual exports + unified `entities` object).

### Migration
- `apps/api/src/database/migrations/1779400000000-messaging.ts` — plain CREATE TABLE + FK + INDEX form (following `1779100000000-password-history.ts`), with reversible `up()`/`down()`. Registered in `migrations/index.ts`.

## Testing
- `database-entities` + `api` lint ✅, TypeScript typecheck ✅
- Ran the migration against a fresh SQLite db via the real datasource: all three tables + all three indices created, migration is idempotent (re-run no-ops), and `down()` cleanly drops everything (no residual tables/indices).
- Full pre-commit `nx affected` (lint, typecheck, build, test, e2e) passed.

## Acceptance criteria
- [x] Conversation participant-keyed (no resourceId); ConversationParticipant + Message compile and exported (individual + unified object)
- [x] Message carries optional nullable `referenceType`/`referenceId` context
- [x] Migration creates all three tables with FK cascade + specified indices; `down()` cleanly reverses
- [x] App boots and runs the migration against a fresh SQLite db without error
- [x] `lastReadAt` exists on ConversationParticipant (nullable), unused in Phase 1

Closes [ATT-440](https://linear.app/attraccess/issue/ATT-440/add-conversation-conversationparticipant-and-message-entities-with)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Introduce foundational database support for user-to-user messaging, including conversations, participants, and messages, with schema managed via a new migration.

New Features:
- Add Conversation entity to represent people-to-people conversation threads with timestamps.
- Add ConversationParticipant entity linking users to conversations with a unique participant pair constraint and optional last-read timestamp.
- Add Message entity for conversation messages with sender, content, and optional contextual reference metadata, plus supporting indices.

Enhancements:
- Export Conversation, ConversationParticipant, Message, and MessageReferenceType from the shared entities index for use across the application.