### PR TITLE
feat(ATT-448): per-user message send rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ ATTRACCESS_URL=http://localhost:3000
 # uniquelocal. Setting this larger than your real proxy chain lets clients spoof their IP.
 #TRUST_PROXY=1
 
+# Per-user messaging rate limits (abuse prevention). Each scope is throttled
+# independently with a fixed window keyed by the authenticated user. Exceeding a
+# limit returns HTTP 429. Defaults are invisible during normal interactive use.
+#MESSAGING_SEND_RATE_LIMIT_MAX=30
+#MESSAGING_SEND_RATE_LIMIT_WINDOW_SECONDS=60
+#MESSAGING_CONTACT_RATE_LIMIT_MAX=10
+#MESSAGING_CONTACT_RATE_LIMIT_WINDOW_SECONDS=60
+
 SMTP_SERVICE=SMTP
 SMTP_HOST=localhost
 SMTP_PORT=1025

--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,6 @@ ATTRACCESS_URL=http://localhost:3000
 # uniquelocal. Setting this larger than your real proxy chain lets clients spoof their IP.
 #TRUST_PROXY=1
 
-# Per-user messaging rate limits (abuse prevention). Each scope is throttled
-# independently with a fixed window keyed by the authenticated user. Exceeding a
-# limit returns HTTP 429. Defaults are invisible during normal interactive use.
-#MESSAGING_SEND_RATE_LIMIT_MAX=30
-#MESSAGING_SEND_RATE_LIMIT_WINDOW_SECONDS=60
-#MESSAGING_CONTACT_RATE_LIMIT_MAX=10
-#MESSAGING_CONTACT_RATE_LIMIT_WINDOW_SECONDS=60
-
 SMTP_SERVICE=SMTP
 SMTP_HOST=localhost
 SMTP_PORT=1025

--- a/apps/api/src/common/rate-limiting/fixed-window-counter.spec.ts
+++ b/apps/api/src/common/rate-limiting/fixed-window-counter.spec.ts
@@ -1,0 +1,41 @@
+import { FixedWindowCounterStore, WindowCounterEntry } from './fixed-window-counter';
+
+describe('FixedWindowCounterStore', () => {
+  it('stores and retrieves entries by key', () => {
+    const store = new FixedWindowCounterStore<string, WindowCounterEntry>(10);
+    store.set('a', { count: 1, firstAt: 100 });
+    expect(store.get('a')).toEqual({ count: 1, firstAt: 100 });
+    expect(store.has('a')).toBe(true);
+    expect(store.size).toBe(1);
+  });
+
+  it('deletes entries', () => {
+    const store = new FixedWindowCounterStore<string, WindowCounterEntry>(10);
+    store.set('a', { count: 1, firstAt: 100 });
+    store.delete('a');
+    expect(store.has('a')).toBe(false);
+    expect(store.size).toBe(0);
+  });
+
+  it('evicts entries the caller marks stale', () => {
+    const store = new FixedWindowCounterStore<string, WindowCounterEntry>(10);
+    store.set('fresh', { count: 1, firstAt: 1000 });
+    store.set('stale', { count: 1, firstAt: 1 });
+    store.evict((entry) => entry.firstAt < 500);
+    expect(store.has('fresh')).toBe(true);
+    expect(store.has('stale')).toBe(false);
+  });
+
+  it('drops the oldest entries when over capacity', () => {
+    const store = new FixedWindowCounterStore<string, WindowCounterEntry>(2);
+    store.set('oldest', { count: 1, firstAt: 1 });
+    store.set('middle', { count: 1, firstAt: 2 });
+    store.set('newest', { count: 1, firstAt: 3 });
+    // Nothing stale, but capacity is 2 -> the single oldest entry is dropped.
+    store.evict(() => false);
+    expect(store.size).toBe(2);
+    expect(store.has('oldest')).toBe(false);
+    expect(store.has('middle')).toBe(true);
+    expect(store.has('newest')).toBe(true);
+  });
+});

--- a/apps/api/src/common/rate-limiting/fixed-window-counter.ts
+++ b/apps/api/src/common/rate-limiting/fixed-window-counter.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimum shape every fixed-window counter entry must have. Callers may extend
+ * it with their own bookkeeping (e.g. lockout state for auth brute-force).
+ */
+export interface WindowCounterEntry {
+  /** Number of actions recorded in the current window. */
+  count: number;
+  /** Epoch milliseconds when the current window started. */
+  firstAt: number;
+}
+
+/**
+ * Bounded, in-memory fixed-window counter store.
+ *
+ * Provides the storage + housekeeping that the auth brute-force protection and
+ * the per-user messaging rate limiter both need: a per-key counter map, stale
+ * entry eviction, and a hard capacity bound that drops the oldest entries under
+ * abuse. The window/limit semantics (reset, thresholds, lockout, backoff) stay
+ * with the caller — this class only owns bounded storage.
+ */
+export class FixedWindowCounterStore<K, E extends WindowCounterEntry> {
+  private readonly entries = new Map<K, E>();
+
+  constructor(private readonly maxEntries: number) {}
+
+  get(key: K): E | undefined {
+    return this.entries.get(key);
+  }
+
+  set(key: K, entry: E): void {
+    this.entries.set(key, entry);
+  }
+
+  delete(key: K): void {
+    this.entries.delete(key);
+  }
+
+  has(key: K): boolean {
+    return this.entries.has(key);
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Removes every entry the caller deems stale, then enforces the capacity
+   * bound by dropping the oldest (lowest `firstAt`) entries that remain.
+   */
+  evict(isStale: (entry: E) => boolean): void {
+    for (const [key, entry] of this.entries) {
+      if (isStale(entry)) {
+        this.entries.delete(key);
+      }
+    }
+
+    if (this.entries.size > this.maxEntries) {
+      const overflow = this.entries.size - this.maxEntries;
+      const oldest = [...this.entries.entries()].sort(([, a], [, b]) => a.firstAt - b.firstAt);
+      for (let i = 0; i < overflow && i < oldest.length; i += 1) {
+        this.entries.delete(oldest[i][0]);
+      }
+    }
+  }
+}

--- a/apps/api/src/messaging/messaging.controller.ts
+++ b/apps/api/src/messaging/messaging.controller.ts
@@ -51,6 +51,7 @@ export class MessagingController {
     operationId: 'messagingContactUser',
   })
   @ApiResponse({ status: 201, description: 'The existing or newly created conversation', type: ContactResponseDto })
+  @ApiResponse({ status: 429, description: 'Contact rate limit exceeded' })
   async contactUser(
     @Param('userId', ParseIntPipe) userId: number,
     @Req() req: AuthenticatedRequest,
@@ -67,6 +68,7 @@ export class MessagingController {
   })
   @ApiResponse({ status: 201, description: 'The conversation with the resource holder', type: ContactResponseDto })
   @ApiResponse({ status: 404, description: 'No active session for this resource' })
+  @ApiResponse({ status: 429, description: 'Contact rate limit exceeded' })
   async contactResourceHolder(
     @Param('resourceId', ParseIntPipe) resourceId: number,
     @Req() req: AuthenticatedRequest,
@@ -140,6 +142,7 @@ export class MessagingController {
   @ApiOperation({ summary: 'Send a message to a conversation', operationId: 'messagingSendMessage' })
   @ApiResponse({ status: 201, description: 'The created message', type: Message })
   @ApiResponse({ status: 403, description: 'You are not a participant of this conversation' })
+  @ApiResponse({ status: 429, description: 'Message send rate limit exceeded' })
   async sendMessage(
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: SendMessageDto,

--- a/apps/api/src/messaging/messaging.module.ts
+++ b/apps/api/src/messaging/messaging.module.ts
@@ -12,6 +12,7 @@ import { MessagingService } from './messaging.service';
 import { MessagingLiveService } from './messaging-live.service';
 import { MessagingController } from './messaging.controller';
 import { MessageNotificationListener } from './message-notification.listener';
+import { MessageRateLimitService } from './rate-limiting/message-rate-limit.service';
 import { ResourceUsageModule } from '../resources/usage/resourceUsage.module';
 import { EmailModule } from '../email/email.module';
 
@@ -22,7 +23,7 @@ import { EmailModule } from '../email/email.module';
     EmailModule,
   ],
   controllers: [MessagingController],
-  providers: [MessagingService, MessagingLiveService, MessageNotificationListener],
+  providers: [MessagingService, MessagingLiveService, MessageNotificationListener, MessageRateLimitService],
   exports: [MessagingService],
 })
 export class MessagingModule {}

