### PR TITLE
chore(tools): chaos-AP network fault-injection presets (ATT-477)

### DIFF
--- a/tools/chaos-ap/README.md
+++ b/tools/chaos-ap/README.md
@@ -1,0 +1,92 @@
+# chaos-ap — network fault-injection presets
+
+Part B (network) of [ATT-471](https://linear.app/attraccess/issue/ATT-471). A
+controllable "chaos" network between an Attractap reader and the Attraccess
+server, checked into the repo for repeatability.
+
+`chaos-ap.sh` runs **on the AP / gateway** that sits between the reader and the
+server and uses `iptables`, `tc`/`netem`, and (on OpenWRT) `wifi` + `uci` to
+deterministically reproduce one network failure class at a time. Each preset is
+ground truth for validating the matching reader-side fix.
+
+## Target environment
+
+- Primary target: the bench **OpenWRT router** (BusyBox `ash`, `uci`, `wifi`,
+  `dnsmasq`). The script is plain POSIX `sh`.
+- Also runs on any Linux box for the `blackhole` and `netem` presets (they only
+  need `iptables` and `tc`); `flap` falls back to `ifconfig`, and `dhcp-wedge`
+  requires OpenWRT `uci`.
+- Must run as **root**.
+
+`tc netem` needs the scheduler module on the router:
+
+```sh
+opkg update && opkg install kmod-sched tc
+```
+
+## Presets
+
+| Preset | Reproduces | Mechanism |
+| --- | --- | --- |
+| `blackhole` | **ATT-464** half-open sockets | `iptables -A FORWARD ... -j DROP` — silently drops packets with no RST, so the reader's TCP stays half-open |
+| `netem` | **ATT-469** stalls / slow paths | `tc qdisc add dev <if> root netem delay 2000ms loss 30%` |
+| `flap` | **ATT-465 / ATT-467** reconnect churn | kills the SSID (`wifi down <radio>`) and brings it back on a randomized 15–30s interval |
+| `dhcp-wedge` | **ATT-468** DHCP wedge | `uci set dhcp.<section>.ignore=1` — SSID and DNS stay up, but no leases are handed out |
+
+## Usage
+
+```sh
+# enable / disable one preset
+./chaos-ap.sh <preset> on
+./chaos-ap.sh <preset> off
+
+# inspect what is currently active
+./chaos-ap.sh status
+
+# disable everything and restore a clean network
+./chaos-ap.sh clear
+```
+
+### Examples
+
+```sh
+# ATT-464: black-hole one reader (no RST -> half-open socket)
+READER_IP=192.168.8.123 ./chaos-ap.sh blackhole on
+
+# ATT-469: 2s latency + 30% loss on the LAN bridge facing the readers
+IFACE=br-lan DELAY=2000ms LOSS=30% ./chaos-ap.sh netem on
+
+# ATT-465/467: flap the SSID, down 5s, up for a random 15-30s
+RADIO=radio0 FLAP_DOWN=5 FLAP_MIN=15 FLAP_MAX=30 ./chaos-ap.sh flap on
+
+# ATT-468: stop handing out DHCP leases, keep the SSID up
+DHCP_SECTION=lan ./chaos-ap.sh dhcp-wedge on
+
+# undo whatever is running
+./chaos-ap.sh clear
+```
+
+## Config (environment variables)
+
+| Var | Default | Used by | Meaning |
+| --- | --- | --- | --- |
+| `READER_IP` | _(empty)_ | `blackhole` | reader IP to drop; empty = drop **all** FORWARD traffic |
+| `IFACE` | `br-lan` | `netem` | interface that carries reader↔server traffic |
+| `DELAY` | `2000ms` | `netem` | netem added latency |
+| `LOSS` | `30%` | `netem` | netem packet loss |
+| `RADIO` | `radio0` | `flap` | OpenWRT radio (or interface) to toggle |
+| `DHCP_SECTION` | `lan` | `dhcp-wedge` | uci `dhcp.<section>` to wedge |
+| `FLAP_DOWN` | `5` | `flap` | seconds the SSID stays down each cycle |
+| `FLAP_MIN` / `FLAP_MAX` | `15` / `30` | `flap` | random up-time window (seconds) |
+| `FLAP_PIDFILE` | `/tmp/chaos-ap-flap.pid` | `flap` | where the background flap loop records its PID |
+
+## Notes
+
+- Presets are independent; you can stack `blackhole` + `netem`. `clear` (and a
+  reboot) removes everything.
+- `flap` runs a background loop tracked by `FLAP_PIDFILE`; `flap off` / `clear`
+  stops it and brings the radio back up.
+- `dhcp-wedge` keeps DNS working (dnsmasq is only restarted, not stopped) so the
+  failure is isolated to lease acquisition.
+- For per-SSID flapping instead of whole-radio, point `RADIO` at the specific
+  wifi interface (e.g. `wlan0`) so the `ifconfig` fallback is used.

--- a/tools/chaos-ap/chaos-ap.sh
+++ b/tools/chaos-ap/chaos-ap.sh
@@ -1,0 +1,272 @@
+#!/bin/sh
+# chaos-ap.sh — controllable network fault injection for the reader<->server bench.
+#
+# Part B (network) of ATT-471. Runs ON the AP/gateway between an Attractap reader
+# and the Attraccess server (OpenWRT router, or any Linux box with iptables + tc).
+# Each preset deterministically reproduces one real-world failure class so it can
+# be used as ground truth to validate the reader-side fixes:
+#
+#   blackhole   silent black-hole (DROP, no RST)            -> ATT-464 half-open sockets
+#   netem       latency + packet loss (tc netem)            -> ATT-469 stalls / slow paths
+#   flap        kill SSID and flap on an interval           -> ATT-465 / ATT-467 churn
+#   dhcp-wedge  disable DHCP while keeping the SSID up       -> ATT-468 DHCP wedge
+#
+# Usage:
+#   ./chaos-ap.sh <preset> on|off       enable / disable a single preset
+#   ./chaos-ap.sh status                 show what is currently active
+#   ./chaos-ap.sh clear                  disable everything, restore clean state
+#
+# Config is read from the environment (or the defaults below). Override per call:
+#   READER_IP=192.168.8.123 ./chaos-ap.sh blackhole on
+#   IFACE=br-lan DELAY=2000ms LOSS=30% ./chaos-ap.sh netem on
+#   RADIO=radio0 FLAP_MIN=15 FLAP_MAX=30 ./chaos-ap.sh flap on
+#
+# POSIX sh / BusyBox ash compatible. Must run as root.
+
+set -eu
+
+# ----------------------------------------------------------------------------
+# Config (override via environment)
+# ----------------------------------------------------------------------------
+
+# IP of the reader to black-hole (blackhole preset). Empty == all FORWARD traffic.
+READER_IP="${READER_IP:-}"
+
+# Interface that carries reader<->server traffic, where netem is attached.
+# On a typical OpenWRT AP the LAN bridge faces the readers; override for WAN.
+IFACE="${IFACE:-br-lan}"
+
+# netem parameters (netem preset).
+DELAY="${DELAY:-2000ms}"
+LOSS="${LOSS:-30%}"
+
+# Radio / DHCP section for the wifi + dhcp presets (OpenWRT uci names).
+RADIO="${RADIO:-radio0}"
+DHCP_SECTION="${DHCP_SECTION:-lan}"
+
+# Flap timing in seconds (flap preset). Down for FLAP_DOWN, up for a random
+# interval in [FLAP_MIN, FLAP_MAX].
+FLAP_DOWN="${FLAP_DOWN:-5}"
+FLAP_MIN="${FLAP_MIN:-15}"
+FLAP_MAX="${FLAP_MAX:-30}"
+
+# Where the flap background loop records its PID.
+FLAP_PIDFILE="${FLAP_PIDFILE:-/tmp/chaos-ap-flap.pid}"
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+log() { printf 'chaos-ap: %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+require_root() {
+  [ "$(id -u)" = "0" ] || die "must run as root"
+}
+
+require_cmd() {
+  have "$1" || die "required command not found: $1"
+}
+
+rand_between() {
+  # Random integer in [$1, $2] using BusyBox awk (srand from time).
+  awk -v a="$1" -v b="$2" 'BEGIN { srand(); print a + int(rand() * (b - a + 1)) }'
+}
+
+# ----------------------------------------------------------------------------
+# blackhole — silent DROP, no RST. Reader keeps a half-open socket. (ATT-464)
+# ----------------------------------------------------------------------------
+
+blackhole_on() {
+  require_cmd iptables
+  if [ -n "$READER_IP" ]; then
+    iptables -C FORWARD -s "$READER_IP" -j DROP 2>/dev/null \
+      || iptables -A FORWARD -s "$READER_IP" -j DROP
+    iptables -C FORWARD -d "$READER_IP" -j DROP 2>/dev/null \
+      || iptables -A FORWARD -d "$READER_IP" -j DROP
+    log "blackhole ON: dropping FORWARD to/from $READER_IP (no RST)"
+  else
+    iptables -C FORWARD -j DROP 2>/dev/null || iptables -A FORWARD -j DROP
+    log "blackhole ON: dropping ALL FORWARD traffic (no RST)"
+  fi
+}
+
+blackhole_off() {
+  require_cmd iptables
+  if [ -n "$READER_IP" ]; then
+    while iptables -C FORWARD -s "$READER_IP" -j DROP 2>/dev/null; do
+      iptables -D FORWARD -s "$READER_IP" -j DROP
+    done
+    while iptables -C FORWARD -d "$READER_IP" -j DROP 2>/dev/null; do
+      iptables -D FORWARD -d "$READER_IP" -j DROP
+    done
+  else
+    while iptables -C FORWARD -j DROP 2>/dev/null; do
+      iptables -D FORWARD -j DROP
+    done
+  fi
+  log "blackhole OFF"
+}
+
+# ----------------------------------------------------------------------------
+# netem — latency + loss on $IFACE egress. (ATT-469)
+# ----------------------------------------------------------------------------
+
+netem_on() {
+  require_cmd tc
+  tc qdisc del dev "$IFACE" root 2>/dev/null || true
+  tc qdisc add dev "$IFACE" root netem delay "$DELAY" loss "$LOSS"
+  log "netem ON: dev $IFACE delay $DELAY loss $LOSS"
+}
+
+netem_off() {
+  require_cmd tc
+  tc qdisc del dev "$IFACE" root 2>/dev/null || true
+  log "netem OFF: dev $IFACE"
+}
+
+# ----------------------------------------------------------------------------
+# flap — kill the SSID and bring it back on a randomized interval. (ATT-465/467)
+# ----------------------------------------------------------------------------
+
+flap_loop() {
+  while :; do
+    wifi down "$RADIO" 2>/dev/null || ifconfig "$RADIO" down 2>/dev/null || true
+    sleep "$FLAP_DOWN"
+    wifi up "$RADIO" 2>/dev/null || ifconfig "$RADIO" up 2>/dev/null || true
+    sleep "$(rand_between "$FLAP_MIN" "$FLAP_MAX")"
+  done
+}
+
+flap_on() {
+  have wifi || have ifconfig || die "neither 'wifi' (OpenWRT) nor 'ifconfig' available"
+  if [ -f "$FLAP_PIDFILE" ] && kill -0 "$(cat "$FLAP_PIDFILE")" 2>/dev/null; then
+    die "flap already running (pid $(cat "$FLAP_PIDFILE"))"
+  fi
+  flap_loop &
+  echo $! > "$FLAP_PIDFILE"
+  log "flap ON: $RADIO down ${FLAP_DOWN}s / up ${FLAP_MIN}-${FLAP_MAX}s (pid $(cat "$FLAP_PIDFILE"))"
+}
+
+flap_off() {
+  if [ -f "$FLAP_PIDFILE" ]; then
+    kill "$(cat "$FLAP_PIDFILE")" 2>/dev/null || true
+    rm -f "$FLAP_PIDFILE"
+  fi
+  wifi up "$RADIO" 2>/dev/null || ifconfig "$RADIO" up 2>/dev/null || true
+  log "flap OFF: $RADIO restored"
+}
+
+# ----------------------------------------------------------------------------
+# dhcp-wedge — stop handing out leases, keep the SSID + DNS up. (ATT-468)
+# ----------------------------------------------------------------------------
+
+dhcp_wedge_on() {
+  have uci || die "dhcp-wedge requires OpenWRT uci"
+  uci set "dhcp.${DHCP_SECTION}.ignore=1"
+  uci commit dhcp
+  /etc/init.d/dnsmasq restart >/dev/null 2>&1 || true
+  log "dhcp-wedge ON: dhcp.${DHCP_SECTION}.ignore=1 (SSID + DNS stay up, no leases)"
+}
+
+dhcp_wedge_off() {
+  have uci || die "dhcp-wedge requires OpenWRT uci"
+  uci set "dhcp.${DHCP_SECTION}.ignore=0"
+  uci commit dhcp
+  /etc/init.d/dnsmasq restart >/dev/null 2>&1 || true
+  log "dhcp-wedge OFF: dhcp.${DHCP_SECTION}.ignore=0"
+}
+
+# ----------------------------------------------------------------------------
+# status / clear
+# ----------------------------------------------------------------------------
+
+status() {
+  echo "== chaos-ap status =="
+  if have iptables; then
+    echo "-- iptables FORWARD DROP rules --"
+    iptables -S FORWARD 2>/dev/null | grep -- '-j DROP' || echo "(none)"
+  fi
+  if have tc; then
+    echo "-- tc qdisc on $IFACE --"
+    tc qdisc show dev "$IFACE" 2>/dev/null || echo "(none)"
+  fi
+  echo "-- flap --"
+  if [ -f "$FLAP_PIDFILE" ] && kill -0 "$(cat "$FLAP_PIDFILE")" 2>/dev/null; then
+    echo "running (pid $(cat "$FLAP_PIDFILE"), radio $RADIO)"
+  else
+    echo "stopped"
+  fi
+  if have uci; then
+    echo "-- dhcp.${DHCP_SECTION}.ignore --"
+    uci -q get "dhcp.${DHCP_SECTION}.ignore" || echo "0"
+  fi
+}
+
+clear_all() {
+  blackhole_off || true
+  netem_off || true
+  flap_off || true
+  if have uci; then dhcp_wedge_off || true; fi
+  log "all presets cleared"
+}
+
+# ----------------------------------------------------------------------------
+# Dispatch
+# ----------------------------------------------------------------------------
+
+usage() {
+  cat >&2 <<'EOF'
+chaos-ap.sh — network fault injection for the reader<->server bench (ATT-471 part B)
+
+Presets:
+  blackhole   silent DROP, no RST            -> ATT-464 half-open sockets
+  netem       latency + packet loss          -> ATT-469 stalls
+  flap        kill SSID, flap on interval    -> ATT-465 / ATT-467 churn
+  dhcp-wedge  no DHCP leases, SSID stays up  -> ATT-468 DHCP wedge
+
+Usage:
+  chaos-ap.sh <preset> on|off
+  chaos-ap.sh status
+  chaos-ap.sh clear
+
+Config via env (defaults in script): READER_IP IFACE DELAY LOSS RADIO
+  DHCP_SECTION FLAP_DOWN FLAP_MIN FLAP_MAX
+
+Examples:
+  READER_IP=192.168.8.123 chaos-ap.sh blackhole on
+  IFACE=br-lan DELAY=2000ms LOSS=30% chaos-ap.sh netem on
+  RADIO=radio0 FLAP_MIN=15 FLAP_MAX=30 chaos-ap.sh flap on
+EOF
+  exit "${1:-0}"
+}
+
+PRESET="${1:-}"
+ACTION="${2:-}"
+
+# Run on_fn for "on", off_fn for "off", else print usage and exit 1.
+toggle() {
+  case "$ACTION" in
+    on)  "$1" ;;
+    off) "$2" ;;
+    *)   log "preset '$PRESET' needs an action: on|off"; usage 1 ;;
+  esac
+}
+
+case "$PRESET" in
+  -h|--help|help|"") usage 0 ;;
+esac
+
+require_root
+
+case "$PRESET" in
+  blackhole)  toggle blackhole_on  blackhole_off ;;
+  netem)      toggle netem_on      netem_off ;;
+  flap)       toggle flap_on       flap_off ;;
+  dhcp-wedge) toggle dhcp_wedge_on dhcp_wedge_off ;;
+  status)     status ;;
+  clear)      clear_all ;;
+  *) log "unknown preset: $PRESET"; usage 1 ;;
+esac


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Part B (network) of ATT-471: a controllable "chaos" network between an Attractap reader and the Attraccess server, checked into the repo for repeatability.

