### PR TITLE
test(ATT-459): backend plugin-system tests — unit, integration, e2e

### DIFF
--- a/apps/api/src/plugin-system/__test__/make-zip.ts
+++ b/apps/api/src/plugin-system/__test__/make-zip.ts
@@ -1,0 +1,89 @@
+import { crc32 } from 'zlib';
+
+export type ZipFiles = Record<string, string | Buffer>;
+
+interface ZipEntry {
+  name: string;
+  data: Buffer;
+}
+
+export function makeZip(files: ZipFiles): Buffer {
+  const entries: ZipEntry[] = Object.entries(files).map(([name, content]) => ({
+    name,
+    data: Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8'),
+  }));
+
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBuf = Buffer.from(entry.name, 'utf8');
+    const crc = crc32(entry.data) >>> 0;
+    const size = entry.data.length;
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0, 6);
+    localHeader.writeUInt16LE(0, 8);
+    localHeader.writeUInt16LE(0, 10);
+    localHeader.writeUInt16LE(0, 12);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(size, 18);
+    localHeader.writeUInt32LE(size, 22);
+    localHeader.writeUInt16LE(nameBuf.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+    locals.push(localHeader, nameBuf, entry.data);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(0, 8);
+    centralHeader.writeUInt16LE(0, 10);
+    centralHeader.writeUInt16LE(0, 12);
+    centralHeader.writeUInt16LE(0, 14);
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(size, 20);
+    centralHeader.writeUInt32LE(size, 24);
+    centralHeader.writeUInt16LE(nameBuf.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+    centrals.push(centralHeader, nameBuf);
+
+    offset += localHeader.length + nameBuf.length + entry.data.length;
+  }
+
+  const localBuf = Buffer.concat(locals);
+  const centralBuf = Buffer.concat(centrals);
+
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralBuf.length, 12);
+  end.writeUInt32LE(localBuf.length, 16);
+  end.writeUInt16LE(0, 20);
+
+  return Buffer.concat([localBuf, centralBuf, end]);
+}
+
+export function zipFileUpload(files: ZipFiles, overrides: Record<string, unknown> = {}) {
+  const buffer = makeZip(files);
+  return {
+    fieldname: 'pluginZip',
+    originalname: 'plugin.zip',
+    encoding: '7bit',
+    mimetype: 'application/zip',
+    buffer,
+    size: buffer.length,
+    ...overrides,
+  } as never;
+}

