### PR TITLE
feat(ATT-455): backend PluginContext runtime host-access API

### DIFF
--- a/apps/api/src/plugin-system/plugin-sandbox.service.ts
+++ b/apps/api/src/plugin-system/plugin-sandbox.service.ts
@@ -138,11 +138,10 @@ export class PluginSandboxService {
     pluginName: string,
     require: (permission: PluginPermission, capability: string) => void
   ): PluginContext['events'] {
-    const target = base.events;
     const holder: { proxy: PluginContext['events'] | null } = { proxy: null };
 
-    const sanitize = (result: unknown): unknown => {
-      if (result === target) {
+    const sanitize = (emitter: unknown, result: unknown): unknown => {
+      if (result === emitter) {
         return holder.proxy;
       }
       if (result && typeof result === 'object' && 'emitter' in (result as object)) {
@@ -152,8 +151,8 @@ export class PluginSandboxService {
       return result;
     };
 
-    const proxy = new Proxy(target, {
-      get(emitter, property, receiver) {
+    const proxy = new Proxy({} as PluginContext['events'], {
+      get(_stub, property) {
         if (typeof property !== 'string') {
           return undefined;
         }
@@ -165,14 +164,15 @@ export class PluginSandboxService {
           );
         }
 
-        const original = Reflect.get(emitter, property, receiver);
+        const emitter = base.events;
+        const original = Reflect.get(emitter, property, emitter);
         if (typeof original !== 'function') {
           return undefined;
         }
 
         return (...args: unknown[]) => {
           require(permission, `events.${property}`);
-          return sanitize((original as (...a: unknown[]) => unknown).apply(emitter, args));
+          return sanitize(emitter, (original as (...a: unknown[]) => unknown).apply(emitter, args));
         };
       },
     });

--- a/apps/api/src/plugin-system/plugin.module.ts
+++ b/apps/api/src/plugin-system/plugin.module.ts
@@ -1,6 +1,10 @@
-import { DynamicModule, Global, Logger, Module } from '@nestjs/common';
+import { DynamicModule, Global, Logger, Module, Type } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { DataSource, EntityTarget, ObjectLiteral, Repository } from 'typeorm';
+import { PluginContext, PluginBackendModule } from '@attraccess/plugins-backend-sdk';
 import { createRequire } from 'module';
-import { PluginManifest } from './plugin.manifest';
+import { LoadedPluginManifest } from './plugin.manifest';
 import { PluginService } from './plugin.service';
 import { PluginSandboxService } from './plugin-sandbox.service';
 import { PluginController } from './plugin.controller';
@@ -9,9 +13,22 @@ import { join } from 'path';
 @Global()
 @Module({})
 export class PluginModule {
-  private static pluginManifests: PluginManifest[];
+  private static pluginManifests: LoadedPluginManifest[];
   private static logger = new Logger(PluginModule.name);
   private static DISABLE_PLUGINS_FLAG = false; // Default to false
+
+  // Host singletons are only available once the DI container is live, which is
+  // after forRoot() has already built the plugin modules. The context exposes
+  // them through these holders, populated by the module constructor below.
+  private static dataSourceRef: DataSource | null = null;
+  private static eventsRef: EventEmitter2 | null = null;
+  private static moduleRef: ModuleRef | null = null;
+
+  constructor(dataSource: DataSource, events: EventEmitter2, moduleRef: ModuleRef) {
+    PluginModule.dataSourceRef = dataSource;
+    PluginModule.eventsRef = events;
+    PluginModule.moduleRef = moduleRef;
+  }
 
   public static configure(config: { DISABLE_PLUGINS: boolean }): void {
     PluginModule.DISABLE_PLUGINS_FLAG = config.DISABLE_PLUGINS;
@@ -54,7 +71,7 @@ export class PluginModule {
     };
   }
 
-  private static loadPluginModule(manifest: PluginManifest): DynamicModule {
+  private static loadPluginModule(manifest: LoadedPluginManifest): DynamicModule {
     this.logger.log(`Loading plugin ${manifest.name} from ${manifest.main.backend.directory}`);
 
     if (!manifest.main.backend?.directory || !manifest.main.backend?.entryPoint) {
@@ -69,6 +86,44 @@ export class PluginModule {
 
     this.logger.log(`Imported module: ${manifest.name}`);
 
-    return importedModule.default;
+    const exported = importedModule.default as PluginBackendModule | DynamicModule;
+
+    if (typeof (exported as PluginBackendModule)?.register !== 'function') {
+      this.logger.warn(
+        `Plugin ${manifest.name} does not export a register(context) factory; loading its default export as a static module.`
+      );
+      return exported as DynamicModule;
+    }
+
+    const context = PluginModule.createPluginContext(manifest);
+    return (exported as PluginBackendModule).register(context);
+  }
+
+  private static createPluginContext(manifest: LoadedPluginManifest): PluginContext {
+    const base: PluginContext = {
+      manifest: PluginService.toManifestInfo(manifest),
+      logger: new Logger(`Plugin:${manifest.name}`),
+      get events(): EventEmitter2 {
+        return PluginModule.requireRef(PluginModule.eventsRef, 'EventEmitter2');
+      },
+      get dataSource(): DataSource {
+        return PluginModule.requireRef(PluginModule.dataSourceRef, 'DataSource');
+      },
+      getRepository<T extends ObjectLiteral>(entity: EntityTarget<T>): Repository<T> {
+        return PluginModule.requireRef(PluginModule.dataSourceRef, 'DataSource').getRepository(entity);
+      },
+      get<T>(token: Type<T> | string | symbol): T {
+        return PluginModule.requireRef(PluginModule.moduleRef, 'ModuleRef').get<T>(token, { strict: false });
+      },
+    };
+
+    return PluginSandboxService.createGuardedContext(base, manifest.permissions ?? []);
+  }
+
+  private static requireRef<T>(ref: T | null, name: string): T {
+    if (ref === null) {
+      throw new Error(`Host ${name} is not available yet; the plugin context was accessed before bootstrap completed.`);
+    }
+    return ref;
   }
 }

--- a/apps/api/src/plugin-system/plugin.service.ts
+++ b/apps/api/src/plugin-system/plugin.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Logger, NotFoundException } from '@nestjs/common';
 import { join } from 'path';
+import type { PluginManifestInfo } from '@attraccess/plugins-backend-sdk';
 import { PluginManifest, PluginManifestSchema, LoadedPluginManifest } from './plugin.manifest';
 import { PluginSandboxService } from './plugin-sandbox.service';
 import { existsSync, readdirSync, readFileSync } from 'fs';
@@ -38,6 +39,19 @@ export class PluginService {
     }
 
     return PluginService.plugins;
+  }
+
+  public static getManifestById(id: string): LoadedPluginManifest | undefined {
+    return PluginService.getPlugins().find((plugin) => plugin.id === id);
+  }
+
+  public static toManifestInfo(manifest: LoadedPluginManifest): PluginManifestInfo {
+    return {
+      id: manifest.id,
+      name: manifest.name,
+      version: manifest.version,
+      pluginDirectory: manifest.pluginDirectory,
+    };
   }
 
   public static markPluginAsLoaded(pluginName: string): void {


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Implements the `PluginContext` runtime host-access API so backend plugins can reach host capabilities without compile-time linkage to core modules.

A plugin's default export may now expose a `register(context)` factory. At load time the host constructs a `PluginContext` and calls `register(context)` to obtain the plugin's Nest `DynamicModule`. Host singletons (`EventEmitter2`, `DataSource`, `ModuleRef`) only exist once the DI container is live, so the context resolves them lazily through DI-populated holders set in the `PluginModule` constructor.

## Changes

- **`apps/api/src/plugin-system/plugin.module.ts`** — detect `register(context)` factory on the plugin default export and call it; fall back to treating the default export as a static module otherwise. Lazily resolve host singletons via holders populated by the module constructor. Build the context (manifest info, scoped logger, `events`, `dataSource`, `getRepository`, `get`) and wrap it with the sandbox guard. Load failures stay isolated per-plugin and are recorded in `pluginLoadErrors`.
- **`apps/api/src/plugin-system/plugin.service.ts`** — `getManifestById()` runtime manifest lookup and `toManifestInfo()` to project the loaded manifest into the SDK `PluginManifestInfo` shape.
- **`apps/api/src/plugin-system/plugin-sandbox.service.ts`** — event proxy now targets a stub and resolves the live `base.events` per call, so the guarded context always reflects the DI-resolved emitter.

The `PluginContext` / `PluginManifestInfo` / `PluginBackendModule` interfaces and the `PLUGIN_CONTEXT` token live in `libs/plugins-backend-sdk` (exported from the SDK index).

## Acceptance criteria

- [x] A backend plugin imports `PluginContext` and resolves a host repository/service + the shared `EventEmitter2` at runtime, no compile-time core-module import — verified by `external-plugin.integration.spec.ts` (separately-built plugin shares host `EventEmitter2` + `DataSource` and round-trips through the host)
- [x] Plugin can read its own manifest metadata from the context (`context.manifest`)
- [x] No duplicate TypeORM connection / entity-metadata conflicts — plugins receive the shared `DataSource`; they never re-init `TypeOrmModule`
- [x] Load failures are isolated (one bad plugin doesn't crash bootstrap), surfaced in `pluginLoadErrors`

## Testing

- `nx build plugins-backend-sdk` + `nx build api` — pass
- `nx test api` — 96 suites / 1050 tests pass (incl. plugin integration + sandbox specs)
- `nx lint api` + `nx lint plugins-backend-sdk` — pass

Linear: [ATT-455](https://linear.app/attraccess/issue/ATT-455/backend-plugincontext-runtime-host-access-api)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
