### PR TITLE
fix(ATT-273): one-click add for trainers/trainees (search-to-add)

### DIFF
--- a/apps/frontend/src/app/resources/PeopleManagement/AddPersonModal.tsx
+++ b/apps/frontend/src/app/resources/PeopleManagement/AddPersonModal.tsx
@@ -1,11 +1,5 @@
-import {
-  DrawerBody,
-  DrawerFooter,
-  DrawerHeader,
-  Label,
-  TextArea,
-  TextField,
-} from '@heroui/react';
+import { DrawerBody, DrawerFooter, DrawerHeader, Label, TextArea, TextField } from '@heroui/react';
+import { useState } from 'react';
 import { Button } from '../../../components/button';
 import { TFunction, UserSearch } from '@attraccess/plugins-frontend-ui';
 import { User } from '@attraccess/react-query-client';
@@ -16,17 +10,23 @@ interface AddPersonModalProps {
   t: TFunction;
   isOpen: boolean;
   mode: AddMode | null;
-  user: User | null;
   comment: string;
   isPending: boolean;
-  onUserChange: (user: User | null) => void;
   onCommentChange: (comment: string) => void;
-  onSubmit: () => void;
+  onAdd: (user: User) => void;
   onClose: () => void;
 }
 
 export function AddPersonModal(props: Readonly<AddPersonModalProps>) {
-  const { t, isOpen, mode, user, comment, isPending, onUserChange, onCommentChange, onSubmit, onClose } = props;
+  const { t, isOpen, mode, comment, isPending, onCommentChange, onAdd, onClose } = props;
+
+  const [searchResetKey, setSearchResetKey] = useState(0);
+
+  const handleSelectionChange = (user: User | null) => {
+    if (!user) return;
+    onAdd(user);
+    setSearchResetKey((key) => key + 1);
+  };
 
   return (
     <StandardDrawer
@@ -41,26 +41,18 @@ export function AddPersonModal(props: Readonly<AddPersonModalProps>) {
         </h2>
       </DrawerHeader>
       <DrawerBody className="flex flex-col gap-4">
-        <UserSearch label={t('addModal.userLabel')} onSelectionChange={onUserChange} />
         {mode === 'introduction' && (
           <TextField value={comment} onChange={onCommentChange}>
             <Label>{t('addModal.commentLabel')}</Label>
             <TextArea />
           </TextField>
         )}
+        <UserSearch key={searchResetKey} label={t('addModal.userLabel')} onSelectionChange={handleSelectionChange} />
+        <p className="text-sm text-foreground-500">{t('addModal.hint')}</p>
       </DrawerBody>
       <DrawerFooter>
-        <Button variant="ghost" onPress={onClose} isDisabled={isPending}>
-          {t('addModal.cancel')}
-        </Button>
-        <Button
-          variant="primary"
-          onPress={onSubmit}
-          isDisabled={!user}
-          isPending={isPending}
-          data-cy="people-add-submit"
-        >
-          {t('addModal.submit')}
+        <Button variant="primary" onPress={onClose} isDisabled={isPending} data-cy="people-add-done">
+          {t('addModal.done')}
         </Button>
       </DrawerFooter>
     </StandardDrawer>

--- a/apps/frontend/src/app/resources/PeopleManagement/de.json
+++ b/apps/frontend/src/app/resources/PeopleManagement/de.json
@@ -34,8 +34,10 @@
     },
     "userLabel": "Benutzer",
     "commentLabel": "Kommentar (optional)",
+    "hint": "Benutzer aus der Liste auswählen, um ihn sofort hinzuzufügen.",
     "submit": "Bestätigen",
-    "cancel": "Abbrechen"
+    "cancel": "Abbrechen",
+    "done": "Fertig"
   },
   "commentModal": {
     "title": "Kommentar hinzufügen",

--- a/apps/frontend/src/app/resources/PeopleManagement/en.json
+++ b/apps/frontend/src/app/resources/PeopleManagement/en.json
@@ -34,8 +34,10 @@
     },
     "userLabel": "User",
     "commentLabel": "Comment (optional)",
+    "hint": "Select a user from the list to add them instantly.",
     "submit": "Confirm",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "done": "Done"
   },
   "commentModal": {
     "title": "Add comment",

--- a/apps/frontend/src/app/resources/PeopleManagement/index.tsx
+++ b/apps/frontend/src/app/resources/PeopleManagement/index.tsx
@@ -22,7 +22,6 @@ export function PeopleManagement(props: Readonly<PeopleManagementProps & Omit<Ca
 
   const [filter, setFilter] = useState<FilterMode>('all');
   const [addMode, setAddMode] = useState<AddMode | null>(null);
-  const [addUser, setAddUser] = useState<User | null>(null);
   const [addComment, setAddComment] = useState('');
   const { isOpen: isAddOpen, open: openAdd, close: closeAdd } = useOverlayState();
 
@@ -46,7 +45,6 @@ export function PeopleManagement(props: Readonly<PeopleManagementProps & Omit<Ca
   const handleAddOpen = useCallback(
     (mode: AddMode) => {
       setAddMode(mode);
-      setAddUser(null);
       setAddComment('');
       openAdd();
     },
@@ -54,21 +52,22 @@ export function PeopleManagement(props: Readonly<PeopleManagementProps & Omit<Ca
   );
 
   const resetAddState = useCallback(() => {
-    setAddUser(null);
     setAddComment('');
     setAddMode(null);
   }, []);
 
-  const handleAddSubmit = useCallback(async () => {
-    if (!addUser || !addMode) return;
-    if (addMode === 'introducer') {
-      await mutations.grantIntroducer(addUser.id);
-    } else {
-      await mutations.grantIntroduction(addUser.id, addComment);
-    }
-    resetAddState();
-    closeAdd();
-  }, [addUser, addMode, addComment, mutations, resetAddState, closeAdd]);
+  const handleAdd = useCallback(
+    async (user: User) => {
+      if (!addMode) return;
+      if (addMode === 'introducer') {
+        await mutations.grantIntroducer(user.id);
+      } else {
+        await mutations.grantIntroduction(user.id, addComment);
+        setAddComment('');
+      }
+    },
+    [addMode, addComment, mutations],
+  );
 
   const handleIntroductionToggle = useCallback(
     (user: User, action: 'grant' | 'revoke') => {
@@ -172,12 +171,10 @@ export function PeopleManagement(props: Readonly<PeopleManagementProps & Omit<Ca
         t={t}
         isOpen={isAddOpen}
         mode={addMode}
-        user={addUser}
         comment={addComment}
         isPending={mutations.isMutating}
-        onUserChange={setAddUser}
         onCommentChange={setAddComment}
-        onSubmit={handleAddSubmit}
+        onAdd={handleAdd}
         onClose={() => {
           closeAdd();
           resetAddState();


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adding a user as a trainer (introducer) or trainee (introduction) no longer requires a second confirm click. Picking a user from the search dropdown in the People management drawer now grants the role **immediately**.

Closes the UX complaint in [ATT-273](https://linear.app/attraccess/issue/ATT-273/ux-improvement-for-user-selection-list-component): users did not realize they had to click a separate "+"/Confirm button after selecting.

## Approach (Variation A — Search-to-add)

- `AddPersonModal` now adds on selection: `UserSearch.onSelectionChange` → grant. No "+"/Confirm button.
- The drawer stays open and the search field resets after each add, so several people can be added in a row.
- Footer button is now **Done** (just closes); a hint reads *"Select a user from the list to add them instantly."*
- Optional introduction comment still applies — typed comment is consumed on add, then cleared.
- `PeopleManagement` lost its `addUser`/`handleAddSubmit` confirm state; replaced by `handleAdd(user)` that keeps the drawer open.

## Testing

- `nx typecheck/lint/build/test frontend` — all green (141 unit tests pass).
- Manual end-to-end with Playwright against a live dev stack: opened the introducer drawer, typed, selected a user → row appeared with **Introducer: Yes** and an "Introducer added" toast, search reset, **zero extra clicks**.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Streamline adding trainers and trainees from the People management drawer to apply roles immediately on user selection.

Enhancements:
- Change AddPersonModal to grant trainer/trainee roles directly when a user is selected from the search, removing the separate confirm step.
- Keep the add-person drawer open with a reset search field to support adding multiple people in succession, and replace the footer actions with a simple Done button and helper hint text.
- Refactor PeopleManagement add flow to use a direct add handler that triggers the appropriate mutation on selection and clears the optional introduction comment after each add.
- Update i18n copy to reflect the new one-click add interaction and Done-based drawer closure.