--- a/apps/api/src/messaging/messaging.module.ts
+++ b/apps/api/src/messaging/messaging.module.ts
@@ -15,12 +15,14 @@ import { MessageNotificationListener } from './message-notification.listener';
 import { MessageRateLimitService } from './rate-limiting/message-rate-limit.service';
 import { ResourceUsageModule } from '../resources/usage/resourceUsage.module';
 import { EmailModule } from '../email/email.module';
+import { SettingsModule } from '../settings/settings.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Conversation, ConversationParticipant, Message, NotificationPreference, Resource, User]),
     ResourceUsageModule,
     EmailModule,
+    SettingsModule,
   ],
   controllers: [MessagingController],
   providers: [MessagingService, MessagingLiveService, MessageNotificationListener, MessageRateLimitService],

--- a/apps/api/src/messaging/messaging.service.spec.ts
+++ b/apps/api/src/messaging/messaging.service.spec.ts
@@ -16,6 +16,8 @@ import { MessagingService } from './messaging.service';
 import { MessagingLiveService } from './messaging-live.service';
 import { MessageCreatedEvent } from './events/message-created.event';
 import { ResourceUsageService } from '../resources/usage/resourceUsage.service';
+import { MessageRateLimitService } from './rate-limiting/message-rate-limit.service';
+import { MessageRateLimitExceededException } from './rate-limiting/message-rate-limit.exception';
 
 describe('MessagingService', () => {
   let service: MessagingService;
@@ -35,6 +37,7 @@ describe('MessagingService', () => {
   let resourceUsageService: { getActiveSession: jest.Mock };
   let eventEmitter: { emit: jest.Mock };
   let messagingLiveService: { isOnline: jest.Mock };
+  let messageRateLimitService: { assertWithinLimit: jest.Mock };
 
   const pairQuery = {
     select: jest.fn().mockReturnThis(),
@@ -75,6 +78,7 @@ describe('MessagingService', () => {
     resourceUsageService = { getActiveSession: jest.fn() };
     eventEmitter = { emit: jest.fn() };
     messagingLiveService = { isOnline: jest.fn().mockReturnValue(false) };
+    messageRateLimitService = { assertWithinLimit: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -89,6 +93,7 @@ describe('MessagingService', () => {
         { provide: ResourceUsageService, useValue: resourceUsageService },
         { provide: EventEmitter2, useValue: eventEmitter },
         { provide: MessagingLiveService, useValue: messagingLiveService },
+        { provide: MessageRateLimitService, useValue: messageRateLimitService },
       ],
     }).compile();
 
@@ -152,6 +157,38 @@ describe('MessagingService', () => {
       expect(result.referenceType).toBe(MessageReferenceType.RESOURCE);
       expect(result.referenceId).toBe(42);
       expect(eventEmitter.emit).toHaveBeenCalledWith(MessageCreatedEvent.EVENT_NAME, expect.any(MessageCreatedEvent));
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('checks the send_message limit before sending', async () => {
+      participantRepository.findOne.mockResolvedValue({ id: 1 } as ConversationParticipant);
+      messageRepository.save.mockImplementation(async (data) => ({ id: 3, ...data }));
+
+      await service.sendMessage(1, 5, 'hello');
+
+      expect(messageRateLimitService.assertWithinLimit).toHaveBeenCalledWith('send_message', 5);
+    });
+
+    it('propagates the 429 and skips the send when the send limit is exceeded', async () => {
+      const error = new MessageRateLimitExceededException(30);
+      messageRateLimitService.assertWithinLimit.mockImplementation(() => {
+        throw error;
+      });
+
+      await expect(service.sendMessage(1, 5, 'hello')).rejects.toBe(error);
+      expect(participantRepository.findOne).not.toHaveBeenCalled();
+      expect(messageRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('checks the contact limit when opening a conversation', async () => {
+      messageRateLimitService.assertWithinLimit.mockImplementation(() => {
+        throw new MessageRateLimitExceededException(60);
+      });
+
+      await expect(service.getOrCreateConversation(1, 2)).rejects.toBeInstanceOf(MessageRateLimitExceededException);
+      expect(messageRateLimitService.assertWithinLimit).toHaveBeenCalledWith('contact', 1);
+      expect(userRepository.findOne).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/messaging/messaging.service.ts
+++ b/apps/api/src/messaging/messaging.service.ts
@@ -47,7 +47,7 @@ export class MessagingService {
   ) {}
 
   public async getOrCreateConversation(currentUserId: number, targetUserId: number): Promise<Conversation> {
-    this.messageRateLimitService.assertWithinLimit('contact', currentUserId);
+    await this.messageRateLimitService.assertWithinLimit('contact', currentUserId);
 
     if (currentUserId === targetUserId) {
       throw new BadRequestException('Cannot start a conversation with yourself');
@@ -98,7 +98,7 @@ export class MessagingService {
     content: string,
     reference?: MessageReference,
   ): Promise<Message> {
-    this.messageRateLimitService.assertWithinLimit('send_message', senderId);
+    await this.messageRateLimitService.assertWithinLimit('send_message', senderId);
 
     await this.assertParticipant(conversationId, senderId);
 

--- a/apps/api/src/messaging/messaging.service.ts
+++ b/apps/api/src/messaging/messaging.service.ts
@@ -17,6 +17,7 @@ import { ConversationListItemDto } from './dtos/conversationListItem.dto';
 import { MessagingLiveService } from './messaging-live.service';
 import { NotificationPreferenceDto } from './dtos/notificationPreference.dto';
 import { UpdateNotificationPreferenceDto } from './dtos/updateNotificationPreference.dto';
+import { MessageRateLimitService } from './rate-limiting/message-rate-limit.service';
 
 export interface MessageReference {
   referenceType: MessageReferenceType;
@@ -42,9 +43,12 @@ export class MessagingService {
     private readonly resourceUsageService: ResourceUsageService,
     private readonly eventEmitter: EventEmitter2,
     private readonly messagingLiveService: MessagingLiveService,
+    private readonly messageRateLimitService: MessageRateLimitService,
   ) {}
 
   public async getOrCreateConversation(currentUserId: number, targetUserId: number): Promise<Conversation> {
+    this.messageRateLimitService.assertWithinLimit('contact', currentUserId);
+
     if (currentUserId === targetUserId) {
       throw new BadRequestException('Cannot start a conversation with yourself');
     }
@@ -94,6 +98,8 @@ export class MessagingService {
     content: string,
     reference?: MessageReference,
   ): Promise<Message> {
+    this.messageRateLimitService.assertWithinLimit('send_message', senderId);
+
     await this.assertParticipant(conversationId, senderId);
 
     const decoration = await this.resolveReferenceDecoration(reference);

--- a/apps/api/src/messaging/rate-limiting/message-rate-limit.constants.ts
+++ b/apps/api/src/messaging/rate-limiting/message-rate-limit.constants.ts
@@ -2,14 +2,9 @@
  * Per-user messaging rate-limit policy.
  *
  * Each scope is throttled independently with a fixed window keyed by senderId.
- * Defaults are tuned to be invisible during normal interactive usage while
- * still blocking automated abuse. They can be overridden via environment
- * variables (documented in the repo `.env` example / README):
- *
- *   MESSAGING_SEND_RATE_LIMIT_MAX                (default 30)
- *   MESSAGING_SEND_RATE_LIMIT_WINDOW_SECONDS     (default 60)
- *   MESSAGING_CONTACT_RATE_LIMIT_MAX             (default 10)
- *   MESSAGING_CONTACT_RATE_LIMIT_WINDOW_SECONDS  (default 60)
+ * The actual limits are stored in the database and managed through the system
+ * settings UI (Settings → Messaging rate limiting); see `SettingsService`
+ * (MESSAGING_* keys) for the persisted values and defaults.
  */
 
 export type MessageRateLimitScope = 'send_message' | 'contact';
@@ -19,32 +14,6 @@ export interface MessageRateLimit {
   maxActions: number;
   /** Length of the rolling window in seconds. */
   windowSeconds: number;
-}
-
-function readPositiveInt(value: string | undefined, fallback: number): number {
-  if (value === undefined) {
-    return fallback;
-  }
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
-    return fallback;
-  }
-  return parsed;
-}
-
-export function resolveMessageRateLimits(
-  env: NodeJS.ProcessEnv = process.env,
-): Record<MessageRateLimitScope, MessageRateLimit> {
-  return {
-    send_message: {
-      maxActions: readPositiveInt(env.MESSAGING_SEND_RATE_LIMIT_MAX, 30),
-      windowSeconds: readPositiveInt(env.MESSAGING_SEND_RATE_LIMIT_WINDOW_SECONDS, 60),
-    },
-    contact: {
-      maxActions: readPositiveInt(env.MESSAGING_CONTACT_RATE_LIMIT_MAX, 10),
-      windowSeconds: readPositiveInt(env.MESSAGING_CONTACT_RATE_LIMIT_WINDOW_SECONDS, 60),
-    },
-  };
 }
 
 /** Upper bound on tracked counters to keep memory bounded under abuse. */

--- a/apps/api/src/messaging/rate-limiting/message-rate-limit.constants.ts
+++ b/apps/api/src/messaging/rate-limiting/message-rate-limit.constants.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-user messaging rate-limit policy.
+ *
+ * Each scope is throttled independently with a fixed window keyed by senderId.
+ * Defaults are tuned to be invisible during normal interactive usage while
+ * still blocking automated abuse. They can be overridden via environment
+ * variables (documented in the repo `.env` example / README):
+ *
+ *   MESSAGING_SEND_RATE_LIMIT_MAX                (default 30)
+ *   MESSAGING_SEND_RATE_LIMIT_WINDOW_SECONDS     (default 60)
+ *   MESSAGING_CONTACT_RATE_LIMIT_MAX             (default 10)
+ *   MESSAGING_CONTACT_RATE_LIMIT_WINDOW_SECONDS  (default 60)
+ */
+
+export type MessageRateLimitScope = 'send_message' | 'contact';
+
+export interface MessageRateLimit {
+  /** Maximum number of allowed actions within the window. */
+  maxActions: number;
+  /** Length of the rolling window in seconds. */
+  windowSeconds: number;
+}
+
+function readPositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export function resolveMessageRateLimits(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<MessageRateLimitScope, MessageRateLimit> {
+  return {
+    send_message: {
+      maxActions: readPositiveInt(env.MESSAGING_SEND_RATE_LIMIT_MAX, 30),
+      windowSeconds: readPositiveInt(env.MESSAGING_SEND_RATE_LIMIT_WINDOW_SECONDS, 60),
+    },
+    contact: {
+      maxActions: readPositiveInt(env.MESSAGING_CONTACT_RATE_LIMIT_MAX, 10),
+      windowSeconds: readPositiveInt(env.MESSAGING_CONTACT_RATE_LIMIT_WINDOW_SECONDS, 60),
+    },
+  };
+}
+
+/** Upper bound on tracked counters to keep memory bounded under abuse. */
+export const MAX_MESSAGE_RATE_COUNTERS = 50_000;

--- a/apps/api/src/messaging/rate-limiting/message-rate-limit.exception.ts
+++ b/apps/api/src/messaging/rate-limiting/message-rate-limit.exception.ts
@@ -1,0 +1,23 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/**
+ * Thrown when a user exceeds the per-user messaging send/contact rate limit.
+ * Maps to HTTP 429 Too Many Requests and carries the number of seconds the
+ * client should wait before retrying.
+ */
+export class MessageRateLimitExceededException extends HttpException {
+  public readonly retryAfterSeconds: number;
+
+  constructor(retryAfterSeconds: number) {
+    super(
+      {
+        statusCode: HttpStatus.TOO_MANY_REQUESTS,
+        message: `You are sending messages too quickly. Please wait ${retryAfterSeconds} second(s) before trying again.`,
+        error: 'MessageRateLimitExceeded',
+        retryAfterSeconds,
+      },
+      HttpStatus.TOO_MANY_REQUESTS,
+    );
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}

--- a/apps/api/src/messaging/rate-limiting/message-rate-limit.service.spec.ts
+++ b/apps/api/src/messaging/rate-limiting/message-rate-limit.service.spec.ts
@@ -1,0 +1,71 @@
+import { MessageRateLimitService } from './message-rate-limit.service';
+import { MessageRateLimitExceededException } from './message-rate-limit.exception';
+
+describe('MessageRateLimitService', () => {
+  let service: MessageRateLimitService;
+  let now: number;
+
+  beforeEach(() => {
+    service = new MessageRateLimitService();
+    now = 1_000_000;
+    // Deterministic clock and small limits for the test.
+    (service as unknown as { nowFn: () => number }).nowFn = () => now;
+    (service as unknown as { limits: Record<string, { maxActions: number; windowSeconds: number }> }).limits = {
+      send_message: { maxActions: 3, windowSeconds: 60 },
+      contact: { maxActions: 2, windowSeconds: 60 },
+    };
+  });
+
+  it('allows actions up to the configured limit', () => {
+    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
+    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
+    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
+  });
+
+  it('throws a 429 once the limit is exceeded within the window', () => {
+    for (let i = 0; i < 3; i += 1) {
+      service.assertWithinLimit('send_message', 1);
+    }
+    expect(() => service.assertWithinLimit('send_message', 1)).toThrow(MessageRateLimitExceededException);
+  });
+
+  it('exposes a positive retryAfterSeconds on the exception', () => {
+    for (let i = 0; i < 3; i += 1) {
+      service.assertWithinLimit('send_message', 1);
+    }
+    try {
+      service.assertWithinLimit('send_message', 1);
+      fail('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(MessageRateLimitExceededException);
+      expect((error as MessageRateLimitExceededException).retryAfterSeconds).toBeGreaterThan(0);
+    }
+  });
+
+  it('resets after the window elapses', () => {
+    for (let i = 0; i < 3; i += 1) {
+      service.assertWithinLimit('send_message', 1);
+    }
+    expect(() => service.assertWithinLimit('send_message', 1)).toThrow(MessageRateLimitExceededException);
+
+    now += 60_000; // advance past the window
+    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
+  });
+
+  it('tracks limits independently per user', () => {
+    for (let i = 0; i < 3; i += 1) {
+      service.assertWithinLimit('send_message', 1);
+    }
+    expect(() => service.assertWithinLimit('send_message', 1)).toThrow(MessageRateLimitExceededException);
+    // A different user is unaffected.
+    expect(() => service.assertWithinLimit('send_message', 2)).not.toThrow();
+  });
+
+  it('tracks limits independently per scope', () => {
+    service.assertWithinLimit('contact', 1);
+    service.assertWithinLimit('contact', 1);
+    expect(() => service.assertWithinLimit('contact', 1)).toThrow(MessageRateLimitExceededException);
+    // The send_message scope for the same user still has budget.
+    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
+  });
+});

--- a/apps/api/src/messaging/rate-limiting/message-rate-limit.service.spec.ts
+++ b/apps/api/src/messaging/rate-limiting/message-rate-limit.service.spec.ts
@@ -1,40 +1,50 @@
 import { MessageRateLimitService } from './message-rate-limit.service';
 import { MessageRateLimitExceededException } from './message-rate-limit.exception';
+import { MessagingRateLimitPolicy } from '../../settings/constants';
+import { SettingsService } from '../../settings/settings.service';
 
 describe('MessageRateLimitService', () => {
   let service: MessageRateLimitService;
   let now: number;
+  // Small limits for the test: 3 sends / window, 2 contacts / window.
+  const policy: MessagingRateLimitPolicy = {
+    sendMaxPerWindow: 3,
+    sendWindowSeconds: 60,
+    contactMaxPerWindow: 2,
+    contactWindowSeconds: 60,
+  };
 
   beforeEach(() => {
-    service = new MessageRateLimitService();
+    const settingsService = {
+      getMessagingRateLimitPolicy: jest.fn().mockResolvedValue(policy),
+    } as unknown as SettingsService;
+    service = new MessageRateLimitService(settingsService);
     now = 1_000_000;
-    // Deterministic clock and small limits for the test.
+    // Deterministic clock.
     (service as unknown as { nowFn: () => number }).nowFn = () => now;
-    (service as unknown as { limits: Record<string, { maxActions: number; windowSeconds: number }> }).limits = {
-      send_message: { maxActions: 3, windowSeconds: 60 },
-      contact: { maxActions: 2, windowSeconds: 60 },
-    };
   });
 
-  it('allows actions up to the configured limit', () => {
-    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
-    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
-    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
+  it('allows actions up to the configured limit', async () => {
+    await expect(service.assertWithinLimit('send_message', 1)).resolves.toBeUndefined();
+    await expect(service.assertWithinLimit('send_message', 1)).resolves.toBeUndefined();
+    await expect(service.assertWithinLimit('send_message', 1)).resolves.toBeUndefined();
   });
 
-  it('throws a 429 once the limit is exceeded within the window', () => {
+  it('throws a 429 once the limit is exceeded within the window', async () => {
     for (let i = 0; i < 3; i += 1) {
-      service.assertWithinLimit('send_message', 1);
+      await service.assertWithinLimit('send_message', 1);
     }
-    expect(() => service.assertWithinLimit('send_message', 1)).toThrow(MessageRateLimitExceededException);
+    await expect(service.assertWithinLimit('send_message', 1)).rejects.toBeInstanceOf(
+      MessageRateLimitExceededException,
+    );
   });
 
-  it('exposes a positive retryAfterSeconds on the exception', () => {
+  it('exposes a positive retryAfterSeconds on the exception', async () => {
     for (let i = 0; i < 3; i += 1) {
-      service.assertWithinLimit('send_message', 1);
+      await service.assertWithinLimit('send_message', 1);
     }
     try {
-      service.assertWithinLimit('send_message', 1);
+      await service.assertWithinLimit('send_message', 1);
       fail('expected throw');
     } catch (error) {
       expect(error).toBeInstanceOf(MessageRateLimitExceededException);
@@ -42,30 +52,36 @@ describe('MessageRateLimitService', () => {
     }
   });
 
-  it('resets after the window elapses', () => {
+  it('resets after the window elapses', async () => {
     for (let i = 0; i < 3; i += 1) {
-      service.assertWithinLimit('send_message', 1);
+      await service.assertWithinLimit('send_message', 1);
     }
-    expect(() => service.assertWithinLimit('send_message', 1)).toThrow(MessageRateLimitExceededException);
+    await expect(service.assertWithinLimit('send_message', 1)).rejects.toBeInstanceOf(
+      MessageRateLimitExceededException,
+    );
 
     now += 60_000; // advance past the window
-    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
+    await expect(service.assertWithinLimit('send_message', 1)).resolves.toBeUndefined();
   });
 
-  it('tracks limits independently per user', () => {
+  it('tracks limits independently per user', async () => {
     for (let i = 0; i < 3; i += 1) {
-      service.assertWithinLimit('send_message', 1);
+      await service.assertWithinLimit('send_message', 1);
     }
-    expect(() => service.assertWithinLimit('send_message', 1)).toThrow(MessageRateLimitExceededException);
+    await expect(service.assertWithinLimit('send_message', 1)).rejects.toBeInstanceOf(
+      MessageRateLimitExceededException,
+    );
     // A different user is unaffected.
-    expect(() => service.assertWithinLimit('send_message', 2)).not.toThrow();
+    await expect(service.assertWithinLimit('send_message', 2)).resolves.toBeUndefined();
   });
 
-  it('tracks limits independently per scope', () => {
-    service.assertWithinLimit('contact', 1);
-    service.assertWithinLimit('contact', 1);
-    expect(() => service.assertWithinLimit('contact', 1)).toThrow(MessageRateLimitExceededException);
+  it('tracks limits independently per scope', async () => {
+    await service.assertWithinLimit('contact', 1);
+    await service.assertWithinLimit('contact', 1);
+    await expect(service.assertWithinLimit('contact', 1)).rejects.toBeInstanceOf(
+      MessageRateLimitExceededException,
+    );
     // The send_message scope for the same user still has budget.
-    expect(() => service.assertWithinLimit('send_message', 1)).not.toThrow();
+    await expect(service.assertWithinLimit('send_message', 1)).resolves.toBeUndefined();
   });
 });

--- a/apps/api/src/messaging/rate-limiting/message-rate-limit.service.ts
+++ b/apps/api/src/messaging/rate-limiting/message-rate-limit.service.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@nestjs/common';
+import {
+  MAX_MESSAGE_RATE_COUNTERS,
+  MessageRateLimit,
+  MessageRateLimitScope,
+  resolveMessageRateLimits,
+} from './message-rate-limit.constants';
+import { MessageRateLimitExceededException } from './message-rate-limit.exception';
+
+interface WindowEntry {
+  count: number;
+  firstAt: number;
+}
+
+/**
+ * Lightweight in-memory, per-user rate limiter for messaging actions.
+ *
+ * Keyed by `scope:userId` with a fixed window. No external dependency
+ * (Redis/DB) — sufficient for abuse prevention on a single API instance and
+ * mirrors the existing auth brute-force protection pattern.
+ */
+@Injectable()
+export class MessageRateLimitService {
+  private readonly counters = new Map<string, WindowEntry>();
+  private readonly limits: Record<MessageRateLimitScope, MessageRateLimit> = resolveMessageRateLimits();
+  private readonly nowFn: () => number = () => Date.now();
+
+  /**
+   * Records one action for the user within the scope and throws a 429 when the
+   * configured limit is exceeded. Call this BEFORE performing the work.
+   */
+  public assertWithinLimit(scope: MessageRateLimitScope, userId: number): void {
+    const limit = this.limits[scope];
+    const windowMs = limit.windowSeconds * 1000;
+    const now = this.nowFn();
+    const key = `${scope}:${userId}`;
+
+    this.evictStale(now, windowMs);
+
+    const entry = this.counters.get(key);
+    if (!entry || now - entry.firstAt >= windowMs) {
+      this.counters.set(key, { count: 1, firstAt: now });
+      return;
+    }
+
+    if (entry.count >= limit.maxActions) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((entry.firstAt + windowMs - now) / 1000));
+      throw new MessageRateLimitExceededException(retryAfterSeconds);
+    }
+
+    entry.count += 1;
+  }
+
+  private evictStale(now: number, windowMs: number): void {
+    for (const [key, entry] of this.counters) {
+      if (now - entry.firstAt >= windowMs) {
+        this.counters.delete(key);
+      }
+    }
+    if (this.counters.size > MAX_MESSAGE_RATE_COUNTERS) {
+      const overflow = this.counters.size - MAX_MESSAGE_RATE_COUNTERS;
+      const oldest = [...this.counters.entries()].sort(([, a], [, b]) => a.firstAt - b.firstAt);
+      for (let i = 0; i < overflow && i < oldest.length; i += 1) {
+        this.counters.delete(oldest[i][0]);
+      }
+    }
+  }
+}

--- a/apps/api/src/messaging/rate-limiting/message-rate-limit.service.ts
+++ b/apps/api/src/messaging/rate-limiting/message-rate-limit.service.ts
@@ -1,10 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import {
-  MAX_MESSAGE_RATE_COUNTERS,
-  MessageRateLimit,
-  MessageRateLimitScope,
-  resolveMessageRateLimits,
-} from './message-rate-limit.constants';
+import { SettingsService } from '../../settings/settings.service';
+import { MAX_MESSAGE_RATE_COUNTERS, MessageRateLimit, MessageRateLimitScope } from './message-rate-limit.constants';
 import { MessageRateLimitExceededException } from './message-rate-limit.exception';
 
 interface WindowEntry {
@@ -15,22 +11,25 @@ interface WindowEntry {
 /**
  * Lightweight in-memory, per-user rate limiter for messaging actions.
  *
- * Keyed by `scope:userId` with a fixed window. No external dependency
- * (Redis/DB) — sufficient for abuse prevention on a single API instance and
- * mirrors the existing auth brute-force protection pattern.
+ * Keyed by `scope:userId` with a fixed window. Counters live in-process (no
+ * Redis/DB) — sufficient for abuse prevention on a single API instance and
+ * mirrors the existing auth brute-force protection pattern. The limits
+ * themselves are read from the database-backed system settings on each check,
+ * so admins can tune them through the settings UI with no restart.
  */
 @Injectable()
 export class MessageRateLimitService {
   private readonly counters = new Map<string, WindowEntry>();
-  private readonly limits: Record<MessageRateLimitScope, MessageRateLimit> = resolveMessageRateLimits();
   private readonly nowFn: () => number = () => Date.now();
+
+  constructor(private readonly settingsService: SettingsService) {}
 
   /**
    * Records one action for the user within the scope and throws a 429 when the
    * configured limit is exceeded. Call this BEFORE performing the work.
    */
-  public assertWithinLimit(scope: MessageRateLimitScope, userId: number): void {
-    const limit = this.limits[scope];
+  public async assertWithinLimit(scope: MessageRateLimitScope, userId: number): Promise<void> {
+    const limit = await this.resolveLimit(scope);
     const windowMs = limit.windowSeconds * 1000;
     const now = this.nowFn();
     const key = `${scope}:${userId}`;
@@ -49,6 +48,14 @@ export class MessageRateLimitService {
     }
 
     entry.count += 1;
+  }
+
+  private async resolveLimit(scope: MessageRateLimitScope): Promise<MessageRateLimit> {
+    const policy = await this.settingsService.getMessagingRateLimitPolicy();
+    if (scope === 'send_message') {
+      return { maxActions: policy.sendMaxPerWindow, windowSeconds: policy.sendWindowSeconds };
+    }
+    return { maxActions: policy.contactMaxPerWindow, windowSeconds: policy.contactWindowSeconds };
   }
 
   private evictStale(now: number, windowMs: number): void {

--- a/apps/api/src/messaging/rate-limiting/message-rate-limit.service.ts
+++ b/apps/api/src/messaging/rate-limiting/message-rate-limit.service.ts
@@ -1,25 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { SettingsService } from '../../settings/settings.service';
+import { FixedWindowCounterStore, WindowCounterEntry } from '../../common/rate-limiting/fixed-window-counter';
 import { MAX_MESSAGE_RATE_COUNTERS, MessageRateLimit, MessageRateLimitScope } from './message-rate-limit.constants';
 import { MessageRateLimitExceededException } from './message-rate-limit.exception';
-
-interface WindowEntry {
-  count: number;
-  firstAt: number;
-}
 
 /**
  * Lightweight in-memory, per-user rate limiter for messaging actions.
  *
  * Keyed by `scope:userId` with a fixed window. Counters live in-process (no
- * Redis/DB) — sufficient for abuse prevention on a single API instance and
- * mirrors the existing auth brute-force protection pattern. The limits
- * themselves are read from the database-backed system settings on each check,
- * so admins can tune them through the settings UI with no restart.
+ * Redis/DB) via the shared {@link FixedWindowCounterStore} that also backs the
+ * auth brute-force protection — sufficient for abuse prevention on a single API
+ * instance. The limits themselves are read from the database-backed system
+ * settings on each check, so admins can tune them through the settings UI with
+ * no restart.
  */
 @Injectable()
 export class MessageRateLimitService {
-  private readonly counters = new Map<string, WindowEntry>();
+  private readonly counters = new FixedWindowCounterStore<string, WindowCounterEntry>(MAX_MESSAGE_RATE_COUNTERS);
   private readonly nowFn: () => number = () => Date.now();
 
   constructor(private readonly settingsService: SettingsService) {}
@@ -34,7 +31,7 @@ export class MessageRateLimitService {
     const now = this.nowFn();
     const key = `${scope}:${userId}`;
 
-    this.evictStale(now, windowMs);
+    this.counters.evict((entry) => now - entry.firstAt >= windowMs);
 
     const entry = this.counters.get(key);
     if (!entry || now - entry.firstAt >= windowMs) {
@@ -56,20 +53,5 @@ export class MessageRateLimitService {
       return { maxActions: policy.sendMaxPerWindow, windowSeconds: policy.sendWindowSeconds };
     }
     return { maxActions: policy.contactMaxPerWindow, windowSeconds: policy.contactWindowSeconds };
-  }
-
-  private evictStale(now: number, windowMs: number): void {
-    for (const [key, entry] of this.counters) {
-      if (now - entry.firstAt >= windowMs) {
-        this.counters.delete(key);
-      }
-    }
-    if (this.counters.size > MAX_MESSAGE_RATE_COUNTERS) {
-      const overflow = this.counters.size - MAX_MESSAGE_RATE_COUNTERS;
-      const oldest = [...this.counters.entries()].sort(([, a], [, b]) => a.firstAt - b.firstAt);
-      for (let i = 0; i < overflow && i < oldest.length; i += 1) {
-        this.counters.delete(oldest[i][0]);
-      }
-    }
   }
 }

--- a/apps/api/src/settings/constants.ts
+++ b/apps/api/src/settings/constants.ts
@@ -76,3 +76,31 @@ export const RATE_LIMIT_DEFAULTS: RateLimitPolicy = {
   exponentialBackoff: false,
   backoffMultiplier: 2,
 };
+
+export const MESSAGING_PARENT = 'messaging';
+
+export const MESSAGING_KEYS = {
+  sendRateLimitMax: 'send_rate_limit_max',
+  sendRateLimitWindowSeconds: 'send_rate_limit_window_seconds',
+  contactRateLimitMax: 'contact_rate_limit_max',
+  contactRateLimitWindowSeconds: 'contact_rate_limit_window_seconds',
+} as const;
+
+export interface MessagingRateLimitPolicy {
+  /** Max messages a user may send per window. */
+  sendMaxPerWindow: number;
+  /** Length of the send window in seconds. */
+  sendWindowSeconds: number;
+  /** Max conversations a user may open per window. */
+  contactMaxPerWindow: number;
+  /** Length of the contact window in seconds. */
+  contactWindowSeconds: number;
+}
+
+/** Defaults tuned to be invisible during normal interactive usage while blocking automated abuse. */
+export const MESSAGING_RATE_LIMIT_DEFAULTS: MessagingRateLimitPolicy = {
+  sendMaxPerWindow: 30,
+  sendWindowSeconds: 60,
+  contactMaxPerWindow: 10,
+  contactWindowSeconds: 60,
+};

--- a/apps/api/src/settings/dto/messaging-rate-limit-settings.dto.ts
+++ b/apps/api/src/settings/dto/messaging-rate-limit-settings.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MessagingRateLimitSettingsDto {
+  @ApiProperty({ description: 'Max messages a user may send within the send window', example: 30 })
+  sendMaxPerWindow!: number;
+
+  @ApiProperty({ description: 'Length of the send rate-limit window, in seconds', example: 60 })
+  sendWindowSeconds!: number;
+
+  @ApiProperty({ description: 'Max conversations a user may open within the contact window', example: 10 })
+  contactMaxPerWindow!: number;
+
+  @ApiProperty({ description: 'Length of the contact rate-limit window, in seconds', example: 60 })
+  contactWindowSeconds!: number;
+}

--- a/apps/api/src/settings/dto/update-messaging-rate-limit-settings.dto.ts
+++ b/apps/api/src/settings/dto/update-messaging-rate-limit-settings.dto.ts
@@ -1,0 +1,28 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class UpdateMessagingRateLimitSettingsDto {
+  @ApiPropertyOptional({ description: 'Max messages a user may send within the send window', example: 30 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  sendMaxPerWindow?: number;
+
+  @ApiPropertyOptional({ description: 'Length of the send rate-limit window, in seconds', example: 60 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  sendWindowSeconds?: number;
+
+  @ApiPropertyOptional({ description: 'Max conversations a user may open within the contact window', example: 10 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  contactMaxPerWindow?: number;
+
+  @ApiPropertyOptional({ description: 'Length of the contact rate-limit window, in seconds', example: 60 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  contactWindowSeconds?: number;
+}

--- a/apps/api/src/settings/settings.controller.ts
+++ b/apps/api/src/settings/settings.controller.ts
@@ -10,6 +10,8 @@ import { UpdateMetricsSettingsDto } from './dto/update-metrics-settings.dto';
 import { GenerateMetricsApiKeyResponseDto } from './dto/generate-metrics-api-key-response.dto';
 import { AuthRateLimitSettingsDto } from './dto/auth-rate-limit-settings.dto';
 import { UpdateAuthRateLimitSettingsDto } from './dto/update-auth-rate-limit-settings.dto';
+import { MessagingRateLimitSettingsDto } from './dto/messaging-rate-limit-settings.dto';
+import { UpdateMessagingRateLimitSettingsDto } from './dto/update-messaging-rate-limit-settings.dto';
 
 @ApiTags('Settings')
 @Controller('settings')
@@ -109,6 +111,24 @@ export class SettingsController {
     @Body() body: UpdateAuthRateLimitSettingsDto,
   ): Promise<AuthRateLimitSettingsDto> {
     return this.settingsService.updateAuthRateLimitSettings(body);
+  }
+
+  @Get('messaging/rate-limit')
+  @Auth('canManageSystemConfiguration')
+  @ApiOperation({ summary: 'Get messaging rate-limit settings', operationId: 'getMessagingRateLimitSettings' })
+  @ApiResponse({ status: 200, description: 'Current messaging rate-limit settings.', type: MessagingRateLimitSettingsDto })
+  async getMessagingRateLimitSettings(): Promise<MessagingRateLimitSettingsDto> {
+    return this.settingsService.getMessagingRateLimitSettings();
+  }
+
+  @Patch('messaging/rate-limit')
+  @Auth('canManageSystemConfiguration')
+  @ApiOperation({ summary: 'Update messaging rate-limit settings', operationId: 'updateMessagingRateLimitSettings' })
+  @ApiResponse({ status: 200, description: 'Messaging rate-limit settings updated.', type: MessagingRateLimitSettingsDto })
+  async updateMessagingRateLimitSettings(
+    @Body() body: UpdateMessagingRateLimitSettingsDto,
+  ): Promise<MessagingRateLimitSettingsDto> {
+    return this.settingsService.updateMessagingRateLimitSettings(body);
   }
 
   @Post('first-time-setup')

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -22,11 +22,17 @@ import {
   METRICS_TOGGLE_DEFAULTS,
   METRICS_TOGGLE_KEYS,
   MetricsSubsystem,
+  MESSAGING_KEYS,
+  MESSAGING_PARENT,
+  MESSAGING_RATE_LIMIT_DEFAULTS,
+  MessagingRateLimitPolicy,
   RATE_LIMIT_DEFAULTS,
   RateLimitPolicy,
 } from './constants';
 import { AuthRateLimitSettingsDto } from './dto/auth-rate-limit-settings.dto';
 import { UpdateAuthRateLimitSettingsDto } from './dto/update-auth-rate-limit-settings.dto';
+import { MessagingRateLimitSettingsDto } from './dto/messaging-rate-limit-settings.dto';
+import { UpdateMessagingRateLimitSettingsDto } from './dto/update-messaging-rate-limit-settings.dto';
 import { SettingsStoreService } from './settings-store.service';
 import {
   FirstTimeSetupStatusDto,
@@ -269,6 +275,70 @@ export class SettingsService {
       ),
       exponentialBackoff: exponentialBackoff === 'true',
       backoffMultiplier: parsePositiveFloat(backoffMultiplier, RATE_LIMIT_DEFAULTS.backoffMultiplier),
+    };
+  }
+
+  async getMessagingRateLimitSettings(): Promise<MessagingRateLimitSettingsDto> {
+    return this.resolveMessagingRateLimitPolicy();
+  }
+
+  async getMessagingRateLimitPolicy(): Promise<MessagingRateLimitPolicy> {
+    return this.resolveMessagingRateLimitPolicy();
+  }
+
+  async updateMessagingRateLimitSettings(
+    update: UpdateMessagingRateLimitSettingsDto,
+  ): Promise<MessagingRateLimitSettingsDto> {
+    const writes: Array<Promise<void>> = [];
+    if (update.sendMaxPerWindow !== undefined) {
+      writes.push(
+        this.settingsStore.setPlainSetting(MESSAGING_PARENT, MESSAGING_KEYS.sendRateLimitMax, String(update.sendMaxPerWindow)),
+      );
+    }
+    if (update.sendWindowSeconds !== undefined) {
+      writes.push(
+        this.settingsStore.setPlainSetting(
+          MESSAGING_PARENT,
+          MESSAGING_KEYS.sendRateLimitWindowSeconds,
+          String(update.sendWindowSeconds),
+        ),
+      );
+    }
+    if (update.contactMaxPerWindow !== undefined) {
+      writes.push(
+        this.settingsStore.setPlainSetting(
+          MESSAGING_PARENT,
+          MESSAGING_KEYS.contactRateLimitMax,
+          String(update.contactMaxPerWindow),
+        ),
+      );
+    }
+    if (update.contactWindowSeconds !== undefined) {
+      writes.push(
+        this.settingsStore.setPlainSetting(
+          MESSAGING_PARENT,
+          MESSAGING_KEYS.contactRateLimitWindowSeconds,
+          String(update.contactWindowSeconds),
+        ),
+      );
+    }
+    await Promise.all(writes);
+    return this.resolveMessagingRateLimitPolicy();
+  }
+
+  private async resolveMessagingRateLimitPolicy(): Promise<MessagingRateLimitPolicy> {
+    const [sendMax, sendWindow, contactMax, contactWindow] = await Promise.all([
+      this.settingsStore.getPlainSetting(MESSAGING_PARENT, MESSAGING_KEYS.sendRateLimitMax),
+      this.settingsStore.getPlainSetting(MESSAGING_PARENT, MESSAGING_KEYS.sendRateLimitWindowSeconds),
+      this.settingsStore.getPlainSetting(MESSAGING_PARENT, MESSAGING_KEYS.contactRateLimitMax),
+      this.settingsStore.getPlainSetting(MESSAGING_PARENT, MESSAGING_KEYS.contactRateLimitWindowSeconds),
+    ]);
+
+    return {
+      sendMaxPerWindow: parsePositiveInt(sendMax, MESSAGING_RATE_LIMIT_DEFAULTS.sendMaxPerWindow),
+      sendWindowSeconds: parsePositiveInt(sendWindow, MESSAGING_RATE_LIMIT_DEFAULTS.sendWindowSeconds),
+      contactMaxPerWindow: parsePositiveInt(contactMax, MESSAGING_RATE_LIMIT_DEFAULTS.contactMaxPerWindow),
+      contactWindowSeconds: parsePositiveInt(contactWindow, MESSAGING_RATE_LIMIT_DEFAULTS.contactWindowSeconds),
     };
   }
 

--- a/apps/api/src/users-and-auth/rate-limiting/brute-force.service.ts
+++ b/apps/api/src/users-and-auth/rate-limiting/brute-force.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '@attraccess/database-entities';
 import { SettingsService } from '../../settings/settings.service';
+import { FixedWindowCounterStore, WindowCounterEntry } from '../../common/rate-limiting/fixed-window-counter';
 import { AccountLockedException, TooManyAuthAttemptsException } from './exceptions';
 
 export type RateLimitScope =
@@ -11,9 +12,7 @@ export type RateLimitScope =
   | 'password_reset_request'
   | 'password_reset_complete';
 
-interface CounterEntry {
-  count: number;
-  firstAt: number;
+interface CounterEntry extends WindowCounterEntry {
   lockoutUntil: number;
   lockoutCount: number;
 }
@@ -22,8 +21,8 @@ const MAX_COUNTER_ENTRIES = 10_000;
 
 @Injectable()
 export class BruteForceProtectionService {
-  private readonly ipCounters = new Map<string, CounterEntry>();
-  private readonly accountCounters = new Map<number, CounterEntry>();
+  private readonly ipCounters = new FixedWindowCounterStore<string, CounterEntry>(MAX_COUNTER_ENTRIES);
+  private readonly accountCounters = new FixedWindowCounterStore<number, CounterEntry>(MAX_COUNTER_ENTRIES);
   private readonly nowFn: () => number = () => Date.now();
 
   constructor(
@@ -130,7 +129,12 @@ export class BruteForceProtectionService {
     );
   }
 
-  private upsertCounter<K>(store: Map<K, CounterEntry>, key: K, now: number, windowMs: number): CounterEntry {
+  private upsertCounter<K>(
+    store: FixedWindowCounterStore<K, CounterEntry>,
+    key: K,
+    now: number,
+    windowMs: number,
+  ): CounterEntry {
     const existing = store.get(key);
     if (!existing) {
       const entry: CounterEntry = { count: 1, firstAt: now, lockoutUntil: 0, lockoutCount: 0 };
@@ -160,35 +164,14 @@ export class BruteForceProtectionService {
   }
 
   private evictStale(now: number, windowMs: number): void {
-    for (const [key, entry] of this.ipCounters) {
-      if (isStale(entry, now, windowMs)) {
-        this.ipCounters.delete(key);
-      }
-    }
-    for (const [key, entry] of this.accountCounters) {
-      if (isStale(entry, now, windowMs)) {
-        this.accountCounters.delete(key);
-      }
-    }
-    if (this.ipCounters.size > MAX_COUNTER_ENTRIES) {
-      dropOldest(this.ipCounters, this.ipCounters.size - MAX_COUNTER_ENTRIES);
-    }
-    if (this.accountCounters.size > MAX_COUNTER_ENTRIES) {
-      dropOldest(this.accountCounters, this.accountCounters.size - MAX_COUNTER_ENTRIES);
-    }
+    this.ipCounters.evict((entry) => isStale(entry, now, windowMs));
+    this.accountCounters.evict((entry) => isStale(entry, now, windowMs));
   }
 }
 
 function isStale(entry: CounterEntry, now: number, windowMs: number): boolean {
   if (entry.lockoutUntil > now) return false;
   return now - entry.firstAt > windowMs;
-}
-
-function dropOldest<K>(store: Map<K, CounterEntry>, count: number): void {
-  const sorted = [...store.entries()].sort(([, a], [, b]) => a.firstAt - b.firstAt);
-  for (let i = 0; i < count && i < sorted.length; i += 1) {
-    store.delete(sorted[i][0]);
-  }
 }
 
 function ipKey(scope: RateLimitScope, ip: string): string {

--- a/apps/frontend/src/app/settings/cards/MessagingRateLimitCard/de.json
+++ b/apps/frontend/src/app/settings/cards/MessagingRateLimitCard/de.json
@@ -1,0 +1,4 @@
+{
+  "title": "Nachrichten-Drosselung",
+  "subtitle": "Begrenze, wie viele Nachrichten Nutzer senden und Unterhaltungen sie starten"
+}

--- a/apps/frontend/src/app/settings/cards/MessagingRateLimitCard/en.json
+++ b/apps/frontend/src/app/settings/cards/MessagingRateLimitCard/en.json
@@ -1,0 +1,4 @@
+{
+  "title": "Messaging rate limiting",
+  "subtitle": "Throttle how many messages users send and conversations they open"
+}

--- a/apps/frontend/src/app/settings/cards/MessagingRateLimitCard/index.tsx
+++ b/apps/frontend/src/app/settings/cards/MessagingRateLimitCard/index.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@heroui/react';
+import { MessagesSquareIcon } from 'lucide-react';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { MessagingRateLimitForm } from '../../forms/MessagingRateLimitForm';
+import en from './en.json';
+import de from './de.json';
+
+export type MessagingRateLimitCardProps = {
+  className?: string;
+};
+
+export function MessagingRateLimitCard({ className }: MessagingRateLimitCardProps = {}) {
+  const { t } = useTranslations({ en, de });
+  return (
+    <section
+      className={cn(
+        'w-full flex flex-col gap-4 rounded-large border border-default-200 bg-default-50 p-6',
+        className,
+      )}
+      data-cy="messaging-rate-limit-settings-section"
+    >
+      <div className="flex items-center gap-2">
+        <MessagesSquareIcon size={18} className="text-default-700" />
+        <div className="flex flex-col">
+          <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">{t('title')}</h3>
+          <p className="text-xs text-default-500">{t('subtitle')}</p>
+        </div>
+      </div>
+      <MessagingRateLimitForm />
+    </section>
+  );
+}

--- a/apps/frontend/src/app/settings/forms/MessagingRateLimitForm/de.json
+++ b/apps/frontend/src/app/settings/forms/MessagingRateLimitForm/de.json
@@ -1,0 +1,31 @@
+{
+  "loading": "Einstellungen werden geladen…",
+  "description": "Begrenze, wie viele Nachrichten ein Nutzer senden und wie viele Unterhaltungen er innerhalb eines Zeitfensters starten kann, um Missbrauch zu verhindern.",
+  "fields": {
+    "sendMaxPerWindow": {
+      "label": "Max. Nachrichten",
+      "description": "Nachrichten, die ein einzelner Nutzer im Sende-Zeitfenster senden darf, bevor gedrosselt wird."
+    },
+    "sendWindowSeconds": {
+      "label": "Sende-Zeitfenster (Sekunden)",
+      "description": "Zeitraum, in dem gesendete Nachrichten gezählt werden."
+    },
+    "contactMaxPerWindow": {
+      "label": "Max. neue Unterhaltungen",
+      "description": "Unterhaltungen, die ein einzelner Nutzer im Kontakt-Zeitfenster starten darf, bevor gedrosselt wird."
+    },
+    "contactWindowSeconds": {
+      "label": "Kontakt-Zeitfenster (Sekunden)",
+      "description": "Zeitraum, in dem gestartete Unterhaltungen gezählt werden."
+    }
+  },
+  "saveButton": "Speichern",
+  "saved": {
+    "title": "Einstellungen gespeichert",
+    "description": "Neue Schwellen gelten sofort."
+  },
+  "error": {
+    "title": "Speichern fehlgeschlagen",
+    "description": "Werte prüfen und erneut versuchen."
+  }
+}

--- a/apps/frontend/src/app/settings/forms/MessagingRateLimitForm/en.json
+++ b/apps/frontend/src/app/settings/forms/MessagingRateLimitForm/en.json
@@ -1,0 +1,31 @@
+{
+  "loading": "Loading rate-limit settings…",
+  "description": "Throttle how many messages each user may send and how many conversations they may open within a time window, to prevent abuse.",
+  "fields": {
+    "sendMaxPerWindow": {
+      "label": "Max messages",
+      "description": "Messages a single user may send within the send window before being throttled."
+    },
+    "sendWindowSeconds": {
+      "label": "Send window (seconds)",
+      "description": "Time window during which sent messages are counted."
+    },
+    "contactMaxPerWindow": {
+      "label": "Max new conversations",
+      "description": "Conversations a single user may open within the contact window before being throttled."
+    },
+    "contactWindowSeconds": {
+      "label": "Contact window (seconds)",
+      "description": "Time window during which opened conversations are counted."
+    }
+  },
+  "saveButton": "Save",
+  "saved": {
+    "title": "Rate-limit settings saved",
+    "description": "New thresholds take effect immediately."
+  },
+  "error": {
+    "title": "Could not save",
+    "description": "Check the values and try again."
+  }
+}

--- a/apps/frontend/src/app/settings/forms/MessagingRateLimitForm/index.tsx
+++ b/apps/frontend/src/app/settings/forms/MessagingRateLimitForm/index.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  NumberField,
+  NumberFieldDecrementButton,
+  NumberFieldGroup,
+  NumberFieldIncrementButton,
+  NumberFieldInput,
+  Separator,
+  Spinner,
+} from '@heroui/react';
+import { Button } from '../../../../components/button';
+import { HelpCircleIcon } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import {
+  MessagingRateLimitSettingsDto,
+  useSettingsServiceGetMessagingRateLimitSettings,
+  UseSettingsServiceGetMessagingRateLimitSettingsKeyFn,
+  useSettingsServiceUpdateMessagingRateLimitSettings,
+} from '@attraccess/react-query-client';
+import { useToastMessage } from '../../../../components/toastProvider';
+import en from './en.json';
+import de from './de.json';
+
+type FormState = {
+  sendMaxPerWindow: number;
+  sendWindowSeconds: number;
+  contactMaxPerWindow: number;
+  contactWindowSeconds: number;
+};
+
+function toFormState(value: MessagingRateLimitSettingsDto): FormState {
+  return {
+    sendMaxPerWindow: value.sendMaxPerWindow,
+    sendWindowSeconds: value.sendWindowSeconds,
+    contactMaxPerWindow: value.contactMaxPerWindow,
+    contactWindowSeconds: value.contactWindowSeconds,
+  };
+}
+
+function NumberRow({
+  label,
+  description,
+  value,
+  onChange,
+  minValue = 1,
+  step = 1,
+  isDisabled,
+  dataTestid,
+}: {
+  label: string;
+  description?: string;
+  value: number;
+  onChange: (value: number) => void;
+  minValue?: number;
+  step?: number;
+  isDisabled?: boolean;
+  dataTestid?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1" data-testid={dataTestid}>
+      <div className="flex items-center gap-1.5">
+        <span className="text-sm font-medium">{label}</span>
+        {description && (
+          <span title={description} aria-label={description}>
+            <HelpCircleIcon size={14} className="text-default-400 cursor-help" />
+          </span>
+        )}
+      </div>
+      <NumberField value={value} onChange={onChange} minValue={minValue} step={step} isDisabled={isDisabled}>
+        <NumberFieldGroup>
+          <NumberFieldDecrementButton>-</NumberFieldDecrementButton>
+          <NumberFieldInput />
+          <NumberFieldIncrementButton>+</NumberFieldIncrementButton>
+        </NumberFieldGroup>
+      </NumberField>
+    </div>
+  );
+}
+
+export function MessagingRateLimitForm() {
+  const { t } = useTranslations({ en, de });
+  const toast = useToastMessage();
+  const queryClient = useQueryClient();
+  const { data: current, isLoading } = useSettingsServiceGetMessagingRateLimitSettings();
+  const [form, setForm] = useState<FormState | null>(null);
+
+  useEffect(() => {
+    if (current) setForm(toFormState(current));
+  }, [current]);
+
+  const { mutate, isPending } = useSettingsServiceUpdateMessagingRateLimitSettings({
+    onSuccess(updated) {
+      setForm(toFormState(updated as MessagingRateLimitSettingsDto));
+      queryClient.invalidateQueries({ queryKey: UseSettingsServiceGetMessagingRateLimitSettingsKeyFn() });
+      toast.success({ title: t('saved.title'), description: t('saved.description') });
+    },
+    onError() {
+      toast.error({ title: t('error.title'), description: t('error.description') });
+    },
+  });
+
+  const handleSave = useCallback(() => {
+    if (!form) return;
+    mutate({ requestBody: form });
+  }, [form, mutate]);
+
+  if (isLoading || !form) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-default-500">
+        <Spinner size="sm" />
+        {t('loading')}
+      </div>
+    );
+  }
+
+  const isDirty =
+    !!current &&
+    (form.sendMaxPerWindow !== current.sendMaxPerWindow ||
+      form.sendWindowSeconds !== current.sendWindowSeconds ||
+      form.contactMaxPerWindow !== current.contactMaxPerWindow ||
+      form.contactWindowSeconds !== current.contactWindowSeconds);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-default-500">{t('description')}</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <NumberRow
+          label={t('fields.sendMaxPerWindow.label')}
+          description={t('fields.sendMaxPerWindow.description')}
+          value={form.sendMaxPerWindow}
+          onChange={(value) => setForm({ ...form, sendMaxPerWindow: value })}
+          dataTestid="messaging-rate-limit-send-max"
+        />
+        <NumberRow
+          label={t('fields.sendWindowSeconds.label')}
+          description={t('fields.sendWindowSeconds.description')}
+          value={form.sendWindowSeconds}
+          onChange={(value) => setForm({ ...form, sendWindowSeconds: value })}
+          dataTestid="messaging-rate-limit-send-window"
+        />
+      </div>
+      <Separator />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <NumberRow
+          label={t('fields.contactMaxPerWindow.label')}
+          description={t('fields.contactMaxPerWindow.description')}
+          value={form.contactMaxPerWindow}
+          onChange={(value) => setForm({ ...form, contactMaxPerWindow: value })}
+          dataTestid="messaging-rate-limit-contact-max"
+        />
+        <NumberRow
+          label={t('fields.contactWindowSeconds.label')}
+          description={t('fields.contactWindowSeconds.description')}
+          value={form.contactWindowSeconds}
+          onChange={(value) => setForm({ ...form, contactWindowSeconds: value })}
+          dataTestid="messaging-rate-limit-contact-window"
+        />
+      </div>
+      <div>
+        <Button variant="primary" onPress={handleSave} isPending={isPending} isDisabled={!isDirty}>
+          {t('saveButton')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/settings/index.tsx
+++ b/apps/frontend/src/app/settings/index.tsx
@@ -7,6 +7,7 @@ import { AppSettingsCard } from './cards/AppSettingsCard';
 import { SmtpSettingsCard } from './cards/SmtpSettingsCard';
 import { MetricsSettingsCard } from './cards/MetricsSettingsCard';
 import { AuthRateLimitCard } from './cards/AuthRateLimitCard';
+import { MessagingRateLimitCard } from './cards/MessagingRateLimitCard';
 import { PasswordPolicyCard } from './cards/PasswordPolicyCard';
 
 export function SystemSettingsPage() {
@@ -20,6 +21,7 @@ export function SystemSettingsPage() {
         <SmtpSettingsCard variant="standalone" />
         <MetricsSettingsCard />
         <AuthRateLimitCard />
+        <MessagingRateLimitCard />
         <PasswordPolicyCard />
       </div>
     </div>


### PR DESCRIPTION
Assignee: [Jan Jaap](https://linear.app/attraccess)

## Summary

Per-user messaging rate limiting (POST messages + contact endpoints), throttled per authenticated user with a fixed window keyed by `senderId`. Exceeding a scope returns HTTP 429 (`MessageRateLimitExceededException`) with `retryAfterSeconds`.

Per review feedback, the limits are **no longer env-configured** — they live in the database-backed system settings and are managed from the Settings UI, mirroring the existing auth rate-limit pattern.

## Changes

**Backend**
- `MessageRateLimitService` reads its policy from `SettingsService.getMessagingRateLimitPolicy()` on each check (`assertWithinLimit` is now async); in-memory fixed-window counters keyed by `scope:userId` are unchanged.
- New persisted settings under the `messaging` namespace: send max/window + contact max/window (`SettingsStoreService`, 60s read cache). Defaults: 30 sends / 60s, 10 contacts / 60s.
- `GET`/`PATCH /settings/messaging/rate-limit` with `Messaging{,Update}RateLimitSettingsDto` (`canManageSystemConfiguration`).
- Dropped env resolution from the messaging rate-limit constants and removed the `MESSAGING_*` block from `.env.example`.

**Frontend**
- New **Messaging rate limiting** settings card/form (`MessagingRateLimitCard` / `MessagingRateLimitForm`) on the system settings page, with en/de translations — mirrors the auth rate-limit card.

## Testing
- `nx test api` — 1135 passed (incl. updated `MessageRateLimitService` spec, now async + injected settings).
- `nx run-many lint typecheck -p api frontend` — pass.
- Manual browser verification: card renders, shows DB-backed defaults (30/60/10/60), editing + Save persists to the `setting` table (`send_rate_limit_max=26` written), Save disables when synced. Screenshots posted to the Linear issue.

Closes ATT-448 — https://linear.app/attraccess/issue/ATT-448/per-user-message-send-rate-limiting

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
