### PR TITLE
fix(ATT-485): don't count sender's own message as unread

### DIFF
--- a/apps/frontend/src/app/messaging/MessageThread.tsx
+++ b/apps/frontend/src/app/messaging/MessageThread.tsx
@@ -54,7 +54,7 @@ export function MessageThread(props: Props) {
     onSuccess: (created) => {
       setDraft('');
       setAttachedResourceId(undefined);
-      applyIncomingMessage(queryClient, created);
+      applyIncomingMessage(queryClient, created, currentUserId);
     },
   });
 

--- a/apps/frontend/src/app/messaging/index.tsx
+++ b/apps/frontend/src/app/messaging/index.tsx
@@ -71,12 +71,12 @@ export function MessagesPage() {
 
   const handleLiveMessage = useCallback(
     (message: Message) => {
-      applyIncomingMessage(queryClient, message);
+      applyIncomingMessage(queryClient, message, user?.id ?? -1);
       if (message.conversationId === selectedConversationId) {
         markRead(message.conversationId);
       }
     },
-    [queryClient, selectedConversationId, markRead],
+    [queryClient, selectedConversationId, markRead, user?.id],
   );
 
   useMessagingLive({ onMessage: handleLiveMessage });

--- a/apps/frontend/src/app/messaging/messageCache.spec.ts
+++ b/apps/frontend/src/app/messaging/messageCache.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import {
+  ConversationListItemDto,
+  Message,
+  UnreadCountResponseDto,
+  UseMessagingServiceMessagingGetUnreadCountKeyFn,
+  UseMessagingServiceMessagingListConversationsKeyFn,
+} from '@attraccess/react-query-client';
+import { applyIncomingMessage } from './messageCache';
+
+const CURRENT_USER_ID = 1;
+const OTHER_USER_ID = 2;
+const CONVERSATION_ID = 10;
+
+function makeMessage(senderId: number, overrides: Partial<Message> = {}): Message {
+  return {
+    id: Math.floor(Math.random() * 1_000_000),
+    conversationId: CONVERSATION_ID,
+    senderId,
+    content: 'hi',
+    createdAt: new Date().toISOString(),
+    referenceType: null,
+    referenceId: null,
+    referenceLabel: null,
+    referenceUrl: null,
+    ...overrides,
+  } as unknown as Message;
+}
+
+function seedCaches(queryClient: QueryClient) {
+  queryClient.setQueryData<ConversationListItemDto[]>(UseMessagingServiceMessagingListConversationsKeyFn(), [
+    { id: CONVERSATION_ID, unreadCount: 0 } as unknown as ConversationListItemDto,
+  ]);
+  queryClient.setQueryData<UnreadCountResponseDto>(UseMessagingServiceMessagingGetUnreadCountKeyFn(), { total: 0 });
+}
+
+function readUnread(queryClient: QueryClient) {
+  const list = queryClient.getQueryData<ConversationListItemDto[]>(
+    UseMessagingServiceMessagingListConversationsKeyFn(),
+  );
+  const total = queryClient.getQueryData<UnreadCountResponseDto>(
+    UseMessagingServiceMessagingGetUnreadCountKeyFn(),
+  );
+  return { conversationUnread: list?.[0]?.unreadCount ?? 0, total: total?.total ?? 0 };
+}
+
+describe('applyIncomingMessage', () => {
+  it('does not increase unread counters for the sender\'s own message', () => {
+    const queryClient = new QueryClient();
+    seedCaches(queryClient);
+
+    applyIncomingMessage(queryClient, makeMessage(CURRENT_USER_ID), CURRENT_USER_ID);
+
+    expect(readUnread(queryClient)).toEqual({ conversationUnread: 0, total: 0 });
+  });
+
+  it('increases unread counters for a message from another user', () => {
+    const queryClient = new QueryClient();
+    seedCaches(queryClient);
+
+    applyIncomingMessage(queryClient, makeMessage(OTHER_USER_ID), CURRENT_USER_ID);
+
+    expect(readUnread(queryClient)).toEqual({ conversationUnread: 1, total: 1 });
+  });
+});

--- a/apps/frontend/src/app/messaging/messageCache.ts
+++ b/apps/frontend/src/app/messaging/messageCache.ts
@@ -11,7 +11,10 @@ import {
   useMessagingServiceMessagingListMessagesKey,
 } from '@attraccess/react-query-client';
 
-export function applyIncomingMessage(queryClient: QueryClient, message: Message) {
+export function applyIncomingMessage(queryClient: QueryClient, message: Message, currentUserId: number) {
+  // Own messages never count as unread for the sender — only stitch them into the thread/list.
+  const isOwnMessage = message.senderId === currentUserId;
+
   queryClient.setQueriesData<ListMessagesResponseDto>(
     {
       predicate: (query) =>
@@ -40,13 +43,15 @@ export function applyIncomingMessage(queryClient: QueryClient, message: Message)
       const updated = {
         ...current[index],
         lastMessage: message,
-        unreadCount: (current[index].unreadCount ?? 0) + 1,
+        unreadCount: (current[index].unreadCount ?? 0) + (isOwnMessage ? 0 : 1),
       };
       return [updated, ...current.slice(0, index), ...current.slice(index + 1)];
     },
   );
 
-  bumpTotalUnread(queryClient, 1);
+  if (!isOwnMessage) {
+    bumpTotalUnread(queryClient, 1);
+  }
 }
 
 export function markConversationReadInCache(queryClient: QueryClient, conversationId: number, total: number) {


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Sending a message bumped the **sender's own** unread counter. It should only affect the recipient.

### Root cause

`applyIncomingMessage` (frontend `messageCache.ts`) unconditionally incremented the conversation `unreadCount` and the total unread counter for every message it stitched into the cache. It is called for the sender's own message from two paths:

- `MessageThread` send-success handler (`onSuccess`)
- the per-user SSE live stream (`index.tsx` `handleLiveMessage`), which echoes the sender's own message back

Both bumped the sender's unread badge.

### Fix

- `applyIncomingMessage` now takes `currentUserId` and skips both unread bumps when `message.senderId === currentUserId`. The message is still stitched into the thread + conversation list (lastMessage/reorder) as before.
- Both callers updated to pass the current user id.

Backend `countUnread` already excluded own messages (`senderId: Not(userId)`), so this was purely an optimistic-cache bug.

### Testing

- New `messageCache.spec.ts`: own message → no unread increase; other user's message → unread +1.
- `nx test frontend` (messageCache) passes; lint + typecheck clean.

Closes [ATT-485](https://linear.app/attraccess/issue/ATT-485/bug-sending-a-message-increases-my-own-unread-notifications-counter)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
