### PR TITLE
feat(ATT-447): email fallback for offline recipients with unread messages

### DIFF
--- a/apps/api/src/database/migrations/1781100000000-message-email-fallback.ts
+++ b/apps/api/src/database/migrations/1781100000000-message-email-fallback.ts
@@ -1,0 +1,88 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const MESSAGE_RECEIVED_MJML = `
+<mjml>
+  <mj-head>
+    <mj-attributes>
+      <mj-all font-family="Helvetica, Arial, sans-serif" />
+      <mj-text font-size="16px" line-height="1.5" />
+      <mj-button background-color="#2563EB" color="#FFFFFF" font-size="16px" font-weight="bold" padding="12px 24px" border-radius="4px" />
+    </mj-attributes>
+    <mj-style>
+      a { color: inherit !important; text-decoration: none !important; }
+    </mj-style>
+  </mj-head>
+  <mj-body background-color="#F3F7FB" width="600px">
+    <mj-section background-color="#1E40AF" padding="20px 0">
+      <mj-column>
+        <mj-text align="center" font-size="22px" color="#FFFFFF" font-weight="bold" padding="0">
+          New message from {{message.senderName}}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#FFFFFF" padding="20px">
+      <mj-column>
+        <mj-text>Hello {{user.username}},</mj-text>
+        <mj-text>
+          <strong>{{message.senderName}}</strong> sent you a message on Attraccess while you were offline:
+        </mj-text>
+        <mj-text font-size="15px" color="#374151" padding="10px 20px" background-color="#F3F7FB">
+          {{message.preview}}
+        </mj-text>
+        <mj-button href="{{message.conversationUrl}}" align="left">
+          Open Conversation
+        </mj-button>
+        <mj-text font-size="14px" color="#4B5563" padding="20px 0 0 0">
+          If the button does not work, paste this into your browser:
+          <br />
+          <a href="{{message.conversationUrl}}">{{message.conversationUrl}}</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#FFFFFF" padding="0 20px 20px 20px">
+      <mj-column>
+        <mj-text font-size="12px" color="#6B7280" align="center">
+          You received this email because you were offline when this message arrived. You can disable
+          these notifications in your messaging preferences.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+`;
+
+const MESSAGE_RECEIVED_VARIABLES = [
+  'user.username',
+  'user.email',
+  'user.id',
+  'host.frontend',
+  'host.backend',
+  'message.senderName',
+  'message.preview',
+  'message.conversationUrl',
+].join(',');
+
+export class MessageEmailFallback1781100000000 implements MigrationInterface {
+  name = 'MessageEmailFallback1781100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "conversation_participant" ADD COLUMN "lastNotifiedAt" datetime`);
+
+    await queryRunner.query(
+      `INSERT OR IGNORE INTO "email_templates" ("type", "subject", "body", "variables") VALUES ($1, $2, $3, $4)`,
+      [
+        'message-received',
+        'New message from {{message.senderName}}',
+        MESSAGE_RECEIVED_MJML,
+        MESSAGE_RECEIVED_VARIABLES,
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM "email_templates" WHERE "type" = 'message-received'`);
+    await queryRunner.query(`ALTER TABLE "conversation_participant" DROP COLUMN "lastNotifiedAt"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -119,3 +119,4 @@ export * from './1779500000000-attractap-crash-report';
 export * from './1780000000000-user-retraining-requirement';
 export * from './1780100000000-notification-preferences';
 export * from './1781000000000-maintenance-requests';
+export * from './1781100000000-message-email-fallback';

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -357,6 +357,31 @@ export class EmailService {
     await this.sendEmail(recipient, EmailTemplateType.MAINTENANCE_REQUEST_CREATED, context);
   }
 
+  async sendNewMessageEmail(
+    recipient: User,
+    message: { conversationId: number; senderName: string; preview: string },
+  ) {
+    if (!recipient?.email) {
+      return;
+    }
+
+    const base = await this.getBaseContext(recipient);
+    const conversationUrl = `${base.host.frontend}/messages?conversation=${message.conversationId}`;
+    const preview =
+      message.preview.length > 200 ? `${message.preview.slice(0, 200).trimEnd()}…` : message.preview;
+
+    const context = {
+      ...base,
+      message: {
+        senderName: message.senderName,
+        preview,
+        conversationUrl,
+      },
+    };
+
+    await this.sendEmail(recipient, EmailTemplateType.MESSAGE_RECEIVED, context);
+  }
+
   private async createTransporter(): Promise<{ transporter: ReturnType<typeof createTransport>; from: string }> {
     const smtpConfig = await this.settingsService.getSmtpConfiguration();
     if (!smtpConfig) {

--- a/apps/api/src/messaging/message-notification.listener.spec.ts
+++ b/apps/api/src/messaging/message-notification.listener.spec.ts
@@ -1,0 +1,190 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConversationParticipant, Message, User } from '@attraccess/database-entities';
+import { MessageNotificationListener } from './message-notification.listener';
+import { MessagingLiveService } from './messaging-live.service';
+import { MessagingService } from './messaging.service';
+import { EmailService } from '../email/email.service';
+import { MessageCreatedEvent } from './events/message-created.event';
+
+describe('MessageNotificationListener', () => {
+  let listener: MessageNotificationListener;
+  let participantRepository: { find: jest.Mock; update: jest.Mock };
+  let userRepository: { findOne: jest.Mock };
+  let liveService: { isOnline: jest.Mock };
+  let messagingService: { shouldEmailMessageOnOffline: jest.Mock };
+  let emailService: { sendNewMessageEmail: jest.Mock };
+
+  const SENDER_ID = 1;
+  const RECIPIENT_ID = 2;
+
+  const buildMessage = (overrides: Partial<Message> = {}): Message =>
+    ({
+      id: 100,
+      conversationId: 10,
+      senderId: SENDER_ID,
+      content: 'Hello there',
+      createdAt: new Date('2025-01-18T12:00:00.000Z'),
+      ...overrides,
+    } as Message);
+
+  const buildParticipant = (overrides: Partial<ConversationParticipant> = {}): ConversationParticipant =>
+    ({
+      id: 50,
+      conversationId: 10,
+      userId: RECIPIENT_ID,
+      lastReadAt: null,
+      lastNotifiedAt: null,
+      user: { id: RECIPIENT_ID, username: 'bob', email: 'bob@example.com' } as User,
+      ...overrides,
+    } as ConversationParticipant);
+
+  beforeEach(async () => {
+    participantRepository = { find: jest.fn(), update: jest.fn().mockResolvedValue(undefined) };
+    userRepository = { findOne: jest.fn().mockResolvedValue({ id: SENDER_ID, username: 'alice' } as User) };
+    liveService = { isOnline: jest.fn().mockReturnValue(false) };
+    messagingService = { shouldEmailMessageOnOffline: jest.fn().mockResolvedValue(true) };
+    emailService = { sendNewMessageEmail: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageNotificationListener,
+        { provide: getRepositoryToken(ConversationParticipant), useValue: participantRepository },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: MessagingLiveService, useValue: liveService },
+        { provide: MessagingService, useValue: messagingService },
+        { provide: EmailService, useValue: emailService },
+      ],
+    }).compile();
+
+    listener = module.get(MessageNotificationListener);
+  });
+
+  it('emails an offline recipient with an unread message and records the delivery marker', async () => {
+    participantRepository.find.mockResolvedValue([
+      buildParticipant(),
+      buildParticipant({ id: 51, userId: SENDER_ID, user: { id: SENDER_ID, username: 'alice' } as User }),
+    ]);
+
+    const message = buildMessage();
+    await listener.handleMessageCreated(new MessageCreatedEvent(message));
+
+    expect(emailService.sendNewMessageEmail).toHaveBeenCalledTimes(1);
+    expect(emailService.sendNewMessageEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ id: RECIPIENT_ID, email: 'bob@example.com' }),
+      { conversationId: 10, senderName: 'alice', preview: 'Hello there' },
+    );
+    expect(participantRepository.update).toHaveBeenCalledWith({ id: 50 }, { lastNotifiedAt: message.createdAt });
+  });
+
+  it('never emails the sender', async () => {
+    participantRepository.find.mockResolvedValue([
+      buildParticipant({ id: 51, userId: SENDER_ID, user: { id: SENDER_ID, username: 'alice' } as User }),
+    ]);
+
+    await listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()));
+
+    expect(emailService.sendNewMessageEmail).not.toHaveBeenCalled();
+  });
+
+  it('never emails an online recipient', async () => {
+    liveService.isOnline.mockReturnValue(true);
+    participantRepository.find.mockResolvedValue([buildParticipant()]);
+
+    await listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()));
+
+    expect(emailService.sendNewMessageEmail).not.toHaveBeenCalled();
+    expect(participantRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('never emails an opted-out recipient', async () => {
+    messagingService.shouldEmailMessageOnOffline.mockResolvedValue(false);
+    participantRepository.find.mockResolvedValue([buildParticipant()]);
+
+    await listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()));
+
+    expect(emailService.sendNewMessageEmail).not.toHaveBeenCalled();
+    expect(participantRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('does not re-send within the same unread burst (already notified, unread)', async () => {
+    participantRepository.find.mockResolvedValue([
+      buildParticipant({ lastNotifiedAt: new Date('2025-01-18T11:00:00.000Z'), lastReadAt: null }),
+    ]);
+
+    await listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()));
+
+    expect(emailService.sendNewMessageEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not re-send when notified after the last read', async () => {
+    participantRepository.find.mockResolvedValue([
+      buildParticipant({
+        lastReadAt: new Date('2025-01-18T10:00:00.000Z'),
+        lastNotifiedAt: new Date('2025-01-18T11:00:00.000Z'),
+      }),
+    ]);
+
+    await listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()));
+
+    expect(emailService.sendNewMessageEmail).not.toHaveBeenCalled();
+  });
+
+  it('starts a new burst once the recipient has read past the last notification', async () => {
+    participantRepository.find.mockResolvedValue([
+      buildParticipant({
+        lastNotifiedAt: new Date('2025-01-18T10:00:00.000Z'),
+        lastReadAt: new Date('2025-01-18T11:00:00.000Z'),
+      }),
+    ]);
+
+    await listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()));
+
+    expect(emailService.sendNewMessageEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips recipients without an email address', async () => {
+    participantRepository.find.mockResolvedValue([
+      buildParticipant({ user: { id: RECIPIENT_ID, username: 'bob', email: null } as unknown as User }),
+    ]);
+
+    await listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()));
+
+    expect(emailService.sendNewMessageEmail).not.toHaveBeenCalled();
+    expect(participantRepository.update).not.toHaveBeenCalled();
+  });
+
+  it('isolates per-recipient failures so other recipients still get emailed', async () => {
+    const failing = buildParticipant({ id: 50, userId: RECIPIENT_ID });
+    const other = buildParticipant({
+      id: 52,
+      userId: 3,
+      user: { id: 3, username: 'carol', email: 'carol@example.com' } as User,
+    });
+    participantRepository.find.mockResolvedValue([failing, other]);
+    emailService.sendNewMessageEmail.mockImplementation((recipient: User) => {
+      if (recipient.id === RECIPIENT_ID) {
+        return Promise.reject(new Error('smtp down'));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await expect(listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()))).resolves.toBeUndefined();
+
+    expect(emailService.sendNewMessageEmail).toHaveBeenCalledTimes(2);
+    expect(participantRepository.update).toHaveBeenCalledTimes(1);
+    expect(participantRepository.update).toHaveBeenCalledWith({ id: 52 }, expect.any(Object));
+  });
+
+  it('falls back to a generic sender name when the sender is missing', async () => {
+    userRepository.findOne.mockResolvedValue(null);
+    participantRepository.find.mockResolvedValue([buildParticipant()]);
+
+    await listener.handleMessageCreated(new MessageCreatedEvent(buildMessage()));
+
+    expect(emailService.sendNewMessageEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ senderName: 'Someone' }),
+    );
+  });
+});