`tools/chaos-ap/chaos-ap.sh` runs **on the bench AP/gateway** (the OpenWRT router we have on hand, or any Linux box for the iptables/tc presets) and deterministically reproduces one network failure class at a time, to serve as ground truth for validating the reader-side fixes.

## Presets

| Preset | Reproduces | Mechanism |
| --- | --- | --- |
| `blackhole` | **ATT-464** half-open sockets | `iptables -A FORWARD … -j DROP` — silent drop, no RST |
| `netem` | **ATT-469** stalls | `tc qdisc add dev <if> root netem delay 2000ms loss 30%` |
| `flap` | **ATT-465 / ATT-467** churn | kills SSID (`wifi down <radio>`), flaps back on a random 15–30s interval |
| `dhcp-wedge` | **ATT-468** DHCP wedge | `uci set dhcp.<section>.ignore=1` — SSID + DNS stay up, no leases |

Plus `status` and `clear` subcommands. All config is via env vars (`READER_IP`, `IFACE`, `DELAY`, `LOSS`, `RADIO`, `DHCP_SECTION`, `FLAP_*`) with sane defaults documented in `tools/chaos-ap/README.md`.

## Implementation notes

- Plain POSIX `sh`, BusyBox-`ash` compatible (OpenWRT target). Must run as root.
- `blackhole`/`netem` work on any Linux (only need `iptables`/`tc`); `flap` falls back to `ifconfig`; `dhcp-wedge` requires OpenWRT `uci`.
- `flap` runs a background loop tracked by a PID file; `clear`/`flap off` stops it and restores the radio.
- `dhcp-wedge` only restarts dnsmasq (DNS keeps working), isolating the failure to lease acquisition.

## Testing performed

- `sh -n` syntax check passes.
- `--help` runs without root and prints usage.
- shellcheck not installed locally — runs only where available (CI).
- Per-preset bench validation against a live reader is the manual "done when" step, to be run on the OpenWRT router.

## Linear

https://linear.app/attraccess/issue/ATT-477

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