--- a/apps/api/src/plugin-system/plugin-events.service.spec.ts
+++ b/apps/api/src/plugin-system/plugin-events.service.spec.ts
@@ -1,0 +1,103 @@
+import { Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Resource, User } from '@attraccess/database-entities';
+import {
+  PluginContext,
+  PluginPermission,
+  SystemEvent,
+  SystemEventPayload,
+} from '@attraccess/plugins-backend-sdk';
+import { PluginSandboxService } from './plugin-sandbox.service';
+
+function baseContext(events: EventEmitter2, name: string): PluginContext {
+  return {
+    manifest: { id: name, name, version: '1.0.0', pluginDirectory: name },
+    events,
+    dataSource: {} as never,
+    logger: new Logger(name),
+    getRepository: (() => ({})) as never,
+    get: (() => ({})) as never,
+  };
+}
+
+function guarded(events: EventEmitter2, name: string, permissions: PluginPermission[]): PluginContext {
+  return PluginSandboxService.createGuardedContext(baseContext(events, name), permissions);
+}
+
+const BOTH = [PluginPermission.EMIT_EVENTS, PluginPermission.LISTEN_EVENTS];
+
+describe('Plugin event bus (typed emit/subscribe through the guarded context)', () => {
+  let events: EventEmitter2;
+
+  beforeEach(() => {
+    events = new EventEmitter2();
+  });
+
+  it('delivers a host-emitted system event to a subscribed plugin with its payload intact', () => {
+    const plugin = guarded(events, 'listener-plugin', [PluginPermission.LISTEN_EVENTS]);
+    const received: SystemEventPayload[SystemEvent.RESOURCE_USAGE_STARTED][] = [];
+    plugin.events.on(SystemEvent.RESOURCE_USAGE_STARTED, (payload) => received.push(payload));
+
+    const payload = { resource: { id: 7 } as Resource, user: { id: 3 } as User };
+    events.emit(SystemEvent.RESOURCE_USAGE_STARTED, payload);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe(payload);
+  });
+
+  it('round-trips an event emitted by one plugin to another plugin on the shared bus', () => {
+    const emitter = guarded(events, 'emitter-plugin', [PluginPermission.EMIT_EVENTS]);
+    const subscriber = guarded(events, 'subscriber-plugin', [PluginPermission.LISTEN_EVENTS]);
+
+    const spy = jest.fn();
+    subscriber.events.on('plugin.custom.event', spy);
+    emitter.events.emit('plugin.custom.event', { value: 42 });
+
+    expect(spy).toHaveBeenCalledWith({ value: 42 });
+  });
+
+  it('collects listener responses through emitAsync', async () => {
+    events.on('ask', () => 'answer-a');
+    events.on('ask', () => 'answer-b');
+    const plugin = guarded(events, 'asker', [PluginPermission.EMIT_EVENTS]);
+
+    await expect(plugin.events.emitAsync('ask')).resolves.toEqual(['answer-a', 'answer-b']);
+  });
+
+  it('fires a once subscription exactly one time', () => {
+    const plugin = guarded(events, 'once-plugin', BOTH);
+    const spy = jest.fn();
+    plugin.events.once('ping', spy);
+
+    plugin.events.emit('ping');
+    plugin.events.emit('ping');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves waitFor with the emitted arguments', async () => {
+    const plugin = guarded(events, 'waiter', BOTH);
+    const pending = plugin.events.waitFor('later');
+    plugin.events.emit('later', 'payload');
+    await expect(pending).resolves.toEqual(['payload']);
+  });
+
+  it('denies emitting without EMIT_EVENTS and subscribing without LISTEN_EVENTS', () => {
+    const listenOnly = guarded(events, 'listen-only', [PluginPermission.LISTEN_EVENTS]);
+    expect(() => listenOnly.events.emit('x')).toThrow(/EMIT_EVENTS/);
+
+    const emitOnly = guarded(events, 'emit-only', [PluginPermission.EMIT_EVENTS]);
+    expect(() => emitOnly.events.on('x', () => undefined)).toThrow(/LISTEN_EVENTS/);
+  });
+
+  it('removes a listener through off so later emits are not delivered', () => {
+    const plugin = guarded(events, 'off-plugin', BOTH);
+    const spy = jest.fn();
+    plugin.events.on('toggle', spy);
+    plugin.events.emit('toggle');
+    plugin.events.off('toggle', spy);
+    plugin.events.emit('toggle');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/plugin-system/plugin.controller.spec.ts
+++ b/apps/api/src/plugin-system/plugin.controller.spec.ts
@@ -1,0 +1,77 @@
+import { NotFoundException, StreamableFile } from '@nestjs/common';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PluginController } from './plugin.controller';
+import { PluginService } from './plugin.service';
+import { LoadedPluginManifest } from './plugin.manifest';
+import { FileUpload } from '../common/types/file-upload.types';
+
+function frontendPlugin(name: string): LoadedPluginManifest {
+  return {
+    id: name,
+    name,
+    version: '1.0.0',
+    pluginDirectory: name,
+    permissions: [],
+    main: { frontend: { directory: join(name, 'frontend'), entryPoint: 'index.mjs' } },
+    attraccessVersion: { min: '1.0.0' },
+  } as LoadedPluginManifest;
+}
+
+describe('PluginController', () => {
+  let root: string;
+  let service: { uploadPlugin: jest.Mock; deletePlugin: jest.Mock };
+  let controller: PluginController;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'plugin-controller-'));
+    PluginService.configure({ PLUGIN_DIR: root, RESTART_BY_EXIT: true });
+    service = { uploadPlugin: jest.fn(), deletePlugin: jest.fn() };
+    controller = new PluginController(service as unknown as PluginService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns every discovered plugin', () => {
+    const plugins = [frontendPlugin('a'), frontendPlugin('b')];
+    jest.spyOn(PluginService, 'getPlugins').mockReturnValue(plugins);
+    expect(controller.getAllPlugins()).toBe(plugins);
+  });
+
+  describe('getFrontendPluginFile', () => {
+    it('streams an existing frontend file', () => {
+      const plugin = frontendPlugin('streamed');
+      jest.spyOn(PluginService, 'getPlugins').mockReturnValue([plugin]);
+      mkdirSync(join(root, 'streamed', 'frontend'), { recursive: true });
+      writeFileSync(join(root, 'streamed', 'frontend', 'index.js'), 'console.log(1)');
+
+      expect(controller.getFrontendPluginFile('streamed', 'index.js')).toBeInstanceOf(StreamableFile);
+    });
+
+    it('throws when the plugin is unknown', () => {
+      jest.spyOn(PluginService, 'getPlugins').mockReturnValue([]);
+      expect(() => controller.getFrontendPluginFile('ghost', 'index.js')).toThrow(NotFoundException);
+    });
+
+    it('throws when the requested file is missing', () => {
+      jest.spyOn(PluginService, 'getPlugins').mockReturnValue([frontendPlugin('present')]);
+      expect(() => controller.getFrontendPluginFile('present', 'missing.js')).toThrow(NotFoundException);
+    });
+  });
+
+  it('delegates upload to the plugin service', async () => {
+    const file = { originalname: 'plugin.zip' } as FileUpload;
+    service.uploadPlugin.mockResolvedValue({ name: 'uploaded' });
+    await expect(controller.uploadPlugin(file, {})).resolves.toEqual({ name: 'uploaded' });
+    expect(service.uploadPlugin).toHaveBeenCalledWith(file);
+  });
+
+  it('delegates delete to the plugin service', () => {
+    controller.deletePlugin('plugin-id');
+    expect(service.deletePlugin).toHaveBeenCalledWith('plugin-id');
+  });
+});

