### PR TITLE
feat(ATT-476): bench freeze-repro build flags + serial fault-injection commands

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.3"'
+	-D FIRMWARE_VERSION='"1.3.4"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v
@@ -64,6 +64,17 @@ build_flags =
 	; LVGL
 	-D LV_CONF_PATH='"${PROJECT_DIR}/include/lv_conf.h"'
 	-D USER_SETUP_LOADED=1
+
+[env:attractap-touch-bench]
+extends = env:attractap-touch
+board_build.sdkconfig_override = sdkconfig.bench
+
+build_flags =
+	${env:attractap-touch.build_flags}
+
+	; Bench freeze-repro harness (ATT-476). Test build only — never shipped.
+	-D LOG_MEMORY_DEBUG
+	-D BENCH_FREEZE_REPRO=1
 
 [env:attractap-touch-v2]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -76,6 +76,17 @@ build_flags =
 	-D LOG_MEMORY_DEBUG
 	-D BENCH_FREEZE_REPRO=1
 
+[env:attractap-touch-v2-bench]
+extends = env:attractap-touch-v2
+board_build.sdkconfig_override = sdkconfig.bench
+
+build_flags =
+	${env:attractap-touch-v2.build_flags}
+
+	; Bench freeze-repro harness (ATT-476). Test build only — never shipped.
+	-D LOG_MEMORY_DEBUG
+	-D BENCH_FREEZE_REPRO=1
+
 [env:attractap-touch-v2]
 board = esp32-s3-devkitc-1-n16r8v
 platform = platformio/espressif32

--- a/apps/attractap/firmware/sdkconfig.bench
+++ b/apps/attractap/firmware/sdkconfig.bench
@@ -1,0 +1,31 @@
+CONFIG_SPIRAM_SUPPORT=y
+CONFIG_SPIRAM_USE_MALLOC=y
+CONFIG_MBEDTLS_EXTERNAL_MEM_ALLOC=y
+CONFIG_MBEDTLS_SSL_IN_CONTENT_LEN=4096
+CONFIG_MBEDTLS_SSL_OUT_CONTENT_LEN=4096
+
+CONFIG_MBEDTLS_TLS_ENABLED=y
+CONFIG_MBEDTLS_SSL_PROTO_TLS1_2=y
+CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED=y
+CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED=y
+CONFIG_MBEDTLS_PEM_PARSE_C=y
+CONFIG_MBEDTLS_PEM_WRITE_C=y
+
+# Disable legacy/unused ones
+# CONFIG_MBEDTLS_KEY_EXCHANGE_RSA_ENABLED is not set
+# CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED is not set
+
+# --- Bench freeze-repro options (ATT-476). Compiled into the bench env only. ---
+# Comprehensive heap poisoning: head/tail canaries + freed-block fill, so heap
+# corruption (crash_heap) is caught by the next heap_caps_check_integrity_all().
+CONFIG_HEAP_POISONING_COMPREHENSIVE=y
+
+# Dump the core dump as base64 over UART on panic so the bench operator gets the
+# backtrace + registers on the serial console without a flash coredump partition.
+CONFIG_ESP_COREDUMP_ENABLE_TO_UART=y
+CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=y
+CONFIG_ESP_COREDUMP_CHECKSUM_CRC32=y
+
+# Task watchdog with panic so hang_wdt produces a real reset + backtrace.
+CONFIG_ESP_TASK_WDT_EN=y
+CONFIG_ESP_TASK_WDT_PANIC=y

