### PR TITLE
feat(ATT-457): frontend plugin route registration (GET_ROUTES → React Router)

### DIFF
--- a/apps/frontend/src/app/routes/index.tsx
+++ b/apps/frontend/src/app/routes/index.tsx
@@ -4,13 +4,13 @@ import { ResourceOverviewTab } from '../resources/details/overview/ResourceOverv
 import { ResourceHistoryTab } from '../resources/details/history/ResourceHistoryTab';
 import { ResourcePeopleTab } from '../resources/details/people/ResourcePeopleTab';
 import { ResourceGroupsTab } from '../resources/details/groups/ResourceGroupsTab';
-import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useMemo } from 'react';
 import { Spinner } from '@heroui/react';
 import { MqttServersPage, EditMqttServerPage } from '../mqtt';
 import { SSOProvidersPage } from '../sso/SSOProvidersPage';
 import { UserManagementPage } from '../user-management';
-import { usePluginStore } from 'react-pluggable';
 import { RouteConfig } from '@attraccess/plugins-frontend-sdk';
+import { PluginRouteBoundary } from '../../components/pluginRouteBoundary';
 import { PluginsList } from '../plugins/PluginsList';
 import usePluginState, { PluginManifestWithPlugin } from '../plugins/plugin.state';
 import { AttractapList } from '../attractap/AttractapList';
@@ -276,28 +276,41 @@ const coreRoutes: RouteConfig[] = [
   },
 ];
 