--- a/apps/api/src/plugin-system/plugin.e2e.spec.ts
+++ b/apps/api/src/plugin-system/plugin.e2e.spec.ts
@@ -1,0 +1,214 @@
+import 'reflect-metadata';
+import { Global, INestApplication, Module } from '@nestjs/common';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { Test } from '@nestjs/testing';
+import { Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  PluginContext,
+  PluginPermission,
+  PluginPermissionError,
+} from '@attraccess/plugins-backend-sdk';
+import { build } from 'esbuild';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import request from 'supertest';
+import { PluginService } from './plugin.service';
+import { PluginModule } from './plugin.module';
+import { LoadedPluginManifest } from './plugin.manifest';
+import { zipFileUpload } from './__test__/make-zip';
+
+let hostDataSource: DataSource;
+
+@Global()
+@Module({
+  providers: [
+    { provide: DataSource, useFactory: () => hostDataSource },
+    { provide: 'POC_HOST_GREETER', useValue: { greet: () => 'hello from host' } },
+  ],
+  exports: [DataSource, 'POC_HOST_GREETER'],
+})
+class HostModule {}
+
+@Entity()
+class PocNote {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  message!: string;
+}
+
+interface PocPongPayload {
+  eventsInstanceMatch: boolean;
+  dataSourceInstanceMatch: boolean;
+  savedId: number;
+  savedMessage: string;
+  hostGreeting: string;
+}
+
+const PING_EVENT = 'poc.host.ping';
+const PONG_EVENT = 'poc.plugin.pong';
+const PLUGIN_NAME = 'poc-backend-plugin';
+const ALL_PERMISSIONS = [
+  PluginPermission.LISTEN_EVENTS,
+  PluginPermission.EMIT_EVENTS,
+  PluginPermission.DATABASE_ACCESS,
+  PluginPermission.RESOLVE_HOST_PROVIDERS,
+];
+
+function findRepoRoot(start: string): string {
+  let dir = start;
+  while (dir !== dirname(dir)) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml'))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error('repo root (pnpm-workspace.yaml) not found');
+}
+
+const REPO_ROOT = findRepoRoot(__dirname);
+const PLUGIN_ENTRY = resolve(REPO_ROOT, 'examples/poc-backend-plugin/src/index.ts');
+const CACHE_DIR = join(REPO_ROOT, 'node_modules', '.cache', 'att-459-plugin-e2e');
+const PLUGIN_PATH = join(CACHE_DIR, 'plugins');
+const ARTIFACT = join(CACHE_DIR, 'index.js');
+
+const SHARED = [
+  '@nestjs/common',
+  '@nestjs/core',
+  '@nestjs/event-emitter',
+  'eventemitter2',
+  'typeorm',
+  'reflect-metadata',
+  '@attraccess/plugins-backend-sdk',
+];
+
+const PLUGIN_JSON = {
+  name: PLUGIN_NAME,
+  version: '1.0.0',
+  main: {
+    frontend: { directory: 'frontend', entryPoint: 'index.mjs' },
+    backend: { directory: 'dist', entryPoint: 'index.js' },
+  },
+  attraccessVersion: { min: '1.0.0' },
+  permissions: ALL_PERMISSIONS,
+};
+
+describe('Plugin system end-to-end (upload, load, endpoints, event round-trip, permission denial)', () => {
+  let app: INestApplication;
+  let events: EventEmitter2;
+  let dataSource: DataSource;
+  let restartSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    rmSync(CACHE_DIR, { recursive: true, force: true });
+    mkdirSync(PLUGIN_PATH, { recursive: true });
+    await build({
+      entryPoints: [PLUGIN_ENTRY],
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: 'es2021',
+      outfile: ARTIFACT,
+      external: SHARED,
+      tsconfigRaw: { compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true } },
+      logLevel: 'silent',
+    });
+
+    restartSpy = jest
+      .spyOn(PluginService.prototype as unknown as { restartApp: () => void }, 'restartApp')
+      .mockImplementation(() => undefined);
+    const realSetTimeout = global.setTimeout;
+    jest.spyOn(global, 'setTimeout').mockImplementation(((fn: (...a: unknown[]) => void, delay?: number, ...rest: unknown[]) => {
+      if (delay === 1000) return 0 as unknown as NodeJS.Timeout;
+      return realSetTimeout(fn, delay as number, ...rest);
+    }) as unknown as typeof setTimeout);
+
+    PluginService.configure({ PLUGIN_DIR: PLUGIN_PATH, RESTART_BY_EXIT: true });
+
+    const zip = zipFileUpload({
+      'plugin.json': JSON.stringify(PLUGIN_JSON),
+      'dist/index.js': readFileSync(ARTIFACT),
+      'frontend/index.mjs': 'export default {};',
+    });
+    await new PluginService().uploadPlugin(zip);
+
+    PluginService.configure({ PLUGIN_DIR: PLUGIN_PATH, RESTART_BY_EXIT: true });
+    PluginModule.configure({ DISABLE_PLUGINS: false });
+
+    dataSource = new DataSource({ type: 'sqlite', database: ':memory:', synchronize: true, entities: [PocNote] });
+    await dataSource.initialize();
+    hostDataSource = dataSource;
+    events = new EventEmitter2();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [EventEmitterModule.forRoot(), HostModule, PluginModule.forRoot()],
+    })
+      .overrideProvider(EventEmitter2)
+      .useValue(events)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  }, 120000);
+
+  afterAll(async () => {
+    if (app) await app.close();
+    if (dataSource?.isInitialized) await dataSource.destroy();
+    jest.restoreAllMocks();
+    rmSync(CACHE_DIR, { recursive: true, force: true });
+  });
+
+  it('discovers the uploaded fixture plugin on disk', () => {
+    const plugin = PluginService.getManifestById(PluginService.getPlugins()[0].id);
+    expect(plugin?.name).toBe(PLUGIN_NAME);
+    expect(existsSync(join(PLUGIN_PATH, PLUGIN_NAME, 'dist', 'index.js'))).toBe(true);
+  });
+
+  it('serves the loaded plugin through the GET /plugins endpoint', async () => {
+    const response = await request(app.getHttpServer()).get('/plugins');
+    expect(response.status).toBe(200);
+    const names = (response.body as LoadedPluginManifest[]).map((p) => p.name);
+    expect(names).toContain(PLUGIN_NAME);
+    const loaded = (response.body as LoadedPluginManifest[]).find((p) => p.name === PLUGIN_NAME);
+    expect(loaded?.permissions).toEqual(expect.arrayContaining(ALL_PERMISSIONS));
+  });
+
+  it('round-trips an event through the loaded plugin and the shared host bus', async () => {
+    const pong = new Promise<PocPongPayload>((res) => events.once(PONG_EVENT, res));
+    events.emit(PING_EVENT, 'hello');
+    const payload = await pong;
+
+    expect(payload.dataSourceInstanceMatch).toBe(true);
+    expect(payload.savedId).toBeGreaterThan(0);
+    expect(payload.savedMessage).toBe(`${PLUGIN_NAME}:hello`);
+    expect(payload.hostGreeting).toBe('hello from host');
+  });
+
+  it('enforces a permission denial when the manifest omits a capability', () => {
+    const manifest = {
+      id: 'denied',
+      name: PLUGIN_NAME,
+      version: '1.0.0',
+      pluginDirectory: PLUGIN_NAME,
+      permissions: [PluginPermission.LISTEN_EVENTS],
+      main: PLUGIN_JSON.main,
+      attraccessVersion: { min: '1.0.0' },
+    } as unknown as LoadedPluginManifest;
+
+    const ctx = (
+      PluginModule as unknown as { createPluginContext(m: LoadedPluginManifest): PluginContext }
+    ).createPluginContext(manifest);
+
+    expect(() => ctx.dataSource).toThrow(PluginPermissionError);
+    expect(() => ctx.dataSource).toThrow(/DATABASE_ACCESS/);
+  });
+
+  it('deletes the plugin and removes it from disk', async () => {
+    const plugin = PluginService.getPlugins().find((p) => p.name === PLUGIN_NAME);
+    expect(plugin).toBeDefined();
+
+    await new PluginService().deletePlugin((plugin as LoadedPluginManifest).id);
+
+    expect(existsSync(join(PLUGIN_PATH, PLUGIN_NAME))).toBe(false);
+    expect(restartSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/apps/api/src/plugin-system/plugin.module.spec.ts
+++ b/apps/api/src/plugin-system/plugin.module.spec.ts
@@ -1,0 +1,130 @@
+import 'reflect-metadata';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ModuleRef } from '@nestjs/core';
+import { DataSource } from 'typeorm';
+import { PluginPermission, PluginPermissionError } from '@attraccess/plugins-backend-sdk';
+import { PluginModule } from './plugin.module';
+import { PluginService } from './plugin.service';
+import { PluginSandboxService } from './plugin-sandbox.service';
+import { PluginController } from './plugin.controller';
+import { LoadedPluginManifest } from './plugin.manifest';
+
+function newPluginDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plugin-module-'));
+  PluginService.configure({ PLUGIN_DIR: dir, RESTART_BY_EXIT: true });
+  return dir;
+}
+
+function manifest(overrides: Partial<LoadedPluginManifest> = {}): LoadedPluginManifest {
+  return {
+    id: 'plugin-id',
+    name: 'ctx-plugin',
+    version: '1.0.0',
+    pluginDirectory: 'ctx-plugin',
+    permissions: [],
+    main: { backend: { directory: 'ctx-plugin/dist', entryPoint: 'index.js' } },
+    attraccessVersion: { min: '1.0.0' },
+    ...overrides,
+  } as LoadedPluginManifest;
+}
+
+describe('PluginModule', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = newPluginDir();
+    PluginModule.configure({ DISABLE_PLUGINS: false });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  describe('forRoot', () => {
+    it('exposes only the host providers and controller when plugins are disabled', () => {
+      PluginModule.configure({ DISABLE_PLUGINS: true });
+      const module = PluginModule.forRoot();
+      expect(module.providers).toEqual([PluginService, PluginSandboxService]);
+      expect(module.controllers).toEqual([PluginController]);
+      expect(module.imports).toBeUndefined();
+    });
+
+    it('builds an empty import list when no plugins are present', () => {
+      const module = PluginModule.forRoot();
+      expect(module.imports).toEqual([]);
+      expect(module.controllers).toEqual([PluginController]);
+    });
+
+    it('isolates a failing plugin load without crashing the module', () => {
+      mkdirSync(join(root, 'broken'), { recursive: true });
+      writeFileSync(
+        join(root, 'broken', 'plugin.json'),
+        JSON.stringify({
+          name: 'broken',
+          version: '1.0.0',
+          main: { backend: { directory: 'dist', entryPoint: 'missing.js' } },
+          attraccessVersion: { min: '1.0.0' },
+        })
+      );
+
+      const discovered = PluginService.getPlugins();
+      expect(discovered).toHaveLength(1);
+
+      const module = PluginModule.forRoot();
+      expect(module.imports).toEqual([]);
+      expect(PluginService.getManifestById(discovered[0].id)).toBeDefined();
+    });
+  });
+
+  describe('createPluginContext', () => {
+    const events = new EventEmitter2();
+    const dataSource = { kind: 'host-datasource' } as unknown as DataSource;
+    const moduleRef = { get: jest.fn((token: unknown) => ({ token })) } as unknown as ModuleRef;
+
+    function build(permissions: PluginPermission[]) {
+      new PluginModule(dataSource, events, moduleRef);
+      return (
+        PluginModule as unknown as { createPluginContext(m: LoadedPluginManifest): import('@attraccess/plugins-backend-sdk').PluginContext }
+      ).createPluginContext(manifest({ permissions }));
+    }
+
+    it('projects the manifest down to public info', () => {
+      const ctx = build([]);
+      expect(ctx.manifest).toEqual({ id: 'plugin-id', name: 'ctx-plugin', version: '1.0.0', pluginDirectory: 'ctx-plugin' });
+    });
+
+    it('hands back the live host DataSource when DATABASE_ACCESS is granted', () => {
+      expect(build([PluginPermission.DATABASE_ACCESS]).dataSource).toBe(dataSource);
+      expect(() => build([]).dataSource).toThrow(PluginPermissionError);
+    });
+
+    it('resolves host providers through the ModuleRef when permitted', () => {
+      const ctx = build([PluginPermission.RESOLVE_HOST_PROVIDERS]);
+      ctx.get('SOME_TOKEN');
+      expect(moduleRef.get).toHaveBeenCalledWith('SOME_TOKEN', { strict: false });
+      expect(() => build([]).get('SOME_TOKEN')).toThrow(/RESOLVE_HOST_PROVIDERS/);
+    });
+
+    it('gates the shared event bus behind EMIT/LISTEN permissions', () => {
+      expect(() => build([PluginPermission.EMIT_EVENTS]).events.emit('x')).not.toThrow();
+      expect(() => build([]).events.emit('x')).toThrow(/EMIT_EVENTS/);
+    });
+  });
+
+  describe('requireRef', () => {
+    const requireRef = (PluginModule as unknown as { requireRef<T>(ref: T | null, name: string): T }).requireRef;
+
+    it('throws a bootstrap-ordering error when a host singleton is missing', () => {
+      expect(() => requireRef(null, 'EventEmitter2')).toThrow(/accessed before bootstrap completed/);
+    });
+
+    it('returns the reference when it is available', () => {
+      const ref = {};
+      expect(requireRef(ref, 'DataSource')).toBe(ref);
+    });
+  });
+});

