### PR TITLE
feat(ATT-484): server-side coredump symbolication — store ELF, pre-parse on upload, render in debug UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,21 @@ RUN groupadd -g ${APP_GID} appuser && useradd -u ${APP_UID} -g ${APP_GID} -m -d 
 # Set working directory
 WORKDIR /app
 
-# Minimal runtime libs for native Node modules and privilege drop
-RUN apt-get update && apt-get install -y --no-install-recommends libstdc++6 gosu && rm -rf /var/lib/apt/lists/*
+# Minimal runtime libs for native Node modules and privilege drop.
+# python3 + esp-coredump are required for server-side coredump symbolication.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libstdc++6 \
+    gosu \
+    python3 \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install esp-coredump into an isolated venv and expose it on PATH
+RUN python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/venv/bin/pip install --no-cache-dir esp-coredump
+ENV PATH="/opt/venv/bin:${PATH}"
+ENV ESP_COREDUMP_CMD=/opt/venv/bin/esp-coredump
 
 # Copy the pre-built application (these will be built in the CI pipeline)
 COPY --from=builder /app/dist dist

--- a/apps/api/src/attractap/attractap.module.ts
+++ b/apps/api/src/attractap/attractap.module.ts
@@ -15,6 +15,7 @@ import { ResourcesModule } from '../resources/resources.module';
 import { ResourceUsageModule } from '../resources/usage/resourceUsage.module';
 import { AttractapFirmwareController } from './firmware.controller';
 import { AttractapFirmwareService } from './firmware.service';
+import { CoredumpSymbolicationService } from './coredump-symbolication.service';
 import { ResourceMaintenanceModule } from '../resources/maintenances/maintenance.module';
 import { LicenseModule } from '../license/license.module';
 import { ResourceIntroductionsModule } from '../resources/introductions/resourceIntroductions.module';
@@ -40,7 +41,14 @@ import { ResourceFormsModule } from '../resources/forms/forms.module';
     ProjectsModule,
     ResourceFormsModule,
   ],
-  providers: [AttractapService, WebsocketService, AttractapGateway, WebSocketEventService, AttractapFirmwareService],
+  providers: [
+    AttractapService,
+    WebsocketService,
+    AttractapGateway,
+    WebSocketEventService,
+    AttractapFirmwareService,
+    CoredumpSymbolicationService,
+  ],
   controllers: [AttractapController, AttractapNfcCardsController, AttractapFirmwareController],
 })
 export class AttractapModule {}

--- a/apps/api/src/attractap/attractap.service.ts
+++ b/apps/api/src/attractap/attractap.service.ts
@@ -10,6 +10,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { AttractapFirmwareVersion } from '@attraccess/database-entities';
 import { EncryptionService } from '../encryption/encryption.service';
 import { MetricsService } from '../metrics/metrics.service';
+import { CoredumpSymbolicationService } from './coredump-symbolication.service';
 
 @Injectable()
 export class AttractapService {
@@ -30,6 +31,7 @@ export class AttractapService {
     private readonly userRepository: Repository<User>,
     private readonly encryptionService: EncryptionService,
     private readonly metricsService: MetricsService,
+    private readonly coredumpSymbolicationService: CoredumpSymbolicationService,
   ) { }
 
   public async getNFCCardByID(id: number): Promise<NFCCard | undefined> {
@@ -250,10 +252,45 @@ export class AttractapService {
       firmwareVersion: payload.firmwareVersion ?? null,
       coredumpSize: coredump ? coredump.length : null,
       coredump,
+      symbolicationStatus: coredump ? 'pending' : null,
     });
+
+    if (coredump) {
+      await this.symbolicateCrashReport(report, readerId, coredump);
+    }
 
     report.coredump = null;
     return report;
+  }
+
+  private async symbolicateCrashReport(
+    report: AttractapCrashReport,
+    readerId: number,
+    coredump: Buffer,
+  ): Promise<void> {
+    try {
+      const reader = await this.readerRepository.findOne({ where: { id: readerId } });
+      const result = await this.coredumpSymbolicationService.symbolicate(coredump, {
+        variant: reader?.firmware?.variant ?? null,
+        buildId: null,
+      });
+      await this.crashReportRepository.update(report.id, {
+        coredumpBuildId: result.buildId,
+        symbolicationStatus: result.status,
+        symbolizedBacktrace: result.backtrace,
+      });
+      report.coredumpBuildId = result.buildId;
+      report.symbolicationStatus = result.status;
+      report.symbolizedBacktrace = result.backtrace;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to symbolicate coredump for report ${report.id}: ${message}`);
+      await this.crashReportRepository
+        .update(report.id, { symbolicationStatus: 'failed', symbolizedBacktrace: message })
+        .catch(() => undefined);
+      report.symbolicationStatus = 'failed';
+      report.symbolizedBacktrace = message;
+    }
   }
 
   public async getCrashReportsForReader(readerId: number): Promise<AttractapCrashReport[]> {

--- a/apps/api/src/attractap/coredump-symbolication.service.spec.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.spec.ts
@@ -1,0 +1,79 @@
+import { CoredumpSymbolicationService } from './coredump-symbolication.service';
+import { AttractapFirmwareService } from './firmware.service';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+function makeService(firmware: Partial<AttractapFirmwareService>): CoredumpSymbolicationService {
+  return new CoredumpSymbolicationService(firmware as AttractapFirmwareService);
+}
+
+describe('CoredumpSymbolicationService', () => {
+  const tempDirs: string[] = [];
+  const originalCmd = process.env.ESP_COREDUMP_CMD;
+
+  function tempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'symbolication-test-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    if (originalCmd === undefined) {
+      delete process.env.ESP_COREDUMP_CMD;
+    } else {
+      process.env.ESP_COREDUMP_CMD = originalCmd;
+    }
+  });
+
+  afterAll(() => {
+    tempDirs.forEach((dir) => rmSync(dir, { recursive: true, force: true }));
+  });
+
+  it('returns skipped when there is no coredump', async () => {
+    const service = makeService({ resolveElfFile: jest.fn() });
+    const result = await service.symbolicate(null, { variant: 'eth', buildId: null });
+    expect(result.status).toBe('skipped');
+    expect(result.backtrace).toBeNull();
+  });
+
+  it('returns failed when no matching ELF is found', async () => {
+    const service = makeService({ resolveElfFile: jest.fn().mockReturnValue(null) });
+    const result = await service.symbolicate(Buffer.from('core'), { variant: 'eth', buildId: null });
+    expect(result.status).toBe('failed');
+    expect(result.backtrace).toContain('No matching firmware ELF');
+  });
+
+  it('returns unavailable when the esp-coredump tool is missing', async () => {
+    process.env.ESP_COREDUMP_CMD = join(tempDir(), 'does-not-exist-esp-coredump');
+    const elfDir = tempDir();
+    const elfPath = join(elfDir, 'fw.elf');
+    writeFileSync(elfPath, 'elf');
+    const service = makeService({
+      resolveElfFile: jest.fn().mockReturnValue({ path: elfPath, firmware: { chip: 'esp32s3', buildId: 'abc' } }),
+    });
+    const result = await service.symbolicate(Buffer.from('core'), { variant: 'eth', buildId: null });
+    expect(result.status).toBe('unavailable');
+  });
+
+  it('returns success and the tool output when symbolication succeeds', async () => {
+    const binDir = tempDir();
+    const fakeTool = join(binDir, 'fake-esp-coredump');
+    writeFileSync(fakeTool, '#!/bin/sh\necho "#0 0x42066718 in ApplicationLoop::tick() at main.cpp:212"\n');
+    chmodSync(fakeTool, 0o755);
+    process.env.ESP_COREDUMP_CMD = fakeTool;
+
+    const elfPath = join(binDir, 'fw.elf');
+    writeFileSync(elfPath, 'elf');
+    const service = makeService({
+      resolveElfFile: jest
+        .fn()
+        .mockReturnValue({ path: elfPath, firmware: { chip: 'esp32s3', buildId: 'f6899cb1067e5043' } }),
+    });
+
+    const result = await service.symbolicate(Buffer.from('core'), { variant: 'eth', buildId: null });
+    expect(result.status).toBe('success');
+    expect(result.backtrace).toContain('ApplicationLoop::tick()');
+    expect(result.buildId).toBe('f6899cb1067e5043');
+  });
+});

--- a/apps/api/src/attractap/coredump-symbolication.service.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { execFile } from 'child_process';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { AttractapFirmwareService } from './firmware.service';
+
+export type SymbolicationStatus = 'success' | 'failed' | 'skipped' | 'unavailable';
+
+export interface SymbolicationResult {
+  status: SymbolicationStatus;
+  backtrace: string | null;
+  buildId: string | null;
+}
+
+const SYMBOLICATION_TIMEOUT_MS = 30000;
+const MAX_OUTPUT_BYTES = 2 * 1024 * 1024;
+
+@Injectable()
+export class CoredumpSymbolicationService {
+  private readonly logger = new Logger(CoredumpSymbolicationService.name);
+  private readonly toolCommand = process.env.ESP_COREDUMP_CMD || 'esp-coredump';
+
+  public constructor(private readonly firmwareService: AttractapFirmwareService) {}
+
+  public async symbolicate(
+    coredump: Buffer | null,
+    options: { variant?: string | null; buildId?: string | null },
+  ): Promise<SymbolicationResult> {
+    if (!coredump || coredump.length === 0) {
+      return { status: 'skipped', backtrace: null, buildId: options.buildId ?? null };
+    }
+
+    const elf = this.firmwareService.resolveElfFile({ buildId: options.buildId, variant: options.variant });
+    if (!elf) {
+      this.logger.warn(
+        `No matching ELF for coredump (variant=${options.variant ?? 'n/a'}, buildId=${options.buildId ?? 'n/a'})`,
+      );
+      return {
+        status: 'failed',
+        backtrace: 'No matching firmware ELF was found on the server, so the coredump could not be symbolized.',
+        buildId: options.buildId ?? null,
+      };
+    }
+
+    const workingDir = await mkdtemp(join(tmpdir(), 'attractap-coredump-'));
+    const corePath = join(workingDir, 'core.bin');
+
+    try {
+      await writeFile(corePath, coredump);
+      const output = await this.runTool(elf.path, corePath, elf.firmware.chip);
+      return {
+        status: 'success',
+        backtrace: output,
+        buildId: elf.firmware.buildId ?? options.buildId ?? null,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (this.isToolMissing(message)) {
+        this.logger.error(`esp-coredump tool not available: ${message}`);
+        return { status: 'unavailable', backtrace: null, buildId: options.buildId ?? null };
+      }
+      this.logger.error(`Coredump symbolication failed: ${message}`);
+      return { status: 'failed', backtrace: message, buildId: elf.firmware.buildId ?? options.buildId ?? null };
+    } finally {
+      await rm(workingDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  private runTool(elfPath: string, corePath: string, chip: string | null): Promise<string> {
+    const args = [
+      ...(chip ? ['--chip', chip] : []),
+      'info_corefile',
+      '--core',
+      corePath,
+      '--core-format',
+      'raw',
+      elfPath,
+    ];
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        this.toolCommand,
+        args,
+        { timeout: SYMBOLICATION_TIMEOUT_MS, maxBuffer: MAX_OUTPUT_BYTES, windowsHide: true },
+        (error, stdout, stderr) => {
+          const combined = `${stdout || ''}${stderr ? `\n${stderr}` : ''}`.trim();
+          if (error && this.isToolMissing(error.message)) {
+            reject(error);
+            return;
+          }
+          if (!combined) {
+            reject(error || new Error('esp-coredump produced no output'));
+            return;
+          }
+          resolve(combined);
+        },
+      );
+    });
+  }
+
+  private isToolMissing(message: string): boolean {
+    return message.includes('ENOENT') || message.includes('not found');
+  }
+}

--- a/apps/api/src/attractap/dtos/firmware.dto.ts
+++ b/apps/api/src/attractap/dtos/firmware.dto.ts
@@ -50,6 +50,22 @@ export class AttractapFirmware {
   filenameOTA: string;
 
   @ApiProperty({
+    description: 'The filename of the unstripped ELF used to symbolicate coredumps',
+    example: 'attractap_eth.elf',
+    nullable: true,
+    required: false,
+  })
+  elfFilename?: string | null;
+
+  @ApiProperty({
+    description: 'The app ELF SHA256 (build id) that matches this firmware to a coredump',
+    example: 'f6899cb1067e5043',
+    nullable: true,
+    required: false,
+  })
+  buildId?: string | null;
+
+  @ApiProperty({
     description: 'The ESP chip type (esp32, esp32s2, esp32s3, esp32c3)',
     example: 'esp32s3',
   })

--- a/apps/api/src/attractap/firmware.service.ts
+++ b/apps/api/src/attractap/firmware.service.ts
@@ -92,6 +92,47 @@ export class AttractapFirmwareService {
     return stats.size;
   }
 
+  public getFirmwareByBuildId(buildId: string): AttractapFirmware | undefined {
+    const normalized = buildId.trim().toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+    return this.firmwares.find((firmware) => {
+      const candidate = firmware.buildId?.toLowerCase();
+      return !!candidate && (candidate.startsWith(normalized) || normalized.startsWith(candidate));
+    });
+  }
+
+  public resolveElfFile(options: {
+    buildId?: string | null;
+    variant?: string | null;
+  }): { path: string; firmware: AttractapFirmware } | null {
+    let firmware: AttractapFirmware | undefined;
+
+    if (options.buildId) {
+      firmware = this.getFirmwareByBuildId(options.buildId);
+    }
+
+    if (!firmware && options.variant) {
+      firmware = this.firmwares.find((entry) => entry.variant === options.variant && !!entry.elfFilename);
+    }
+
+    if (!firmware || !firmware.elfFilename) {
+      this.logger.debug(
+        `No ELF resolved for buildId=${options.buildId ?? 'n/a'}, variant=${options.variant ?? 'n/a'}`,
+      );
+      return null;
+    }
+
+    const elfPath = join(this.firmwareAssetsDirectory, firmware.elfFilename);
+    if (!existsSync(elfPath)) {
+      this.logger.error(`ELF file does not exist: ${elfPath}`);
+      return null;
+    }
+
+    return { path: elfPath, firmware };
+  }
+
   public getFirmwareDownloadUrl(firmwareName: string, variantName: string): string {
     // Return path only; devices will prepend their configured host/scheme/port
     const path = `/api/attractap/firmwares/${firmwareName}/variants/${variantName}`;

--- a/apps/api/src/database/migrations/1780200000000-attractap-crash-report-symbolication.ts
+++ b/apps/api/src/database/migrations/1780200000000-attractap-crash-report-symbolication.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AttractapCrashReportSymbolication1780200000000 implements MigrationInterface {
+  name = 'AttractapCrashReportSymbolication1780200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "attractap_crash_report" ADD COLUMN "coredumpBuildId" text`);
+    await queryRunner.query(`ALTER TABLE "attractap_crash_report" ADD COLUMN "symbolicationStatus" text`);
+    await queryRunner.query(`ALTER TABLE "attractap_crash_report" ADD COLUMN "symbolizedBacktrace" text`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "attractap_crash_report" DROP COLUMN "symbolizedBacktrace"`);
+    await queryRunner.query(`ALTER TABLE "attractap_crash_report" DROP COLUMN "symbolicationStatus"`);
+    await queryRunner.query(`ALTER TABLE "attractap_crash_report" DROP COLUMN "coredumpBuildId"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -120,3 +120,4 @@ export * from './1780000000000-user-retraining-requirement';
 export * from './1780100000000-notification-preferences';
 export * from './1781000000000-maintenance-requests';
 export * from './1781100000000-message-email-fallback';
+export * from './1780200000000-attractap-crash-report-symbolication';

--- a/apps/attractap/firmware/build_firmwares.py
+++ b/apps/attractap/firmware/build_firmwares.py
@@ -48,6 +48,22 @@ def hex_to_int(hex_str):
         return int(hex_str, 16)
     return hex_str
 
+def extract_build_id(firmware_bin_path, esptool_cmd, chip):
+    """Best-effort: read app_elf_sha256 from the app image so the server can
+    match the exact ELF to a coredump's build id. Returns lowercase hex or None."""
+    if not os.path.exists(firmware_bin_path):
+        return None
+    try:
+        info_cmd = [*esptool_cmd, '--chip', chip, 'image_info', firmware_bin_path]
+        result = subprocess.run(info_cmd, capture_output=True, text=True)
+        output = (result.stdout or '') + '\n' + (result.stderr or '')
+        match = re.search(r'(?:ELF file SHA256|app_elf_sha256)[^0-9a-fA-F]*([0-9a-fA-F]{64})', output)
+        if match:
+            return match.group(1).lower()
+    except Exception as e:
+        print(f"Warning: Could not extract build id from {firmware_bin_path}: {e}")
+    return None
+
 def main():
     if not shutil.which('platformio'):
         print("Warning: platformio not found, skipping firmware build")
@@ -352,6 +368,23 @@ def main():
                 print(f"Error: Failed to create merged firmware for environment '{env}': {e}")
                 sys.exit(1)
 
+            # Also export the unstripped ELF so the server can symbolicate coredumps
+            elf_path = f".pio/build/{env}/firmware.elf"
+            elf_filename = f"{current_firmware_name}_{firmware_variant}.elf"
+            build_id = None
+            if os.path.exists(elf_path):
+                try:
+                    shutil.copyfile(elf_path, os.path.join(output_dir, elf_filename))
+                    print(f"ELF copied to: {os.path.join(output_dir, elf_filename)}")
+                    build_id = extract_build_id(firmware_path, esptool_cmd, chip)
+                    print(f"  Build id: {build_id}")
+                except Exception as e:
+                    print(f"Error: Failed to copy ELF for environment '{env}': {e}")
+                    sys.exit(1)
+            else:
+                elf_filename = None
+                print(f"Warning: ELF not found at {elf_path}; symbolication will be unavailable for {env}")
+
             # Also export the app-only OTA image (do not merge bootloader/partitions)
             ota_filename = f"{current_firmware_name}_{firmware_variant}_ota.bin"
             ota_bin_path = os.path.join(output_dir, ota_filename)
@@ -390,6 +423,8 @@ def main():
                 "boardFamily": board_family if board_family else board_family_auto,
                 "filename": firmware_filename,
                 "filenameOTA": ota_filename,
+                "elfFilename": elf_filename,
+                "buildId": build_id,
                 "chip": chip,
                 "flashMode": flash_mode,
                 "flashFreq": flash_freq,

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.de.json
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.de.json
@@ -21,5 +21,17 @@
   "coredump": "Coredump",
   "downloadCoredump": "Coredump herunterladen",
   "noCoredump": "Kein Coredump",
-  "downloadFailed": "Coredump-Download fehlgeschlagen"
+  "downloadFailed": "Coredump-Download fehlgeschlagen",
+  "backtrace": "Symbolisierter Backtrace",
+  "buildId": "Build-ID",
+  "symbolication": {
+    "pending": "Symbolisierung läuft…",
+    "success": "Symbolisiert",
+    "failed": "Symbolisierung fehlgeschlagen",
+    "skipped": "Kein Coredump",
+    "unavailable": "Symbolisierung nicht verfügbar"
+  },
+  "symbolicationUnavailableHint": "Die Server-Toolchain oder die passende Firmware-ELF war nicht verfügbar, daher konnte dieser Coredump nicht symbolisiert werden. Lade den rohen Coredump für die Offline-Analyse herunter.",
+  "showBacktrace": "Backtrace anzeigen",
+  "hideBacktrace": "Backtrace ausblenden"
 }

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.en.json
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.en.json
@@ -21,5 +21,17 @@
   "coredump": "Coredump",
   "downloadCoredump": "Download coredump",
   "noCoredump": "No coredump",
-  "downloadFailed": "Failed to download coredump"
+  "downloadFailed": "Failed to download coredump",
+  "backtrace": "Symbolized backtrace",
+  "buildId": "Build id",
+  "symbolication": {
+    "pending": "Symbolizing…",
+    "success": "Symbolized",
+    "failed": "Symbolication failed",
+    "skipped": "No coredump",
+    "unavailable": "Symbolication unavailable"
+  },
+  "symbolicationUnavailableHint": "The server toolchain or matching firmware ELF was not available, so this coredump could not be symbolized. Download the raw coredump for offline analysis.",
+  "showBacktrace": "Show backtrace",
+  "hideBacktrace": "Hide backtrace"
 }

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.tsx
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { Chip, Spinner } from '@heroui/react';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { OpenAPI, useAttractapServiceGetReaderCrashReports } from '@attraccess/react-query-client';
 import { Button } from '../../../components/button';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -32,9 +32,27 @@ function formatUptime(ms: number | null | undefined, fallback: string): string {
   return [hours ? `${hours}h` : null, minutes ? `${minutes}m` : null, `${seconds}s`].filter(Boolean).join(' ');
 }
 
+function symbolicationChipColor(status: string | null | undefined): 'success' | 'danger' | 'warning' | 'default' {
+  switch (status) {
+    case 'success':
+      return 'success';
+    case 'failed':
+      return 'danger';
+    case 'unavailable':
+      return 'warning';
+    default:
+      return 'default';
+  }
+}
+
 export function AttractapDiagnostics(props: Readonly<Props>) {
   const { t } = useTranslations({ de, en });
   const toast = useToastMessage();
+  const [expandedReports, setExpandedReports] = useState<Record<number, boolean>>({});
+
+  const toggleBacktrace = useCallback((reportId: number) => {
+    setExpandedReports((prev) => ({ ...prev, [reportId]: !prev[reportId] }));
+  }, []);
 
   const {
     data: reports,
@@ -146,9 +164,21 @@ export function AttractapDiagnostics(props: Readonly<Props>) {
               data-cy="attractap-diagnostics-report"
             >
               <div className="flex items-center justify-between gap-2 flex-wrap">
-                <Chip color="warning" variant="soft" size="sm">
-                  {report.resetReason}
-                </Chip>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <Chip color="warning" variant="soft" size="sm">
+                    {report.resetReason}
+                  </Chip>
+                  {report.symbolicationStatus && (
+                    <Chip
+                      color={symbolicationChipColor(report.symbolicationStatus)}
+                      variant="soft"
+                      size="sm"
+                      data-cy="attractap-diagnostics-symbolication-status"
+                    >
+                      {t(`symbolication.${report.symbolicationStatus}`)}
+                    </Chip>
+                  )}
+                </div>
                 <span className="text-xs text-default-400">{new Date(report.createdAt).toLocaleString()}</span>
               </div>
               <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-3">
@@ -171,6 +201,43 @@ export function AttractapDiagnostics(props: Readonly<Props>) {
                   {t('fields.firmware')}: {report.firmwareVersion ?? fallback}
                 </span>
               </div>
+              {report.symbolizedBacktrace && (
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
+                    <span className="text-sm font-medium">
+                      {t('backtrace')}
+                      {report.coredumpBuildId ? (
+                        <span className="ml-2 font-mono text-xs text-default-400">
+                          {t('buildId')}: {report.coredumpBuildId}
+                        </span>
+                      ) : null}
+                    </span>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onPress={() => toggleBacktrace(report.id)}
+                      data-cy="attractap-diagnostics-toggle-backtrace"
+                    >
+                      {expandedReports[report.id] ? t('hideBacktrace') : t('showBacktrace')}
+                    </Button>
+                  </div>
+                  {expandedReports[report.id] && (
+                    <pre
+                      className="max-h-96 overflow-auto rounded-medium bg-default-100 p-3 text-xs font-mono whitespace-pre-wrap break-words"
+                      data-cy="attractap-diagnostics-backtrace"
+                    >
+                      {report.symbolizedBacktrace}
+                    </pre>
+                  )}
+                </div>
+              )}
+
+              {report.symbolicationStatus === 'unavailable' && (
+                <p className="text-xs text-warning" data-cy="attractap-diagnostics-symbolication-hint">
+                  {t('symbolicationUnavailableHint')}
+                </p>
+              )}
+
               <div>
                 {report.coredumpSize ? (
                   <Button

--- a/libs/database-entities/src/lib/entities/attractapCrashReport.entity.ts
+++ b/libs/database-entities/src/lib/entities/attractapCrashReport.entity.ts
@@ -89,6 +89,31 @@ export class AttractapCrashReport {
   @Exclude()
   coredump!: Buffer | null;
 
+  @Column({ type: 'text', nullable: true })
+  @ApiProperty({
+    description: 'Build id (app ELF SHA256) extracted from the coredump, used to match the ELF',
+    example: 'f6899cb1067e5043',
+    nullable: true,
+  })
+  coredumpBuildId!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  @ApiProperty({
+    description: 'Status of server-side coredump symbolication',
+    example: 'success',
+    enum: ['pending', 'success', 'failed', 'skipped', 'unavailable'],
+    nullable: true,
+  })
+  symbolicationStatus!: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  @ApiProperty({
+    description: 'Symbolized backtrace, task list, and register dump produced from the coredump + ELF',
+    example: '#0  0x42066718 in app_loop() at main.cpp:120',
+    nullable: true,
+  })
+  symbolizedBacktrace!: string | null;
+
   @CreateDateColumn()
   @ApiProperty({
     description: 'When this crash report was received by the server',


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Closes the diagnostics gap from ATT-462/ATT-483: a raw coredump is useless without the exact-matching firmware ELF. This makes the **server** do the symbolication, so a human never needs the ELF or a local toolchain.

Builds on ATT-471 (crash-report ingest + per-reader debug view, already on `main`).

## What changed

**1. Persist the matching ELF per firmware build**
- `build_firmwares.py`: copies `firmware.elf` into `firmware_output/` and adds `elfFilename` + best-effort `buildId` (app ELF SHA256, parsed from `esptool image_info`) to each manifest entry. The existing asset-copy step already propagates both to the API.
- `firmware.dto.ts` / `firmware.service.ts`: carry `elfFilename`/`buildId`; `resolveElfFile({ buildId, variant })` picks the exact ELF by build id, falling back to the reader's firmware variant.

**2. Pre-parse the coredump on upload (server-side)**
- New columns on `AttractapCrashReport`: `coredumpBuildId`, `symbolicationStatus`, `symbolizedBacktrace` (+ migration `1780200000000`).
- New `CoredumpSymbolicationService`: writes the blob to a temp file and runs `esp-coredump info_corefile --core <blob> --core-format raw <elf>` via `execFile` (no shell), with a 30s timeout and output cap. Wired into `createCrashReport`; degrades gracefully to `skipped` / `failed` / `unavailable` when there is no coredump, no matching ELF, or the tool is missing.
- `Dockerfile`: installs `python3` + `esp-coredump` into the **runtime** image (the builder already had esptool; the runtime stage did not).

**3. Debug UI — render inline, no download required**
- `AttractapDiagnostics.tsx`: status chip (Symbolized / failed / unavailable), build id, and a collapsible monospace symbolized backtrace. Keeps the raw-coredump download as an escape hatch, plus a hint when symbolication is unavailable. EN/DE i18n added.

## Testing

- Unit tests for `CoredumpSymbolicationService` (skipped / no-ELF / tool-missing / success via a fake tool) — 4/4 pass.
- `migrations-down` e2e passes (up + down of the new migration in the full chain).
- API build, full `api:test` (1062 tests), lint, and frontend/client typecheck all green.
- Browser-verified the debug UI against seeded crash reports: a symbolized `TASK_WDT` report (build id `f6899cb1067e5043`, expandable backtrace) and an `unavailable` report with the download escape hatch. Screenshots posted to the Linear issue.

## Notes
- No firmware `FIRMWARE_VERSION` bump: `build_firmwares.py` only changes build output (emits the `.elf`), not the device binary.
- Symbolization for an existing reader only works once its firmware is re-released with the updated build script (so the manifest carries `elfFilename`/`buildId`); older builds resolve to `unavailable` and keep the raw-download path.

Linear: [ATT-484](https://linear.app/attraccess/issue/ATT-484/featattractap-server-side-coredump-symbolication-store-matching-elf)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
