### PR TITLE
feat(ATT-442): per-user SSE realtime delivery for new messages

### DIFF
--- a/apps/api/src/messaging/messaging-live.service.spec.ts
+++ b/apps/api/src/messaging/messaging-live.service.spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { firstValueFrom, take, toArray } from 'rxjs';
+import { ConversationParticipant, Message } from '@attraccess/database-entities';
+import { MessagingLiveService } from './messaging-live.service';
+import { MessageCreatedEvent } from './events/message-created.event';
+
+describe('MessagingLiveService', () => {
+  let service: MessagingLiveService;
+  let participantRepository: { find: jest.Mock };
+
+  beforeEach(async () => {
+    participantRepository = { find: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessagingLiveService,
+        { provide: getRepositoryToken(ConversationParticipant), useValue: participantRepository },
+      ],
+    }).compile();
+
+    service = module.get(MessagingLiveService);
+  });
+
+  it('returns a stable subject per user', () => {
+    const first = service.getUserMessageSubject(1);
+    const second = service.getUserMessageSubject(1);
+    expect(first).toBe(second);
+  });
+
+  it('pushes the new message to every recipient except the sender', async () => {
+    participantRepository.find.mockResolvedValue([
+      { userId: 5 } as ConversationParticipant,
+      { userId: 9 } as ConversationParticipant,
+    ]);
+
+    const message = { id: 3, conversationId: 1, senderId: 5 } as Message;
+
+    const recipientEvents = firstValueFrom(
+      service.getUserMessageSubject(9).pipe(take(1), toArray()),
+    );
+
+    const senderEvents: { data: Message }[] = [];
+    service.getUserMessageSubject(5).subscribe((event) => senderEvents.push(event));
+
+    await service.notifyNewMessage(new MessageCreatedEvent(message));
+
+    await expect(recipientEvents).resolves.toEqual([{ data: message }]);
+    expect(senderEvents).toHaveLength(0);
+  });
+});

--- a/apps/api/src/messaging/messaging-live.service.ts
+++ b/apps/api/src/messaging/messaging-live.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Subject } from 'rxjs';
+import { Repository } from 'typeorm';
+import { ConversationParticipant, Message } from '@attraccess/database-entities';
+import { MessageCreatedEvent } from './events/message-created.event';
+
+@Injectable()
+export class MessagingLiveService {
+  private readonly messageSubjects: Map<number, Subject<{ data: Message }>> = new Map();
+
+  public constructor(
+    @InjectRepository(ConversationParticipant)
+    private readonly participantRepository: Repository<ConversationParticipant>,
+  ) {}
+
+  public getUserMessageSubject(userId: number): Subject<{ data: Message }> {
+    if (!this.messageSubjects.has(userId)) {
+      this.messageSubjects.set(userId, new Subject<{ data: Message }>());
+    }
+    return this.messageSubjects.get(userId);
+  }
+
+  @OnEvent(MessageCreatedEvent.EVENT_NAME)
+  public async notifyNewMessage(event: MessageCreatedEvent): Promise<void> {
+    const message = event.message;
+
+    const participants = await this.participantRepository.find({
+      where: { conversationId: message.conversationId },
+    });
+
+    for (const participant of participants) {
+      if (participant.userId === message.senderId) {
+        continue;
+      }
+      this.getUserMessageSubject(participant.userId).next({ data: message });
+    }
+  }
+}

--- a/apps/api/src/messaging/messaging.controller.ts
+++ b/apps/api/src/messaging/messaging.controller.ts
@@ -1,8 +1,11 @@
-import { Body, Controller, Get, NotFoundException, Param, ParseIntPipe, Post, Query, Req } from '@nestjs/common';
+import { Body, Controller, Get, NotFoundException, Param, ParseIntPipe, Post, Query, Req, Sse } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Auth, AuthenticatedRequest } from '@attraccess/plugins-backend-sdk';
 import { Message, MessageReferenceType } from '@attraccess/database-entities';
