### PR TITLE
feat(ATT-452): AttraccessUser popover with Start direct message action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### 🚀 Features
+
+- **ATT-452:** AttraccessUser popover with user info + "Start direct message" action that opens/creates a 1:1 conversation and routes to `/messages` ([ATT-452](https://linear.app/attraccess/issue/ATT-452))
+
 ## 1.6.0 (2026-05-30)
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## [Unreleased]
-
-### 🚀 Features
-
-- **ATT-452:** AttraccessUser popover with user info + "Start direct message" action that opens/creates a 1:1 conversation and routes to `/messages` ([ATT-452](https://linear.app/attraccess/issue/ATT-452), [#1158](https://github.com/Attraccess/Attraccess/pull/1158))
-
 ## 1.6.0 (2026-05-30)
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 🚀 Features
 
-- **ATT-452:** AttraccessUser popover with user info + "Start direct message" action that opens/creates a 1:1 conversation and routes to `/messages` ([ATT-452](https://linear.app/attraccess/issue/ATT-452))
+- **ATT-452:** AttraccessUser popover with user info + "Start direct message" action that opens/creates a 1:1 conversation and routes to `/messages` ([ATT-452](https://linear.app/attraccess/issue/ATT-452), [#1158](https://github.com/Attraccess/Attraccess/pull/1158))
 
 ## 1.6.0 (2026-05-30)
 

--- a/apps/frontend/src/app/app.tsx
+++ b/apps/frontend/src/app/app.tsx
@@ -23,6 +23,7 @@ import { AccessDenied } from './unauthorized/accessDenied';
 import { getBaseUrl } from '../api';
 import { AcceptInvitation } from './accept-invitation';
 import { TwoFactorGate } from './two-factor-gate';
+import { AttraccessUserActionsBridge } from '../components/attraccessUserActionsBridge';
 
 function useRoutesWithAuthElements(routes: RouteConfig[]) {
   const { user } = useAuth();
@@ -117,9 +118,11 @@ function AppLayout(props: PropsWithChildren) {
         <I18nProvider locale={language}>
           <ToastProvider>
             <ReactFlowProvider>
-              <Layout noLayout={!isAuthenticated}>
-                {props.children}
-              </Layout>
+              <AttraccessUserActionsBridge>
+                <Layout noLayout={!isAuthenticated}>
+                  {props.children}
+                </Layout>
+              </AttraccessUserActionsBridge>
             </ReactFlowProvider>
           </ToastProvider>
         </I18nProvider>

--- a/apps/frontend/src/app/messaging/index.tsx
+++ b/apps/frontend/src/app/messaging/index.tsx
@@ -6,7 +6,8 @@ import {
 } from '@attraccess/react-query-client';
 import { Card, cn } from '@heroui/react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { MailIcon, ArrowLeftIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
@@ -24,7 +25,17 @@ export function MessagesPage() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
 
-  const [selectedConversationId, setSelectedConversationId] = useState<number | null>(null);
+  const [searchParams] = useSearchParams();
+  const conversationParam = Number(searchParams.get('conversation'));
+  const [selectedConversationId, setSelectedConversationId] = useState<number | null>(
+    Number.isInteger(conversationParam) && conversationParam > 0 ? conversationParam : null,
+  );
+
+  useEffect(() => {
+    if (Number.isInteger(conversationParam) && conversationParam > 0) {
+      setSelectedConversationId(conversationParam);
+    }
+  }, [conversationParam]);
 
   const { data: conversations, isLoading } = useMessagingServiceMessagingListConversations();
 

--- a/apps/frontend/src/components/attraccessUserActionsBridge/index.tsx
+++ b/apps/frontend/src/components/attraccessUserActionsBridge/index.tsx
@@ -1,0 +1,22 @@
+// Wires AttraccessUser direct-message action to the messaging API and routing
+// FEATURE: Messaging inbox page
+import { ReactNode, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { User, useMessagingServiceMessagingContactUser } from '@attraccess/react-query-client';
+import { AttraccessUserActionsProvider } from '@attraccess/plugins-frontend-ui';
+
+interface AttraccessUserActionsBridgeProps {
+  children: ReactNode;
+}
+
+export function AttraccessUserActionsBridge({ children }: Readonly<AttraccessUserActionsBridgeProps>) {
+  const navigate = useNavigate();
+
+  const { mutate: contactUser } = useMessagingServiceMessagingContactUser({
+    onSuccess: (result) => navigate(`/messages?conversation=${result.conversationId}`),
+  });
+
+  const onStartDirectMessage = useCallback((user: User) => contactUser({ userId: user.id }), [contactUser]);
+
+  return <AttraccessUserActionsProvider onStartDirectMessage={onStartDirectMessage}>{children}</AttraccessUserActionsProvider>;
+}

--- a/libs/plugins-frontend-ui/src/lib/components/attraccess-user/AttraccessUser.tsx
+++ b/libs/plugins-frontend-ui/src/lib/components/attraccess-user/AttraccessUser.tsx
@@ -2,10 +2,11 @@
 // FEATURE: User identity display using HeroUI v3 Avatar compound
 import { User } from '@attraccess/react-query-client';
 import { useTranslations } from '../../i18n';
-import { Avatar, AvatarFallback, AvatarImage } from '@heroui/react';
+import { Avatar, AvatarFallback, AvatarImage, Button, Popover } from '@heroui/react';
 import { toSvg } from 'jdenticon';
 import { useMemo, ReactNode } from 'react';
-import { AlertTriangleIcon } from 'lucide-react';
+import { AlertTriangleIcon, MessageCircleIcon } from 'lucide-react';
+import { useAttraccessUserActions } from './AttraccessUserActionsContext';
 import en from './en.json';
 import de from './de.json';
 
@@ -13,10 +14,12 @@ interface AttraccessUserProps {
   user?: User;
   description?: ReactNode;
   className?: string;
+  onStartDirectMessage?: (user: User) => void;
 }
 
-export function AttraccessUser({ user, description, className }: Readonly<AttraccessUserProps>) {
+export function AttraccessUser({ user, description, className, onStartDirectMessage }: Readonly<AttraccessUserProps>) {
   const { t } = useTranslations({ en, de });
+  const actions = useAttraccessUserActions();
 
   const isDeleted = !user || !!user?.deletedAt;
 
@@ -28,7 +31,10 @@ export function AttraccessUser({ user, description, className }: Readonly<Attrac
 
   const name = user?.username || t('unknown');
 
-  return (
+  const startDirectMessage = onStartDirectMessage ?? actions.onStartDirectMessage;
+  const isInteractive = !!user && !!startDirectMessage;
+
+  const body = (
     <div className={`flex items-center gap-2 ${className ?? ''}`}>
       <Avatar>
         {avatarIcon ? <AvatarImage src={avatarIcon} /> : null}
@@ -38,8 +44,51 @@ export function AttraccessUser({ user, description, className }: Readonly<Attrac
       </Avatar>
       <div className="flex flex-col">
         <span className="text-sm font-medium">{isDeleted ? <del>{name}</del> : name}</span>
-        {description && <span className="text-xs text-muted-foreground">{isDeleted ? <del>{description}</del> : description}</span>}
+        {description && (
+          <span className="text-xs text-muted-foreground">{isDeleted ? <del>{description}</del> : description}</span>
+        )}
       </div>
     </div>
+  );
+
+  if (!isInteractive) {
+    return body;
+  }
+
+  return (
+    <Popover>
+      <Popover.Trigger className="inline-flex w-fit cursor-pointer rounded-md outline-none focus-visible:ring-2">
+        {body}
+      </Popover.Trigger>
+      <Popover.Content>
+        <Popover.Dialog className="flex w-64 flex-col gap-3 p-4">
+          <div className="flex items-center gap-3">
+            <Avatar className="h-12 w-12">
+              {avatarIcon ? <AvatarImage src={avatarIcon} /> : null}
+              <AvatarFallback>{name.slice(0, 2).toUpperCase()}</AvatarFallback>
+            </Avatar>
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate text-sm font-semibold">{name}</span>
+              <span className="text-xs text-muted-foreground">#{user.id}</span>
+            </div>
+          </div>
+          <span
+            className={`w-fit rounded-full px-2 py-0.5 text-xs ${
+              user.isEmailVerified
+                ? 'bg-success-100 text-success-700'
+                : 'bg-default-100 text-default-600'
+            }`}
+          >
+            {user.isEmailVerified ? t('emailVerified') : t('emailUnverified')}
+          </span>
+          {!isDeleted && (
+            <Button variant="primary" size="sm" className="w-full" onPress={() => startDirectMessage(user)}>
+              <MessageCircleIcon className="h-4 w-4" />
+              {t('startDirectMessage')}
+            </Button>
+          )}
+        </Popover.Dialog>
+      </Popover.Content>
+    </Popover>
   );
 }

--- a/libs/plugins-frontend-ui/src/lib/components/attraccess-user/AttraccessUserActionsContext.tsx
+++ b/libs/plugins-frontend-ui/src/lib/components/attraccess-user/AttraccessUserActionsContext.tsx
@@ -1,0 +1,29 @@
+// React context injecting optional user actions into AttraccessUser display
+// FEATURE: User identity display using HeroUI v3 Avatar compound
+import { User } from '@attraccess/react-query-client';
+import { createContext, useContext, ReactNode } from 'react';
+
+interface AttraccessUserActions {
+  onStartDirectMessage?: (user: User) => void;
+}
+
+interface AttraccessUserActionsProviderProps extends AttraccessUserActions {
+  children: ReactNode;
+}
+
+const AttraccessUserActionsContext = createContext<AttraccessUserActions>({});
+
+export function AttraccessUserActionsProvider({
+  children,
+  onStartDirectMessage,
+}: Readonly<AttraccessUserActionsProviderProps>) {
+  return (
+    <AttraccessUserActionsContext.Provider value={{ onStartDirectMessage }}>
+      {children}
+    </AttraccessUserActionsContext.Provider>
+  );
+}
+
+export function useAttraccessUserActions() {
+  return useContext(AttraccessUserActionsContext);
+}

--- a/libs/plugins-frontend-ui/src/lib/components/attraccess-user/de.json
+++ b/libs/plugins-frontend-ui/src/lib/components/attraccess-user/de.json
@@ -1,4 +1,6 @@
 {
-  "unknown": "Gelöscht"
+  "unknown": "Gelöscht",
+  "startDirectMessage": "Direktnachricht starten",
+  "emailVerified": "E-Mail bestätigt",
+  "emailUnverified": "E-Mail nicht bestätigt"
 }
-

--- a/libs/plugins-frontend-ui/src/lib/components/attraccess-user/en.json
+++ b/libs/plugins-frontend-ui/src/lib/components/attraccess-user/en.json
@@ -1,4 +1,6 @@
 {
-  "unknown": "Unknown"
+  "unknown": "Unknown",
+  "startDirectMessage": "Start direct message",
+  "emailVerified": "Email verified",
+  "emailUnverified": "Email not verified"
 }
-

--- a/libs/plugins-frontend-ui/src/lib/components/index.ts
+++ b/libs/plugins-frontend-ui/src/lib/components/index.ts
@@ -1,4 +1,5 @@
 export * from './attraccess-user/AttraccessUser';
+export * from './attraccess-user/AttraccessUserActionsContext';
 export * from './datetime-display/DateTimeDisplay';
 export * from './duration-display/DurationDisplay';
 export * from './user-search/UserSearch';


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Makes the shared `AttraccessUser` component a global entry point into direct messaging. On hover/click it now shows a HeroUI v3 popover with user info (avatar, username, id, email-verified status) plus a **Start direct message** action that opens/creates the 1:1 conversation and routes into `/messages`.

## Implementation

- **Lib stays dependency-clean.** `plugins-frontend-ui` gets an optional `onStartDirectMessage?(user)` prop and a new `AttraccessUserActionsProvider` context. The component reads the prop first, falling back to context. No app routes/react-query hooks imported in the lib.
- **Backwards compatible.** When no action is wired (no prop, no context), the component renders exactly as before — all 15 existing call sites are untouched.
- **Deleted/unknown users.** No popover for unknown users; deleted users show info but no DM action.
- **App wiring.** `AttraccessUserActionsBridge` provides the callback app-wide: it calls the user-scoped contact endpoint (`useMessagingServiceMessagingContactUser`) and navigates to `/messages?conversation=<id>`. `MessagesPage` reads the `conversation` query param to preselect the thread.

## Testing

- `nx lint` + `nx typecheck` pass for `plugins-frontend-ui` and `frontend`; full `nx affected` (lint/typecheck/build/test) green via precommit hook.
- Validated against the running app with two seeded users (screenshots on the Linear issue): popover open state, and the resulting DM thread.

## Acceptance criteria

- [x] Popover with user info on hover/click
- [x] Start direct message opens/creates 1:1 and routes to /messages
- [x] Backwards-compatible — existing call sites unchanged
- [x] No DM action for deleted/unknown users
- [x] Lib has no new app route/hook imports (injected via prop/context)
- [x] Validated with screenshots

Linear: https://linear.app/attraccess/issue/ATT-452

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->