+function getRoutesOfPlugin(pluginManifest: PluginManifestWithPlugin): RouteConfig[] {
+  const plugin = pluginManifest.plugin;
+  const pluginName = plugin.getPluginName();
+
+  let routes: RouteConfig[] | undefined;
+  try {
+    routes = plugin.getRoutes?.();
+  } catch (error) {
+    console.error(`Attraccess Plugin System: getRoutes() of plugin "${pluginName}" threw`, error);
+    return [];
+  }
+
+  if (!routes) {
+    return [];
+  }
+
+  if (!Array.isArray(routes)) {
+    console.error(`Attraccess Plugin System: getRoutes() of plugin "${pluginName}" did not return an array`);
+    return [];
+  }
+
+  // Wrap each plugin route element so a throwing render can't crash the app shell.
+  return routes.map((route) => ({
+    ...route,
+    element: <PluginRouteBoundary pluginName={pluginName}>{route.element}</PluginRouteBoundary>,
+  }));
+}
+
 export function useAllRoutes() {
   const { plugins: pluginManifests } = usePluginState();
-  const pluginStore = usePluginStore();
 
-  const [pluginRoutes, setPluginRoutes] = useState<RouteConfig[]>([]);
-
-  const getRoutesOfPlugin = useCallback(
-    (pluginManifest: PluginManifestWithPlugin) => {
-      const pluginRoutes = pluginStore.executeFunction(
-        `${pluginManifest.plugin.getPluginName()}.GET_ROUTES`,
-        pluginManifest,
-      );
-
-      return pluginRoutes;
-    },
-    [pluginStore],
+  const pluginRoutes = useMemo(
+    () => pluginManifests.flatMap((pluginManifest) => getRoutesOfPlugin(pluginManifest)),
+    [pluginManifests],
   );
-
-  useEffect(() => {
-    const routesOfAllPlugins = pluginManifests.map((pluginManifest) => getRoutesOfPlugin(pluginManifest)).flat();
-    setPluginRoutes(routesOfAllPlugins);
-  }, [pluginManifests, getRoutesOfPlugin]);
 
   return useMemo(() => [...coreRoutes, ...pluginRoutes], [pluginRoutes]);
 }

--- a/apps/frontend/src/components/pluginRouteBoundary.tsx
+++ b/apps/frontend/src/components/pluginRouteBoundary.tsx
@@ -1,0 +1,41 @@
+import { Component, ErrorInfo, PropsWithChildren, ReactNode } from 'react';
+
+interface PluginRouteBoundaryProps extends PropsWithChildren {
+  pluginName?: string;
+}
+
+interface PluginRouteBoundaryState {
+  hasError: boolean;
+}
+
+// Isolates a plugin-contributed route so a throwing plugin page cannot crash the app shell.
+export class PluginRouteBoundary extends Component<PluginRouteBoundaryProps, PluginRouteBoundaryState> {
+  constructor(props: PluginRouteBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): PluginRouteBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(
+      `Attraccess Plugin System: route from plugin "${this.props.pluginName ?? 'unknown'}" crashed`,
+      error,
+      info
+    );
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="flex items-center justify-center p-8 text-center text-sm text-danger" role="alert">
+          This plugin page failed to load.
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/libs/plugins-frontend-sdk/src/lib/frontend.pluggable.ts
+++ b/libs/plugins-frontend-sdk/src/lib/frontend.pluggable.ts
@@ -1,5 +1,6 @@
 import { User } from '@attraccess/database-entities';
 import { IPlugin } from 'react-pluggable';
+import { RouteConfig } from './frontend.routing';
 
 export enum FrontendLocation {}
 
@@ -19,4 +20,6 @@ export interface AttraccessFrontendPluginAuthData {
 export interface AttraccessFrontendPlugin extends IPlugin {
   onApiAuthStateChange(authData: null | AttraccessFrontendPluginAuthData): void;
   onApiEndpointChange(endpoint: string): void;
+  // Optional. Return the routes this plugin contributes to the app router.
+  getRoutes?(): RouteConfig[];
 }

--- a/libs/plugins-frontend-sdk/src/lib/frontend.routing.ts
+++ b/libs/plugins-frontend-sdk/src/lib/frontend.routing.ts
@@ -1,7 +1,8 @@
 import { SystemPermissions } from '@attraccess/database-entities';
 import { PathRouteProps } from 'react-router-dom';
 
-// Extended route type that includes sidebar options
+// Route definition shared by the app shell and frontend plugins.
+// `authRequired`: false = public, true = any logged-in user, or one/many required permissions.
 export interface RouteConfig extends Omit<PathRouteProps, 'children'> {
   authRequired: boolean | keyof SystemPermissions | (keyof SystemPermissions)[];
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Wires the previously-unused `GET_ROUTES` frontend-plugin capability into React Router, so a frontend plugin can register its own pages.

## Changes

- **SDK contract** (`libs/plugins-frontend-sdk`): added optional `getRoutes(): RouteConfig[]` to the `AttraccessFrontendPlugin` interface and clarified the `RouteConfig` doc comment.
- **Route collection** (`apps/frontend/.../routes/index.tsx`): `useAllRoutes` now calls `plugin.getRoutes?.()` directly (replacing the fragile `pluginStore.executeFunction('<name>.GET_ROUTES')` call that **threw** for any plugin not registering that function — which would crash the whole route tree). Each plugin's `getRoutes()` is wrapped in a per-plugin `try/catch`, and non-array returns are rejected.
- **Crash isolation** (`apps/frontend/src/components/pluginRouteBoundary.tsx`): new error boundary wraps every plugin-contributed route element, so a throwing plugin page renders a small fallback instead of taking down the app shell.

The existing module-federation load path is untouched — federated plugins land in `usePluginState` via `addPlugin()` exactly as before, and `useAllRoutes` reactively merges their routes.

## Testing

- `nx typecheck` + `nx lint` for `frontend` and `plugins-frontend-sdk`: pass
- `nx test frontend`: 163 tests pass
- **Browser validation** with a temporary stub plugin (removed before commit):
  - `/__plugin_test__` route mounted and rendered ✅
  - `/__plugin_crash__` (route that throws on render) showed the isolated fallback while the app shell stayed alive and recovered on navigation ✅
  - Screenshots posted on the Linear issue.

## Acceptance criteria

- [x] A frontend plugin exporting `getRoutes(): RouteConfig[]` has its routes mounted and navigable
- [x] Plugin routes are isolated — a throwing plugin route doesn't crash the app shell
- [x] Works with the existing module-federation load path
- [x] Validated against the running app with a screenshot

Closes [ATT-457](https://linear.app/attraccess/issue/ATT-457/frontend-plugin-route-registration-get-routes-react-router)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
