### PR TITLE
feat(attractap): upload persisted crash record + coredump on next connect (ATT-474)

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.8"'
+	-D FIRMWARE_VERSION='"1.3.9"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.9"'
+	-D FIRMWARE_VERSION='"1.3.10"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/api/api.cpp
+++ b/apps/attractap/firmware/src/api/api.cpp
@@ -72,8 +72,12 @@ void API::processIncomingMessage(const char *buf, size_t len)
         return;
     }
 
+    // Crash-report responses carry their own error codes (e.g. INVALID_CRASH_REPORT)
+    // that must not surface as a user-facing error dialog; route them to the handler.
+    bool isCrashReportEvent = strcmp(eventType, "READER_CRASH_REPORT") == 0;
+
     // Early error handling: if payload.error is present and non-empty, raise error callback and stop
-    if (inboundDoc["data"]["payload"].is<JsonObject>())
+    if (!isCrashReportEvent && inboundDoc["data"]["payload"].is<JsonObject>())
     {
         JsonObject payload = inboundDoc["data"]["payload"].as<JsonObject>();
         if (payload["error"].is<String>())
@@ -175,6 +179,10 @@ void API::processIncomingMessage(const char *buf, size_t len)
     else if (strcmp(eventType, "PROJECTS_OF_USER") == 0)
     {
         this->onProjectsOfUserResponse(inboundDoc["data"].as<JsonObject>());
+    }
+    else if (strcmp(eventType, "READER_CRASH_REPORT") == 0)
+    {
+        this->onCrashReportResponse(inboundDoc["data"].as<JsonObject>());
     }
     else if (strcmp(eventType, "RESOURCE_USAGE_FORM_REQUEST") == 0)
     {

--- a/apps/attractap/firmware/src/api/api.hpp
+++ b/apps/attractap/firmware/src/api/api.hpp
@@ -305,6 +305,14 @@ private:
     void sendAuthenticationRequest();
     void onReaderAuthenticated(JsonObject data);
     void sendFirmwareInfo();
+
+    // Persisted crash/boot diagnostics upload (ATT-474). On a successful
+    // connect the stored NVS record + (if present) the coredump blob are
+    // pushed to the server; both are cleared once the server confirms receipt.
+    void sendPendingCrashReport();
+    void onCrashReportResponse(JsonObject data);
+    bool crashReportAwaitingAck = false;
+    bool crashReportSentCoredump = false;
     void onResourceList(JsonObject data);
     void onProjectsOfUserResponse(JsonObject data);
     void onCardAuthenticationDetailsResponse(JsonObject data);

--- a/apps/attractap/firmware/src/api/api_auth.cpp
+++ b/apps/attractap/firmware/src/api/api_auth.cpp
@@ -128,6 +128,7 @@ void API::onReaderAuthenticated(JsonObject data)
     logger.info("Reader Authentication successful.");
 
     this->sendFirmwareInfo();
+    this->sendPendingCrashReport();
 }
 
 void API::onDeviceName(std::function<void(String)> callback)

--- a/apps/attractap/firmware/src/api/api_diag.cpp
+++ b/apps/attractap/firmware/src/api/api_diag.cpp
@@ -1,0 +1,253 @@
+// Upload persisted boot/crash record + coredump blob on next successful connect
+// FEATURE: api-diag
+
+#include "api.hpp"
+
+#ifdef ESP_PLATFORM
+#include <Preferences.h>
+#include <memory>
+#include "esp_system.h"
+#include "esp_heap_caps.h"
+#include "esp_partition.h"
+#include "esp_core_dump.h"
+#include "mbedtls/base64.h"
+
+// Must stay byte-compatible with Application::BootDiagnostics_t, persisted by
+// application_bootdiag.cpp. A layout/size mismatch fails the magic/size guard
+// below and simply skips the upload, so it can never crash the reader.
+struct CrashBootRecord
+{
+    uint32_t magic;
+    uint8_t resetReason;
+    uint32_t uptimeMs;
+    uint32_t freeInternalHeap;
+    uint32_t largestFreeBlock;
+    bool websocketConnected;
+    bool wifiConnected;
+};
+
+#define BOOT_DIAG_NAMESPACE "bootdiag"
+#define BOOT_DIAG_PENDING_KEY "pending"
+#define BOOT_DIAG_MAGIC 0x41545431
+
+// Cap the coredump we are willing to base64-encode and hold in RAM at once.
+// Larger dumps stay in flash (readable over USB on the bench) and only the
+// record is uploaded, so we never exhaust the internal heap on a reader.
+#define CRASH_COREDUMP_MAX_BYTES (32 * 1024)
+
+static const char *crashResetReasonToString(uint8_t reason)
+{
+    switch ((esp_reset_reason_t)reason)
+    {
+    case ESP_RST_POWERON:
+        return "POWERON";
+    case ESP_RST_EXT:
+        return "EXT";
+    case ESP_RST_SW:
+        return "SW";
+    case ESP_RST_PANIC:
+        return "PANIC";
+    case ESP_RST_INT_WDT:
+        return "INT_WDT";
+    case ESP_RST_TASK_WDT:
+        return "TASK_WDT";
+    case ESP_RST_WDT:
+        return "WDT";
+    case ESP_RST_DEEPSLEEP:
+        return "DEEPSLEEP";
+    case ESP_RST_BROWNOUT:
+        return "BROWNOUT";
+    case ESP_RST_SDIO:
+        return "SDIO";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+// Read the stored coredump, base64-encode it into a heap buffer, and return it
+// (null when absent, too large, or the heap is too low). b64Len excludes the
+// trailing terminator written by mbedtls.
+static std::unique_ptr<char[]> readCoredumpBase64(Logger &logger, size_t &b64Len)
+{
+    b64Len = 0;
+    size_t addr = 0;
+    size_t size = 0;
+    if (esp_core_dump_image_get(&addr, &size) != ESP_OK || size == 0)
+    {
+        return nullptr;
+    }
+    if (size > CRASH_COREDUMP_MAX_BYTES)
+    {
+        logger.errorf("Coredump too large to upload (%u bytes); kept in flash", (unsigned)size);
+        return nullptr;
+    }
+
+    const esp_partition_t *part = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_COREDUMP, NULL);
+    if (!part)
+    {
+        logger.error("Coredump partition not found");
+        return nullptr;
+    }
+
+    size_t encodedLen = 0;
+    mbedtls_base64_encode(NULL, 0, &encodedLen, NULL, size);
+
+    // The encoded blob is held by both this buffer and the outgoing message
+    // buffer at once, so reserve generous headroom (8-bit heap covers PSRAM
+    // when enabled, which is where these large allocations land).
+    uint32_t freeHeap = (uint32_t)heap_caps_get_free_size(MALLOC_CAP_8BIT);
+    if (freeHeap < size + 3 * encodedLen + 16384)
+    {
+        logger.errorf("Insufficient heap for coredump upload (free=%u need~%u)",
+                      (unsigned)freeHeap, (unsigned)(size + 3 * encodedLen));
+        return nullptr;
+    }
+
+    std::unique_ptr<uint8_t[]> raw(new (std::nothrow) uint8_t[size]);
+    std::unique_ptr<char[]> encoded(new (std::nothrow) char[encodedLen]);
+    if (!raw || !encoded)
+    {
+        logger.error("Coredump buffer allocation failed");
+        return nullptr;
+    }
+    if (esp_partition_read(part, 0, raw.get(), size) != ESP_OK)
+    {
+        logger.error("Coredump partition read failed");
+        return nullptr;
+    }
+
+    size_t written = 0;
+    if (mbedtls_base64_encode((unsigned char *)encoded.get(), encodedLen, &written, raw.get(), size) != 0)
+    {
+        logger.error("Coredump base64 encode failed");
+        return nullptr;
+    }
+    b64Len = written;
+    return encoded;
+}
+
+void API::sendPendingCrashReport()
+{
+    if (this->crashReportAwaitingAck)
+    {
+        return;
+    }
+
+    CrashBootRecord rec = {0};
+    Preferences prefs;
+    prefs.begin(BOOT_DIAG_NAMESPACE, true);
+    size_t read = prefs.getBytes(BOOT_DIAG_PENDING_KEY, &rec, sizeof(rec));
+    prefs.end();
+    if (read != sizeof(rec) || rec.magic != BOOT_DIAG_MAGIC)
+    {
+        return;
+    }
+
+    const char *resetStr = crashResetReasonToString(rec.resetReason);
+
+    size_t b64Len = 0;
+    std::unique_ptr<char[]> coredump = readCoredumpBase64(this->logger, b64Len);
+    this->crashReportSentCoredump = (bool)coredump;
+
+    this->logger.infof("Uploading crash report: reset=%s uptime=%ums heap=%u coredump=%s",
+                       resetStr, rec.uptimeMs, rec.freeInternalHeap, coredump ? "yes" : "no");
+
+    // Build the event manually into a single heap buffer: an oversized coredump
+    // base64 string would otherwise be copied several times through ArduinoJson.
+    const char *ws = rec.websocketConnected ? "CONNECTED" : "DISCONNECTED";
+    const char *wifi = rec.wifiConnected ? "CONNECTED" : "DISCONNECTED";
+
+    char head[320];
+    int headLen = snprintf(
+        head, sizeof(head),
+        "{\"event\":\"EVENT\",\"data\":{\"type\":\"READER_CRASH_REPORT\",\"payload\":{"
+        "\"resetReason\":\"%s\",\"heapFreeBytes\":%u,\"largestFreeBlockBytes\":%u,"
+        "\"uptimeBeforeResetMs\":%u,\"wsState\":\"%s\",\"wifiState\":\"%s\",\"firmwareVersion\":\"%s\"",
+        resetStr, (unsigned)rec.freeInternalHeap, (unsigned)rec.largestFreeBlock,
+        (unsigned)rec.uptimeMs, ws, wifi, FIRMWARE_VERSION);
+    if (headLen <= 0 || headLen >= (int)sizeof(head))
+    {
+        this->logger.error("Failed to format crash report header");
+        return;
+    }
+
+    const char *coredumpKey = ",\"coredumpBase64\":\"";
+    const char *tailWithCoredump = "\"}}}";
+    const char *tailPlain = "}}}";
+
+    size_t total = (size_t)headLen + 1;
+    if (coredump)
+    {
+        total += strlen(coredumpKey) + b64Len + strlen(tailWithCoredump);
+    }
+    else
+    {
+        total += strlen(tailPlain);
+    }
+
+    std::unique_ptr<char[]> buf(new (std::nothrow) char[total]);
+    if (!buf)
+    {
+        this->logger.error("Failed to allocate crash report buffer");
+        return;
+    }
+
+    size_t pos = 0;
+    memcpy(buf.get() + pos, head, headLen);
+    pos += headLen;
+    if (coredump)
+    {
+        memcpy(buf.get() + pos, coredumpKey, strlen(coredumpKey));
+        pos += strlen(coredumpKey);
+        memcpy(buf.get() + pos, coredump.get(), b64Len);
+        pos += b64Len;
+        memcpy(buf.get() + pos, tailWithCoredump, strlen(tailWithCoredump));
+        pos += strlen(tailWithCoredump);
+    }
+    else
+    {
+        memcpy(buf.get() + pos, tailPlain, strlen(tailPlain));
+        pos += strlen(tailPlain);
+    }
+    buf.get()[pos] = '\0';
+
+    this->websocket.sendMessage(buf.get(), pos);
+    this->crashReportAwaitingAck = true;
+}
+
+void API::onCrashReportResponse(JsonObject data)
+{
+    JsonObject payload = data["payload"].as<JsonObject>();
+    bool received = !payload.isNull() && payload["received"].is<bool>() && payload["received"].as<bool>();
+    if (!received)
+    {
+        this->logger.error("Crash report rejected by server; keeping record for next boot");
+        this->crashReportAwaitingAck = false;
+        return;
+    }
+
+    this->logger.info("Crash report accepted; clearing stored record");
+    Preferences prefs;
+    prefs.begin(BOOT_DIAG_NAMESPACE, false);
+    prefs.remove(BOOT_DIAG_PENDING_KEY);
+    prefs.end();
+
+    if (this->crashReportSentCoredump)
+    {
+        esp_err_t err = esp_core_dump_image_erase();
+        if (err != ESP_OK)
+        {
+            this->logger.errorf("esp_core_dump_image_erase failed: %s", esp_err_to_name(err));
+        }
+    }
+
+    this->crashReportAwaitingAck = false;
+}
+
+#else
+
+void API::sendPendingCrashReport() {}
+void API::onCrashReportResponse(JsonObject) {}
+
+#endif

--- a/apps/attractap/firmware/src/api/api_diag.cpp
+++ b/apps/attractap/firmware/src/api/api_diag.cpp
@@ -144,7 +144,10 @@ void API::sendPendingCrashReport()
         return;
     }
 
-    const char *resetStr = crashResetReasonToString(rec.resetReason);
+    // esp_reset_reason() reports what ENDED the previous session (the crash we
+    // are reporting). The stored record's resetReason is what started it, so the
+    // live reset reason is the correct label to pair with the pre-freeze snapshot.
+    const char *resetStr = crashResetReasonToString((uint8_t)esp_reset_reason());
 
     size_t b64Len = 0;
     std::unique_ptr<char[]> coredump = readCoredumpBase64(this->logger, b64Len);

--- a/apps/attractap/firmware/src/application/application_bootdiag.cpp
+++ b/apps/attractap/firmware/src/application/application_bootdiag.cpp
@@ -74,6 +74,13 @@ void Application::setupBootDiagnostics() {
         resetReasonToString(reason), prior.uptimeMs, prior.freeInternalHeap,
         prior.largestFreeBlock, prior.websocketConnected, prior.wifiConnected,
         failureClass);
+
+    // Preserve the prior session's last snapshot as a pending crash report so
+    // the API layer can upload it on the next successful connect (ATT-474).
+    // The live "record" key is overwritten with the current session just below.
+    this->bootDiagPreferences.begin(BOOT_DIAG_NAMESPACE, false);
+    this->bootDiagPreferences.putBytes("pending", &prior, sizeof(prior));
+    this->bootDiagPreferences.end();
   } else {
     this->logger.infof("No prior boot record (reset=%s)",
                        resetReasonToString(reason));

--- a/apps/attractap/firmware/src/serial/serialCommandHandler.cpp
+++ b/apps/attractap/firmware/src/serial/serialCommandHandler.cpp
@@ -195,6 +195,14 @@ void SerialCommandHandler::handleCommand(const String &topic, const String &payl
         payloadObj = payloadDoc.to<JsonObject>(); // empty object
     }
 
+    if (topic == "debug.crash")
+    {
+        logger.error("debug.crash received - forcing panic for crash-report e2e test (ATT-474)");
+        Serial.flush();
+        abort();
+        return;
+    }
+
     if (topic == "auth.status.get")
     {
         DynamicJsonDocument resp(64);


### PR DESCRIPTION
## What

Part A.3 of ATT-471. On a successful reconnect the Attractap reader uploads its stored boot/crash diagnostics to the server and clears them once receipt is confirmed — so the report rides along on the next boot even though the user power-cycled the device.

Closes ATT-474.

## How

- **`application_bootdiag.cpp`** — before the live `record` NVS key is overwritten with the current session, stash the prior session's record into a `pending` key so the dead session's last pre-freeze snapshot survives the reboot.
- **`api_diag.cpp`** (new module) — on `READER_AUTHENTICATED`, read the `pending` NVS record and (if present) the flash coredump, base64-encode it, and send a `READER_CRASH_REPORT` event matching the server's `ReaderCrashReportPayload` (resetReason, heapFreeBytes, largestFreeBlockBytes, uptimeBeforeResetMs, wsState, wifiState, firmwareVersion, coredumpBase64).
- On a `received:true` ack the `pending` record is removed and the coredump image erased (`esp_core_dump_image_erase`). A rejected/failed upload keeps the record for the next boot.
- **`api.cpp`** — dispatch the `READER_CRASH_REPORT` response and exclude it from the user-facing error dialog.
- **`platformio.ini`** — bump `FIRMWARE_VERSION` 1.3.8 → 1.3.9 (OTA).

### Memory safety
The coredump partition is 128 KB but ESP32 RAM is limited, so the blob is **size-capped (32 KB raw)** and **heap-guarded** (8-bit heap, covers PSRAM). Oversized dumps stay in flash (USB-readable on the bench) and only the record uploads. The event JSON is assembled in a single heap buffer to avoid ArduinoJson copying the large base64 string multiple times.

## Dependencies
Builds on ATT-472 (coredump partition + sdkconfig), ATT-473 (NVS boot/crash record), ATT-475 (server receive endpoint) — all merged to `main`. Branch was based on `main` to pick these up.

## Testing
- `pio run -e attractap-touch` → **SUCCESS** (esp32s3 image created; RAM 45.6%, Flash 81.5%).
- Bench end-to-end (per ATT-471 manual test): flash, fault-inject, power-cycle, confirm reader reconnects and uploads with record cleared after ack — to be run on hardware.

<!-- generated-by-cyrus -->