### PR TITLE
fix(ATT-479): danger variant for terminate other-user session button

### DIFF
--- a/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/index.tsx
@@ -205,13 +205,14 @@ export function OtherUserSessionDisplay({ resourceId }: OtherUserSessionDisplayP
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">{t('takeover.available')}</p>
             <ButtonGroup className="w-full">
               <Button
+                variant="danger-soft"
                 isPending={startSession.isPending}
                 onPress={handleImmediateTakeover}
               ><UserX className="w-4 h-4" />
                 {t('takeover.button')}
               </Button>
               <Dropdown>
-                <DropdownTrigger className={buttonVariants({ isIconOnly: true })}>
+                <DropdownTrigger className={buttonVariants({ isIconOnly: true, variant: 'danger-soft' })}>
                   <ChevronDownIcon />
                 </DropdownTrigger>
                 <DropdownPopover>
@@ -234,13 +235,14 @@ export function OtherUserSessionDisplay({ resourceId }: OtherUserSessionDisplayP
             <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">{t('stopOtherUserSession.available')}</p>
             <ButtonGroup className="w-full">
               <Button
+                variant="danger"
                 isPending={startSession.isPending}
                 onPress={handleImmediateStopOtherUserSession}
               ><UserX className="w-4 h-4" />
                 {t('stopOtherUserSession.button')}
               </Button>
               <Dropdown>
-                <DropdownTrigger className={buttonVariants({ isIconOnly: true })}>
+                <DropdownTrigger className={buttonVariants({ isIconOnly: true, variant: 'danger' })}>
                   <ChevronDownIcon />
                 </DropdownTrigger>
                 <DropdownPopover>


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
The "stop other user session" (terminate) button on the resource usage panel used the default **primary** style, making a destructive admin action look like a normal action.

- **Terminate other user's session** → `variant="danger"` (solid red), matching the existing own-session "End session" button.
- **Takeover (adjacent button, same panel)** → `variant="danger-soft"` — also acts on another user's session, but softer since it hands the resource over rather than just terminating.
- Dropdown trigger icons in both `ButtonGroup`s updated to the same variants for visual consistency.

No `warning` variant exists in the HeroUI v3 theme; `danger` / `danger-soft` are the established destructive variants.

## Testing
- `nx typecheck frontend` ✓
- `nx lint frontend` ✓
- Browser-verified: logged in as admin viewing a resource held by another user — terminate button renders solid danger red, takeover renders danger-soft. Screenshot posted to the Linear issue.

Closes [ATT-479](https://linear.app/attraccess/issue/ATT-479/terminate-session-of-other-user-button-color)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
