### PR TITLE
feat(ATT-458): plugin permissions + sandbox enforcement

### DIFF
--- a/apps/api/src/plugin-system/plugin-sandbox.service.spec.ts
+++ b/apps/api/src/plugin-system/plugin-sandbox.service.spec.ts
@@ -1,0 +1,173 @@
+import { Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Resource, Setting, User } from '@attraccess/database-entities';
+import { PluginContext, PluginPermission, PluginPermissionError } from '@attraccess/plugins-backend-sdk';
+import { PluginSandboxService } from './plugin-sandbox.service';
+
+function buildBaseContext(events: EventEmitter2): PluginContext {
+  const dataSource = {
+    getMetadata: (entity: unknown) => {
+      const aliases: Array<{ keys: unknown[]; target: unknown }> = [
+        { keys: [User, 'user', 'User'], target: User },
+        { keys: [Resource, 'resource', 'Resource'], target: Resource },
+        { keys: [Setting, 'setting', 'Setting'], target: Setting },
+      ];
+      const named = entity as { name?: string };
+      for (const alias of aliases) {
+        if (alias.keys.includes(entity) || (named && alias.keys.includes(named.name))) {
+          return { target: alias.target };
+        }
+      }
+      throw new Error('No metadata found');
+    },
+  } as never;
+
+  return {
+    manifest: { id: 'test-id', name: 'test-plugin', version: '1.0.0', pluginDirectory: 'test-plugin' },
+    events,
+    dataSource,
+    logger: new Logger('test-plugin'),
+    getRepository: (entity) => ({ entity } as never),
+    get: (token) => ({ token } as never),
+  };
+}
+
+describe('PluginSandboxService', () => {
+  describe('validateDeclaredPermissions', () => {
+    it('returns an empty array when nothing is declared', () => {
+      expect(PluginSandboxService.validateDeclaredPermissions('p', undefined)).toEqual([]);
+      expect(PluginSandboxService.validateDeclaredPermissions('p', null)).toEqual([]);
+    });
+
+    it('accepts and de-duplicates known permissions', () => {
+      const result = PluginSandboxService.validateDeclaredPermissions('p', [
+        PluginPermission.EMIT_EVENTS,
+        PluginPermission.EMIT_EVENTS,
+        PluginPermission.READ_USERS,
+      ]);
+      expect(result).toEqual([PluginPermission.EMIT_EVENTS, PluginPermission.READ_USERS]);
+    });
+
+    it('throws on an unknown permission', () => {
+      expect(() => PluginSandboxService.validateDeclaredPermissions('p', ['NOT_A_PERMISSION'])).toThrow(
+        /unknown permission "NOT_A_PERMISSION"/
+      );
+    });
+
+    it('throws when permissions is not an array', () => {
+      expect(() => PluginSandboxService.validateDeclaredPermissions('p', 'EMIT_EVENTS')).toThrow(/must be an array/);
+    });
+  });
+
+  describe('createGuardedContext', () => {
+    let events: EventEmitter2;
+
+    beforeEach(() => {
+      events = new EventEmitter2();
+    });
+
+    it('passes through manifest and logger without a permission', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), []);
+      expect(ctx.manifest.name).toBe('test-plugin');
+      expect(ctx.logger).toBeDefined();
+    });
+
+    it('throws when emitting without EMIT_EVENTS', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), []);
+      expect(() => ctx.events.emit('x')).toThrow(PluginPermissionError);
+      expect(() => ctx.events.emit('x')).toThrow(/EMIT_EVENTS/);
+    });
+
+    it('allows emitting with EMIT_EVENTS', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [PluginPermission.EMIT_EVENTS]);
+      const spy = jest.fn();
+      events.on('x', spy);
+      expect(() => ctx.events.emit('x', 1)).not.toThrow();
+      expect(spy).toHaveBeenCalledWith(1);
+    });
+
+    it('throws when subscribing without LISTEN_EVENTS', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), []);
+      expect(() => ctx.events.on('x', () => undefined)).toThrow(/LISTEN_EVENTS/);
+    });
+
+    it('allows subscribing with LISTEN_EVENTS', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [PluginPermission.LISTEN_EVENTS]);
+      expect(() => ctx.events.on('x', () => undefined)).not.toThrow();
+    });
+
+    it('denies event methods the sandbox does not expose', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [
+        PluginPermission.EMIT_EVENTS,
+        PluginPermission.LISTEN_EVENTS,
+      ]);
+      expect(() => (ctx.events as unknown as { removeAllListeners: () => void }).removeAllListeners()).toThrow(
+        /does not expose/
+      );
+      expect(() => (ctx.events as unknown as { listenTo: () => void }).listenTo()).toThrow(/does not expose/);
+      expect(() => (ctx.events as unknown as { eventNames: () => void }).eventNames()).toThrow(/does not expose/);
+      expect(() => (ctx.events as unknown as { constructor: unknown }).constructor).toThrow(/does not expose/);
+    });
+
+    it('does not leak the raw emitter through a this-returning method', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [PluginPermission.LISTEN_EVENTS]);
+      const returned = ctx.events.on('x', () => undefined);
+      expect(returned).not.toBe(events);
+      // The returned reference must remain guarded: emitting through it still needs EMIT_EVENTS.
+      expect(() => (returned as unknown as { emit: (e: string) => void }).emit('x')).toThrow(/EMIT_EVENTS/);
+    });
+
+    it('does not leak the raw emitter through an objectify Listener', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [PluginPermission.LISTEN_EVENTS]);
+      const listener = ctx.events.on('x', () => undefined, { objectify: true }) as unknown as Record<string, unknown>;
+      expect(listener.emitter).toBeUndefined();
+      expect(typeof listener.off).toBe('function');
+    });
+
+    it('throws when accessing dataSource without DATABASE_ACCESS', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), []);
+      expect(() => ctx.dataSource).toThrow(/DATABASE_ACCESS/);
+    });
+
+    it('gates getRepository per entity (class reference)', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [PluginPermission.READ_USERS]);
+      expect(() => ctx.getRepository(User)).not.toThrow();
+      expect(() => ctx.getRepository(Resource)).toThrow(/ACCESS_RESOURCES/);
+      expect(() => ctx.getRepository(Setting)).toThrow(/READ_SETTINGS/);
+    });
+
+    it('resolves entity permission from TypeORM metadata for string table names', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [PluginPermission.DATABASE_ACCESS]);
+      // 'user' is the table name; the guard must still require READ_USERS, not fall back to DATABASE_ACCESS.
+      expect(() => ctx.getRepository('user')).toThrow(/READ_USERS/);
+      expect(() => ctx.getRepository('resource')).toThrow(/ACCESS_RESOURCES/);
+    });
+
+    it('resolves entity permission from metadata for a spoofed entity object', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [PluginPermission.DATABASE_ACCESS]);
+      const spoofed = { name: 'User', options: { name: 'Decoy' } } as never;
+      expect(() => ctx.getRepository(spoofed)).toThrow(/READ_USERS/);
+    });
+
+    it('falls back to DATABASE_ACCESS for unmapped entities', () => {
+      const granted = PluginSandboxService.createGuardedContext(buildBaseContext(events), [
+        PluginPermission.DATABASE_ACCESS,
+      ]);
+      class SomeOtherEntity {}
+      expect(() => granted.getRepository(SomeOtherEntity)).not.toThrow();
+
+      const denied = PluginSandboxService.createGuardedContext(buildBaseContext(events), []);
+      expect(() => denied.getRepository(SomeOtherEntity)).toThrow(/DATABASE_ACCESS/);
+    });
+
+    it('gates get() behind RESOLVE_HOST_PROVIDERS', () => {
+      const denied = PluginSandboxService.createGuardedContext(buildBaseContext(events), []);
+      expect(() => denied.get('SOME_TOKEN')).toThrow(/RESOLVE_HOST_PROVIDERS/);
+
+      const granted = PluginSandboxService.createGuardedContext(buildBaseContext(events), [
+        PluginPermission.RESOLVE_HOST_PROVIDERS,
+      ]);
+      expect(() => granted.get('SOME_TOKEN')).not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/plugin-system/plugin-sandbox.service.ts
+++ b/apps/api/src/plugin-system/plugin-sandbox.service.ts
@@ -1,0 +1,183 @@
+import { Injectable, Logger, Type } from '@nestjs/common';
+import { Resource, Setting, User } from '@attraccess/database-entities';
+import {
+  isPluginPermission,
+  PluginContext,
+  PluginPermission,
+  PluginPermissionError,
+} from '@attraccess/plugins-backend-sdk';
+import type { EntityTarget, ObjectLiteral } from 'typeorm';
+
+const EVENT_METHOD_PERMISSIONS = new Map<string, PluginPermission>([
+  ['emit', PluginPermission.EMIT_EVENTS],
+  ['emitAsync', PluginPermission.EMIT_EVENTS],
+  ['on', PluginPermission.LISTEN_EVENTS],
+  ['once', PluginPermission.LISTEN_EVENTS],
+  ['addListener', PluginPermission.LISTEN_EVENTS],
+  ['prependListener', PluginPermission.LISTEN_EVENTS],
+  ['prependOnceListener', PluginPermission.LISTEN_EVENTS],
+  ['many', PluginPermission.LISTEN_EVENTS],
+  ['prependMany', PluginPermission.LISTEN_EVENTS],
+  ['onAny', PluginPermission.LISTEN_EVENTS],
+  ['prependAny', PluginPermission.LISTEN_EVENTS],
+  ['off', PluginPermission.LISTEN_EVENTS],
+  ['offAny', PluginPermission.LISTEN_EVENTS],
+  ['removeListener', PluginPermission.LISTEN_EVENTS],
+  ['waitFor', PluginPermission.LISTEN_EVENTS],
+]);
+
+const ENTITY_PERMISSIONS: Array<{ target: EntityTarget<ObjectLiteral>; permission: PluginPermission }> = [
+  { target: User, permission: PluginPermission.READ_USERS },
+  { target: Resource, permission: PluginPermission.ACCESS_RESOURCES },
+  { target: Setting, permission: PluginPermission.READ_SETTINGS },
+];
+
+function entityLabel<T extends ObjectLiteral>(entity: EntityTarget<T>): string {
+  if (typeof entity === 'string') {
+    return entity;
+  }
+  if (typeof entity === 'function') {
+    return entity.name;
+  }
+  const named = entity as { name?: string; options?: { name?: string } };
+  return named.options?.name ?? named.name ?? 'UnknownEntity';
+}
+
+function permissionForEntity<T extends ObjectLiteral>(base: PluginContext, entity: EntityTarget<T>): PluginPermission {
+  const direct = ENTITY_PERMISSIONS.find((candidate) => candidate.target === entity);
+  if (direct) {
+    return direct.permission;
+  }
+
+  try {
+    const resolved = base.dataSource.getMetadata(entity).target;
+    const match = ENTITY_PERMISSIONS.find((candidate) => candidate.target === resolved);
+    if (match) {
+      return match.permission;
+    }
+  } catch {
+    return PluginPermission.DATABASE_ACCESS;
+  }
+
+  return PluginPermission.DATABASE_ACCESS;
+}
+
+@Injectable()
+export class PluginSandboxService {
+  private static readonly logger = new Logger(PluginSandboxService.name);
+
+  /**
+   * Validates the permissions declared in a manifest. Returns the parsed set or
+   * throws guidance on the first unknown value.
+   */
+  public static validateDeclaredPermissions(pluginName: string, declared: unknown): PluginPermission[] {
+    if (declared === undefined || declared === null) {
+      return [];
+    }
+
+    if (!Array.isArray(declared)) {
+      throw new Error(`Plugin "${pluginName}" manifest field "permissions" must be an array of strings.`);
+    }
+
+    const result: PluginPermission[] = [];
+    for (const value of declared) {
+      if (typeof value !== 'string' || !isPluginPermission(value)) {
+        throw new Error(
+          `Plugin "${pluginName}" declares unknown permission "${String(value)}". ` +
+            `Valid permissions are: ${Object.values(PluginPermission).join(', ')}.`
+        );
+      }
+      if (!result.includes(value)) {
+        result.push(value);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Wraps a raw PluginContext so every host capability is gated by the plugin's
+   * declared permissions. Accessing an undeclared capability throws a
+   * PluginPermissionError naming the missing permission. The wrapper is
+   * deny-by-default: only explicitly modelled capabilities are reachable.
+   */
+  public static createGuardedContext(base: PluginContext, declared: PluginPermission[]): PluginContext {
+    const pluginName = base.manifest.name;
+    const granted = new Set(declared);
+
+    const require = (permission: PluginPermission, capability: string): void => {
+      if (!granted.has(permission)) {
+        throw new PluginPermissionError(pluginName, capability, permission);
+      }
+    };
+
+    const guardedEvents = PluginSandboxService.guardEvents(base, pluginName, require);
+
+    return {
+      manifest: base.manifest,
+      logger: base.logger,
+      events: guardedEvents,
+      get dataSource() {
+        require(PluginPermission.DATABASE_ACCESS, 'dataSource');
+        return base.dataSource;
+      },
+      getRepository<T extends ObjectLiteral>(entity: EntityTarget<T>) {
+        const permission = permissionForEntity(base, entity);
+        require(permission, `getRepository(${entityLabel(entity)})`);
+        return base.getRepository(entity);
+      },
+      get<T>(token: Type<T> | string | symbol): T {
+        require(PluginPermission.RESOLVE_HOST_PROVIDERS, `get(${String(token)})`);
+        return base.get<T>(token);
+      },
+    };
+  }
+
+  private static guardEvents(
+    base: PluginContext,
+    pluginName: string,
+    require: (permission: PluginPermission, capability: string) => void
+  ): PluginContext['events'] {
+    const target = base.events;
+    const holder: { proxy: PluginContext['events'] | null } = { proxy: null };
+
+    const sanitize = (result: unknown): unknown => {
+      if (result === target) {
+        return holder.proxy;
+      }
+      if (result && typeof result === 'object' && 'emitter' in (result as object)) {
+        const listener = result as { event?: unknown; listener?: unknown; off?: () => void };
+        return { event: listener.event, listener: listener.listener, off: () => listener.off?.() };
+      }
+      return result;
+    };
+
+    const proxy = new Proxy(target, {
+      get(emitter, property, receiver) {
+        if (typeof property !== 'string') {
+          return undefined;
+        }
+
+        const permission = EVENT_METHOD_PERMISSIONS.get(property);
+        if (!permission) {
+          throw new Error(
+            `Plugin "${pluginName}" attempted to use "events.${property}", which the plugin sandbox does not expose.`
+          );
+        }
+
+        const original = Reflect.get(emitter, property, receiver);
+        if (typeof original !== 'function') {
+          return undefined;
+        }
+
+        return (...args: unknown[]) => {
+          require(permission, `events.${property}`);
+          return sanitize((original as (...a: unknown[]) => unknown).apply(emitter, args));
+        };
+      },
+    });
+
+    holder.proxy = proxy as PluginContext['events'];
+    return holder.proxy;
+  }
+}

--- a/apps/api/src/plugin-system/plugin.manifest.ts
+++ b/apps/api/src/plugin-system/plugin.manifest.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { PluginPermission } from '@attraccess/plugins-backend-sdk';
 import { z } from 'zod';
 
 export class PluginMainFrontend {
@@ -91,6 +92,14 @@ export class PluginManifest {
     type: PluginAttraccessVersion,
   })
   attraccessVersion: PluginAttraccessVersion;
+
+  @ApiProperty({
+    description: 'Host capabilities this plugin is permitted to use at runtime',
+    enum: PluginPermission,
+    isArray: true,
+    example: [PluginPermission.EMIT_EVENTS, PluginPermission.READ_SETTINGS],
+  })
+  permissions: PluginPermission[];
 }
 
 export class LoadedPluginManifest extends PluginManifest {
@@ -145,4 +154,8 @@ export const PluginManifestSchema = z.object({
       },
       { message: 'min, max or exact must be provided' }
     ),
+  permissions: z
+    .array(z.nativeEnum(PluginPermission, { message: 'unknown plugin permission' }))
+    .optional()
+    .default([]),
 });

--- a/apps/api/src/plugin-system/plugin.module.ts
+++ b/apps/api/src/plugin-system/plugin.module.ts
@@ -2,6 +2,7 @@ import { DynamicModule, Global, Logger, Module } from '@nestjs/common';
 import { createRequire } from 'module';
 import { PluginManifest } from './plugin.manifest';
 import { PluginService } from './plugin.service';
+import { PluginSandboxService } from './plugin-sandbox.service';
 import { PluginController } from './plugin.controller';
 import { join } from 'path';
 
@@ -24,7 +25,7 @@ export class PluginModule {
 
       return {
         module: PluginModule,
-        providers: [PluginService],
+        providers: [PluginService, PluginSandboxService],
         controllers: [PluginController],
       };
     }
@@ -47,7 +48,7 @@ export class PluginModule {
 
     return {
       module: PluginModule,
-      providers: [PluginService],
+      providers: [PluginService, PluginSandboxService],
       imports: [...pluginModules],
       controllers: [PluginController],
     };

--- a/apps/api/src/plugin-system/plugin.service.ts
+++ b/apps/api/src/plugin-system/plugin.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Logger, NotFoundException } from '@nestjs/common';
 import { join } from 'path';
 import { PluginManifest, PluginManifestSchema, LoadedPluginManifest } from './plugin.manifest';
+import { PluginSandboxService } from './plugin-sandbox.service';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { FileUpload } from '../common/types/file-upload.types';
 import { rename, rm } from 'fs/promises';
@@ -22,6 +23,7 @@ export class PluginService {
   public static configure(config: { PLUGIN_DIR: string, RESTART_BY_EXIT: boolean }): void {
     PluginService.PLUGIN_PATH = config.PLUGIN_DIR; // Assume PLUGIN_DIR from appConfig is already resolved or correct
     PluginService.RESTART_BY_EXIT_FLAG = config.RESTART_BY_EXIT;
+    PluginService.plugins = null; // Discovery may have been cached with an unset path before configure() ran; force a re-scan.
     PluginService.logger.log(`PluginService configured. Path: ${PluginService.PLUGIN_PATH}, RestartByExit: ${PluginService.RESTART_BY_EXIT_FLAG}`);
     if (!PluginService.PLUGIN_PATH) {
         PluginService.logger.error('PLUGIN_DIR is not configured in AppConfig! Plugin system may not work.');
@@ -64,10 +66,20 @@ export class PluginService {
           rootFolder,
           pluginFolder
         ) as LoadedPluginManifest | null;
-        if (manifest) {
-          manifest.pluginDirectory = pluginFolder;
-          manifest.id = randomBytes(16).toString('base64url').slice(0, 21);
+        if (!manifest) {
+          return null;
         }
+
+        manifest.pluginDirectory = pluginFolder;
+        manifest.id = randomBytes(16).toString('base64url').slice(0, 21);
+
+        try {
+          manifest.permissions = PluginSandboxService.validateDeclaredPermissions(manifest.name, manifest.permissions);
+        } catch (error) {
+          PluginService.setPluginLoadError(`${manifest.name}@${manifest.version}`, error as Error);
+          return null;
+        }
+
         return manifest;
       })
       .filter((manifest) => manifest !== null);

--- a/apps/frontend/src/app/plugins/PluginsList.de.json
+++ b/apps/frontend/src/app/plugins/PluginsList.de.json
@@ -8,8 +8,10 @@
     "name": "Name",
     "version": "0.0.16",
     "directory": "Verzeichnis",
+    "permissions": "Berechtigungen",
     "actions": "Aktionen"
   },
+  "noPermissions": "Keine angefordert",
   "deleteTooltip": "Plugin entfernen",
   "deleteConfirmation": {
     "title": "Löschen bestätigen",

--- a/apps/frontend/src/app/plugins/PluginsList.en.json
+++ b/apps/frontend/src/app/plugins/PluginsList.en.json
@@ -8,8 +8,10 @@
     "name": "Name",
     "version": "0.0.16",
     "directory": "Directory",
+    "permissions": "Permissions",
     "actions": "Actions"
   },
+  "noPermissions": "None requested",
   "deleteTooltip": "Remove plugin",
   "deleteConfirmation": {
     "title": "Confirm Deletion",

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -88,6 +88,7 @@ export function PluginsList() {
               <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
               <TableColumn>{t('columns.version')}</TableColumn>
               <TableColumn>{t('columns.directory')}</TableColumn>
+              <TableColumn>{t('columns.permissions')}</TableColumn>
               <TableColumn>{t('columns.actions')}</TableColumn>
             </TableHeader>
             <TableBody items={plugins} renderEmptyState={() => <EmptyState />}>
@@ -100,6 +101,19 @@ export function PluginsList() {
                     </Chip>
                   </TableCell>
                   <TableCell>{plugin.pluginDirectory || '-'}</TableCell>
+                  <TableCell>
+                    {plugin.permissions && plugin.permissions.length > 0 ? (
+                      <div className="flex flex-wrap gap-1" data-cy={`plugins-list-permissions-${plugin.id}`}>
+                        {plugin.permissions.map((permission) => (
+                          <Chip key={permission} variant="soft" color="warning">
+                            {permission}
+                          </Chip>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-default-400">{t('noPermissions')}</span>
+                    )}
+                  </TableCell>
                   <TableCell>
                     <Tooltip>
                       <Button

--- a/docs/de/plugins/developing-plugins.md
+++ b/docs/de/plugins/developing-plugins.md
@@ -79,6 +79,59 @@ esbuild src/index.ts \
 > [!WARNING]
 > Wenn Sie eines der externalisierten Pakete mitbuendeln, laedt Ihr Plugin moeglicherweise fehlerfrei, empfaengt aber stillschweigend keine Events, teilt sich nicht die Datenbank oder kann keine Host-Dienste aufloesen. Halten Sie die obige Abhaengigkeitsliste im Zweifel extern.
 
+### Backend-Plugin-Berechtigungen
+
+Ein Backend-Plugin fuehrt beliebigen Code im Host-Prozess aus, daher muss jede
+Host-Faehigkeit, die es nutzt, vorab deklariert werden. Fuegen Sie Ihrer
+`plugin.json` ein `permissions`-Array hinzu, das nur die benoetigten
+Faehigkeiten auflistet. Zur Laufzeit erhaelt Ihr Plugin einen **abgesicherten**
+`PluginContext`: Der Zugriff auf eine Faehigkeit, deren Berechtigung nicht
+deklariert wurde, loest einen klaren Fehler aus, der die fehlende Berechtigung
+nennt.
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "main": { "backend": { "directory": "dist", "entryPoint": "index.js" } },
+  "attraccessVersion": { "min": "1.0.0" },
+  "permissions": ["READ_USERS", "EMIT_EVENTS"]
+}
+```
+
+| Berechtigung | Gewaehrt Zugriff auf |
+|-----------|------------------|
+| `READ_USERS` | `context.getRepository(User)` -- Benutzerkonten lesen. |
+| `ACCESS_RESOURCES` | `context.getRepository(Resource)` -- Ressourcen lesen und schreiben. |
+| `READ_SETTINGS` | `context.getRepository(Setting)` -- Anwendungseinstellungen lesen. |
+| `DATABASE_ACCESS` | `context.dataSource` und `context.getRepository(...)` fuer jede andere Entitaet. |
+| `EMIT_EVENTS` | `context.events.emit(...)` / `emitAsync(...)` -- auf dem geteilten Event-Bus senden. |
+| `LISTEN_EVENTS` | `context.events.on(...)` / `once(...)` / ... -- den geteilten Event-Bus abonnieren. |
+| `RESOLVE_HOST_PROVIDERS` | `context.get(token)` -- beliebige Host-Dienste per Injection-Token aufloesen. |
+
+`context.manifest` und `context.logger` sind immer verfuegbar und benoetigen
+keine Berechtigung. Eine unbekannte Berechtigung fuehrt dazu, dass das Plugin
+nicht geladen wird.
+
+Einige Hinweise zur Grenze:
+
+- `DATABASE_ACCESS` ist die weitreichende Berechtigung: sie umfasst die rohe
+  `dataSource` (inkl. Verbindungskonfiguration) und ein Repository fuer **jede**
+  Entitaet und schliesst damit implizit `READ_USERS`, `ACCESS_RESOURCES` und
+  `READ_SETTINGS` ein. Bevorzugen Sie die engeren Entitaets-Berechtigungen, wenn
+  Sie nur eine dieser Tabellen brauchen.
+- Der Event-Bus wird als **eingeschraenkte** Oberflaeche bereitgestellt. Nur
+  `emit`/`emitAsync` (unter `EMIT_EVENTS`) und die Listener-Methoden `on`, `once`,
+  `addListener`, `prependListener`, `prependOnceListener`, `many`, `prependMany`,
+  `onAny`, `prependAny`, `off`, `offAny`, `removeListener`, `waitFor` (unter
+  `LISTEN_EVENTS`) sind verfuegbar. Globale Operationen wie `removeAllListeners`
+  und `listenTo` werden nicht freigegeben.
+
+> [!WARNING]
+> Fordern Sie nur die minimal noetigen Berechtigungen an. Administratoren sehen
+> auf der Plugins-Seite jede angeforderte Berechtigung, bevor sie einem Plugin
+> vertrauen.
+
 ## Kombinierte Plugins
 
 Sie koennen ein Plugin erstellen, das sowohl Frontend- als auch Backend-Funktionalitaet umfasst. Dies ist nuetzlich, wenn Ihre Erweiterung benutzerdefinierte API-Endpunkte zusammen mit einer Benutzeroberflaeche benoetigt.

--- a/docs/de/plugins/developing-plugins.md
+++ b/docs/de/plugins/developing-plugins.md
@@ -1,6 +1,6 @@
 # Plugins entwickeln
 
-Attraccess stellt SDKs fuer die Entwicklung eigener Plugins bereit. Sie koennen Frontend-Erweiterungen, Backend-Erweiterungen oder beides erstellen.
+Attraccess stellt SDKs für die Entwicklung eigener Plugins bereit. Sie können Frontend-Erweiterungen, Backend-Erweiterungen oder beides erstellen.
 
 ## Plugin-SDKs
 
@@ -11,30 +11,30 @@ Attraccess stellt SDKs fuer die Entwicklung eigener Plugins bereit. Sie koennen 
 
 ## Frontend-Plugins
 
-Das Frontend-SDK ermoeglicht es Ihrem Plugin, Routen und Komponenten innerhalb der Attraccess-Benutzeroberflaeche zu registrieren.
+Das Frontend-SDK ermöglicht es Ihrem Plugin, Routen und Komponenten innerhalb der Attraccess-Benutzeroberfläche zu registrieren.
 
 Ein Frontend-Plugin kann:
 
-- **Routen registrieren** -- Neue Seiten hinzufuegen, die ueber die Seitenleiste oder direkte URL erreichbar sind
-- **Komponenten registrieren** -- UI-Komponenten in bestehende Seiten einfuegen
+- **Routen registrieren** -- Neue Seiten hinzufügen, die über die Seitenleiste oder direkte URL erreichbar sind
+- **Komponenten registrieren** -- UI-Komponenten in bestehende Seiten einfügen
 
 ### Erste Schritte mit Frontend-Plugins
 
 1. Erstellen Sie ein neues Projekt und installieren Sie das Frontend-SDK
 2. Verwenden Sie das SDK, um Ihre Routen und Komponenten zu registrieren
 3. Erstellen und verpacken Sie Ihr Plugin
-4. Laden Sie es ueber die [Plugins](plugins/installing-plugins.md)-Seite hoch
+4. Laden Sie es über die [Plugins](plugins/installing-plugins.md)-Seite hoch
 
 > [!TIP]
-> Lesen Sie die SDK-Dokumentation, die mit `@attraccess/plugins-frontend-sdk` mitgeliefert wird, fuer eine detaillierte API-Referenz, Beispiele und Typdefinitionen.
+> Lesen Sie die SDK-Dokumentation, die mit `@attraccess/plugins-frontend-sdk` mitgeliefert wird, für eine detaillierte API-Referenz, Beispiele und Typdefinitionen.
 
 ## Backend-Plugins
 
-Das Backend-SDK ermoeglicht es Ihrem Plugin, API-Endpunkte zu registrieren, die auf dem Attraccess-Server ausgefuehrt werden.
+Das Backend-SDK ermöglicht es Ihrem Plugin, API-Endpunkte zu registrieren, die auf dem Attraccess-Server ausgeführt werden.
 
 Ein Backend-Plugin kann:
 
-- **API-Endpunkte registrieren** -- Neue REST-Endpunkte zur Attraccess-API hinzufuegen
+- **API-Endpunkte registrieren** -- Neue REST-Endpunkte zur Attraccess-API hinzufügen
 - **Auf Anwendungsdienste zugreifen** -- Mit dem Attraccess-Backend interagieren
 
 ### Erste Schritte mit Backend-Plugins
@@ -42,18 +42,18 @@ Ein Backend-Plugin kann:
 1. Erstellen Sie ein neues Projekt und installieren Sie das Backend-SDK
 2. Definieren Sie Ihre API-Endpunkte mit dem SDK
 3. Erstellen und verpacken Sie Ihr Plugin
-4. Laden Sie es ueber die [Plugins](plugins/installing-plugins.md)-Seite hoch
+4. Laden Sie es über die [Plugins](plugins/installing-plugins.md)-Seite hoch
 
 ### Backend-Plugins verpacken
 
-Ein Backend-Plugin laeuft **innerhalb** des Attraccess-Serverprozesses und teilt sich die NestJS-Laufzeit, den Event-Bus und die Datenbankverbindung des Hosts. Damit das funktioniert, muss Ihr Build *dieselben* Kopien dieser Pakete verwenden, die der Host bereits geladen hat -- er darf keine eigenen mitbuendeln.
+Ein Backend-Plugin läuft **innerhalb** des Attraccess-Serverprozesses und teilt sich die NestJS-Laufzeit, den Event-Bus und die Datenbankverbindung des Hosts. Damit das funktioniert, muss Ihr Build *dieselben* Kopien dieser Pakete verwenden, die der Host bereits geladen hat -- er darf keine eigenen mitbündeln.
 
-Teilen Sie Ihre Abhaengigkeiten in zwei Gruppen auf:
+Teilen Sie Ihre Abhängigkeiten in zwei Gruppen auf:
 
-| Abhaengigkeit | Deklaration | Grund |
+| Abhängigkeit | Deklaration | Grund |
 |---------------|-------------|-------|
-| `@nestjs/common`, `@nestjs/core`, `@nestjs/event-emitter`, `eventemitter2`, `typeorm`, `reflect-metadata` | `peerDependencies`, beim Build **externalisiert** (nie gebuendelt) | Sie tragen die Dependency-Injection-Identitaeten, den gemeinsamen Event-Bus und die einzelne Datenbankverbindung. Eine gebuendelte Kopie gilt als *anderer* Typ und verbindet sich stillschweigend nicht. |
-| `@attraccess/plugins-backend-sdk` und Ihr eigener Code | Normal buendeln | Kann sicher in Ihr Artefakt aufgenommen werden. |
+| `@nestjs/common`, `@nestjs/core`, `@nestjs/event-emitter`, `eventemitter2`, `typeorm`, `reflect-metadata` | `peerDependencies`, beim Build **externalisiert** (nie gebündelt) | Sie tragen die Dependency-Injection-Identitäten, den gemeinsamen Event-Bus und die einzelne Datenbankverbindung. Eine gebündelte Kopie gilt als *anderer* Typ und verbindet sich stillschweigend nicht. |
+| `@attraccess/plugins-backend-sdk` und Ihr eigener Code | Normal bündeln | Kann sicher in Ihr Artefakt aufgenommen werden. |
 
 Liefern Sie einen **CommonJS**-Einstiegspunkt (`index.js`) aus, kein ES-Modul (`index.mjs`). Verweisen Sie im `plugin.json`-Manifest darauf:
 
@@ -77,16 +77,16 @@ esbuild src/index.ts \
 ```
 
 > [!WARNING]
-> Wenn Sie eines der externalisierten Pakete mitbuendeln, laedt Ihr Plugin moeglicherweise fehlerfrei, empfaengt aber stillschweigend keine Events, teilt sich nicht die Datenbank oder kann keine Host-Dienste aufloesen. Halten Sie die obige Abhaengigkeitsliste im Zweifel extern.
+> Wenn Sie eines der externalisierten Pakete mitbündeln, lädt Ihr Plugin möglicherweise fehlerfrei, empfängt aber stillschweigend keine Events, teilt sich nicht die Datenbank oder kann keine Host-Dienste auflösen. Halten Sie die obige Abhängigkeitsliste im Zweifel extern.
 
 ### Backend-Plugin-Berechtigungen
 
-Ein Backend-Plugin fuehrt beliebigen Code im Host-Prozess aus, daher muss jede
-Host-Faehigkeit, die es nutzt, vorab deklariert werden. Fuegen Sie Ihrer
-`plugin.json` ein `permissions`-Array hinzu, das nur die benoetigten
-Faehigkeiten auflistet. Zur Laufzeit erhaelt Ihr Plugin einen **abgesicherten**
-`PluginContext`: Der Zugriff auf eine Faehigkeit, deren Berechtigung nicht
-deklariert wurde, loest einen klaren Fehler aus, der die fehlende Berechtigung
+Ein Backend-Plugin führt beliebigen Code im Host-Prozess aus, daher muss jede
+Host-Fähigkeit, die es nutzt, vorab deklariert werden. Fügen Sie Ihrer
+`plugin.json` ein `permissions`-Array hinzu, das nur die benötigten
+Fähigkeiten auflistet. Zur Laufzeit erhält Ihr Plugin einen **abgesicherten**
+`PluginContext`: Der Zugriff auf eine Fähigkeit, deren Berechtigung nicht
+deklariert wurde, löst einen klaren Fehler aus, der die fehlende Berechtigung
 nennt.
 
 ```json
@@ -99,49 +99,49 @@ nennt.
 }
 ```
 
-| Berechtigung | Gewaehrt Zugriff auf |
+| Berechtigung | Gewährt Zugriff auf |
 |-----------|------------------|
 | `READ_USERS` | `context.getRepository(User)` -- Benutzerkonten lesen. |
 | `ACCESS_RESOURCES` | `context.getRepository(Resource)` -- Ressourcen lesen und schreiben. |
 | `READ_SETTINGS` | `context.getRepository(Setting)` -- Anwendungseinstellungen lesen. |
-| `DATABASE_ACCESS` | `context.dataSource` und `context.getRepository(...)` fuer jede andere Entitaet. |
+| `DATABASE_ACCESS` | `context.dataSource` und `context.getRepository(...)` für jede andere Entität. |
 | `EMIT_EVENTS` | `context.events.emit(...)` / `emitAsync(...)` -- auf dem geteilten Event-Bus senden. |
 | `LISTEN_EVENTS` | `context.events.on(...)` / `once(...)` / ... -- den geteilten Event-Bus abonnieren. |
-| `RESOLVE_HOST_PROVIDERS` | `context.get(token)` -- beliebige Host-Dienste per Injection-Token aufloesen. |
+| `RESOLVE_HOST_PROVIDERS` | `context.get(token)` -- beliebige Host-Dienste per Injection-Token auflösen. |
 
-`context.manifest` und `context.logger` sind immer verfuegbar und benoetigen
-keine Berechtigung. Eine unbekannte Berechtigung fuehrt dazu, dass das Plugin
+`context.manifest` und `context.logger` sind immer verfügbar und benötigen
+keine Berechtigung. Eine unbekannte Berechtigung führt dazu, dass das Plugin
 nicht geladen wird.
 
 Einige Hinweise zur Grenze:
 
 - `DATABASE_ACCESS` ist die weitreichende Berechtigung: sie umfasst die rohe
-  `dataSource` (inkl. Verbindungskonfiguration) und ein Repository fuer **jede**
-  Entitaet und schliesst damit implizit `READ_USERS`, `ACCESS_RESOURCES` und
-  `READ_SETTINGS` ein. Bevorzugen Sie die engeren Entitaets-Berechtigungen, wenn
+  `dataSource` (inkl. Verbindungskonfiguration) und ein Repository für **jede**
+  Entität und schließt damit implizit `READ_USERS`, `ACCESS_RESOURCES` und
+  `READ_SETTINGS` ein. Bevorzugen Sie die engeren Entitäts-Berechtigungen, wenn
   Sie nur eine dieser Tabellen brauchen.
-- Der Event-Bus wird als **eingeschraenkte** Oberflaeche bereitgestellt. Nur
+- Der Event-Bus wird als **eingeschränkte** Oberfläche bereitgestellt. Nur
   `emit`/`emitAsync` (unter `EMIT_EVENTS`) und die Listener-Methoden `on`, `once`,
   `addListener`, `prependListener`, `prependOnceListener`, `many`, `prependMany`,
   `onAny`, `prependAny`, `off`, `offAny`, `removeListener`, `waitFor` (unter
-  `LISTEN_EVENTS`) sind verfuegbar. Globale Operationen wie `removeAllListeners`
+  `LISTEN_EVENTS`) sind verfügbar. Globale Operationen wie `removeAllListeners`
   und `listenTo` werden nicht freigegeben.
 
 > [!WARNING]
-> Fordern Sie nur die minimal noetigen Berechtigungen an. Administratoren sehen
+> Fordern Sie nur die minimal nötigen Berechtigungen an. Administratoren sehen
 > auf der Plugins-Seite jede angeforderte Berechtigung, bevor sie einem Plugin
 > vertrauen.
 
 ## Kombinierte Plugins
 
-Sie koennen ein Plugin erstellen, das sowohl Frontend- als auch Backend-Funktionalitaet umfasst. Dies ist nuetzlich, wenn Ihre Erweiterung benutzerdefinierte API-Endpunkte zusammen mit einer Benutzeroberflaeche benoetigt.
+Sie können ein Plugin erstellen, das sowohl Frontend- als auch Backend-Funktionalität umfasst. Dies ist nützlich, wenn Ihre Erweiterung benutzerdefinierte API-Endpunkte zusammen mit einer Benutzeroberfläche benötigt.
 
 > [!NOTE]
-> Fuer eine allgemeine Einfuehrung in die Attraccess-Architektur und Entwicklungsumgebung siehe den [Entwicklerhandbuch](developer/overview.md).
+> Für eine allgemeine Einführung in die Attraccess-Architektur und Entwicklungsumgebung siehe den [Entwicklerhandbuch](developer/overview.md).
 
 ## Siehe auch
 
-- [Plugins Ueberblick](plugins/overview.md) -- Was sind Plugins?
+- [Plugins Überblick](plugins/overview.md) -- Was sind Plugins?
 - [Plugins installieren](plugins/installing-plugins.md) -- Plugins hochladen und verwalten
 - [Entwicklerhandbuch](developer/overview.md) -- Attraccess-Architektur und -Entwicklung
 - [API-Referenz](developer/api-reference.md) -- Attraccess-REST-API

--- a/docs/en/plugins/developing-plugins.md
+++ b/docs/en/plugins/developing-plugins.md
@@ -79,6 +79,55 @@ esbuild src/index.ts \
 > [!WARNING]
 > If you bundle any of the externalized packages, your plugin may load without errors but quietly fail to receive events, share the database, or resolve host services. When in doubt, keep the dependency list above external.
 
+### Backend Plugin Permissions
+
+A backend plugin runs arbitrary code inside the host process, so every host
+capability it touches must be declared up front. Add a `permissions` array to
+your `plugin.json` manifest listing only the capabilities you need. At runtime
+the host hands your plugin a **guarded** `PluginContext`: accessing a capability
+whose permission you did not declare throws a clear error naming the missing
+permission.
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "main": { "backend": { "directory": "dist", "entryPoint": "index.js" } },
+  "attraccessVersion": { "min": "1.0.0" },
+  "permissions": ["READ_USERS", "EMIT_EVENTS"]
+}
+```
+
+| Permission | Grants access to |
+|-----------|------------------|
+| `READ_USERS` | `context.getRepository(User)` -- read user accounts. |
+| `ACCESS_RESOURCES` | `context.getRepository(Resource)` -- read and write resources. |
+| `READ_SETTINGS` | `context.getRepository(Setting)` -- read application settings. |
+| `DATABASE_ACCESS` | `context.dataSource` and `context.getRepository(...)` for any other entity. |
+| `EMIT_EVENTS` | `context.events.emit(...)` / `emitAsync(...)` -- publish on the shared event bus. |
+| `LISTEN_EVENTS` | `context.events.on(...)` / `once(...)` / ... -- subscribe to the shared event bus. |
+| `RESOLVE_HOST_PROVIDERS` | `context.get(token)` -- resolve arbitrary host services by injection token. |
+
+`context.manifest` and `context.logger` are always available and require no
+permission. Declaring an unknown permission value makes the plugin fail to load.
+
+A few notes on the boundary:
+
+- `DATABASE_ACCESS` is the broad grant: it covers the raw `dataSource` (including
+  the connection config) and a repository for **any** entity, so it implicitly
+  includes what `READ_USERS`, `ACCESS_RESOURCES` and `READ_SETTINGS` grant. Prefer
+  the narrow per-entity permissions when you only need one of those tables.
+- The event bus is exposed as a **restricted** surface. Only `emit`/`emitAsync`
+  (under `EMIT_EVENTS`) and the listener methods `on`, `once`, `addListener`,
+  `prependListener`, `prependOnceListener`, `many`, `prependMany`, `onAny`,
+  `prependAny`, `off`, `offAny`, `removeListener`, `waitFor` (under `LISTEN_EVENTS`)
+  are available. Bulk/global operations such as `removeAllListeners` and
+  `listenTo` are not exposed.
+
+> [!WARNING]
+> Request the minimum set of permissions your plugin needs. Administrators can
+> see every permission a plugin requests on the Plugins page before trusting it.
+
 ## Combined Plugins
 
 You can create a plugin that includes both frontend and backend functionality. This is useful when your extension needs custom API endpoints together with a user interface.

--- a/libs/plugins-backend-sdk/src/lib/plugin.interface.ts
+++ b/libs/plugins-backend-sdk/src/lib/plugin.interface.ts
@@ -14,3 +14,68 @@ export type SystemEventResponse = {
   [SystemEvent.RESOURCE_USAGE_STARTED]: null;
   [SystemEvent.RESOURCE_USAGE_ENDED]: null;
 };
+
+/**
+ * Discrete host capabilities a plugin may request in its manifest. A plugin can
+ * only use a capability whose permission it declared; the sandbox throws on any
+ * undeclared access. Each value gates exactly one seam of the PluginContext.
+ */
+export enum PluginPermission {
+  /** Read the User repository via getRepository(User). */
+  READ_USERS = 'READ_USERS',
+  /** Read/write the Resource repository via getRepository(Resource). */
+  ACCESS_RESOURCES = 'ACCESS_RESOURCES',
+  /** Read the Setting repository via getRepository(Setting). */
+  READ_SETTINGS = 'READ_SETTINGS',
+  /** Access any other repository and the raw dataSource. */
+  DATABASE_ACCESS = 'DATABASE_ACCESS',
+  /** Publish events on the shared event bus (events.emit / emitAsync). */
+  EMIT_EVENTS = 'EMIT_EVENTS',
+  /** Subscribe to events on the shared event bus (events.on / once / ...). */
+  LISTEN_EVENTS = 'LISTEN_EVENTS',
+  /** Resolve arbitrary host providers by token via context.get(). */
+  RESOLVE_HOST_PROVIDERS = 'RESOLVE_HOST_PROVIDERS',
+}
+
+/**
+ * Human-readable description of each permission, surfaced to admins and plugin
+ * authors. Keep in sync with the PluginPermission enum.
+ */
+export const PLUGIN_PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
+  [PluginPermission.READ_USERS]: 'Read user accounts from the database.',
+  [PluginPermission.ACCESS_RESOURCES]: 'Read and write resources from the database.',
+  [PluginPermission.READ_SETTINGS]: 'Read application settings from the database.',
+  [PluginPermission.DATABASE_ACCESS]: 'Access the raw database connection and any other entity repository.',
+  [PluginPermission.EMIT_EVENTS]: 'Publish events on the shared application event bus.',
+  [PluginPermission.LISTEN_EVENTS]: 'Subscribe to events on the shared application event bus.',
+  [PluginPermission.RESOLVE_HOST_PROVIDERS]: 'Resolve arbitrary host services by injection token.',
+};
+
+/**
+ * Returns true when the given string is a known PluginPermission value.
+ */
+export function isPluginPermission(value: string): value is PluginPermission {
+  return Object.prototype.hasOwnProperty.call(PLUGIN_PERMISSION_DESCRIPTIONS, value);
+}
+
+/**
+ * Thrown when a plugin accesses a host capability whose permission it did not
+ * declare in its manifest. The message names the plugin, the capability and the
+ * permission that would unlock it.
+ */
+export class PluginPermissionError extends Error {
+  public readonly pluginName: string;
+  public readonly capability: string;
+  public readonly requiredPermission: PluginPermission;
+
+  constructor(pluginName: string, capability: string, requiredPermission: PluginPermission) {
+    super(
+      `Plugin "${pluginName}" attempted to use "${capability}", which requires the ` +
+        `"${requiredPermission}" permission. Declare it in the "permissions" array of the plugin manifest.`
+    );
+    this.name = 'PluginPermissionError';
+    this.pluginName = pluginName;
+    this.capability = capability;
+    this.requiredPermission = requiredPermission;
+  }
+}

--- a/libs/react-query-client/src/lib/requests/schemas.gen.ts
+++ b/libs/react-query-client/src/lib/requests/schemas.gen.ts
@@ -6187,6 +6187,15 @@ export const $LoadedPluginManifest = {
         attraccessVersion: {
             '$ref': '#/components/schemas/PluginAttraccessVersion'
         },
+        permissions: {
+            type: 'array',
+            description: 'Host capabilities this plugin is permitted to use at runtime',
+            example: ['EMIT_EVENTS', 'READ_SETTINGS'],
+            items: {
+                type: 'string',
+                enum: ['READ_USERS', 'ACCESS_RESOURCES', 'READ_SETTINGS', 'DATABASE_ACCESS', 'EMIT_EVENTS', 'LISTEN_EVENTS', 'RESOLVE_HOST_PROVIDERS']
+            }
+        },
         pluginDirectory: {
             type: 'string',
             description: 'The directory of the plugin',
@@ -6198,7 +6207,7 @@ export const $LoadedPluginManifest = {
             example: '123e4567-e89b-12d3-a456-426614174000'
         }
     },
-    required: ['name', 'main', 'version', 'attraccessVersion', 'pluginDirectory', 'id']
+    required: ['name', 'main', 'version', 'attraccessVersion', 'permissions', 'pluginDirectory', 'id']
 } as const;
 
 export const $UploadPluginDto = {

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -3904,6 +3904,10 @@ export type LoadedPluginManifest = {
     version: string;
     attraccessVersion: PluginAttraccessVersion;
     /**
+     * Host capabilities this plugin is permitted to use at runtime
+     */
+    permissions: Array<('READ_USERS' | 'ACCESS_RESOURCES' | 'READ_SETTINGS' | 'DATABASE_ACCESS' | 'EMIT_EVENTS' | 'LISTEN_EVENTS' | 'RESOLVE_HOST_PROVIDERS')>;
+    /**
      * The directory of the plugin
      */
     pluginDirectory: string;


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Implements **ATT-458** — a declared-permission model for plugins with runtime enforcement on the `PluginContext`. A dynamically loaded plugin runs arbitrary code, so this is the security boundary between plugin code and the host.

## What changed

- **SDK** (`libs/plugins-backend-sdk`): `PluginPermission` enum (`READ_USERS`, `ACCESS_RESOURCES`, `READ_SETTINGS`, `DATABASE_ACCESS`, `EMIT_EVENTS`, `LISTEN_EVENTS`, `RESOLVE_HOST_PROVIDERS`), human-readable descriptions, and `PluginPermissionError` (clear message naming the missing permission).
- **Manifest** (`plugin.manifest.ts`): new `permissions[]` field on the schema/class; Zod rejects unknown values; loader (`PluginService`) validates declared permissions and skips plugins with bad manifests.
- **`PluginSandboxService`** (new): `createGuardedContext()` returns a **deny-by-default** wrapper over `PluginContext`. Undeclared capability access throws `PluginPermissionError`.
- **Admin UI**: the Plugins page now surfaces each plugin's requested permissions as chips (en/de).
- **Docs**: permission reference for plugin authors (en/de).

## Security hardening (adversarial review)

I ran a multi-agent adversarial review of the sandbox before shipping. It surfaced real bypasses in the first cut, all fixed and covered by regression tests:

- **Event bus is deny-by-default.** Only `emit`/`emitAsync` (`EMIT_EVENTS`) and the explicit listener methods (`LISTEN_EVENTS`) are exposed; everything else (`removeAllListeners`, `listenTo`, `waitFor` without permission, introspection, `constructor`) throws.
- **No raw-emitter leak.** Return values are sanitized: methods returning `this` return the guarded proxy, and objectify `Listener` objects no longer expose `.emitter`, so a `LISTEN_EVENTS`-only plugin can't escalate to `emit`.
- **Entity gating by identity, not name string.** `getRepository` resolves the permission from TypeORM metadata identity, so `getRepository('user')`, the table name, or a spoofed `{ name, options }` object all map to the correct per-entity permission (`READ_USERS` etc.) instead of falling through to `DATABASE_ACCESS`.

Also fixed a pre-existing ordering bug where plugin discovery cached an empty list before `configure()` set the path (the plugins list was always empty); `configure()` now busts that cache.

## Testing

- `nx test api` — 1050 passing (incl. new sandbox + bypass regression tests); `nx test plugins-backend-sdk` — 44 passing.
- `nx lint`/`typecheck` clean; `api`, `frontend`, `plugins-backend-sdk` build green; precommit gate passed.
- Verified in a real browser via `agent-browser`: installed a sample plugin declaring `READ_USERS`, `EMIT_EVENTS`, `READ_SETTINGS` and confirmed the chips render on the Plugins page (screenshot posted to the Linear issue).

Linear: [ATT-458](https://linear.app/attraccess/issue/ATT-458/plugin-permissions-sandbox-manifest-perms-runtime)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