--- a/apps/api/src/messaging/message-notification.listener.ts
+++ b/apps/api/src/messaging/message-notification.listener.ts
@@ -1,0 +1,109 @@
+// Sends an email fallback to offline conversation participants who have an unread message.
+// FEATURE: Messaging email fallback for offline recipients
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConversationParticipant, Message, User } from '@attraccess/database-entities';
+import { MessageCreatedEvent } from './events/message-created.event';
+import { MessagingLiveService } from './messaging-live.service';
+import { MessagingService } from './messaging.service';
+import { EmailService } from '../email/email.service';
+
+@Injectable()
+export class MessageNotificationListener {
+  private readonly logger = new Logger(MessageNotificationListener.name);
+
+  constructor(
+    @InjectRepository(ConversationParticipant)
+    private readonly participantRepository: Repository<ConversationParticipant>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly liveService: MessagingLiveService,
+    private readonly messagingService: MessagingService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  @OnEvent(MessageCreatedEvent.EVENT_NAME)
+  async handleMessageCreated(event: MessageCreatedEvent): Promise<void> {
+    const message = event.message;
+
+    try {
+      const participants = await this.participantRepository.find({
+        where: { conversationId: message.conversationId },
+        relations: ['user'],
+      });
+
+      const recipients = participants.filter((participant) => participant.userId !== message.senderId);
+      if (recipients.length === 0) {
+        return;
+      }
+
+      const sender = await this.userRepository.findOne({ where: { id: message.senderId } });
+      const senderName = sender?.username ?? 'Someone';
+
+      await Promise.all(
+        recipients.map((recipient) =>
+          this.notifyRecipient(recipient, message, senderName).catch((error) => {
+            this.logger.error(
+              `Failed to send offline message email to user ${recipient.userId} for conversation ${message.conversationId}: ${error.message}`,
+              error.stack,
+            );
+          }),
+        ),
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to process message-created notification for message ${message.id}: ${error.message}`,
+        error.stack,
+      );
+    }
+  }
+
+  private async notifyRecipient(
+    participant: ConversationParticipant,
+    message: Message,
+    senderName: string,
+  ): Promise<void> {
+    // Online recipients see the message live; no email needed.
+    if (this.liveService.isOnline(participant.userId)) {
+      return;
+    }
+
+    // Debounce per conversation: only one email per unread burst. If we already notified this
+    // participant and they have not read the conversation since, skip until they catch up.
+    if (this.alreadyNotifiedForCurrentBurst(participant)) {
+      return;
+    }
+
+    // Respect the opt-out preference.
+    if (!(await this.messagingService.shouldEmailMessageOnOffline(participant.userId))) {
+      return;
+    }
+
+    const recipient = participant.user;
+    if (!recipient?.email) {
+      return;
+    }
+
+    await this.emailService.sendNewMessageEmail(recipient, {
+      conversationId: message.conversationId,
+      senderName,
+      preview: message.content,
+    });
+
+    // Record the delivery marker so subsequent messages in this burst do not re-send.
+    await this.participantRepository.update({ id: participant.id }, { lastNotifiedAt: message.createdAt });
+  }
+
+  private alreadyNotifiedForCurrentBurst(participant: ConversationParticipant): boolean {
+    if (!participant.lastNotifiedAt) {
+      return false;
+    }
+    // A new burst starts once the participant reads past the last notification.
+    if (!participant.lastReadAt) {
+      return true;
+    }
+    return participant.lastNotifiedAt.getTime() > participant.lastReadAt.getTime();
+  }
+}

--- a/apps/api/src/messaging/messaging.module.ts
+++ b/apps/api/src/messaging/messaging.module.ts
@@ -11,15 +11,18 @@ import {
 import { MessagingService } from './messaging.service';
 import { MessagingLiveService } from './messaging-live.service';
 import { MessagingController } from './messaging.controller';
+import { MessageNotificationListener } from './message-notification.listener';
 import { ResourceUsageModule } from '../resources/usage/resourceUsage.module';
+import { EmailModule } from '../email/email.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Conversation, ConversationParticipant, Message, NotificationPreference, Resource, User]),
     ResourceUsageModule,
+    EmailModule,
   ],
   controllers: [MessagingController],
-  providers: [MessagingService, MessagingLiveService],
+  providers: [MessagingService, MessagingLiveService, MessageNotificationListener],
   exports: [MessagingService],
 })
 export class MessagingModule {}

--- a/libs/database-entities/src/lib/entities/conversation-participant.entity.ts
+++ b/libs/database-entities/src/lib/entities/conversation-participant.entity.ts
@@ -26,6 +26,15 @@ export class ConversationParticipant {
   })
   lastReadAt!: Date | null;
 
+  @Column({ type: 'datetime', nullable: true })
+  @ApiProperty({
+    description:
+      'When this participant was last sent an offline email notification for this conversation. Used to debounce email fallback to once per unread burst.',
+    example: '2025-01-18T12:30:00.000Z',
+    nullable: true,
+  })
+  lastNotifiedAt!: Date | null;
+
   @ManyToOne(() => Conversation, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'conversationId' })
   @ApiProperty({ description: 'The conversation this participant belongs to', type: () => Conversation })

--- a/libs/database-entities/src/lib/entities/email-template.entity.ts
+++ b/libs/database-entities/src/lib/entities/email-template.entity.ts
@@ -14,6 +14,7 @@ export enum EmailTemplateType {
   RESOURCE_HEALTH_CHANGED = 'resource-health-changed',
   USER_RETRAINING_REQUIRED = 'user-retraining-required',
   MAINTENANCE_REQUEST_CREATED = 'maintenance-request-created',
+  MESSAGE_RECEIVED = 'message-received',
 }
 
 @Entity('email_templates')


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds an email fallback so offline users don't miss direct messages. When a message is created, a new `MessageNotificationListener` emails each recipient who is **offline** and **opted-in**, linking back to the conversation.

Closes [ATT-447](https://linear.app/attraccess/issue/ATT-447/email-fallback-for-offline-recipients-with-unread-messages).

## Approach

- **Listener** — `apps/api/src/messaging/message-notification.listener.ts`, modeled on `resource-health-notification.listener.ts`. `@OnEvent(MessageCreatedEvent.EVENT_NAME)`; loads conversation participants (excluding the sender), fans out with `Promise.all` + per-recipient `.catch()`.
- **Presence** — skips recipients where `MessagingLiveService.isOnline(userId)` is true (SSE-based presence from ATT-445).
- **Opt-out** — skips recipients where `MessagingService.shouldEmailMessageOnOffline(userId)` is false.
- **Burst debounce / delivery marker** — new nullable `lastNotifiedAt` column on `ConversationParticipant`. An email is sent only when the recipient has not been notified since they last read the conversation (`lastNotifiedAt <= lastReadAt`, or never notified). After sending, `lastNotifiedAt` is set to the message timestamp, so later messages in the same unread burst do **not** re-send. Reading the conversation starts a fresh burst.
- **Email** — `EmailService.sendNewMessageEmail()` renders the new `message-received` MJML DB template (seeded by migration `1781100000000-message-email-fallback.ts`), with a button/link to `/messages?conversation=<id>` and a 200-char content preview.

## Acceptance criteria

- [x] offline recipient with unread message gets exactly one email per unread burst (no per-message storm)
- [x] online recipients and opted-out users never receive an email
- [x] email rendered from seeded MJML DB template via EmailService, links back to the conversation
- [x] delivery marker prevents re-sending for an already-notified message
- [x] per-recipient failure does not block others

## Testing

- New unit spec `message-notification.listener.spec.ts` (10 cases) covers every acceptance criterion: offline+unread → one email + marker write, sender excluded, online skip, opted-out skip, burst debounce (unread & notified-after-read), new burst after read, missing-email skip, per-recipient failure isolation, generic-sender fallback.
- `nx test api` — 1114/1114 pass (incl. `migrations-down.e2e` exercising the new migration up/down).
- `nx lint api database-entities` clean; `nx build api database-entities` and `nx typecheck frontend` (with regenerated client) green.

> Note: the metrics-guard integration test can time out under heavy parallel load in the pre-commit hook; it passes in isolation and is unrelated to this change.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.
<!-- generated-by-cyrus -->
