### PR TITLE
feat(ATT-481): toast on new in-app message

### DIFF
--- a/apps/frontend/src/app/app.tsx
+++ b/apps/frontend/src/app/app.tsx
@@ -23,6 +23,7 @@ import { AccessDenied } from './unauthorized/accessDenied';
 import { getBaseUrl } from '../api';
 import { AcceptInvitation } from './accept-invitation';
 import { TwoFactorGate } from './two-factor-gate';
+import { MessagingLiveNotifications } from './messaging/MessagingLiveNotifications';
 
 function useRoutesWithAuthElements(routes: RouteConfig[]) {
   const { user } = useAuth();
@@ -116,6 +117,7 @@ function AppLayout(props: PropsWithChildren) {
       <RouterProvider navigate={navigate}>
         <I18nProvider locale={language}>
           <ToastProvider>
+            <MessagingLiveNotifications />
             <ReactFlowProvider>
               <Layout noLayout={!isAuthenticated}>
                 {props.children}

--- a/apps/frontend/src/app/messaging/MessagingLiveNotifications.tsx
+++ b/apps/frontend/src/app/messaging/MessagingLiveNotifications.tsx
@@ -1,0 +1,66 @@
+// Subscribes app-wide to live messages and toasts ones the user is not viewing
+// FEATURE: Messaging toast notifications
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  ConversationListItemDto,
+  Message,
+  UseMessagingServiceMessagingListConversationsKeyFn,
+} from '@attraccess/react-query-client';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { useAuth } from '../../hooks/useAuth';
+import { useToastMessage } from '../../components/toastProvider';
+import { useMessagingLive } from './useMessagingLive';
+import { applyIncomingMessage } from './messageCache';
+import en from './en.json';
+import de from './de.json';
+
+export function MessagingLiveNotifications() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const toast = useToastMessage();
+  const { t } = useTranslations({ en, de });
+
+  const handleMessage = useCallback(
+    (message: Message) => {
+      applyIncomingMessage(queryClient, message);
+
+      if (user && message.senderId === user.id) {
+        return;
+      }
+
+      const isViewingConversation =
+        location.pathname === '/messages' &&
+        new URLSearchParams(location.search).get('conversation') === String(message.conversationId);
+      if (isViewingConversation) {
+        return;
+      }
+
+      const conversations = queryClient.getQueryData<ConversationListItemDto[]>(
+        UseMessagingServiceMessagingListConversationsKeyFn(),
+      );
+      const senderName =
+        conversations?.find((conversation) => conversation.id === message.conversationId)?.otherParticipant?.username ??
+        t('toast.unknownSender');
+
+      toast.info({
+        title: t('toast.title', { sender: senderName }),
+        description: message.content,
+        action: {
+          label: t('toast.view'),
+          onClick: () => navigate(`/messages?conversation=${message.conversationId}`),
+        },
+      });
+    },
+    [queryClient, user, location.pathname, location.search, t, toast, navigate],
+  );
+
+  useMessagingLive({ onMessage: handleMessage, enabled: !!user });
+
+  return null;
+}
+
+export default MessagingLiveNotifications;

--- a/apps/frontend/src/app/messaging/de.json
+++ b/apps/frontend/src/app/messaging/de.json
@@ -17,5 +17,10 @@
   "composer": {
     "placeholder": "Nachricht schreiben…",
     "send": "Senden"
+  },
+  "toast": {
+    "title": "Neue Nachricht von {{sender}}",
+    "unknownSender": "jemandem",
+    "view": "Anzeigen"
   }
 }

--- a/apps/frontend/src/app/messaging/en.json
+++ b/apps/frontend/src/app/messaging/en.json
@@ -17,5 +17,10 @@
   "composer": {
     "placeholder": "Write a message…",
     "send": "Send"
+  },
+  "toast": {
+    "title": "New message from {{sender}}",
+    "unknownSender": "someone",
+    "view": "View"
   }
 }

--- a/apps/frontend/src/app/messaging/index.tsx
+++ b/apps/frontend/src/app/messaging/index.tsx
@@ -1,12 +1,9 @@
 // Inbox page combining conversation list, thread view and live SSE updates
 // FEATURE: Messaging inbox page
-import {
-  Message,
-  useMessagingServiceMessagingListConversations,
-} from '@attraccess/react-query-client';
+import { useMessagingServiceMessagingListConversations } from '@attraccess/react-query-client';
 import { Card, cn } from '@heroui/react';
