### PR TITLE
feat(ATT-445): messaging presence detection

### DIFF
--- a/apps/api/src/messaging/dtos/conversationListItem.dto.ts
+++ b/apps/api/src/messaging/dtos/conversationListItem.dto.ts
@@ -16,6 +16,12 @@ export class ConversationListItemDto {
   otherParticipant!: User | null;
 
   @ApiProperty({
+    description: 'Whether the other participant currently has an open live messaging stream',
+    example: true,
+  })
+  otherParticipantOnline!: boolean;
+
+  @ApiProperty({
     description: 'The most recent message in the conversation',
     type: () => Message,
     nullable: true,

--- a/apps/api/src/messaging/messaging-live.service.spec.ts
+++ b/apps/api/src/messaging/messaging-live.service.spec.ts
@@ -28,6 +28,20 @@ describe('MessagingLiveService', () => {
     expect(first).toBe(second);
   });
 
+  it('reports a user online while a tracked stream is subscribed and offline after teardown', () => {
+    expect(service.isOnline(1)).toBe(false);
+
+    const subscription = service.trackPresence(1, service.getUserMessageSubject(1).asObservable()).subscribe();
+    expect(service.isOnline(1)).toBe(true);
+
+    const second = service.trackPresence(1, service.getUserMessageSubject(1).asObservable()).subscribe();
+    subscription.unsubscribe();
+    expect(service.isOnline(1)).toBe(true);
+
+    second.unsubscribe();
+    expect(service.isOnline(1)).toBe(false);
+  });
+
   it('pushes the new message to every recipient except the sender', async () => {
     participantRepository.find.mockResolvedValue([
       { userId: 5 } as ConversationParticipant,

--- a/apps/api/src/messaging/messaging-live.service.ts
+++ b/apps/api/src/messaging/messaging-live.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { Repository } from 'typeorm';
 import { ConversationParticipant, Message } from '@attraccess/database-entities';
 import { MessageCreatedEvent } from './events/message-created.event';
@@ -9,6 +9,7 @@ import { MessageCreatedEvent } from './events/message-created.event';
 @Injectable()
 export class MessagingLiveService {
   private readonly messageSubjects: Map<number, Subject<{ data: Message }>> = new Map();
+  private readonly connectionCounts: Map<number, number> = new Map();
 
   public constructor(
     @InjectRepository(ConversationParticipant)
@@ -20,6 +21,39 @@ export class MessagingLiveService {
       this.messageSubjects.set(userId, new Subject<{ data: Message }>());
     }
     return this.messageSubjects.get(userId);
+  }
+
+  // Presence is derived from live SSE subscriptions, not Session.lastAccessedAt.
+  // lastAccessedAt is an @UpdateDateColumn that is unreliable for JWT/SPA clients:
+  // a stateless JWT is validated without touching the Session row, so the column
+  // can stay stale for an active user or fresh for one who already closed the tab.
+  // An open /messaging/live stream is the only signal that the user is truly connected.
+  public trackPresence<T>(userId: number, source: Observable<T>): Observable<T> {
+    return new Observable<T>((subscriber) => {
+      this.addConnection(userId);
+      const sub = source.subscribe(subscriber);
+      return () => {
+        sub.unsubscribe();
+        this.removeConnection(userId);
+      };
+    });
+  }
+
+  public isOnline(userId: number): boolean {
+    return (this.connectionCounts.get(userId) ?? 0) > 0;
+  }
+
+  private addConnection(userId: number): void {
+    this.connectionCounts.set(userId, (this.connectionCounts.get(userId) ?? 0) + 1);
+  }
+
+  private removeConnection(userId: number): void {
+    const next = (this.connectionCounts.get(userId) ?? 0) - 1;
+    if (next > 0) {
+      this.connectionCounts.set(userId, next);
+    } else {
+      this.connectionCounts.delete(userId);
+    }
   }
 
   @OnEvent(MessageCreatedEvent.EVENT_NAME)

--- a/apps/api/src/messaging/messaging.controller.ts
+++ b/apps/api/src/messaging/messaging.controller.ts
@@ -41,7 +41,7 @@ export class MessagingController {
   @ApiOperation({ summary: 'Subscribe to live new messages for the authenticated user', operationId: 'messagingLive' })
   streamMessages(@Req() req: AuthenticatedRequest): Observable<{ data: Message }> {
     const subject = this.messagingLiveService.getUserMessageSubject(req.user.id);
-    return this.sse.wrap('messaging', subject.asObservable());
+    return this.messagingLiveService.trackPresence(req.user.id, this.sse.wrap('messaging', subject.asObservable()));
   }
 
   @Post('users/:userId/contact')

--- a/apps/api/src/messaging/messaging.service.spec.ts
+++ b/apps/api/src/messaging/messaging.service.spec.ts
@@ -13,6 +13,7 @@ import {
   User,
 } from '@attraccess/database-entities';
 import { MessagingService } from './messaging.service';
+import { MessagingLiveService } from './messaging-live.service';
 import { MessageCreatedEvent } from './events/message-created.event';
 import { ResourceUsageService } from '../resources/usage/resourceUsage.service';
 
@@ -33,6 +34,7 @@ describe('MessagingService', () => {
   let dataSource: { transaction: jest.Mock };
   let resourceUsageService: { getActiveSession: jest.Mock };
   let eventEmitter: { emit: jest.Mock };
+  let messagingLiveService: { isOnline: jest.Mock };
 
   const pairQuery = {
     select: jest.fn().mockReturnThis(),
@@ -72,6 +74,7 @@ describe('MessagingService', () => {
     dataSource = { transaction: jest.fn() };
     resourceUsageService = { getActiveSession: jest.fn() };
     eventEmitter = { emit: jest.fn() };
+    messagingLiveService = { isOnline: jest.fn().mockReturnValue(false) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -85,6 +88,7 @@ describe('MessagingService', () => {
         { provide: DataSource, useValue: dataSource },
         { provide: ResourceUsageService, useValue: resourceUsageService },
         { provide: EventEmitter2, useValue: eventEmitter },
+        { provide: MessagingLiveService, useValue: messagingLiveService },
       ],
     }).compile();
 
@@ -217,6 +221,21 @@ describe('MessagingService', () => {
       const result = await service.listConversations(7);
 
       expect(result[0].unreadCount).toBe(4);
+    });
+
+    it('reflects the other participant online state from MessagingLiveService', async () => {
+      participantRepository.find.mockResolvedValue([
+        { conversationId: 1, lastReadAt: null, conversation: { updatedAt: new Date(1000) } },
+      ]);
+      messageRepository.findOne.mockResolvedValue({ id: 5, createdAt: new Date(2000) } as Message);
+      pairQuery.getOne = jest.fn().mockResolvedValue({ user: { id: 2 } });
+      messageRepository.count.mockResolvedValue(0);
+      messagingLiveService.isOnline.mockReturnValue(true);
+
+      const result = await service.listConversations(7);
+
+      expect(result[0].otherParticipantOnline).toBe(true);
+      expect(messagingLiveService.isOnline).toHaveBeenCalledWith(2);
     });
   });
 

--- a/apps/api/src/messaging/messaging.service.ts
+++ b/apps/api/src/messaging/messaging.service.ts
@@ -14,6 +14,7 @@ import {
 import { ResourceUsageService } from '../resources/usage/resourceUsage.service';
 import { MessageCreatedEvent } from './events/message-created.event';
 import { ConversationListItemDto } from './dtos/conversationListItem.dto';
+import { MessagingLiveService } from './messaging-live.service';
 import { NotificationPreferenceDto } from './dtos/notificationPreference.dto';
 import { UpdateNotificationPreferenceDto } from './dtos/updateNotificationPreference.dto';
 
@@ -40,6 +41,7 @@ export class MessagingService {
     private readonly dataSource: DataSource,
     private readonly resourceUsageService: ResourceUsageService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly messagingLiveService: MessagingLiveService,
   ) {}
 
   public async getOrCreateConversation(currentUserId: number, targetUserId: number): Promise<Conversation> {
@@ -148,9 +150,12 @@ export class MessagingService {
           order: { createdAt: 'DESC' },
         });
 
+        const otherParticipant = await this.resolveOtherParticipant(participation.conversationId, userId);
+
         return {
           id: participation.conversationId,
-          otherParticipant: await this.resolveOtherParticipant(participation.conversationId, userId),
+          otherParticipant,
+          otherParticipantOnline: otherParticipant ? this.messagingLiveService.isOnline(otherParticipant.id) : false,
           lastMessage,
           updatedAt: participation.conversation.updatedAt,
           unreadCount: await this.countUnread(participation.conversationId, userId, participation.lastReadAt),

--- a/apps/frontend/src/app/messaging/ConversationList.tsx
+++ b/apps/frontend/src/app/messaging/ConversationList.tsx
@@ -52,8 +52,17 @@ export function ConversationList(props: Props) {
               selectedConversationId === conversation.id && 'bg-zinc-100 dark:bg-zinc-800',
             )}
           >
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-zinc-200 text-small font-medium uppercase text-zinc-600 dark:bg-zinc-700 dark:text-zinc-200">
-              {username.charAt(0)}
+            <div className="relative shrink-0">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-zinc-200 text-small font-medium uppercase text-zinc-600 dark:bg-zinc-700 dark:text-zinc-200">
+                {username.charAt(0)}
+              </div>
+              {conversation.otherParticipantOnline && (
+                <span
+                  data-cy={`conversation-online-${conversation.id}`}
+                  className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-white bg-green-500 dark:border-zinc-900"
+                  aria-label={t('conversations.online')}
+                />
+              )}
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex items-center justify-between gap-2">

--- a/apps/frontend/src/app/messaging/de.json
+++ b/apps/frontend/src/app/messaging/de.json
@@ -5,7 +5,8 @@
     "title": "Posteingang",
     "empty": "Du hast noch keine Unterhaltungen.",
     "unknownUser": "Unbekannter Nutzer",
-    "noMessages": "Noch keine Nachrichten"
+    "noMessages": "Noch keine Nachrichten",
+    "online": "Online"
   },
   "thread": {
     "selectPrompt": "Wähle eine Unterhaltung, um Nachrichten anzuzeigen.",

--- a/apps/frontend/src/app/messaging/en.json
+++ b/apps/frontend/src/app/messaging/en.json
@@ -5,7 +5,8 @@
     "title": "Inbox",
     "empty": "You have no conversations yet.",
     "unknownUser": "Unknown user",
-    "noMessages": "No messages yet"
+    "noMessages": "No messages yet",
+    "online": "Online"
   },
   "thread": {
     "selectPrompt": "Select a conversation to view messages.",

--- a/libs/react-query-client/src/lib/requests/schemas.gen.ts
+++ b/libs/react-query-client/src/lib/requests/schemas.gen.ts
@@ -6815,6 +6815,11 @@ export const $ConversationListItemDto = {
                 }
             ]
         },
+        otherParticipantOnline: {
+            type: 'boolean',
+            description: 'Whether the other participant currently has an open live messaging stream',
+            example: true
+        },
         lastMessage: {
             description: 'The most recent message in the conversation',
             nullable: true,
@@ -6837,7 +6842,7 @@ export const $ConversationListItemDto = {
             example: 3
         }
     },
-    required: ['id', 'otherParticipant', 'lastMessage', 'updatedAt', 'unreadCount']
+    required: ['id', 'otherParticipant', 'otherParticipantOnline', 'lastMessage', 'updatedAt', 'unreadCount']
 } as const;
 
 export const $UnreadCountResponseDto = {

--- a/libs/react-query-client/src/lib/requests/types.gen.ts
+++ b/libs/react-query-client/src/lib/requests/types.gen.ts
@@ -4316,6 +4316,10 @@ export type ConversationListItemDto = {
      */
     otherParticipant: (User) | null;
     /**
+     * Whether the other participant currently has an open live messaging stream
+     */
+    otherParticipantOnline: boolean;
+    /**
      * The most recent message in the conversation
      */
     lastMessage: (Message) | null;


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds **presence detection** to messaging, completing ATT-445. Per-conversation unread tracking + badges were shipped independently in **ATT-482 (#1174)**; this PR builds on that and adds the missing presence half rather than duplicating it.

Presence is derived from active `/messaging/live` SSE subscriptions, **not** `Session.lastAccessedAt` — that column is an `@UpdateDateColumn` and is unreliable for stateless JWT/SPA clients (a JWT is validated without touching the Session row, so it can stay stale for an active user or fresh for one who already left). An open live stream is the only reliable "connected" signal. Rationale is documented in code.

## Changes

**Backend**
- `MessagingLiveService`: per-user connection-count map; `trackPresence()` increments on SSE subscribe and decrements on teardown; `isOnline(userId)`.
- `/messaging/live` controller wraps its stream with `trackPresence`.
- `listConversations` returns `otherParticipantOnline` (via `isOnline`); new field on `ConversationListItemDto`.

**Frontend**
- Green online dot on the conversation avatar in `ConversationList` when the other participant is online (+ `online` i18n key en/de).

**Client:** regenerated react-query-client (new DTO field only).

**Tests:** presence subscribe/teardown test in the live-service spec; `otherParticipantOnline` assertion in the service spec.

## Acceptance criteria
- [x] `isOnline(userId)` from active SSE connections, decrementing on disconnect
- [x] marking read updates lastReadAt + accurate inbox unread counts — *(shipped in ATT-482)*
- [x] frontend unread badge clears when a thread is opened — *(shipped in ATT-482)*
- [x] presence does not rely solely on `Session.lastAccessedAt` (documented why)

## Verification
All checks green via pre-commit hook (lint, typecheck, build, test, e2e; 1060 API unit tests). Browser screenshot of the online indicator to follow as a comment.

Closes ATT-445

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->