--- a/apps/attractap/firmware/src/api/api.cpp
+++ b/apps/attractap/firmware/src/api/api.cpp
@@ -37,6 +37,15 @@ void API::setFirmwareUpdateMetaCallback(std::function<void(String availableVersi
     this->firmwareUpdateMetaCallback = callback;
 }
 
+#ifdef BENCH_FREEZE_REPRO
+void API::dropWebsocket()
+{
+    this->logger.warn("BENCH drop_ws: tearing down websocket, reconnect will follow");
+    this->websocket.disableConnectionAttempts();
+    this->websocket.enableConnectionAttempts();
+}
+#endif
+
 void API::loop()
 {
     this->websocket.loop();

--- a/apps/attractap/firmware/src/api/api.hpp
+++ b/apps/attractap/firmware/src/api/api.hpp
@@ -17,6 +17,9 @@ public:
     void setup();
     void loop();
     void processIncomingMessage(const char *buf, size_t len);
+#ifdef BENCH_FREEZE_REPRO
+    void dropWebsocket();
+#endif
     static constexpr size_t MAX_RESOURCES = 10;
     static constexpr size_t MAX_RESOURCE_NAME_LEN = 64;
     static constexpr size_t MAX_DESC_LEN = 128;

--- a/apps/attractap/firmware/src/application/application.cpp
+++ b/apps/attractap/firmware/src/application/application.cpp
@@ -61,6 +61,10 @@ void Application::setup() {
 
   this->api.setup();
 
+#ifdef BENCH_FREEZE_REPRO
+  SerialCommandHandler::setDropWebsocketHook([this]() { this->api.dropWebsocket(); });
+#endif
+
 #ifdef HAS_LVGL_DISPLAY
   this->api.onDeviceName(
       [this](String deviceName) { Display::setDeviceName(deviceName); });

--- a/apps/attractap/firmware/src/main.cpp
+++ b/apps/attractap/firmware/src/main.cpp
@@ -1,5 +1,8 @@
 #include <Arduino.h>
 #include "esp_err.h"
+#ifdef BENCH_FREEZE_REPRO
+#include "esp_heap_caps.h"
+#endif
 #include "logger/logger.hpp"
 #include <Wire.h>
 #include "freertos/FreeRTOS.h"
@@ -25,6 +28,21 @@ void logLoopStackUsage()
     Logger logger("Stack");
     logger.debugf("loopTask high watermark: %u words (~%u bytes)",
                   watermarkWords, watermarkWords * sizeof(StackType_t));
+}
+#endif
+
+#ifdef BENCH_FREEZE_REPRO
+void checkHeapIntegrity()
+{
+    static uint32_t lastCheck = 0;
+    if (millis() - lastCheck < 1000)
+        return;
+    lastCheck = millis();
+
+    if (!heap_caps_check_integrity_all(true))
+    {
+        Logger("HeapCheck").error("heap integrity check FAILED");
+    }
 }
 #endif
 
@@ -89,6 +107,10 @@ void loop()
 {
 #ifdef LOG_MEMORY_DEBUG
     logLoopStackUsage();
+#endif
+
+#ifdef BENCH_FREEZE_REPRO
+    checkHeapIntegrity();
 #endif
 
     application.loop();

--- a/apps/attractap/firmware/src/serial/serialCommandHandler.cpp
+++ b/apps/attractap/firmware/src/serial/serialCommandHandler.cpp
@@ -4,6 +4,10 @@
 #include <lwip/inet.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#ifdef BENCH_FREEZE_REPRO
+#include <cstdlib>
+#include "esp_heap_caps.h"
+#endif
 
 #include "../settings/settings.hpp"
 #include "../network/wifi/wifi.hpp"
@@ -11,6 +15,20 @@
 
 String SerialCommandHandler::inputBuffer = "";
 Logger SerialCommandHandler::logger("SerialCmd");
+
+#ifdef BENCH_FREEZE_REPRO
+std::function<void()> SerialCommandHandler::dropWebsocketHook = nullptr;
+
+static volatile uint32_t benchStackSink = 0;
+
+static uint32_t benchRecurse(uint32_t depth)
+{
+    volatile uint8_t frame[256];
+    frame[0] = static_cast<uint8_t>(depth);
+    benchStackSink += frame[0];
+    return benchRecurse(depth + 1) + frame[0];
+}
+#endif
 
 void SerialCommandHandler::setup()
 {
@@ -176,6 +194,13 @@ const char *SerialCommandHandler::encryptionTypeToString(wifi_auth_mode_t mode)
 
 void SerialCommandHandler::handleCommand(const String &topic, const String &payload)
 {
+#ifdef BENCH_FREEZE_REPRO
+    if (handleBenchFaultCommand(topic))
+    {
+        return;
+    }
+#endif
+
     bool hasPin = pinIsSet();
 
     StaticJsonDocument<512> payloadDoc;
@@ -401,3 +426,92 @@ void SerialCommandHandler::sendErrorResponse(const String &topic, const char *er
     serializeJson(resp, json);
     sendJsonResponse(topic, json);
 }
+
+#ifdef BENCH_FREEZE_REPRO
+void SerialCommandHandler::setDropWebsocketHook(std::function<void()> hook)
+{
+    dropWebsocketHook = hook;
+}
+
+bool SerialCommandHandler::handleBenchFaultCommand(const String &topic)
+{
+    if (topic != "crash_heap" && topic != "crash_null" && topic != "crash_abort" &&
+        topic != "crash_stack" && topic != "hang_loop" && topic != "hang_wdt" &&
+        topic != "drop_ws")
+    {
+        return false;
+    }
+
+    logger.errorf("BENCH fault injection requested: %s", topic.c_str());
+    DynamicJsonDocument resp(96);
+    resp["fault"] = topic;
+    resp["triggered"] = true;
+    String json;
+    serializeJson(resp, json);
+    sendJsonResponse(topic, json);
+    Serial.flush();
+
+    if (topic == "drop_ws")
+    {
+        if (dropWebsocketHook)
+        {
+            dropWebsocketHook();
+        }
+        else
+        {
+            logger.error("drop_ws: no websocket hook registered");
+        }
+        return true;
+    }
+
+    if (topic == "crash_heap")
+    {
+        volatile uint8_t *buf = static_cast<uint8_t *>(malloc(16));
+        if (buf)
+        {
+            for (size_t i = 0; i < 64; i++)
+            {
+                buf[i] = 0xAB;
+            }
+            heap_caps_check_integrity_all(true);
+        }
+        return true;
+    }
+
+    if (topic == "crash_null")
+    {
+        volatile uint32_t *p = nullptr;
+        *p = 0xDEADBEEF;
+        return true;
+    }
+
+    if (topic == "crash_abort")
+    {
+        abort();
+    }
+
+    if (topic == "crash_stack")
+    {
+        benchStackSink += benchRecurse(0);
+        return true;
+    }
+
+    if (topic == "hang_loop")
+    {
+        while (true)
+        {
+            delay(1000);
+        }
+    }
+
+    if (topic == "hang_wdt")
+    {
+        portDISABLE_INTERRUPTS();
+        while (true)
+        {
+        }
+    }
+
+    return true;
+}
+#endif

--- a/apps/attractap/firmware/src/serial/serialCommandHandler.hpp
+++ b/apps/attractap/firmware/src/serial/serialCommandHandler.hpp
@@ -5,11 +5,19 @@
 #include "../network/wifi/wifi.hpp"
 #include "../logger/logger.hpp"
 
+#ifdef BENCH_FREEZE_REPRO
+#include <functional>
+#endif
+
 class SerialCommandHandler
 {
 public:
     static void setup();
     static void loop();
+
+#ifdef BENCH_FREEZE_REPRO
+    static void setDropWebsocketHook(std::function<void()> hook);
+#endif
 
 private:
     static constexpr size_t MAX_COMMAND_LENGTH = 256;
@@ -19,6 +27,11 @@ private:
 
     static void processLine(const String &line);
     static void handleCommand(const String &topic, const String &payload);
+
+#ifdef BENCH_FREEZE_REPRO
+    static std::function<void()> dropWebsocketHook;
+    static bool handleBenchFaultCommand(const String &topic);
+#endif
 
     static bool pinIsSet();
     static bool validateNewCode(const char *code);

--- a/apps/attractap/firmware/tools/bench_fault_test.py
+++ b/apps/attractap/firmware/tools/bench_fault_test.py
@@ -1,0 +1,43 @@
+import sys
+import time
+import glob
+import serial
+
+
+def find_port():
+    for _ in range(40):
+        ports = glob.glob("/dev/cu.usbmodem*")
+        if ports:
+            return ports[0]
+        time.sleep(0.25)
+    return None
+
+
+def run(cmd, settle=2.0, capture=8.0):
+    port = find_port()
+    if not port:
+        print("NO_PORT")
+        return
+    try:
+        ser = serial.Serial(port, 115200, timeout=0.2)
+    except Exception as e:
+        print("OPEN_FAIL", e)
+        return
+    time.sleep(settle)
+    ser.reset_input_buffer()
+    line = ("CMND " + cmd + "\n").encode()
+    ser.write(line)
+    ser.flush()
+    print("=== sent:", line.decode().strip())
+    end = time.time() + capture
+    buf = b""
+    while time.time() < end:
+        buf += ser.read(4096)
+    ser.close()
+    text = buf.decode("utf-8", "replace")
+    print(text)
+    print("=== end", cmd, "(", len(buf), "bytes )")
+
+
+if __name__ == "__main__":
+    run(sys.argv[1], capture=float(sys.argv[2]) if len(sys.argv) > 2 else 8.0)


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Part B (firmware) of ATT-471. Adds a **bench-only** build that can fault-inject every freeze class on demand on a USB-attached dev unit — so freezes can be reproduced in minutes instead of waiting days for natural churn. Everything is gated behind `BENCH_FREEZE_REPRO` and compiled out of every release env.

## Changes

**Bench build (`platformio.ini` + `sdkconfig.bench`)**
- New `[env:attractap-touch-bench]` extending `attractap-touch`, with `-D LOG_MEMORY_DEBUG` and `-D BENCH_FREEZE_REPRO=1`.
- `sdkconfig.bench` enables `CONFIG_HEAP_POISONING_COMPREHENSIVE` (head/tail canaries + freed-fill), coredump-to-UART (`CONFIG_ESP_COREDUMP_ENABLE_TO_UART`, ELF + CRC32) so backtrace/registers dump to serial on panic without a flash partition, and task WDT with panic.
- `FIRMWARE_VERSION` bumped 1.3.3 → 1.3.4 (OTA).

**Periodic heap integrity (`main.cpp`)**
- Under `BENCH_FREEZE_REPRO`, the main loop calls `heap_caps_check_integrity_all(true)` ~1×/s, so heap corruption surfaces quickly even without an explicit command.

**Serial fault-injection commands (`serialCommandHandler.cpp/.hpp`, bench only)**
- `crash_heap` — overflows a heap block, smashing the poisoning canary; next integrity check panics (ATT-465/466 heap/UAF class).
- `crash_null` — null-pointer store (StoreProhibited panic).
- `crash_abort` — `abort()` → SW-reset panic.
- `crash_stack` — unbounded recursion → stack-overflow canary panic.
- `hang_loop` — blocks the loop task forever while RTOS keeps running → true silent hang (ATT-463/464 class).
- `hang_wdt` — disables interrupts and spins → watchdog reset.
- `drop_ws` — drops + reconnects the websocket to drive reconnect churn (ATT-464/465), via a hook into `API::dropWebsocket()` registered in `Application::setup()`.

Each command acks over serial (`RESP <topic> {"fault":...,"triggered":true}`) and flushes before triggering, so the operator sees the request immediately followed by the coredump/heap state.

## Testing

Hardware-in-the-loop verification (flash bench build, run each command on a USB-attached dev unit, confirm the expected crash/hang + serial coredump/heap readout) requires the physical bench unit and is not runnable in CI. Code is compile-gated so release builds are unaffected.

## Linear

https://linear.app/attraccess/issue/ATT-476

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->