-import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { MailIcon, ArrowLeftIcon } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
@@ -16,29 +13,38 @@ import { Button } from '../../components/button';
 import { useAuth } from '../../hooks/useAuth';
 import { ConversationList } from './ConversationList';
 import { MessageThread } from './MessageThread';
-import { useMessagingLive } from './useMessagingLive';
-import { applyIncomingMessage } from './messageCache';
 
 export function MessagesPage() {
   const { t } = useTranslations({ en, de });
   const { user } = useAuth();
-  const queryClient = useQueryClient();
 
-  const [selectedConversationId, setSelectedConversationId] = useState<number | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const conversationParam = searchParams.get('conversation');
+  const selectedConversationId =
+    conversationParam && Number.isFinite(Number(conversationParam)) ? Number(conversationParam) : null;
+
+  const selectConversation = useCallback(
+    (conversationId: number | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (conversationId === null) {
+            next.delete('conversation');
+          } else {
+            next.set('conversation', String(conversationId));
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const { data: conversations, isLoading } = useMessagingServiceMessagingListConversations();
 
   const selectedConversation = conversations?.find((conversation) => conversation.id === selectedConversationId);
   const partnerName = selectedConversation?.otherParticipant?.username ?? t('conversations.unknownUser');
-
-  const handleLiveMessage = useCallback(
-    (message: Message) => {
-      applyIncomingMessage(queryClient, message);
-    },
-    [queryClient],
-  );
-
-  useMessagingLive({ onMessage: handleLiveMessage });
 
   return (
     <div>
@@ -56,7 +62,7 @@ export function MessagesPage() {
               conversations={conversations}
               isLoading={isLoading}
               selectedConversationId={selectedConversationId}
-              onSelect={setSelectedConversationId}
+              onSelect={selectConversation}
             />
           </div>
 
@@ -69,7 +75,7 @@ export function MessagesPage() {
                     size="sm"
                     isIconOnly
                     className="lg:hidden"
-                    onPress={() => setSelectedConversationId(null)}
+                    onPress={() => selectConversation(null)}
                     aria-label={t('thread.back')}
                     data-cy="thread-back-button"
                   >

--- a/apps/frontend/src/components/toastProvider.tsx
+++ b/apps/frontend/src/components/toastProvider.tsx
@@ -5,11 +5,17 @@ import { getTranslationKeyForApiError, Props as ApiErrorToastProps } from '../ut
 
 export type ToastType = 'success' | 'error' | 'info' | 'warning';
 
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface ToastOptions {
   title: string;
   description?: string;
   type?: ToastType;
   duration?: number;
+  action?: ToastAction;
 }
 
 const toastIcons = {
@@ -33,7 +39,7 @@ export function ToastProvider({ children }: ToastProviderProps) {
 }
 
 export function useToastMessage() {
-  const showToast = useCallback(({ title, description, type = 'info', duration = 5000 }: ToastOptions) => {
+  const showToast = useCallback(({ title, description, type = 'info', duration = 5000, action }: ToastOptions) => {
     const toastFn =
       type === 'error'
         ? toast.error
@@ -47,6 +53,7 @@ export function useToastMessage() {
       description,
       icon: toastIcons[type],
       duration,
+      action: action ? { label: action.label, onClick: action.onClick } : undefined,
     });
   }, []);
 


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
Shows a toast when a new message arrives via the live SSE stream and the user is not already viewing that conversation. Toast click navigates to the conversation.

## Changes
- **App-wide live subscription** — new `MessagingLiveNotifications` component mounted in `app.tsx` (inside `ToastProvider`). Subscribes to `/api/messaging/live` once for the whole app, applies incoming messages to the react-query cache, and fires a toast. Removed the page-local subscription from `MessagesPage` (single SSE connection).
- **Toast** — fires only when the message is not from the current user and the conversation is not the currently-open thread. Sender name resolved from the conversations cache (`otherParticipant.username`), content shown as description.
- **Click navigation** — toast action button navigates to `/messages?conversation=<id>`. Added optional `action` support to `useToastMessage` (sonner action button).
- **URL-driven selection** — `MessagesPage` now reads/writes the open conversation via the `?conversation=` query param, so toast suppression and click-through align with the open thread.
- **i18n** — `toast.title` / `toast.unknownSender` / `toast.view` in en + de.

## Base branch
Stacked on `att-443` (messaging inbox + live hook + cache foundation), which this work depends on. Retarget to the epic once the foundation lands.

## Testing
- `nx affected` lint + typecheck + build + test (frontend) via precommit hook — green.

## Out of scope
Unread counts/badges (ATT-482), browser push.

Linear: https://linear.app/attraccess/issue/ATT-481

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->