--- a/apps/api/src/plugin-system/plugin.service.spec.ts
+++ b/apps/api/src/plugin-system/plugin.service.spec.ts
@@ -1,0 +1,231 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PluginPermission } from '@attraccess/plugins-backend-sdk';
+import { zipFileUpload } from './__test__/make-zip';
+
+const mockSpawn = jest.fn(() => ({ unref: jest.fn() }));
+jest.mock('child_process', () => ({ spawn: mockSpawn }));
+
+import { PluginService } from './plugin.service';
+
+const VALID_MANIFEST = {
+  name: 'uploaded-plugin',
+  version: '1.2.3',
+  main: {
+    frontend: { directory: 'frontend', entryPoint: 'index.mjs' },
+    backend: { directory: 'dist', entryPoint: 'index.js' },
+  },
+  attraccessVersion: { min: '1.0.0' },
+  permissions: [PluginPermission.EMIT_EVENTS],
+};
+
+function newPluginDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'plugin-service-'));
+  PluginService.configure({ PLUGIN_DIR: dir, RESTART_BY_EXIT: true });
+  return dir;
+}
+
+function writePlugin(root: string, folder: string, manifest: unknown): void {
+  const dir = join(root, folder);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'plugin.json'), JSON.stringify(manifest));
+}
+
+describe('PluginService', () => {
+  let root: string;
+  let exitSpy: jest.SpyInstance;
+  let restartSpy: jest.SpyInstance;
+  let capturedRestart: (() => void) | null;
+
+  function flushScheduledRestart(): void {
+    expect(capturedRestart).not.toBeNull();
+    (capturedRestart as () => void)();
+  }
+
+  beforeEach(() => {
+    mockSpawn.mockClear();
+    capturedRestart = null;
+    root = newPluginDir();
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((((() => {
+      throw new Error('process.exit');
+    }) as unknown) as never));
+    restartSpy = jest
+      .spyOn(PluginService.prototype as unknown as { restartApp: () => void }, 'restartApp')
+      .mockImplementation(() => undefined);
+    const realSetTimeout = global.setTimeout;
+    jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation(((fn: (...a: unknown[]) => void, delay?: number, ...args: unknown[]) => {
+        if (delay === 1000) {
+          capturedRestart = () => fn();
+          return 0 as unknown as NodeJS.Timeout;
+        }
+        return realSetTimeout(fn, delay as number, ...args);
+      }) as unknown as typeof setTimeout);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  describe('discovery', () => {
+    it('returns an empty array when the plugin folder does not exist', () => {
+      PluginService.configure({ PLUGIN_DIR: join(root, 'does-not-exist'), RESTART_BY_EXIT: true });
+      expect(PluginService.getPlugins()).toEqual([]);
+    });
+
+    it('discovers a manifest and assigns an id and prefixed backend directory', () => {
+      writePlugin(root, 'my-plugin', {
+        name: 'my-plugin',
+        version: '1.0.0',
+        main: { backend: { directory: 'dist', entryPoint: 'index.js' } },
+        attraccessVersion: { min: '1.0.0' },
+      });
+
+      const plugins = PluginService.getPlugins();
+      expect(plugins).toHaveLength(1);
+      expect(plugins[0].name).toBe('my-plugin');
+      expect(plugins[0].pluginDirectory).toBe('my-plugin');
+      expect(plugins[0].id).toEqual(expect.any(String));
+      expect(plugins[0].main.backend.directory).toBe(join('my-plugin', 'dist'));
+    });
+
+    it('caches discovery between calls and re-scans after configure', () => {
+      writePlugin(root, 'plugin-a', {
+        name: 'plugin-a',
+        version: '1.0.0',
+        main: { backend: { directory: 'dist', entryPoint: 'index.js' } },
+        attraccessVersion: { min: '1.0.0' },
+      });
+
+      const first = PluginService.getPlugins();
+      expect(PluginService.getPlugins()).toBe(first);
+
+      PluginService.configure({ PLUGIN_DIR: root, RESTART_BY_EXIT: true });
+      expect(PluginService.getPlugins()).not.toBe(first);
+    });
+
+    it('skips folders without a manifest', () => {
+      mkdirSync(join(root, 'not-a-plugin'), { recursive: true });
+      expect(PluginService.getPlugins()).toEqual([]);
+    });
+
+    it('excludes a plugin whose declared permissions are invalid', () => {
+      writePlugin(root, 'bad-perms', {
+        name: 'bad-perms',
+        version: '1.0.0',
+        main: { backend: { directory: 'dist', entryPoint: 'index.js' } },
+        attraccessVersion: { min: '1.0.0' },
+        permissions: ['NOT_A_REAL_PERMISSION'],
+      });
+
+      expect(PluginService.getPlugins()).toEqual([]);
+    });
+  });
+
+  describe('getManifestById / toManifestInfo', () => {
+    it('finds a discovered plugin by id and returns undefined for unknown ids', () => {
+      writePlugin(root, 'find-me', {
+        name: 'find-me',
+        version: '1.0.0',
+        main: { backend: { directory: 'dist', entryPoint: 'index.js' } },
+        attraccessVersion: { min: '1.0.0' },
+      });
+
+      const [plugin] = PluginService.getPlugins();
+      expect(PluginService.getManifestById(plugin.id)).toBe(plugin);
+      expect(PluginService.getManifestById('missing')).toBeUndefined();
+    });
+
+    it('projects a manifest down to its public info shape', () => {
+      const info = PluginService.toManifestInfo({
+        id: 'abc',
+        name: 'n',
+        version: '2.0.0',
+        pluginDirectory: 'dir',
+        permissions: [],
+      } as never);
+      expect(info).toEqual({ id: 'abc', name: 'n', version: '2.0.0', pluginDirectory: 'dir' });
+    });
+  });
+
+  describe('uploadPlugin', () => {
+    it('rejects a non-zip upload', async () => {
+      const service = new PluginService();
+      const file = zipFileUpload({ 'plugin.json': '{}' }, { mimetype: 'text/plain' });
+      await expect(service.uploadPlugin(file)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('unpacks a valid plugin, moves it into place and schedules a restart', async () => {
+      const service = new PluginService();
+      const file = zipFileUpload({ 'plugin.json': JSON.stringify(VALID_MANIFEST) });
+
+      const manifest = await service.uploadPlugin(file);
+
+      expect(manifest.name).toBe('uploaded-plugin');
+      expect(existsSync(join(root, 'uploaded-plugin', 'plugin.json'))).toBe(true);
+      expect(restartSpy).not.toHaveBeenCalled();
+      flushScheduledRestart();
+      expect(restartSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a manifest that fails schema validation', async () => {
+      const service = new PluginService();
+      const file = zipFileUpload({ 'plugin.json': JSON.stringify({ name: 'x' }) });
+      await expect(service.uploadPlugin(file)).rejects.toBeDefined();
+    });
+
+    it('rejects when a plugin with the same name already exists', async () => {
+      const service = new PluginService();
+      await service.uploadPlugin(zipFileUpload({ 'plugin.json': JSON.stringify(VALID_MANIFEST) }));
+
+      const again = zipFileUpload({ 'plugin.json': JSON.stringify(VALID_MANIFEST) });
+      await expect(service.uploadPlugin(again)).rejects.toThrow(/already exists/);
+    });
+  });
+
+  describe('deletePlugin', () => {
+    it('throws when the plugin id is unknown', async () => {
+      const service = new PluginService();
+      await expect(service.deletePlugin('nope')).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('removes the plugin folder and schedules a restart', async () => {
+      writePlugin(root, 'delete-me', {
+        name: 'delete-me',
+        version: '1.0.0',
+        main: { backend: { directory: 'dist', entryPoint: 'index.js' } },
+        attraccessVersion: { min: '1.0.0' },
+      });
+      const [plugin] = PluginService.getPlugins();
+      const service = new PluginService();
+
+      await service.deletePlugin(plugin.id);
+
+      expect(existsSync(join(root, 'delete-me'))).toBe(false);
+      flushScheduledRestart();
+      expect(restartSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('restartApp', () => {
+    it('restarts by exiting when RESTART_BY_EXIT is set', () => {
+      restartSpy.mockRestore();
+      PluginService.configure({ PLUGIN_DIR: root, RESTART_BY_EXIT: true });
+      expect(() => (new PluginService() as unknown as { restartApp: () => void }).restartApp()).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalled();
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('respawns a detached process when RESTART_BY_EXIT is not set', () => {
+      restartSpy.mockRestore();
+      PluginService.configure({ PLUGIN_DIR: root, RESTART_BY_EXIT: false });
+      expect(() => (new PluginService() as unknown as { restartApp: () => void }).restartApp()).toThrow('process.exit');
+      expect(mockSpawn).toHaveBeenCalledWith(process.argv[0], process.argv.slice(1), expect.objectContaining({ detached: true }));
+      expect(exitSpy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds the previously-missing test coverage for `apps/api/src/plugin-system/` (the plugin system had **zero** tests).

### New specs
- **`plugin.service.spec.ts`** — manifest discovery (cache + re-scan, invalid-permission exclusion, missing folder), `getManifestById`/`toManifestInfo`, ZIP upload (non-zip reject, schema-invalid reject, duplicate reject, happy path), delete (not-found + success), and restart logic (`process.exit` vs detached `spawn`).
- **`plugin.module.spec.ts`** — `forRoot` enabled/disabled, **load-error isolation** (one broken plugin does not crash the module), `createPluginContext` injection + permission gating, and the bootstrap-ordering `requireRef` guard.
- **`plugin-events.service.spec.ts`** — typed emit/subscribe round-trip on the shared bus, `emitAsync`/`once`/`waitFor`/`off`, and EMIT/LISTEN permission denials.
- **`plugin.controller.spec.ts`** — list, frontend-file streaming (found / unknown plugin / missing file), upload + delete delegation.
- **`plugin.e2e.spec.ts`** — builds the `examples/poc-backend-plugin` fixture with esbuild, **uploads it as a ZIP**, loads it through `PluginModule.forRoot()`, serves it via `GET /plugins`, **round-trips an event** host↔plugin, **enforces a permission denial**, and deletes it.
- **`__test__/make-zip.ts`** — dependency-free STORED-zip builder (no zip lib is hoisted in the workspace), used to mint fixture ZIPs.

### Acceptance criteria
- [x] Unit + integration + e2e suites pass in CI (`nx test api`: 100 suites / 1087 tests; `nx e2e api`: 8 tests)
- [x] Covers load success, load-failure isolation, context injection, event round-trip, permission grant + denial, upload/delete
- [x] A fixture/example plugin is loadable in the test env (the PoC backend plugin)
- [x] Meaningful coverage of `plugin-system/` — **~90% lines** (target ≥80%)

## Testing
- `nx run-many -t test e2e -p api` → all green
- `nx lint api` → green
- Coverage (`--collectCoverageFrom='src/plugin-system/**'`): All files 90.1% lines / 89.8% stmts.

Closes [ATT-459](https://linear.app/attraccess/issue/ATT-459/backend-plugin-tests-unit-integration-e2e)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
