### PR TITLE
test(ATT-460): frontend plugin tests — federation, routes, state, admin UI

### DIFF
--- a/apps/frontend/src/app/plugins/PluginsList.spec.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.spec.tsx
@@ -1,0 +1,191 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PluginsList } from './PluginsList';
+
+interface DeleteOptions {
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+}
+
+const hoisted = vi.hoisted(() => ({
+  deleteMutateMock: vi.fn(),
+  successToast: vi.fn(),
+  errorToast: vi.fn(),
+  showToast: vi.fn(),
+  plugins: [] as unknown[],
+  deleteOptions: undefined as DeleteOptions | undefined,
+}));
+
+vi.mock('@attraccess/react-query-client', () => ({
+  usePluginsServiceGetPlugins: () => ({ data: hoisted.plugins }),
+  usePluginsServiceDeletePlugin: (options: DeleteOptions) => {
+    hoisted.deleteOptions = options;
+    return { mutate: hoisted.deleteMutateMock, isPending: false };
+  },
+  usePluginsServiceUploadPlugin: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../../components/toastProvider', () => ({
+  useToastMessage: () => ({
+    success: hoisted.successToast,
+    error: hoisted.errorToast,
+    showToast: hoisted.showToast,
+  }),
+}));
+
+function makePlugin(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'plugin-1',
+    name: 'Cool Plugin',
+    version: '1.2.3',
+    pluginDirectory: '/plugins/cool',
+    permissions: ['read:resources', 'write:resources'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  hoisted.deleteMutateMock.mockReset();
+  hoisted.successToast.mockReset();
+  hoisted.errorToast.mockReset();
+  hoisted.plugins = [];
+  hoisted.deleteOptions = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PluginsList', () => {
+  it('renders the work-in-progress alert, title, upload button and table headers', () => {
+    render(<PluginsList />);
+
+    expect(screen.getByText('Work in progress')).toBeInTheDocument();
+    expect(screen.getByText('Installed Plugins')).toBeInTheDocument();
+    expect(screen.getByText('Upload Plugin')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Directory')).toBeInTheDocument();
+    expect(screen.getByText('Permissions')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no plugins are installed', () => {
+    render(<PluginsList />);
+    expect(screen.getByText('No entries found')).toBeInTheDocument();
+  });
+
+  it('renders a row per plugin with name, version, directory and permission chips', () => {
+    hoisted.plugins = [makePlugin()];
+    render(<PluginsList />);
+
+    expect(screen.getByText('Cool Plugin')).toBeInTheDocument();
+    expect(screen.getByText('1.2.3')).toBeInTheDocument();
+    expect(screen.getByText('/plugins/cool')).toBeInTheDocument();
+    expect(screen.getByText('read:resources')).toBeInTheDocument();
+    expect(screen.getByText('write:resources')).toBeInTheDocument();
+  });
+
+  it('falls back to a dash for a missing directory and "None requested" for no permissions', () => {
+    hoisted.plugins = [makePlugin({ pluginDirectory: '', permissions: [] })];
+    render(<PluginsList />);
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.getByText('None requested')).toBeInTheDocument();
+  });
+
+  it('opens the upload drawer when the upload button is pressed', async () => {
+    const user = userEvent.setup();
+    render(<PluginsList />);
+
+    expect(document.querySelector('[data-cy="upload-plugin-modal"]')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('Upload Plugin'));
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-cy="upload-plugin-modal"]')).toBeInTheDocument()
+    );
+  });
+
+  it('opens the delete confirmation modal when a delete button is pressed', async () => {
+    hoisted.plugins = [makePlugin()];
+    const user = userEvent.setup();
+    render(<PluginsList />);
+
+    await user.click(
+      document.querySelector('[data-cy="plugins-list-delete-plugin-button-plugin-1"]') as Element
+    );
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-cy="plugins-list-delete-confirmation-delete-button"]')
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('calls deletePlugin with the plugin id when deletion is confirmed', async () => {
+    hoisted.plugins = [makePlugin()];
+    const user = userEvent.setup();
+    render(<PluginsList />);
+
+    await user.click(
+      document.querySelector('[data-cy="plugins-list-delete-plugin-button-plugin-1"]') as Element
+    );
+    const confirm = await waitFor(() =>
+      document.querySelector('[data-cy="plugins-list-delete-confirmation-delete-button"]')
+    );
+    await user.click(confirm as Element);
+
+    expect(hoisted.deleteMutateMock).toHaveBeenCalledWith({ pluginId: 'plugin-1' });
+  });
+
+  it('shows a success toast after a successful delete', () => {
+    vi.useFakeTimers();
+    hoisted.plugins = [makePlugin()];
+    render(<PluginsList />);
+
+    hoisted.deleteOptions?.onSuccess?.();
+
+    expect(hoisted.successToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Success' })
+    );
+    vi.useRealTimers();
+  });
+
+  it('shows an error toast when the delete fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    hoisted.plugins = [makePlugin()];
+    render(<PluginsList />);
+
+    hoisted.deleteOptions?.onError?.(new Error('boom'));
+
+    expect(hoisted.errorToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Error' }));
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('cancels the delete without calling the mutation', async () => {
+    hoisted.plugins = [makePlugin()];
+    const user = userEvent.setup();
+    render(<PluginsList />);
+
+    await user.click(
+      document.querySelector('[data-cy="plugins-list-delete-plugin-button-plugin-1"]') as Element
+    );
+    const cancel = await waitFor(() =>
+      document.querySelector('[data-cy="plugins-list-delete-confirmation-cancel-button"]')
+    );
+    await user.click(cancel as Element);
+
+    expect(hoisted.deleteMutateMock).not.toHaveBeenCalled();
+  });
+
+  it('renders permission chips scoped to the plugin row', () => {
+    hoisted.plugins = [makePlugin({ id: 'p-perms', permissions: ['admin'] })];
+    render(<PluginsList />);
+
+    const container = document.querySelector('[data-cy="plugins-list-permissions-p-perms"]') as HTMLElement;
+    expect(container).toBeInTheDocument();
+    expect(within(container).getByText('admin')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/plugins/UploadPluginModal.spec.tsx
+++ b/apps/frontend/src/app/plugins/UploadPluginModal.spec.tsx
@@ -1,0 +1,150 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UploadPluginModal } from './UploadPluginModal';
+
+interface UploadOptions {
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
+}
+
+const hoisted = vi.hoisted(() => ({
+  uploadMutateMock: vi.fn(),
+  successToast: vi.fn(),
+  errorToast: vi.fn(),
+  showToast: vi.fn(),
+  uploadOptions: undefined as UploadOptions | undefined,
+}));
+
+vi.mock('@attraccess/react-query-client', () => ({
+  usePluginsServiceUploadPlugin: (options: UploadOptions) => {
+    hoisted.uploadOptions = options;
+    return { mutate: hoisted.uploadMutateMock, isPending: false };
+  },
+}));
+
+vi.mock('../../components/toastProvider', () => ({
+  useToastMessage: () => ({
+    success: hoisted.successToast,
+    error: hoisted.errorToast,
+    showToast: hoisted.showToast,
+  }),
+}));
+
+const fileInput = () =>
+  document.querySelector('[data-cy="upload-plugin-modal-file-input"]') as HTMLInputElement;
+const uploadButton = () =>
+  document.querySelector('[data-cy="upload-plugin-modal-upload-button"]') as HTMLButtonElement;
+const cancelButton = () =>
+  document.querySelector('[data-cy="upload-plugin-modal-cancel-button"]') as HTMLButtonElement;
+
+beforeEach(() => {
+  hoisted.uploadMutateMock.mockReset();
+  hoisted.successToast.mockReset();
+  hoisted.errorToast.mockReset();
+  hoisted.uploadOptions = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('UploadPluginModal', () => {
+  it('renders nothing while closed', () => {
+    render(<UploadPluginModal isOpen={false} onClose={vi.fn()} />);
+    expect(document.querySelector('[data-cy="upload-plugin-modal"]')).not.toBeInTheDocument();
+  });
+
+  it('renders the title, description, file input and action buttons when open', () => {
+    render(<UploadPluginModal isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText('Upload Plugin')).toBeInTheDocument();
+    expect(screen.getByText(/Upload a plugin as a ZIP file/)).toBeInTheDocument();
+    expect(fileInput()).toBeInTheDocument();
+    expect(uploadButton()).toBeInTheDocument();
+    expect(cancelButton()).toBeInTheDocument();
+  });
+
+  it('disables the upload button until a file is selected', () => {
+    render(<UploadPluginModal isOpen onClose={vi.fn()} />);
+    expect(uploadButton()).toBeDisabled();
+  });
+
+  it('enables upload and shows the file name after selecting a .zip file', async () => {
+    const user = userEvent.setup();
+    render(<UploadPluginModal isOpen onClose={vi.fn()} />);
+
+    const file = new File(['content'], 'my-plugin.zip', { type: 'application/zip' });
+    await user.upload(fileInput(), file);
+
+    expect(screen.getByText('my-plugin.zip')).toBeInTheDocument();
+    expect(uploadButton()).not.toBeDisabled();
+  });
+
+  it('marks a non-zip file invalid, shows an error and keeps upload disabled', async () => {
+    render(<UploadPluginModal isOpen onClose={vi.fn()} />);
+
+    const file = new File(['content'], 'not-a-plugin.txt', { type: 'text/plain' });
+    fireEvent.change(fileInput(), { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText('not-a-plugin.txt')).toBeInTheDocument());
+    expect(uploadButton()).toBeDisabled();
+  });
+
+  it('calls uploadPlugin with the selected file when upload is pressed', async () => {
+    const user = userEvent.setup();
+    render(<UploadPluginModal isOpen onClose={vi.fn()} />);
+
+    const file = new File(['content'], 'my-plugin.zip', { type: 'application/zip' });
+    await user.upload(fileInput(), file);
+    await user.click(uploadButton());
+
+    expect(hoisted.uploadMutateMock).toHaveBeenCalledWith({
+      formData: { pluginZip: file },
+    });
+  });
+
+  it('does not upload an invalid file even if upload is triggered', async () => {
+    const user = userEvent.setup();
+    render(<UploadPluginModal isOpen onClose={vi.fn()} />);
+
+    const file = new File(['content'], 'bad.txt', { type: 'text/plain' });
+    await user.upload(fileInput(), file, { applyAccept: false });
+    await user.click(uploadButton());
+
+    expect(hoisted.uploadMutateMock).not.toHaveBeenCalled();
+  });
+
+  it('shows a success toast and closes after a successful upload', () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    render(<UploadPluginModal isOpen onClose={onClose} />);
+
+    hoisted.uploadOptions?.onSuccess?.();
+
+    expect(onClose).toHaveBeenCalled();
+    expect(hoisted.successToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Success' }));
+    vi.useRealTimers();
+  });
+
+  it('shows an error toast when the upload fails', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    render(<UploadPluginModal isOpen onClose={vi.fn()} />);
+
+    hoisted.uploadOptions?.onError?.(new Error('boom'));
+
+    expect(hoisted.errorToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Error' }));
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('invokes onClose when cancel is pressed', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<UploadPluginModal isOpen onClose={onClose} />);
+
+    await user.click(cancelButton());
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/plugins/plugin-provider.spec.tsx
+++ b/apps/frontend/src/app/plugins/plugin-provider.spec.tsx
@@ -1,0 +1,212 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AttraccessFrontendPlugin } from '@attraccess/plugins-frontend-sdk';
+import { PluginProvider } from './plugin-provider';
+import usePluginState from './plugin.state';
+
+const hoisted = vi.hoisted(() => ({
+  setRemoteMock: vi.fn(),
+  getRemoteMock: vi.fn(),
+  refetchMock: vi.fn(),
+  getBaseUrlMock: vi.fn(() => 'http://test.local'),
+  user: { id: 1, username: 'admin' } as Record<string, unknown> | null,
+}));
+
+vi.mock('virtual:__federation__', () => ({
+  __federation_method_setRemote: hoisted.setRemoteMock,
+  __federation_method_getRemote: hoisted.getRemoteMock,
+}));
+
+vi.mock('@attraccess/react-query-client', () => ({
+  usePluginsServiceGetPlugins: () => ({ refetch: hoisted.refetchMock }),
+}));
+
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({ user: hoisted.user }),
+}));
+
+vi.mock('../../api', () => ({
+  getBaseUrl: hoisted.getBaseUrlMock,
+}));
+
+vi.mock('../../components/toastProvider', () => ({
+  useToastMessage: () => ({ showToast: vi.fn(), success: vi.fn(), error: vi.fn() }),
+}));
+
+let pluginCounter = 0;
+
+function createFakePlugin(name: string, routes: unknown[] = []): AttraccessFrontendPlugin {
+  return {
+    getPluginName: () => name,
+    getDependencies: () => [],
+    init: vi.fn(),
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+    onApiAuthStateChange: vi.fn(),
+    onApiEndpointChange: vi.fn(),
+    getRoutes: () => routes,
+  } as unknown as AttraccessFrontendPlugin;
+}
+
+interface ManifestOptions {
+  name?: string;
+  entryPoint?: string | undefined;
+  routes?: unknown[];
+}
+
+function primeManifest(options: ManifestOptions = {}) {
+  const name = options.name ?? `Plugin${++pluginCounter}`;
+  const manifest = {
+    name,
+    version: '1.0.0',
+    main: { frontend: 'entryPoint' in options ? { entryPoint: options.entryPoint } : { entryPoint: 'index.js' } },
+  };
+  hoisted.refetchMock.mockResolvedValue({ data: [manifest] });
+  hoisted.getRemoteMock.mockResolvedValue({ default: function () {
+    return createFakePlugin(name, options.routes ?? []);
+  } });
+  return { name, manifest };
+}
+
+beforeEach(() => {
+  usePluginState.setState({ plugins: [] });
+  hoisted.setRemoteMock.mockReset();
+  hoisted.getRemoteMock.mockReset();
+  hoisted.refetchMock.mockReset();
+  hoisted.getBaseUrlMock.mockReturnValue('http://test.local');
+  hoisted.user = { id: 1, username: 'admin' };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PluginProvider', () => {
+  it('renders its children', async () => {
+    hoisted.refetchMock.mockResolvedValue({ data: [] });
+    render(
+      <PluginProvider>
+        <div>app-shell</div>
+      </PluginProvider>
+    );
+    expect(screen.getByText('app-shell')).toBeInTheDocument();
+  });
+
+  it('sets up the module-federation remote and loads the plugin into the store', async () => {
+    const { name } = primeManifest();
+
+    render(
+      <PluginProvider>
+        <div>app-shell</div>
+      </PluginProvider>
+    );
+
+    await waitFor(() => expect(usePluginState.getState().plugins).toHaveLength(1));
+
+    expect(hoisted.setRemoteMock).toHaveBeenCalledWith(
+      name,
+      expect.objectContaining({ format: 'esm', from: 'vite' })
+    );
+    expect(hoisted.getRemoteMock).toHaveBeenCalledWith(name, './plugin');
+
+    const remoteConfig = hoisted.setRemoteMock.mock.calls.at(-1)?.[1] as { url: () => Promise<string> };
+    await expect(remoteConfig.url()).resolves.toBe(
+      `http://test.local/api/plugins/${name}/frontend/module-federation/index.js`
+    );
+  });
+
+  it('unwraps the default export when the remote returns one', async () => {
+    primeManifest();
+    render(<PluginProvider />);
+    await waitFor(() => expect(usePluginState.getState().plugins).toHaveLength(1));
+    expect(usePluginState.getState().plugins[0].plugin.getPluginName()).toMatch(/^Plugin/);
+  });
+
+  it('skips plugins without a frontend entry point', async () => {
+    primeManifest({ entryPoint: undefined });
+
+    render(<PluginProvider />);
+
+    await waitFor(() => expect(hoisted.refetchMock).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(hoisted.setRemoteMock).not.toHaveBeenCalled();
+    expect(usePluginState.getState().plugins).toHaveLength(0);
+  });
+
+  it('notifies loaded plugins of the API endpoint and auth state', async () => {
+    primeManifest();
+
+    render(<PluginProvider />);
+
+    await waitFor(() => expect(usePluginState.getState().plugins).toHaveLength(1));
+
+    const instance = usePluginState.getState().plugins[0].plugin;
+    await waitFor(() => expect(instance.onApiEndpointChange).toHaveBeenCalledWith('http://test.local'));
+    expect(instance.onApiAuthStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ authToken: '', user: hoisted.user })
+    );
+  });
+
+  it('isolates a failing remote load without crashing the app shell', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    hoisted.refetchMock.mockResolvedValue({
+      data: [{ name: 'BrokenPlugin', version: '1.0.0', main: { frontend: { entryPoint: 'index.js' } } }],
+    });
+    hoisted.getRemoteMock.mockRejectedValue(new Error('federation boom'));
+
+    render(
+      <PluginProvider>
+        <div>app-shell</div>
+      </PluginProvider>
+    );
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(usePluginState.getState().plugins).toHaveLength(0);
+    expect(screen.getByText('app-shell')).toBeInTheDocument();
+  });
+
+  it('injects plugin routes that render and are navigable', async () => {
+    primeManifest({
+      routes: [
+        {
+          path: '/plugin-a',
+          authRequired: false,
+          element: (
+            <div>
+              Plugin Page A
+              <Link to="/plugin-b">Go to B</Link>
+            </div>
+          ),
+        },
+        { path: '/plugin-b', authRequired: false, element: <div>Plugin Page B</div> },
+      ],
+    });
+
+    render(<PluginProvider />);
+    await waitFor(() => expect(usePluginState.getState().plugins).toHaveLength(1));
+
+    const routes = usePluginState
+      .getState()
+      .plugins.flatMap((p) => p.plugin.getRoutes?.() ?? []) as Array<{ path: string; element: React.ReactNode }>;
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={['/plugin-a']}>
+        <Routes>
+          {routes.map((route) => (
+            <Route key={route.path} path={route.path} element={route.element} />
+          ))}
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Plugin Page A')).toBeInTheDocument();
+    await user.click(screen.getByRole('link', { name: 'Go to B' }));
+    expect(screen.getByText('Plugin Page B')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/plugins/plugin.state.spec.ts
+++ b/apps/frontend/src/app/plugins/plugin.state.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AttraccessFrontendPlugin } from '@attraccess/plugins-frontend-sdk';
+import type { LoadedPluginManifest } from '@attraccess/react-query-client';
+import usePluginState, { PluginManifestWithPlugin } from './plugin.state';
+
+function createPlugin(name: string): AttraccessFrontendPlugin {
+  return {
+    getPluginName: () => name,
+    getDependencies: () => [],
+    init: vi.fn(),
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+    onApiAuthStateChange: vi.fn(),
+    onApiEndpointChange: vi.fn(),
+  } as unknown as AttraccessFrontendPlugin;
+}
+
+function createManifest(name: string): PluginManifestWithPlugin {
+  return {
+    name,
+    version: '1.0.0',
+    plugin: createPlugin(name),
+  } as unknown as LoadedPluginManifest & { plugin: AttraccessFrontendPlugin };
+}
+
+describe('usePluginState', () => {
+  beforeEach(() => {
+    usePluginState.setState({ plugins: [] });
+  });
+
+  it('starts with an empty plugin list', () => {
+    expect(usePluginState.getState().plugins).toEqual([]);
+  });
+
+  it('appends plugins via addPlugin without dropping existing ones', () => {
+    const first = createManifest('first');
+    const second = createManifest('second');
+
+    usePluginState.getState().addPlugin(first);
+    usePluginState.getState().addPlugin(second);
+
+    const { plugins } = usePluginState.getState();
+    expect(plugins).toHaveLength(2);
+    expect(plugins.map((p) => p.plugin.getPluginName())).toEqual(['first', 'second']);
+  });
+
+  it('reports isInstalled true only for plugins already added', () => {
+    expect(usePluginState.getState().isInstalled('alpha')).toBe(false);
+
+    usePluginState.getState().addPlugin(createManifest('alpha'));
+
+    expect(usePluginState.getState().isInstalled('alpha')).toBe(true);
+    expect(usePluginState.getState().isInstalled('beta')).toBe(false);
+  });
+
+  it('matches isInstalled on the plugin name, not the manifest name', () => {
+    const manifest = createManifest('manifest-name');
+    (manifest.plugin.getPluginName as ReturnType<typeof vi.fn>) = vi.fn(() => 'runtime-name');
+
+    usePluginState.getState().addPlugin(manifest);
+
+    expect(usePluginState.getState().isInstalled('runtime-name')).toBe(true);
+    expect(usePluginState.getState().isInstalled('manifest-name')).toBe(false);
+  });
+});

--- a/apps/frontend/src/test-utils/federation-stub.ts
+++ b/apps/frontend/src/test-utils/federation-stub.ts
@@ -1,0 +1,7 @@
+import { vi } from 'vitest';
+
+export const __federation_method_setRemote = vi.fn();
+export const __federation_method_getRemote = vi.fn();
+export const __federation_method_unwrapDefault = vi.fn();
+export const __federation_method_ensure = vi.fn();
+export const __federation_method_wrapDefault = vi.fn();

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -12,6 +12,11 @@ export const reactCompilerBabelConfig: TransformOptions = {
 
 export default defineConfig({
   plugins: [react({ babel: reactCompilerBabelConfig }), nxViteTsPaths()],
+  resolve: {
+    alias: {
+      'virtual:__federation__': path.join(__dirname, 'src/test-utils/federation-stub.ts'),
+    },
+  },
   test: {
     root: __dirname,
     globals: true,


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds the first test coverage for `apps/frontend/src/app/plugins/` (previously **zero** tests). Four suites, 32 tests:

- **`plugin-provider.spec.tsx`** — module-federation remote setup, plugin install into the pluggable store, default-export unwrap, skip-when-no-frontend-entry, `onApiEndpointChange`/`onApiAuthStateChange` callbacks, error isolation (failing remote does not crash the app shell), and route injection (plugin route renders + is navigable).
- **`plugin.state.spec.ts`** — Zustand store: append semantics, `isInstalled` keyed on runtime plugin name.
- **`PluginsList.spec.tsx`** — table render, empty state, permission/directory fallbacks, upload-drawer open, delete-confirmation flow, success/error toasts, cancel path.
- **`UploadPluginModal.spec.tsx`** — open/closed render, file selection, `.zip` validation gating, upload mutation payload, success/error toasts, cancel.

### Test harness changes

- `vitest.config.ts` — alias `virtual:__federation__` to a test stub so the provider module resolves under Vitest (the federation virtual module only exists during `vite serve`/`build`).
- `src/test-utils/federation-stub.ts` — no-op stub exporting the `__federation_method_*` functions; specs override via `vi.mock`.

## Coverage (`app/plugins/`)

| Metric | % |
|---|---|
| Lines | **95.3%** |
| Statements | 92.9% |
| Functions | 88.1% |
| Branches | 67.5% |

Exceeds the ≥70% lines target. Full frontend suite green: **195/195**.

## Acceptance criteria

- [x] Suites pass; plugins load with federation mocked
- [x] Route injection verified (plugin route renders + navigable)
- [x] `onApiAuthStateChange` / `onApiEndpointChange` tested
- [x] Admin upload/delete flows covered
- [x] ≥70% lines (95.3%)

> Note: test-only change, no browser-visible behavior — no screenshots. CHANGELOG is release-generated (PR-linked, no `[Unreleased]` section), so no manual entry.

Closes [ATT-460](https://linear.app/attraccess/issue/ATT-460/frontend-plugin-tests-federation-load-route-injection-state-admin-ui)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->