+import { Observable } from 'rxjs';
 import { MessagingService } from './messaging.service';
+import { MessagingLiveService } from './messaging-live.service';
+import { SseInstrumentation } from '../metrics/instrumentation/sse/sse.helper';
 import { ContactResponseDto } from './dtos/contactResponse.dto';
 import { SendMessageDto } from './dtos/sendMessage.dto';
 import { ListMessagesQueryDto } from './dtos/listMessagesQuery.dto';
@@ -12,7 +15,19 @@ import { ConversationListItemDto } from './dtos/conversationListItem.dto';
 @ApiTags('Messaging')
 @Controller('messaging')
 export class MessagingController {
-  constructor(private readonly messagingService: MessagingService) {}
+  constructor(
+    private readonly messagingService: MessagingService,
+    private readonly messagingLiveService: MessagingLiveService,
+    private readonly sse: SseInstrumentation,
+  ) {}
+
+  @Sse('live')
+  @Auth()
+  @ApiOperation({ summary: 'Subscribe to live new messages for the authenticated user', operationId: 'messagingLive' })
+  streamMessages(@Req() req: AuthenticatedRequest): Observable<{ data: Message }> {
+    const subject = this.messagingLiveService.getUserMessageSubject(req.user.id);
+    return this.sse.wrap('messaging', subject.asObservable());
+  }
 
   @Post('users/:userId/contact')
   @Auth()

--- a/apps/api/src/messaging/messaging.module.ts
+++ b/apps/api/src/messaging/messaging.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Conversation, ConversationParticipant, Message, User } from '@attraccess/database-entities';
 import { MessagingService } from './messaging.service';
+import { MessagingLiveService } from './messaging-live.service';
 import { MessagingController } from './messaging.controller';
 import { ResourceUsageModule } from '../resources/usage/resourceUsage.module';
 
@@ -11,7 +12,7 @@ import { ResourceUsageModule } from '../resources/usage/resourceUsage.module';
     ResourceUsageModule,
   ],
   controllers: [MessagingController],
-  providers: [MessagingService],
+  providers: [MessagingService, MessagingLiveService],
   exports: [MessagingService],
 })
 export class MessagingModule {}

--- a/apps/api/src/metrics/instrumentation/sse/sse.helper.ts
+++ b/apps/api/src/metrics/instrumentation/sse/sse.helper.ts
@@ -6,7 +6,7 @@ import { SSE_METRICS } from '../../definitions/tokens';
 import { SseMetrics } from '../../definitions/sse.metrics';
 import { MetricsToggleService } from '../../settings/metrics-toggle.service';
 
-export type SseStream = 'resource_usage' | 'billing' | 'resource_flows';
+export type SseStream = 'resource_usage' | 'billing' | 'resource_flows' | 'messaging';
 
 @Injectable()
 export class SseInstrumentation {


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds per-user Server-Sent Events delivery for new messages, modeled on the billing live-notifications stream.

- New `MessagingLiveService` holds a `Map<number, Subject<{ data: Message }>>` keyed by recipient userId, exposing `getUserMessageSubject(userId)`.
- An `@OnEvent(MessageCreatedEvent.EVENT_NAME)` listener loads the conversation participants and pushes the new message onto each participant's Subject **except the sender**.
- `GET /messaging/live` is exposed as an authed `@Sse()` endpoint returning `this.sse.wrap('messaging', subject.asObservable())`, mirroring `BillingController.streamEvents`.
- Added `'messaging'` to the `SseStream` metrics union so the stream is tracked like billing.

## Testing

- New `messaging-live.service.spec.ts`: verifies stable per-user subjects and that a created message reaches the other participant but not the sender.
- Full api test suite green (1024 tests), lint + typecheck clean.

Closes [ATT-442](https://linear.app/attraccess/issue/ATT-442/per-user-sse-realtime-delivery-for-new-messages)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->