### PR TITLE
feat(ATT-461): plugin docs + working example plugin; drop WIP flag

### DIFF
--- a/apps/api/src/main.bootstrap.ts
+++ b/apps/api/src/main.bootstrap.ts
@@ -1,12 +1,11 @@
 import { NestFactory, HttpAdapterHost } from '@nestjs/core';
-import { AppModule } from './app/app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import { ValidationPipe, ClassSerializerInterceptor, Logger, LogLevel } from '@nestjs/common';
+import { ValidationPipe, ClassSerializerInterceptor, Logger, LogLevel, Module } from '@nestjs/common';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import session from 'express-session';
-import { ConfigService } from '@nestjs/config';
-import { AppConfigType } from './config/app.config';
+import { ConfigModule as NestConfigModule, ConfigService } from '@nestjs/config';
+import appConfiguration, { AppConfigType } from './config/app.config';
 import { DataSource } from 'typeorm';
 import { PluginService } from './plugin-system/plugin.service';
 import { PluginModule } from './plugin-system/plugin.module';
@@ -40,6 +39,17 @@ async function generateSelfSignedCertificates(storageDir: string, domain: string
   await writeFile(join(storageDir, `${domain}.key`), cert.key, { mode: 0o644 });
 }
 
+// Minimal module used to read AppConfig (and load the .env file) WITHOUT importing
+// AppModule. The plugin system must be configured before AppModule is imported,
+// because PluginModule.forRoot() — evaluated at AppModule import time — imports each
+// plugin's backend module from PLUGIN_DIR. If AppModule were imported first to read
+// config, forRoot() would already have run with an unconfigured path and no plugin
+// backend would ever load.
+@Module({
+  imports: [NestConfigModule.forRoot({ load: [appConfiguration], isGlobal: true })],
+})
+class PluginBootstrapConfigModule {}
+
 export async function bootstrap() {
   const bootstrapLogger = new Logger('Bootstrap');
   bootstrapLogger.log('Starting bootstrap process...');
@@ -47,6 +57,34 @@ export async function bootstrap() {
   const initialLogLevels = (process.env.LOG_LEVELS || 'error,warn,log')
     .split(',')
     .filter((level): level is LogLevel => ['error', 'warn', 'log', 'debug', 'verbose'].includes(level));
+
+  // Resolve plugin config and configure the plugin system BEFORE importing AppModule
+  // (see PluginBootstrapConfigModule above for why ordering matters).
+  const configContext = await NestFactory.createApplicationContext(PluginBootstrapConfigModule, {
+    logger: initialLogLevels,
+  });
+  const earlyConfig = configContext.get(ConfigService).get<AppConfigType>('app');
+  await configContext.close();
+
+  if (!earlyConfig) {
+    bootstrapLogger.error("Application configuration ('app') not loaded. Exiting.");
+    process.exit(1);
+  }
+  if (!earlyConfig.PLUGIN_DIR) {
+    bootstrapLogger.warn('PLUGIN_DIR is not set — plugin backends will not be loaded.');
+  }
+  bootstrapLogger.log('Configuring PluginSystem...');
+  PluginService.configure({
+    PLUGIN_DIR: earlyConfig.PLUGIN_DIR,
+    RESTART_BY_EXIT: earlyConfig.RESTART_BY_EXIT,
+  });
+  PluginModule.configure({
+    DISABLE_PLUGINS: earlyConfig.DISABLE_PLUGINS,
+  });
+  bootstrapLogger.log('PluginSystem configured.');
+
+  // Import AppModule only now, so PluginModule.forRoot() sees the configured PLUGIN_DIR.
+  const { AppModule } = await import('./app/app.module');
 
   const appForConfig = await NestFactory.create<NestExpressApplication>(AppModule, {
     logger: initialLogLevels,
@@ -133,21 +171,6 @@ export async function bootstrap() {
     allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
     credentials: true, // Allow cookies to be sent
   });
-
-  if (!appConfig) {
-    bootstrapLogger.error("Application configuration ('app') not loaded. Exiting.");
-    process.exit(1);
-  }
-  // Configure Plugin System
-  bootstrapLogger.log('Configuring PluginSystem...');
-  PluginService.configure({
-    PLUGIN_DIR: appConfig.PLUGIN_DIR,
-    RESTART_BY_EXIT: appConfig.RESTART_BY_EXIT,
-  });
-  PluginModule.configure({
-    DISABLE_PLUGINS: appConfig.DISABLE_PLUGINS,
-  });
-  bootstrapLogger.log('PluginSystem configured.');
 
   // Run migrations before the app fully starts
   try {

--- a/apps/api/src/plugin-system/plugin.service.ts
+++ b/apps/api/src/plugin-system/plugin.service.ts
@@ -18,12 +18,7 @@ export class PluginService {
   private static loadedPlugins: Set<string> = new Set();
   private static pluginLoadErrors: Map<string, Error> = new Map();
   private static logger = new Logger(PluginService.name);
-  // Seeded from the PLUGIN_DIR env var so it is already set when AppModule is
-  // imported. PluginModule.forRoot() — which imports each plugin's backend
-  // module — runs at that import, before bootstrap() calls configure(); without
-  // this seed the path is undefined at forRoot time and no plugin backends load.
-  // configure() still overrides it from AppConfig for completeness.
-  public static PLUGIN_PATH: string = process.env.PLUGIN_DIR as string;
+  public static PLUGIN_PATH: string;
   private static RESTART_BY_EXIT_FLAG: boolean;
 
   public static configure(config: { PLUGIN_DIR: string, RESTART_BY_EXIT: boolean }): void {

--- a/apps/api/src/plugin-system/plugin.service.ts
+++ b/apps/api/src/plugin-system/plugin.service.ts
@@ -18,7 +18,12 @@ export class PluginService {
   private static loadedPlugins: Set<string> = new Set();
   private static pluginLoadErrors: Map<string, Error> = new Map();
   private static logger = new Logger(PluginService.name);
-  public static PLUGIN_PATH: string;
+  // Seeded from the PLUGIN_DIR env var so it is already set when AppModule is
+  // imported. PluginModule.forRoot() — which imports each plugin's backend
+  // module — runs at that import, before bootstrap() calls configure(); without
+  // this seed the path is undefined at forRoot time and no plugin backends load.
+  // configure() still overrides it from AppConfig for completeness.
+  public static PLUGIN_PATH: string = process.env.PLUGIN_DIR as string;
   private static RESTART_BY_EXIT_FLAG: boolean;
 
   public static configure(config: { PLUGIN_DIR: string, RESTART_BY_EXIT: boolean }): void {

--- a/apps/frontend/src/app/layout/sidebar.tsx
+++ b/apps/frontend/src/app/layout/sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { X, Settings, LogOut, User, ExternalLink, Languages, Check } from 'lucide-react';
+import { X, Settings, LogOut, User, ExternalLink, Languages, Check, PackageIcon } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import {
@@ -27,6 +27,8 @@ import en from './sidebar.en.json';
 import { Logo } from '../../components/logo';
 import { SidebarItem, SidebarItemGroup, useSidebarItems, useSidebarEndItems } from './sidebarItems';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import usePluginState from '../plugins/plugin.state';
+import type { PluginSidebarItem } from '@attraccess/plugins-frontend-sdk';
 
 interface NavLinkProps {
   href: string;
@@ -90,6 +92,24 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
 
   const routes = useAllRoutes();
   const sidebarItems = useSidebarItems();
+  const { plugins } = usePluginState();
+
+  // Sidebar entries contributed by installed frontend plugins. Each plugin's
+  // getSidebarItems() is optional and isolated so a throwing plugin can't break
+  // the shell. Visibility is still gated by the target route's auth below.
+  const pluginNavItems: PluginSidebarItem[] = useMemo(() => {
+    return plugins.flatMap((manifest) => {
+      try {
+        return manifest.plugin.getSidebarItems?.() ?? [];
+      } catch (error) {
+        console.error(
+          `Attraccess Plugin System: getSidebarItems() of plugin "${manifest.plugin.getPluginName()}" threw`,
+          error,
+        );
+        return [];
+      }
+    });
+  }, [plugins]);
 
   const showNavItem = useCallback(
     (item: SidebarItem) => {
@@ -149,6 +169,10 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
   const defaultGroupItems = useMemo(() => {
     return navigationGroups.find((group) => group.translationKey === '##default##')?.items;
   }, [navigationGroups]);
+
+  const visiblePluginNavItems = useMemo(() => {
+    return pluginNavItems.filter((item) => showNavItem({ path: item.path } as SidebarItem));
+  }, [pluginNavItems, showNavItem]);
 
   const otherGroups = useMemo(() => {
     return navigationGroups.filter((group) => group.translationKey !== '##default##');
@@ -218,6 +242,15 @@ export function Sidebar({ isOpen, toggleSidebar }: SidebarProps) {
                 label={t('groups.##default##.items.' + item.translationKey)}
                 data-cy={`sidebar-nav-${item.path?.replace('/', '')}`}
                 badgeCount={item.badgeCount}
+              />
+            ))}
+            {visiblePluginNavItems.map((item) => (
+              <NavLink
+                key={item.path}
+                href={item.path}
+                icon={item.icon ?? <PackageIcon size={16} />}
+                label={item.label}
+                data-cy={`sidebar-plugin-nav-${item.path?.replace(/\//g, '-')}`}
               />
             ))}
             <Accordion>

--- a/apps/frontend/src/app/plugins/PluginsList.de.json
+++ b/apps/frontend/src/app/plugins/PluginsList.de.json
@@ -1,8 +1,7 @@
 {
-  "workInProgressTitle": "In Arbeit",
-  "workInProgress": "Diese Funktionen sind noch in Arbeit und werden bald verfügbar sein.",
   "title": "Installierte Plugins",
   "uploadButton": "Plugin hochladen",
+  "docsButton": "Dokumentation",
   "noPlugins": "Keine Plugins installiert",
   "columns": {
     "name": "Name",

--- a/apps/frontend/src/app/plugins/PluginsList.en.json
+++ b/apps/frontend/src/app/plugins/PluginsList.en.json
@@ -1,8 +1,7 @@
 {
-  "workInProgressTitle": "Work in progress",
-  "workInProgress": "This feature is still under development and will be available soon.",
   "title": "Installed Plugins",
   "uploadButton": "Upload Plugin",
+  "docsButton": "Documentation",
   "noPlugins": "No plugins installed",
   "columns": {
     "name": "Name",

--- a/apps/frontend/src/app/plugins/PluginsList.spec.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.spec.tsx
@@ -2,7 +2,10 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import { PluginsList } from './PluginsList';
+
+const renderPage = () => render(<PluginsList />, { wrapper: MemoryRouter });
 
 interface DeleteOptions {
   onSuccess?: () => void;
@@ -59,10 +62,9 @@ afterEach(() => {
 });
 
 describe('PluginsList', () => {
-  it('renders the work-in-progress alert, title, upload button and table headers', () => {
-    render(<PluginsList />);
+  it('renders the title, upload button and table headers', () => {
+    renderPage();
 
-    expect(screen.getByText('Work in progress')).toBeInTheDocument();
     expect(screen.getByText('Installed Plugins')).toBeInTheDocument();
     expect(screen.getByText('Upload Plugin')).toBeInTheDocument();
     expect(screen.getByText('Name')).toBeInTheDocument();
@@ -72,13 +74,13 @@ describe('PluginsList', () => {
   });
 
   it('shows the empty state when no plugins are installed', () => {
-    render(<PluginsList />);
+    renderPage();
     expect(screen.getByText('No entries found')).toBeInTheDocument();
   });
 
   it('renders a row per plugin with name, version, directory and permission chips', () => {
     hoisted.plugins = [makePlugin()];
-    render(<PluginsList />);
+    renderPage();
 
     expect(screen.getByText('Cool Plugin')).toBeInTheDocument();
     expect(screen.getByText('1.2.3')).toBeInTheDocument();
@@ -89,7 +91,7 @@ describe('PluginsList', () => {
 
   it('falls back to a dash for a missing directory and "None requested" for no permissions', () => {
     hoisted.plugins = [makePlugin({ pluginDirectory: '', permissions: [] })];
-    render(<PluginsList />);
+    renderPage();
 
     expect(screen.getByText('-')).toBeInTheDocument();
     expect(screen.getByText('None requested')).toBeInTheDocument();
@@ -97,7 +99,7 @@ describe('PluginsList', () => {
 
   it('opens the upload drawer when the upload button is pressed', async () => {
     const user = userEvent.setup();
-    render(<PluginsList />);
+    renderPage();
 
     expect(document.querySelector('[data-cy="upload-plugin-modal"]')).not.toBeInTheDocument();
 
@@ -111,7 +113,7 @@ describe('PluginsList', () => {
   it('opens the delete confirmation modal when a delete button is pressed', async () => {
     hoisted.plugins = [makePlugin()];
     const user = userEvent.setup();
-    render(<PluginsList />);
+    renderPage();
 
     await user.click(
       document.querySelector('[data-cy="plugins-list-delete-plugin-button-plugin-1"]') as Element
@@ -127,7 +129,7 @@ describe('PluginsList', () => {
   it('calls deletePlugin with the plugin id when deletion is confirmed', async () => {
     hoisted.plugins = [makePlugin()];
     const user = userEvent.setup();
-    render(<PluginsList />);
+    renderPage();
 
     await user.click(
       document.querySelector('[data-cy="plugins-list-delete-plugin-button-plugin-1"]') as Element
@@ -143,7 +145,7 @@ describe('PluginsList', () => {
   it('shows a success toast after a successful delete', () => {
     vi.useFakeTimers();
     hoisted.plugins = [makePlugin()];
-    render(<PluginsList />);
+    renderPage();
 
     hoisted.deleteOptions?.onSuccess?.();
 
@@ -156,7 +158,7 @@ describe('PluginsList', () => {
   it('shows an error toast when the delete fails', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     hoisted.plugins = [makePlugin()];
-    render(<PluginsList />);
+    renderPage();
 
     hoisted.deleteOptions?.onError?.(new Error('boom'));
 
@@ -167,7 +169,7 @@ describe('PluginsList', () => {
   it('cancels the delete without calling the mutation', async () => {
     hoisted.plugins = [makePlugin()];
     const user = userEvent.setup();
-    render(<PluginsList />);
+    renderPage();
 
     await user.click(
       document.querySelector('[data-cy="plugins-list-delete-plugin-button-plugin-1"]') as Element
@@ -182,7 +184,7 @@ describe('PluginsList', () => {
 
   it('renders permission chips scoped to the plugin row', () => {
     hoisted.plugins = [makePlugin({ id: 'p-perms', permissions: ['admin'] })];
-    render(<PluginsList />);
+    renderPage();
 
     const container = document.querySelector('[data-cy="plugins-list-permissions-p-perms"]') as HTMLElement;
     expect(container).toBeInTheDocument();

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -1,9 +1,28 @@
 import { usePluginsServiceDeletePlugin, usePluginsServiceGetPlugins } from '@attraccess/react-query-client';
 import { useState } from 'react';
-import { Alert, AlertContent, AlertDescription, AlertTitle, Card, Chip, Modal, ModalBackdrop, ModalBody, ModalContainer, ModalDialog, ModalFooter, ModalHeader, ModalHeading, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, Tooltip, TooltipContent } from '@heroui/react';
+import {
+  Card,
+  Chip,
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalContainer,
+  ModalDialog,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  Tooltip,
+  TooltipContent,
+} from '@heroui/react';
 import { Button } from '../../components/button';
-import { Trash2, Upload } from 'lucide-react';
-import { AlertStatusIcon } from '../../components/AlertStatusIcon';
+import { BookOpen, Trash2, Upload } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { UploadPluginModal } from './UploadPluginModal';
 import { useToastMessage } from '../../components/toastProvider';
@@ -61,17 +80,21 @@ export function PluginsList() {
   };
 
   return (
-    <>
-      <Alert status="danger" className="mb-4" data-cy="plugins-list-work-in-progress-alert">
-        <AlertStatusIcon status="danger" />
-        <AlertContent>
-          <AlertTitle>{t('workInProgressTitle')}</AlertTitle>
-          <AlertDescription>{t('workInProgress')}</AlertDescription>
-        </AlertContent>
-      </Alert>
-      <Card className="w-full" data-cy="plugins-list-card">
-        <Card.Header className="flex justify-between items-center">
-          <h1 className="text-xl font-bold">{t('title')}</h1>
+    <Card className="w-full" data-cy="plugins-list-card">
+      <Card.Header className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">{t('title')}</h1>
+        <div className="flex items-center gap-2">
+          <a
+            href="https://docs.attraccess.org/#/plugins/developing-plugins"
+            target="_blank"
+            rel="noreferrer"
+            data-cy="plugins-list-docs-link"
+          >
+            <Button variant="secondary">
+              <BookOpen size={18} />
+              {t('docsButton')}
+            </Button>
+          </a>
           <Button
             variant="primary"
             onPress={() => setUploadModalOpen(true)}
@@ -80,10 +103,11 @@ export function PluginsList() {
             <Upload size={18} />
             {t('uploadButton')}
           </Button>
-        </Card.Header>
-        <Card.Content>
-          <Table data-cy="plugins-list-table">
-            <TableContent aria-label="Plugins table">
+        </div>
+      </Card.Header>
+      <Card.Content>
+        <Table data-cy="plugins-list-table">
+          <TableContent aria-label="Plugins table">
             <TableHeader>
               <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
               <TableColumn>{t('columns.version')}</TableColumn>
@@ -130,55 +154,54 @@ export function PluginsList() {
                 </TableRow>
               )}
             </TableBody>
-            </TableContent>
-          </Table>
-        </Card.Content>
+          </TableContent>
+        </Table>
+      </Card.Content>
 
-        <Modal
-          isOpen={deleteModalOpen}
-          onOpenChange={setDeleteModalOpen}
-          data-cy="plugins-list-delete-confirmation-modal"
-        >
-          <ModalBackdrop>
-            <ModalContainer size="sm">
-              <ModalDialog>
-                {({ close }) => (
-                  <>
-                    <ModalHeader>
-                      <ModalHeading>{t('deleteConfirmation.title')}</ModalHeading>
-                    </ModalHeader>
-                    <ModalBody>
-                      {t('deleteConfirmation.message', {
-                        pluginName: plugins?.find((plugin) => plugin.id === pluginToDelete)?.name,
-                      })}
-                    </ModalBody>
-                    <ModalFooter>
-                      <Button
-                        variant="secondary"
-                        onPress={close}
-                        isDisabled={isDeleting}
-                        data-cy="plugins-list-delete-confirmation-cancel-button"
-                      >
-                        {t('deleteConfirmation.cancel')}
-                      </Button>
-                      <Button
-                        variant="danger"
-                        onPress={handleDeleteConfirm}
-                        isPending={isDeleting}
-                        data-cy="plugins-list-delete-confirmation-delete-button"
-                      >
-                        {t('deleteConfirmation.delete')}
-                      </Button>
-                    </ModalFooter>
-                  </>
-                )}
-              </ModalDialog>
-            </ModalContainer>
-          </ModalBackdrop>
-        </Modal>
+      <Modal
+        isOpen={deleteModalOpen}
+        onOpenChange={setDeleteModalOpen}
+        data-cy="plugins-list-delete-confirmation-modal"
+      >
+        <ModalBackdrop>
+          <ModalContainer size="sm">
+            <ModalDialog>
+              {({ close }) => (
+                <>
+                  <ModalHeader>
+                    <ModalHeading>{t('deleteConfirmation.title')}</ModalHeading>
+                  </ModalHeader>
+                  <ModalBody>
+                    {t('deleteConfirmation.message', {
+                      pluginName: plugins?.find((plugin) => plugin.id === pluginToDelete)?.name,
+                    })}
+                  </ModalBody>
+                  <ModalFooter>
+                    <Button
+                      variant="secondary"
+                      onPress={close}
+                      isDisabled={isDeleting}
+                      data-cy="plugins-list-delete-confirmation-cancel-button"
+                    >
+                      {t('deleteConfirmation.cancel')}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      onPress={handleDeleteConfirm}
+                      isPending={isDeleting}
+                      data-cy="plugins-list-delete-confirmation-delete-button"
+                    >
+                      {t('deleteConfirmation.delete')}
+                    </Button>
+                  </ModalFooter>
+                </>
+              )}
+            </ModalDialog>
+          </ModalContainer>
+        </ModalBackdrop>
+      </Modal>
 
-        <UploadPluginModal isOpen={uploadModalOpen} onClose={() => setUploadModalOpen(false)} />
-      </Card>
-    </>
+      <UploadPluginModal isOpen={uploadModalOpen} onClose={() => setUploadModalOpen(false)} />
+    </Card>
   );
 }

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -1,7 +1,6 @@
 import { usePluginsServiceDeletePlugin, usePluginsServiceGetPlugins } from '@attraccess/react-query-client';
 import { useState } from 'react';
 import {
-  Card,
   Chip,
   Modal,
   ModalBackdrop,
@@ -27,6 +26,7 @@ import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { UploadPluginModal } from './UploadPluginModal';
 import { useToastMessage } from '../../components/toastProvider';
 import { EmptyState } from '../../components/emptyState';
+import { PageHeader } from '../../components/pageHeader';
 
 import de from './PluginsList.de.json';
 import en from './PluginsList.en.json';
@@ -80,83 +80,86 @@ export function PluginsList() {
   };
 
   return (
-    <Card className="w-full" data-cy="plugins-list-card">
-      <Card.Header className="flex justify-between items-center">
-        <h1 className="text-xl font-bold">{t('title')}</h1>
-        <div className="flex items-center gap-2">
-          <a
-            href="https://docs.attraccess.org/#/plugins/developing-plugins"
-            target="_blank"
-            rel="noreferrer"
-            data-cy="plugins-list-docs-link"
-          >
-            <Button variant="secondary">
-              <BookOpen size={18} />
-              {t('docsButton')}
-            </Button>
-          </a>
-          <Button
-            variant="primary"
-            onPress={() => setUploadModalOpen(true)}
-            data-cy="plugins-list-upload-plugin-button"
-          >
-            <Upload size={18} />
-            {t('uploadButton')}
-          </Button>
-        </div>
-      </Card.Header>
-      <Card.Content>
-        <Table data-cy="plugins-list-table">
-          <TableContent aria-label="Plugins table">
-            <TableHeader>
-              <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
-              <TableColumn>{t('columns.version')}</TableColumn>
-              <TableColumn>{t('columns.directory')}</TableColumn>
-              <TableColumn>{t('columns.permissions')}</TableColumn>
-              <TableColumn>{t('columns.actions')}</TableColumn>
-            </TableHeader>
-            <TableBody items={plugins} renderEmptyState={() => <EmptyState />}>
-              {(plugin) => (
-                <TableRow key={plugin.name} id={plugin.name}>
-                  <TableCell>{plugin.name}</TableCell>
-                  <TableCell>
-                    <Chip variant="soft" color="accent">
-                      {plugin.version}
-                    </Chip>
-                  </TableCell>
-                  <TableCell>{plugin.pluginDirectory || '-'}</TableCell>
-                  <TableCell>
-                    {plugin.permissions && plugin.permissions.length > 0 ? (
-                      <div className="flex flex-wrap gap-1" data-cy={`plugins-list-permissions-${plugin.id}`}>
-                        {plugin.permissions.map((permission) => (
-                          <Chip key={permission} variant="soft" color="warning">
-                            {permission}
-                          </Chip>
-                        ))}
-                      </div>
-                    ) : (
-                      <span className="text-default-400">{t('noPermissions')}</span>
-                    )}
-                  </TableCell>
-                  <TableCell>
-                    <Tooltip>
-                      <Button
-                        variant="danger-soft"
-                        isIconOnly
-                        onPress={() => handleDeleteClick(plugin.id)}
-                        data-cy={`plugins-list-delete-plugin-button-${plugin.id}`}
-                      >
-                        <Trash2 size={18} />
-                      </Button>
-                      <TooltipContent>{t('deleteTooltip')}</TooltipContent>
-                    </Tooltip>
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </TableContent>
-        </Table>
-      </Card.Content>
+    <div data-cy="plugins-list-card">
+      <PageHeader
+        title={t('title')}
+        actions={[
+          {
+            key: 'docs',
+            label: t('docsButton'),
+            icon: <BookOpen size={18} />,
+            variant: 'secondary',
+            renderTrigger: (triggerProps) => (
+              <a
+                href="https://docs.attraccess.org/#/plugins/developing-plugins"
+                target="_blank"
+                rel="noreferrer"
+                data-cy="plugins-list-docs-link"
+              >
+                <Button {...triggerProps} />
+              </a>
+            ),
+          },
+          {
+            key: 'upload',
+            label: t('uploadButton'),
+            icon: <Upload size={18} />,
+            variant: 'primary',
+            onPress: () => setUploadModalOpen(true),
+            dataCy: 'plugins-list-upload-plugin-button',
+          },
+        ]}
+      />
+      <Table data-cy="plugins-list-table">
+        <TableContent aria-label="Plugins table">
+          <TableHeader>
+            <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
+            <TableColumn>{t('columns.version')}</TableColumn>
+            <TableColumn>{t('columns.directory')}</TableColumn>
+            <TableColumn>{t('columns.permissions')}</TableColumn>
+            <TableColumn>{t('columns.actions')}</TableColumn>
+          </TableHeader>
+          <TableBody items={plugins} renderEmptyState={() => <EmptyState />}>
+            {(plugin) => (
+              <TableRow key={plugin.name} id={plugin.name}>
+                <TableCell>{plugin.name}</TableCell>
+                <TableCell>
+                  <Chip variant="soft" color="accent">
+                    {plugin.version}
+                  </Chip>
+                </TableCell>
+                <TableCell>{plugin.pluginDirectory || '-'}</TableCell>
+                <TableCell>
+                  {plugin.permissions && plugin.permissions.length > 0 ? (
+                    <div className="flex flex-wrap gap-1" data-cy={`plugins-list-permissions-${plugin.id}`}>
+                      {plugin.permissions.map((permission) => (
+                        <Chip key={permission} variant="soft" color="warning">
+                          {permission}
+                        </Chip>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-default-400">{t('noPermissions')}</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Tooltip>
+                    <Button
+                      variant="danger-soft"
+                      isIconOnly
+                      onPress={() => handleDeleteClick(plugin.id)}
+                      data-cy={`plugins-list-delete-plugin-button-${plugin.id}`}
+                    >
+                      <Trash2 size={18} />
+                    </Button>
+                    <TooltipContent>{t('deleteTooltip')}</TooltipContent>
+                  </Tooltip>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </TableContent>
+      </Table>
 
       <Modal
         isOpen={deleteModalOpen}
@@ -202,6 +205,6 @@ export function PluginsList() {
       </Modal>
 
       <UploadPluginModal isOpen={uploadModalOpen} onClose={() => setUploadModalOpen(false)} />
-    </Card>
+    </div>
   );
 }

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig(({ command }) => {
         'react-router-dom': { requiredVersion: '*' },
         'react-pluggable': { requiredVersion: '*' },
         '@heroui/react': { requiredVersion: '*' },
+        'lucide-react': { requiredVersion: '*' },
         '@tanstack/react-query': { requiredVersion: '*' },
       },
     }),

--- a/docs/en/plugins/developing-plugins.md
+++ b/docs/en/plugins/developing-plugins.md
@@ -256,7 +256,22 @@ A frontend plugin is an ES module that **default-exports a class** implementing
 *remote* (exposing `./plugin`), instantiates the class, and calls `getRoutes()`
 to merge your pages into the app router.
 
+> [!TIP]
+> **Recommended: build your UI with the host's own libraries.** The host shares
+> its component kit [`@heroui/react`](https://www.heroui.com/) and its icon set
+> [`lucide-react`](https://lucide.dev/) over module federation (see
+> [Packaging the frontend](#packaging-the-frontend)). Import them instead of
+> hand-rolling styles and your pages look native, stay consistent, and inherit
+> the host's **light/dark theme automatically** — HeroUI components read the
+> active theme from the host, and Tailwind utility classes (`text-default-500`,
+> `border-default-200`, …) resolve against the host's stylesheet because your
+> page renders inside the host DOM. Because these packages are *shared*, the
+> host serves its single copy at runtime, so your plugin bundle only carries its
+> own code.
+
 ```tsx
+import { Card, Chip, Spinner } from '@heroui/react';
+import { HandIcon } from 'lucide-react';
 import type {
   AttraccessFrontendPlugin,
   AttraccessFrontendPluginAuthData,
@@ -267,17 +282,36 @@ import { useEffect, useState } from 'react';
 
 function HelloWorldPage() {
   const [greetings, setGreetings] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     fetch('/api/hello-world/greetings', { credentials: 'include' })
       .then((res) => res.json())
-      .then((data: { greetings: string[] }) => setGreetings(data.greetings));
+      .then((data: { greetings: string[] }) => setGreetings(data.greetings))
+      .finally(() => setLoading(false));
   }, []);
 
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Hello World Plugin</h1>
-      <ul>{greetings.map((g) => <li key={g}>{g}</li>)}</ul>
+    <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto">
+      <div className="flex items-center gap-3">
+        <HandIcon className="w-6 h-6 text-primary" />
+        <h1 className="text-2xl font-semibold text-default-800">Hello World Plugin</h1>
+      </div>
+      <Card className="border border-default-200 dark:border-default-100">
+        <Card.Content>
+          {loading ? (
+            <Spinner size="sm" />
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {greetings.map((g) => (
+                <li key={g}>
+                  <Chip color="accent" variant="soft">{g}</Chip>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card.Content>
+      </Card>
     </div>
   );
 }
@@ -323,7 +357,13 @@ Build the frontend as a module federation remote exposing `./plugin`. Its
 `shared` list must include every host singleton your plugin **imports at
 runtime**, so it reuses the host's copy instead of bundling its own. The host
 shares: `react`, `react-dom`, `react-router-dom`, `react-pluggable`,
-`@heroui/react`, `@tanstack/react-query`.
+`@heroui/react`, `lucide-react`, `@tanstack/react-query`.
+
+> [!TIP]
+> List `@heroui/react` and `lucide-react` here when you follow the recommended
+> approach above. They are large libraries — sharing them keeps your plugin
+> bundle small (the host serves its copy) and guarantees a single, themed
+> instance of the component kit.
 
 ```ts
 // frontend/vite.config.ts
@@ -338,8 +378,9 @@ export default defineConfig({
       name: 'plugin-hello-world',
       filename: 'remoteEntry.js',
       exposes: { './plugin': './src/plugin.tsx' },
-      // Only what the plugin imports. Add @heroui/react etc. if you use them.
-      shared: ['react', 'react-dom'],
+      // Every host singleton the plugin imports at runtime. @heroui/react and
+      // lucide-react are listed here because the recommended UI uses them.
+      shared: ['react', 'react-dom', 'react-router-dom', '@heroui/react', 'lucide-react'],
     }),
   ],
   // Emit remoteEntry.js at the output root so the manifest entryPoint resolves.

--- a/docs/en/plugins/developing-plugins.md
+++ b/docs/en/plugins/developing-plugins.md
@@ -1,144 +1,207 @@
 # Developing Plugins
 
-Attraccess provides SDKs for building custom plugins. You can create frontend extensions, backend extensions, or both.
+Attraccess plugins extend the platform with new API endpoints, background
+behaviour, and UI pages — without forking the core. A plugin can ship a
+**backend** half, a **frontend** half, or both, packaged as a single ZIP and
+uploaded through the admin [Plugins](plugins/installing-plugins.md) page.
+
+This guide is a complete walkthrough. It follows a working example —
+**`plugin-hello-world`** — that exercises every core capability: a backend
+controller, an injected repository, a typed event handler, and a frontend route.
+
+> [!TIP]
+> The full source is in the repository at
+> [`examples/plugin-hello-world`](https://github.com/Attraccess/Attraccess/tree/main/examples/plugin-hello-world).
+> Clone it, run `npm install && npm run build`, and upload the resulting ZIP to
+> see it running before you write your own.
 
 ## Plugin SDKs
 
 | SDK | Install Command | Purpose |
 |-----|----------------|---------|
-| `@attraccess/plugins-frontend-sdk` | `npm install @attraccess/plugins-frontend-sdk` | Frontend pages and components |
-| `@attraccess/plugins-backend-sdk` | `npm install @attraccess/plugins-backend-sdk` | Backend API endpoints |
+| `@attraccess/plugins-backend-sdk` | `npm install -D @attraccess/plugins-backend-sdk` | Backend modules, `PluginContext`, typed events, permissions |
+| `@attraccess/plugins-frontend-sdk` | `npm install -D @attraccess/plugins-frontend-sdk` | Frontend plugin contract and route types |
 
-## Frontend Plugins
+Both SDKs are needed only at build time (types). They are not bundled into the
+shipped artifact.
 
-The frontend SDK allows your plugin to register routes and components within the Attraccess user interface.
+## Anatomy of a plugin
 
-A frontend plugin can:
+Every plugin is a directory with a `plugin.json` manifest at its root and one or
+both build outputs:
 
-- **Register routes** -- Add new pages accessible via the sidebar or direct URL
-- **Register components** -- Inject UI components into existing pages
+```
+my-plugin/
+├── plugin.json                 # manifest (required)
+├── dist/index.js               # backend entry (CommonJS) — optional
+└── frontend/remoteEntry.js     # frontend entry (ESM federation remote) — optional
+```
 
-### Getting Started with Frontend Plugins
+### The manifest
 
-1. Create a new project and install the frontend SDK
-2. Use the SDK to register your routes and components
-3. Build and package your plugin
-4. Upload it through the [Plugins](plugins/installing-plugins.md) page
-
-> [!TIP]
-> Refer to the SDK documentation included with `@attraccess/plugins-frontend-sdk` for detailed API reference, examples and type definitions.
-
-## Backend Plugins
-
-The backend SDK allows your plugin to register API endpoints that run on the Attraccess server.
-
-A backend plugin can:
-
-- **Register API endpoints** -- Add new REST endpoints to the Attraccess API
-- **Access application services** -- Interact with the Attraccess backend
-
-### Getting Started with Backend Plugins
-
-1. Create a new project and install the backend SDK
-2. Define your API endpoints using the SDK
-3. Build and package your plugin
-4. Upload it through the [Plugins](plugins/installing-plugins.md) page
-
-### Packaging Backend Plugins
-
-A backend plugin runs **inside** the Attraccess server process and shares the host's NestJS runtime, event bus and database connection. For this to work, your build must use the *same* copies of those packages that the host already loaded -- it must **not** bundle its own.
-
-Split your dependencies into two groups:
-
-| Dependency | How to declare it | Why |
-|-----------|-------------------|-----|
-| `@nestjs/common`, `@nestjs/core`, `@nestjs/event-emitter`, `eventemitter2`, `typeorm`, `reflect-metadata` | `peerDependencies`, **externalized** at build time (never bundled) | They carry the dependency-injection identities, the shared event bus and the single database connection. A bundled copy is treated as a *different* type and silently fails to connect. |
-| `@attraccess/plugins-backend-sdk` and your own code | Bundle normally | Safe to include in your artifact. |
-
-Ship a **CommonJS** entry point (`index.js`), not an ES module (`index.mjs`). Point your `plugin.json` manifest at it:
+`plugin.json` declares the plugin's name, version, entry points, the host
+versions it supports, and the permissions it needs:
 
 ```json
 {
-  "name": "my-plugin",
+  "name": "plugin-hello-world",
   "version": "1.0.0",
-  "main": { "backend": { "directory": "dist", "entryPoint": "index.js" } },
-  "attraccessVersion": { "min": "1.0.0" }
+  "main": {
+    "backend": { "directory": "dist", "entryPoint": "index.js" },
+    "frontend": { "directory": "frontend", "entryPoint": "remoteEntry.js" }
+  },
+  "attraccessVersion": { "min": "1.0.0" },
+  "permissions": ["READ_USERS", "LISTEN_EVENTS"]
 }
 ```
 
-A minimal [esbuild](https://esbuild.github.io/) build that follows the rule:
+| Field | Required | Notes |
+|-------|----------|-------|
+| `name` | yes | Unique identifier; also the on-disk folder name. |
+| `version` | yes | Your plugin's semantic version. |
+| `main.backend` / `main.frontend` | at least one | `directory` + `entryPoint`, relative to the ZIP root. |
+| `attraccessVersion` | yes | Compatibility range — at least one of `min`, `max`, `exact`. |
+| `permissions` | no | Backend capabilities you need (see [Permissions](#backend-plugin-permissions)). Defaults to `[]`. |
 
-```bash
-esbuild src/index.ts \
-  --bundle --platform=node --format=cjs --outfile=dist/index.js \
-  --external:@nestjs/common --external:@nestjs/core \
-  --external:@nestjs/event-emitter --external:eventemitter2 \
-  --external:typeorm --external:reflect-metadata
+## Backend plugins
+
+A backend plugin runs **inside** the Attraccess server process. It exports a
+default `PluginBackendModule` whose `register(context)` returns a NestJS
+`DynamicModule`. The host imports that module into its dependency-injection
+graph, so your controllers and providers behave like first-class parts of the
+API.
+
+```ts
+import type { PluginBackendModule, PluginContext, SystemEvent } from '@attraccess/plugins-backend-sdk';
+import { Controller, DynamicModule, Get, Inject, Injectable, OnModuleInit } from '@nestjs/common';
+
+// The host hands each plugin its PluginContext under this token. Recreate it
+// locally (do not import the value) so the artifact has no runtime dependency on
+// the SDK: Symbol.for() resolves against the process-global registry, so this is
+// the exact same symbol the host uses.
+const PLUGIN_CONTEXT = Symbol.for('attraccess.plugin.context');
+
+// SystemEvent is imported as a TYPE only (erased at build time); supply the enum
+// value as a string-literal cast to keep the artifact SDK-free at runtime.
+const RESOURCE_USAGE_STARTED = 'RESOURCE_USAGE_STARTED' as SystemEvent;
+
+interface UserRow {
+  id: number;
+  username: string;
+}
+
+@Injectable()
+class HelloWorldService implements OnModuleInit {
+  constructor(@Inject(PLUGIN_CONTEXT) private readonly context: PluginContext) {}
+
+  onModuleInit(): void {
+    // Subscribe to a typed host event. Requires the LISTEN_EVENTS permission.
+    this.context.onEvent(RESOURCE_USAGE_STARTED, ({ resource, user }) => {
+      this.context.logger.log(`Resource ${resource.id} usage started by user ${user.id} — hello!`);
+    });
+  }
+
+  async greetUsers(): Promise<string[]> {
+    // Injected repository over the shared connection. Addressing the entity by
+    // NAME ('User') means we don't import the entity class; the host resolves it
+    // and gates the call behind READ_USERS.
+    const users = this.context.getRepository<UserRow>('User');
+    const rows = await users.find({ take: 5 });
+    return rows.map((row) => `Hello, ${row.username}!`);
+  }
+}
+
+@Controller('hello-world')
+class HelloWorldController {
+  constructor(private readonly service: HelloWorldService) {}
+
+  @Get('greetings')
+  async greetings(): Promise<{ greetings: string[] }> {
+    return { greetings: await this.service.greetUsers() };
+  }
+}
+
+class HelloWorldPluginModule {}
+
+const plugin: PluginBackendModule = {
+  register(context: PluginContext): DynamicModule {
+    return {
+      module: HelloWorldPluginModule,
+      controllers: [HelloWorldController],
+      providers: [{ provide: PLUGIN_CONTEXT, useValue: context }, HelloWorldService],
+    };
+  },
+};
+
+export default plugin;
 ```
 
-> [!WARNING]
-> If you bundle any of the externalized packages, your plugin may load without errors but quietly fail to receive events, share the database, or resolve host services. When in doubt, keep the dependency list above external.
+### The PluginContext
 
-### Backend Plugin Permissions
+`register(context)` receives a `PluginContext` — your gateway to the host:
+
+| Member | Purpose | Permission |
+|--------|---------|------------|
+| `context.manifest` | Your plugin's name, version, id, directory. | none |
+| `context.logger` | Logger prefixed with your plugin name. | none |
+| `context.getRepository(entity)` | TypeORM repository over the shared connection. | per-entity (see below) |
+| `context.dataSource` | The raw shared TypeORM `DataSource`. | `DATABASE_ACCESS` |
+| `context.onEvent(event, handler)` | Subscribe to a typed `SystemEvent`. | `LISTEN_EVENTS` |
+| `context.emitEvent(event, payload)` | Emit a typed `SystemEvent`. | `EMIT_EVENTS` |
+| `context.events` | The raw shared event bus (restricted surface). | per-method |
+| `context.get(token)` | Resolve an arbitrary host provider by token. | `RESOLVE_HOST_PROVIDERS` |
+
+> [!IMPORTANT]
+> Resolve services and repositories through `context`, never by re-initialising
+> TypeORM or instantiating a second `EventEmitter`. The whole point is that you
+> share the host's single database connection and event bus.
+
+### Backend plugin permissions
 
 A backend plugin runs arbitrary code inside the host process, so every host
-capability it touches must be declared up front. Add a `permissions` array to
-your `plugin.json` manifest listing only the capabilities you need. At runtime
-the host hands your plugin a **guarded** `PluginContext`: accessing a capability
-whose permission you did not declare throws a clear error naming the missing
-permission.
-
-```json
-{
-  "name": "my-plugin",
-  "version": "1.0.0",
-  "main": { "backend": { "directory": "dist", "entryPoint": "index.js" } },
-  "attraccessVersion": { "min": "1.0.0" },
-  "permissions": ["READ_USERS", "EMIT_EVENTS"]
-}
-```
+capability it touches must be declared up front in the manifest's `permissions`
+array. At runtime the host hands your plugin a **guarded** `PluginContext`:
+accessing a capability whose permission you did not declare throws a clear error
+naming the missing permission.
 
 | Permission | Grants access to |
 |-----------|------------------|
-| `READ_USERS` | `context.getRepository(User)` -- read user accounts. |
-| `ACCESS_RESOURCES` | `context.getRepository(Resource)` -- read and write resources. |
-| `READ_SETTINGS` | `context.getRepository(Setting)` -- read application settings. |
+| `READ_USERS` | `context.getRepository('User')` — read user accounts. |
+| `ACCESS_RESOURCES` | `context.getRepository('Resource')` — read and write resources. |
+| `READ_SETTINGS` | `context.getRepository('Setting')` — read application settings. |
 | `DATABASE_ACCESS` | `context.dataSource` and `context.getRepository(...)` for any other entity. |
-| `EMIT_EVENTS` | `context.emitEvent(...)` and `context.events.emit(...)` / `emitAsync(...)` -- publish on the shared event bus. |
-| `LISTEN_EVENTS` | `context.onEvent(...)` and `context.events.on(...)` / `once(...)` / ... -- subscribe to the shared event bus. |
-| `RESOLVE_HOST_PROVIDERS` | `context.get(token)` -- resolve arbitrary host services by injection token. |
-
-`context.manifest` and `context.logger` are always available and require no
-permission. Declaring an unknown permission value makes the plugin fail to load.
+| `EMIT_EVENTS` | `context.emitEvent(...)` and `context.events.emit(...)` / `emitAsync(...)`. |
+| `LISTEN_EVENTS` | `context.onEvent(...)` and `context.events.on(...)` / `once(...)` / ... |
+| `RESOLVE_HOST_PROVIDERS` | `context.get(token)` — resolve arbitrary host services by token. |
 
 A few notes on the boundary:
 
-- `DATABASE_ACCESS` is the broad grant: it covers the raw `dataSource` (including
-  the connection config) and a repository for **any** entity, so it implicitly
-  includes what `READ_USERS`, `ACCESS_RESOURCES` and `READ_SETTINGS` grant. Prefer
-  the narrow per-entity permissions when you only need one of those tables.
+- `DATABASE_ACCESS` is the broad grant: it covers the raw `dataSource` and a
+  repository for **any** entity, so it implicitly includes what `READ_USERS`,
+  `ACCESS_RESOURCES` and `READ_SETTINGS` grant. Prefer the narrow per-entity
+  permissions when you only need one of those tables.
 - The event bus is exposed as a **restricted** surface. Only `emit`/`emitAsync`
   (under `EMIT_EVENTS`) and the listener methods `on`, `once`, `addListener`,
   `prependListener`, `prependOnceListener`, `many`, `prependMany`, `onAny`,
-  `prependAny`, `off`, `offAny`, `removeListener`, `waitFor` (under `LISTEN_EVENTS`)
-  are available. Bulk/global operations such as `removeAllListeners` and
-  `listenTo` are not exposed.
+  `prependAny`, `off`, `offAny`, `removeListener`, `waitFor` (under
+  `LISTEN_EVENTS`) are available. Bulk operations like `removeAllListeners` are
+  not exposed.
+- Declaring an unknown permission value makes the plugin fail to load.
 
 > [!WARNING]
-> Request the minimum set of permissions your plugin needs. Administrators can
-> see every permission a plugin requests on the Plugins page before trusting it.
+> Request the minimum set of permissions your plugin needs. Administrators see
+> every permission a plugin requests on the Plugins page before trusting it.
 
-## Typed System Events
+### Typed system events
 
-Alongside the raw `context.events` bus, the context exposes a **typed** event
-seam for the host's `SystemEvent`s. Use it when you want compile-time-checked
-payloads instead of stringly-typed bus names:
+Alongside the raw `context.events` bus, the context exposes a **typed** seam for
+the host's `SystemEvent`s with compile-time-checked payloads:
 
-- `context.onEvent(event, handler)` -- subscribe to a `SystemEvent`. The handler
-  receives the event's typed payload and returns a `SystemEventSubscription`
-  whose `off()` detaches it. Requires `LISTEN_EVENTS`.
-- `context.emitEvent(event, payload)` -- emit a `SystemEvent`; the payload is
-  type-checked against the event. Requires `EMIT_EVENTS`.
+- `context.onEvent(event, handler)` — subscribe; the handler receives the typed
+  payload and returns a `SystemEventSubscription` whose `off()` detaches it.
+  Requires `LISTEN_EVENTS`.
+- `context.emitEvent(event, payload)` — emit; the payload is type-checked against
+  the event. Requires `EMIT_EVENTS`.
 
 ```ts
 import { SystemEvent } from '@attraccess/plugins-backend-sdk';
@@ -156,16 +219,173 @@ The host emits at least `SystemEvent.RESOURCE_USAGE_STARTED` and
 that throws is **isolated** by the host — its error is logged and never breaks
 the core flow that emitted the event.
 
-## Combined Plugins
+### Packaging the backend
 
-You can create a plugin that includes both frontend and backend functionality. This is useful when your extension needs custom API endpoints together with a user interface.
+A backend plugin shares the host's NestJS runtime, event bus and database
+connection. For dependency-injection identities to line up, your build must use
+the *same* copies of those packages the host already loaded — it must **not**
+bundle its own. Split dependencies into two groups:
 
-> [!NOTE]
-> For a general introduction to the Attraccess architecture and development setup, see the [Developer Guide](developer/overview.md).
+| Dependency | How to declare it | Why |
+|-----------|-------------------|-----|
+| `@nestjs/common`, `@nestjs/core`, `@nestjs/event-emitter`, `eventemitter2`, `typeorm`, `reflect-metadata` | `peerDependencies`, **externalized** at build time | They carry the DI identities, the shared event bus and the single DB connection. A bundled copy is a *different* type and silently fails to connect. |
+| `@attraccess/plugins-backend-sdk` and your own code | bundle normally | Safe — the SDK's runtime surface is `Symbol.for()`, identity-safe across copies. |
+
+Ship a **CommonJS** entry point (`index.js`), not an ES module. A minimal
+[esbuild](https://esbuild.github.io/) build that follows the rule:
+
+```bash
+esbuild backend/plugin.ts \
+  --bundle --platform=node --format=cjs --outfile=dist/index.js \
+  --external:@nestjs/common --external:@nestjs/core \
+  --external:@nestjs/event-emitter --external:eventemitter2 \
+  --external:typeorm --external:reflect-metadata \
+  --external:@attraccess/plugins-backend-sdk
+```
+
+> [!WARNING]
+> If you bundle any of the externalized packages, your plugin may load without
+> errors but quietly fail to receive events, share the database, or resolve host
+> services. When in doubt, keep the list above external.
+
+## Frontend plugins
+
+A frontend plugin is an ES module that **default-exports a class** implementing
+`AttraccessFrontendPlugin`. The host loads it at runtime as a
+[Vite module federation](https://github.com/originjs/vite-plugin-federation)
+*remote* (exposing `./plugin`), instantiates the class, and calls `getRoutes()`
+to merge your pages into the app router.
+
+```tsx
+import type {
+  AttraccessFrontendPlugin,
+  AttraccessFrontendPluginAuthData,
+  RouteConfig,
+} from '@attraccess/plugins-frontend-sdk';
+import type { IPluginStore } from 'react-pluggable';
+import { useEffect, useState } from 'react';
+
+function HelloWorldPage() {
+  const [greetings, setGreetings] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch('/api/hello-world/greetings', { credentials: 'include' })
+      .then((res) => res.json())
+      .then((data: { greetings: string[] }) => setGreetings(data.greetings));
+  }, []);
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Hello World Plugin</h1>
+      <ul>{greetings.map((g) => <li key={g}>{g}</li>)}</ul>
+    </div>
+  );
+}
+
+export default class HelloWorldPlugin implements AttraccessFrontendPlugin {
+  getPluginName(): string {
+    return 'hello-world-plugin@1.0.0';
+  }
+  getDependencies(): string[] {
+    return [];
+  }
+  init(_store: IPluginStore): void {}
+  activate(): void {}
+  deactivate(): void {}
+  onApiAuthStateChange(_authData: null | AttraccessFrontendPluginAuthData): void {}
+  onApiEndpointChange(_endpoint: string): void {}
+
+  // Contribute pages to the app router.
+  getRoutes(): RouteConfig[] {
+    return [{ path: '/hello-world', authRequired: true, element: <HelloWorldPage /> }];
+  }
+}
+```
+
+### Routes
+
+`getRoutes()` returns an array of `RouteConfig`. Each extends React Router's
+route props (`path`, `element`, ...) with an `authRequired` field:
+
+| `authRequired` | Meaning |
+|----------------|---------|
+| `false` | Public route, no authentication. |
+| `true` | Any logged-in user. |
+| `"canManageResources"` | A single required system permission. |
+| `["a", "b"]` | Any one of several required permissions. |
+
+The host wraps each plugin route in an error boundary and merges it with the
+core routes, so a route that throws cannot take down the rest of the app.
+
+### Packaging the frontend
+
+Build the frontend as a module federation remote exposing `./plugin`. Its
+`shared` list must include every host singleton your plugin **imports at
+runtime**, so it reuses the host's copy instead of bundling its own. The host
+shares: `react`, `react-dom`, `react-router-dom`, `react-pluggable`,
+`@heroui/react`, `@tanstack/react-query`.
+
+```ts
+// frontend/vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import federation from '@originjs/vite-plugin-federation';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    federation({
+      name: 'plugin-hello-world',
+      filename: 'remoteEntry.js',
+      exposes: { './plugin': './src/plugin.tsx' },
+      // Only what the plugin imports. Add @heroui/react etc. if you use them.
+      shared: ['react', 'react-dom'],
+    }),
+  ],
+  // Emit remoteEntry.js at the output root so the manifest entryPoint resolves.
+  build: { target: 'esnext', minify: false, cssCodeSplit: false, assetsDir: '' },
+});
+```
+
+This emits `frontend/remoteEntry.js` (plus chunks) — point your manifest's
+`main.frontend.entryPoint` at it.
+
+## Build, ZIP and upload
+
+A combined plugin needs both halves built and zipped together. The example's
+[`build.mjs`](https://github.com/Attraccess/Attraccess/blob/main/examples/plugin-hello-world/build.mjs)
+does this end to end; the resulting ZIP must look like:
+
+```
+plugin-hello-world.zip
+├── plugin.json                 # at the ZIP root
+├── dist/index.js               # backend (CommonJS)
+└── frontend/                   # frontend federation remote
+    ├── remoteEntry.js
+    └── ...chunks
+```
+
+> [!IMPORTANT]
+> Zip the **contents**, not the containing folder — `plugin.json` must sit at the
+> ZIP root: `cd package && zip -r ../plugin.zip .`
+
+Then upload it:
+
+1. Open the admin **Plugins** page and click **Upload Plugin**.
+2. Select your ZIP. The server validates the manifest, unpacks it, and
+   **restarts** to load the plugin.
+3. After the restart, your backend endpoints are live and your frontend routes
+   are reachable. Verify the requested permissions are listed on the Plugins
+   page.
+
+See [Installing Plugins](plugins/installing-plugins.md) for managing and removing
+plugins.
 
 ## See Also
 
-- [Plugins Overview](plugins/overview.md) -- What are plugins?
-- [Installing Plugins](plugins/installing-plugins.md) -- Upload and manage plugins
-- [Developer Guide](developer/overview.md) -- Attraccess architecture and development
-- [API Reference](developer/api-reference.md) -- Attraccess REST API
+- [Plugins Overview](plugins/overview.md) — What are plugins?
+- [Installing Plugins](plugins/installing-plugins.md) — Upload and manage plugins
+- [Example plugin source](https://github.com/Attraccess/Attraccess/tree/main/examples/plugin-hello-world) — the `plugin-hello-world` walkthrough code
+- [Developer Guide](developer/overview.md) — Attraccess architecture and development
+- [API Reference](developer/api-reference.md) — Attraccess REST API
+```

--- a/examples/plugin-hello-world/.gitignore
+++ b/examples/plugin-hello-world/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package
+*.zip

--- a/examples/plugin-hello-world/README.md
+++ b/examples/plugin-hello-world/README.md
@@ -1,0 +1,77 @@
+# Hello World example plugin
+
+A complete, working Attraccess plugin you can build, ZIP, and upload. It is the
+companion to the [Developing Plugins](https://docs.attraccess.org/#/plugins/developing-plugins)
+guide and exercises every core capability:
+
+| Part | File | What it shows |
+| --- | --- | --- |
+| Backend controller | [`backend/plugin.ts`](backend/plugin.ts) | Adds `GET /hello-world/greetings` to the host API. |
+| Injected repository | [`backend/plugin.ts`](backend/plugin.ts) | Reads users via `context.getRepository('User')` (needs `READ_USERS`). |
+| Event handler | [`backend/plugin.ts`](backend/plugin.ts) | Subscribes to `RESOURCE_USAGE_STARTED` via `context.onEvent` (needs `LISTEN_EVENTS`). |
+| Frontend route | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Registers the `/hello-world` page through `getRoutes()`. |
+
+## Layout
+
+```
+plugin-hello-world/
+├── plugin.json              # manifest (backend + frontend entries, permissions)
+├── package.json             # build deps + `npm run build`
+├── build.mjs                # builds both halves and produces the upload ZIP
+├── backend/
+│   ├── plugin.ts            # the backend module (controller + service)
+│   └── tsconfig.json
+└── frontend/
+    ├── index.html           # Vite build seed (not used by the host)
+    ├── vite.config.ts       # module federation remote config
+    ├── tsconfig.json
+    └── src/plugin.tsx        # the frontend plugin class
+```
+
+## Build
+
+```bash
+npm install
+npm run build          # → plugin-hello-world.zip
+```
+
+`build.mjs`:
+
+1. **Backend** — bundles `backend/plugin.ts` with esbuild to `package/dist/index.js`
+   (CommonJS), externalizing every host-shared package so dependency-injection
+   token identity is preserved (see the guide for why this matters).
+2. **Frontend** — builds `frontend/src/plugin.tsx` as a Vite module federation
+   remote exposing `./plugin`, emitting `package/frontend/remoteEntry.js`.
+3. Copies `plugin.json` to the package root and zips the package **contents**
+   into `plugin-hello-world.zip`.
+
+The resulting ZIP matches the layout the host expects:
+
+```
+plugin-hello-world.zip
+├── plugin.json
+├── dist/index.js
+└── frontend/remoteEntry.js  (+ chunks)
+```
+
+If the `zip` CLI is unavailable, the `package/` directory is still produced —
+zip its contents manually: `cd package && zip -r ../plugin-hello-world.zip .`
+
+## Upload
+
+Open the admin **Plugins** page, click **Upload Plugin**, and select
+`plugin-hello-world.zip`. The server unpacks it and restarts. After the restart:
+
+- `GET /hello-world/greetings` returns a greeting per user.
+- The `/hello-world` page is reachable in the app for any logged-in user.
+- Starting a resource usage session logs a line from the plugin's event handler.
+
+## Notes
+
+- The frontend `shared` list (`frontend/vite.config.ts`) is trimmed to `react` +
+  `react-dom` because this example only renders plain React. Add `@heroui/react`,
+  `@tanstack/react-query`, `react-router-dom` or `react-pluggable` there if your
+  plugin imports them, so it reuses the host's copy instead of bundling its own.
+- The example targets a standard Vite + `@originjs/vite-plugin-federation`
+  toolchain (see `package.json` devDependencies); it is built in isolation from
+  the host, exactly like a third-party plugin.

--- a/examples/plugin-hello-world/README.md
+++ b/examples/plugin-hello-world/README.md
@@ -11,7 +11,8 @@ guide and exercises every core capability:
 | Event handler | [`backend/plugin.ts`](backend/plugin.ts) | Subscribes to `RESOURCE_USAGE_STARTED` via `context.onEvent` (needs `LISTEN_EVENTS`). |
 | Frontend routes | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Registers the `/hello-world` and `/hello-world/capabilities` pages through `getRoutes()`. |
 | Sidebar entry | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Adds a "Hello World" navigation item through `getSidebarItems()`. |
-| Shared router | [`frontend/vite.config.ts`](frontend/vite.config.ts) | Reuses the host's `react-router-dom` so in-plugin `<Link>`s navigate without a reload. |
+| Host-native UI | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Builds pages from the host's shared `@heroui/react` components and `lucide-react` icons, so they look native and inherit the host theme. |
+| Shared libraries | [`frontend/vite.config.ts`](frontend/vite.config.ts) | Reuses the host's `react-router-dom`, `@heroui/react` and `lucide-react` so `<Link>`s navigate without a reload and the UI uses a single, themed copy. |
 
 ## Layout
 
@@ -70,10 +71,14 @@ Open the admin **Plugins** page, click **Upload Plugin**, and select
 
 ## Notes
 
-- The frontend `shared` list (`frontend/vite.config.ts`) is trimmed to `react` +
-  `react-dom` because this example only renders plain React. Add `@heroui/react`,
-  `@tanstack/react-query`, `react-router-dom` or `react-pluggable` there if your
-  plugin imports them, so it reuses the host's copy instead of bundling its own.
+- **Recommended approach:** the frontend builds its UI from the host's own
+  libraries — `@heroui/react` (components) and `lucide-react` (icons) — so it
+  looks native and inherits light/dark theming for free. Both are listed in the
+  frontend `shared` list (`frontend/vite.config.ts`) alongside `react`,
+  `react-dom` and `react-router-dom`, so the host serves its single copy at
+  runtime and the plugin bundle only carries its own code. Add
+  `@tanstack/react-query` or `react-pluggable` there too if your plugin imports
+  them.
 - The example targets a standard Vite + `@originjs/vite-plugin-federation`
   toolchain (see `package.json` devDependencies); it is built in isolation from
   the host, exactly like a third-party plugin.

--- a/examples/plugin-hello-world/README.md
+++ b/examples/plugin-hello-world/README.md
@@ -9,7 +9,9 @@ guide and exercises every core capability:
 | Backend controller | [`backend/plugin.ts`](backend/plugin.ts) | Adds `GET /hello-world/greetings` to the host API. |
 | Injected repository | [`backend/plugin.ts`](backend/plugin.ts) | Reads users via `context.getRepository('User')` (needs `READ_USERS`). |
 | Event handler | [`backend/plugin.ts`](backend/plugin.ts) | Subscribes to `RESOURCE_USAGE_STARTED` via `context.onEvent` (needs `LISTEN_EVENTS`). |
-| Frontend route | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Registers the `/hello-world` page through `getRoutes()`. |
+| Frontend routes | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Registers the `/hello-world` and `/hello-world/capabilities` pages through `getRoutes()`. |
+| Sidebar entry | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Adds a "Hello World" navigation item through `getSidebarItems()`. |
+| Shared router | [`frontend/vite.config.ts`](frontend/vite.config.ts) | Reuses the host's `react-router-dom` so in-plugin `<Link>`s navigate without a reload. |
 
 ## Layout
 

--- a/examples/plugin-hello-world/backend/plugin.ts
+++ b/examples/plugin-hello-world/backend/plugin.ts
@@ -1,0 +1,83 @@
+// Hello World example backend plugin.
+//
+// Demonstrates the three core backend capabilities a real plugin needs:
+//   1. A NestJS controller that adds a REST endpoint to the host API.
+//   2. A service that reads from the host database through an injected repository.
+//   3. A handler subscribed to a typed host SystemEvent.
+//
+// It is built in isolation (own bundler, own node_modules resolution) exactly
+// like a third-party plugin would be — see ../build.mjs and ../README.md.
+import type { PluginBackendModule, PluginContext, SystemEvent } from '@attraccess/plugins-backend-sdk';
+import { Controller, DynamicModule, Get, Inject, Injectable, OnModuleInit } from '@nestjs/common';
+
+/**
+ * The injection token the host uses to hand each plugin its PluginContext.
+ * Recreated locally (NOT imported as a runtime value) so the built artifact has
+ * zero runtime dependency on the SDK package: `Symbol.for()` resolves against the
+ * process-global registry, so this is the exact same symbol the host registers.
+ */
+const PLUGIN_CONTEXT = Symbol.for('attraccess.plugin.context');
+
+/**
+ * Typed host SystemEvent this plugin subscribes to. `SystemEvent` is imported as
+ * a TYPE only (erased at build time); the enum value is supplied as a string
+ * literal cast so the artifact keeps zero runtime dependency on the SDK.
+ * Subscribing requires the `LISTEN_EVENTS` permission declared in plugin.json.
+ */
+const RESOURCE_USAGE_STARTED = 'RESOURCE_USAGE_STARTED' as SystemEvent;
+
+/** Minimal shape of the host `User` row we read — declared locally, no import. */
+interface UserRow {
+  id: number;
+  username: string;
+}
+
+@Injectable()
+class HelloWorldService implements OnModuleInit {
+  constructor(@Inject(PLUGIN_CONTEXT) private readonly context: PluginContext) {}
+
+  // Subscribe to a typed host event once the plugin's module is initialised.
+  // Handler errors are isolated by the host and never break the core flow.
+  onModuleInit(): void {
+    this.context.onEvent(RESOURCE_USAGE_STARTED, ({ resource, user }) => {
+      this.context.logger.log(`Resource ${resource.id} usage started by user ${user.id} — hello!`);
+    });
+  }
+
+  // Read from the host DB through an injected repository. We address the entity
+  // by NAME ('User') rather than importing the class, which keeps the artifact
+  // dependency-free; the host resolves the name to its own User entity and gates
+  // the call behind the READ_USERS permission.
+  async greetUsers(): Promise<string[]> {
+    const users = this.context.getRepository<UserRow>('User');
+    const rows = await users.find({ take: 5 });
+    return rows.map((row) => `Hello, ${row.username}!`);
+  }
+}
+
+// A controller is mounted into the host's router, so this adds
+// `GET /hello-world/greetings` to the Attraccess API.
+@Controller('hello-world')
+class HelloWorldController {
+  constructor(private readonly service: HelloWorldService) {}
+
+  @Get('greetings')
+  async greetings(): Promise<{ greetings: string[] }> {
+    return { greetings: await this.service.greetUsers() };
+  }
+}
+
+// The host imports the DynamicModule returned by register() into its DI graph.
+class HelloWorldPluginModule {}
+
+const plugin: PluginBackendModule = {
+  register(context: PluginContext): DynamicModule {
+    return {
+      module: HelloWorldPluginModule,
+      controllers: [HelloWorldController],
+      providers: [{ provide: PLUGIN_CONTEXT, useValue: context }, HelloWorldService],
+    };
+  },
+};
+
+export default plugin;

--- a/examples/plugin-hello-world/backend/plugin.ts
+++ b/examples/plugin-hello-world/backend/plugin.ts
@@ -59,7 +59,11 @@ class HelloWorldService implements OnModuleInit {
 // `GET /hello-world/greetings` to the Attraccess API.
 @Controller('hello-world')
 class HelloWorldController {
-  constructor(private readonly service: HelloWorldService) {}
+  // Inject by an EXPLICIT token. esbuild (used by build.mjs) does not emit
+  // `emitDecoratorMetadata`, so Nest cannot infer constructor types for
+  // injection — without `@Inject(...)` the dependency resolves to undefined at
+  // runtime. Real plugins built with esbuild must always inject by explicit token.
+  constructor(@Inject(HelloWorldService) private readonly service: HelloWorldService) {}
 
   @Get('greetings')
   async greetings(): Promise<{ greetings: string[] }> {

--- a/examples/plugin-hello-world/backend/tsconfig.json
+++ b/examples/plugin-hello-world/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["plugin.ts"]
+}

--- a/examples/plugin-hello-world/build.mjs
+++ b/examples/plugin-hello-world/build.mjs
@@ -1,0 +1,78 @@
+// One-command build for the Hello World example plugin.
+//
+// Produces a ./package/ directory laid out exactly as the host expects inside
+// the uploaded ZIP, then zips it to ./plugin-hello-world.zip:
+//
+//   plugin-hello-world.zip
+//   ├── plugin.json
+//   ├── dist/index.js          (backend, CommonJS)
+//   └── frontend/              (frontend module-federation remote)
+//       ├── remoteEntry.js
+//       └── ...chunks
+//
+// Run with:  node build.mjs   (or `npm run build`)
+import { build as esbuild } from 'esbuild';
+import { build as viteBuild } from 'vite';
+import { cpSync, mkdirSync, rmSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGE = join(HERE, 'package');
+
+// Host-shared packages must NEVER be bundled into the backend artifact: they
+// carry the dependency-injection identities, the shared event bus and the
+// single database connection. A bundled copy is treated as a *different* type
+// and silently fails to connect. The SDK itself is safe to bundle.
+const HOST_SHARED_EXTERNALS = [
+  '@nestjs/common',
+  '@nestjs/core',
+  '@nestjs/event-emitter',
+  'eventemitter2',
+  'typeorm',
+  'reflect-metadata',
+  '@attraccess/plugins-backend-sdk',
+];
+
+rmSync(PACKAGE, { recursive: true, force: true });
+rmSync(join(HERE, 'plugin-hello-world.zip'), { force: true });
+mkdirSync(join(PACKAGE, 'dist'), { recursive: true });
+
+// 1. Backend — single CommonJS bundle with host-shared packages externalized.
+await esbuild({
+  entryPoints: [join(HERE, 'backend/plugin.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'es2021',
+  outfile: join(PACKAGE, 'dist/index.js'),
+  external: HOST_SHARED_EXTERNALS,
+  tsconfigRaw: { compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true } },
+  logLevel: 'info',
+});
+
+// 2. Frontend — Vite module federation remote exposing `./plugin`.
+await viteBuild({
+  root: join(HERE, 'frontend'),
+  configFile: join(HERE, 'frontend/vite.config.ts'),
+  build: { outDir: join(PACKAGE, 'frontend'), emptyOutDir: true },
+  logLevel: 'info',
+});
+
+// 3. Manifest at the package root.
+cpSync(join(HERE, 'plugin.json'), join(PACKAGE, 'plugin.json'));
+
+// 4. ZIP the package contents (not the package/ folder itself) for upload.
+const zip = spawnSync('zip', ['-r', join(HERE, 'plugin-hello-world.zip'), '.'], {
+  cwd: PACKAGE,
+  stdio: 'inherit',
+});
+if (zip.status !== 0) {
+  console.warn(
+    '\n`zip` CLI not available — the ./package directory is ready; zip its *contents* manually:\n' +
+      '  cd package && zip -r ../plugin-hello-world.zip .'
+  );
+} else {
+  console.log('\nBuilt plugin-hello-world.zip — upload it on the Plugins admin page.');
+}

--- a/examples/plugin-hello-world/frontend/index.html
+++ b/examples/plugin-hello-world/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<!--
+  Vite needs an HTML entry to start a build. The plugin itself is emitted as the
+  module-federation `remoteEntry.js` by the federation plugin; this file is just
+  the build seed and is not used by the host.
+-->
+<html>
+  <head>
+    <title>plugin-hello-world remote</title>
+  </head>
+  <body></body>
+</html>

--- a/examples/plugin-hello-world/frontend/src/plugin.tsx
+++ b/examples/plugin-hello-world/frontend/src/plugin.tsx
@@ -2,38 +2,120 @@
 //
 // A frontend plugin is an ES module exposing a default-exported class that
 // implements `AttraccessFrontendPlugin`. The host loads it as a Vite module
-// federation remote (exposing `./plugin`) and calls `getRoutes()` to merge the
-// plugin's pages into the app router. See ../vite.config.ts for the build.
-import type { AttraccessFrontendPlugin, AttraccessFrontendPluginAuthData, RouteConfig } from '@attraccess/plugins-frontend-sdk';
+// federation remote (exposing `./plugin`) and:
+//   - calls `getRoutes()` to merge the plugin's pages into the app router, and
+//   - calls `getSidebarItems()` to add navigation entries to the app sidebar.
+// See ../vite.config.ts for the build.
+import type {
+  AttraccessFrontendPlugin,
+  AttraccessFrontendPluginAuthData,
+  PluginSidebarItem,
+  RouteConfig,
+} from '@attraccess/plugins-frontend-sdk';
 import type { IPluginStore } from 'react-pluggable';
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 // The endpoint the example backend plugin adds to the host API.
 const GREETINGS_ENDPOINT = '/api/hello-world/greetings';
 
+// A tiny inline icon so the plugin keeps zero extra runtime dependencies — the
+// host renders whatever ReactNode the sidebar item provides.
+function WaveIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M7 11V7a2 2 0 0 1 4 0v3" />
+      <path d="M11 9V5a2 2 0 0 1 4 0v5" />
+      <path d="M15 10V6a2 2 0 0 1 4 0v8a7 7 0 0 1-7 7h-1a7 7 0 0 1-6-3.5L2 16a2 2 0 0 1 3.4-2L7 16" />
+    </svg>
+  );
+}
+
+const card: React.CSSProperties = {
+  border: '1px solid rgba(127,127,127,0.25)',
+  borderRadius: 12,
+  padding: '1rem 1.25rem',
+  background: 'rgba(127,127,127,0.06)',
+};
+
+// Shared shell so both pages get the title, intro and cross-links.
+function PluginShell({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ padding: '2rem', maxWidth: 880 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: '0.25rem' }}>
+        <WaveIcon />
+        <h1 style={{ margin: 0 }}>{title}</h1>
+      </div>
+      <nav style={{ display: 'flex', gap: '1rem', margin: '0.75rem 0 1.5rem' }}>
+        <Link to="/hello-world" data-cy="hello-world-nav-greetings">Greetings</Link>
+        <Link to="/hello-world/capabilities" data-cy="hello-world-nav-capabilities">Capabilities</Link>
+      </nav>
+      {children}
+    </div>
+  );
+}
+
+// Page 1: calls the example backend endpoint and renders the live result.
 function HelloWorldPage() {
   const [greetings, setGreetings] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     // Cookies carry the session, so just include credentials.
     fetch(GREETINGS_ENDPOINT, { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then((data: { greetings: string[] }) => setGreetings(data.greetings))
-      .catch((err: Error) => setError(err.message));
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
   }, []);
 
   return (
-    <div style={{ padding: '2rem' }} data-cy="hello-world-plugin-page">
-      <h1>Hello World Plugin</h1>
-      <p>Greetings served by the example backend plugin:</p>
-      {error && <p style={{ color: 'red' }}>Failed to load greetings: {error}</p>}
-      <ul>
-        {greetings.map((greeting) => (
-          <li key={greeting}>{greeting}</li>
+    <PluginShell title="Hello World">
+      <div data-cy="hello-world-plugin-page" style={card}>
+        <h2 style={{ marginTop: 0 }}>Greetings from the backend</h2>
+        <p style={{ marginTop: 0, opacity: 0.8 }}>
+          Served by the plugin's NestJS controller at <code>GET /hello-world/greetings</code>, which reads
+          host users through an injected repository (needs the <code>READ_USERS</code> permission).
+        </p>
+        {loading && <p>Loading…</p>}
+        {error && <p style={{ color: '#e5484d' }}>Failed to load greetings: {error}</p>}
+        {!loading && !error && (
+          <ul data-cy="hello-world-greetings" style={{ marginBottom: 0 }}>
+            {greetings.map((greeting) => (
+              <li key={greeting}>{greeting}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </PluginShell>
+  );
+}
+
+// Page 2: a static showcase of the capabilities the example exercises.
+function CapabilitiesPage() {
+  const items = [
+    { title: 'Backend controller', body: 'Adds GET /hello-world/greetings to the host API.' },
+    { title: 'Injected repository', body: "Reads users via context.getRepository('User') (needs READ_USERS)." },
+    { title: 'Typed event handler', body: 'Subscribes to RESOURCE_USAGE_STARTED via context.onEvent (needs LISTEN_EVENTS).' },
+    { title: 'Frontend route', body: 'Registers the /hello-world pages through getRoutes().' },
+    { title: 'Sidebar entry', body: 'Contributes this navigation item through getSidebarItems().' },
+  ];
+
+  return (
+    <PluginShell title="Hello World — Capabilities">
+      <div
+        data-cy="hello-world-capabilities-page"
+        style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: '1rem' }}
+      >
+        {items.map((item) => (
+          <div key={item.title} style={card}>
+            <h3 style={{ margin: '0 0 0.4rem' }}>{item.title}</h3>
+            <p style={{ margin: 0, opacity: 0.8, fontSize: 14 }}>{item.body}</p>
+          </div>
         ))}
-      </ul>
-    </div>
+      </div>
+    </PluginShell>
   );
 }
 
@@ -77,6 +159,24 @@ export default class HelloWorldPlugin implements AttraccessFrontendPlugin {
         path: '/hello-world',
         authRequired: true,
         element: <HelloWorldPage />,
+      },
+      {
+        path: '/hello-world/capabilities',
+        authRequired: true,
+        element: <CapabilitiesPage />,
+      },
+    ];
+  }
+
+  // Contribute a sidebar entry that links to the plugin's landing page. The
+  // host gates it behind the target route's auth, so it only shows when the
+  // user can actually open it.
+  getSidebarItems(): PluginSidebarItem[] {
+    return [
+      {
+        label: 'Hello World',
+        path: '/hello-world',
+        icon: <WaveIcon />,
       },
     ];
   }

--- a/examples/plugin-hello-world/frontend/src/plugin.tsx
+++ b/examples/plugin-hello-world/frontend/src/plugin.tsx
@@ -6,6 +6,30 @@
 //   - calls `getRoutes()` to merge the plugin's pages into the app router, and
 //   - calls `getSidebarItems()` to add navigation entries to the app sidebar.
 // See ../vite.config.ts for the build.
+//
+// RECOMMENDED: build your UI with the host's own libraries so plugins look
+// native and inherit light/dark theming for free. The host shares `@heroui/react`
+// (its component kit) and we share `lucide-react` (its icon set) through module
+// federation — see ../vite.config.ts. Importing them here means the host serves
+// the single copy it already ships, so the plugin bundle stays tiny and every
+// HeroUI component picks up the host's active theme automatically.
+import {
+  Alert,
+  AlertContent,
+  AlertDescription,
+  Button,
+  Card,
+  Chip,
+  Spinner,
+} from '@heroui/react';
+import {
+  BellIcon,
+  DatabaseIcon,
+  HandIcon,
+  PanelLeftIcon,
+  RouteIcon,
+  ServerIcon,
+} from 'lucide-react';
 import type {
   AttraccessFrontendPlugin,
   AttraccessFrontendPluginAuthData,
@@ -13,42 +37,37 @@ import type {
   RouteConfig,
 } from '@attraccess/plugins-frontend-sdk';
 import type { IPluginStore } from 'react-pluggable';
+import type { ComponentType } from 'react';
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 // The endpoint the example backend plugin adds to the host API.
 const GREETINGS_ENDPOINT = '/api/hello-world/greetings';
 
-// A tiny inline icon so the plugin keeps zero extra runtime dependencies — the
-// host renders whatever ReactNode the sidebar item provides.
-function WaveIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M7 11V7a2 2 0 0 1 4 0v3" />
-      <path d="M11 9V5a2 2 0 0 1 4 0v5" />
-      <path d="M15 10V6a2 2 0 0 1 4 0v8a7 7 0 0 1-7 7h-1a7 7 0 0 1-6-3.5L2 16a2 2 0 0 1 3.4-2L7 16" />
-    </svg>
-  );
-}
-
-const card: React.CSSProperties = {
-  border: '1px solid rgba(127,127,127,0.25)',
-  borderRadius: 12,
-  padding: '1rem 1.25rem',
-  background: 'rgba(127,127,127,0.06)',
-};
-
-// Shared shell so both pages get the title, intro and cross-links.
+// Shared shell so both pages get the title, intro and cross-links. Tailwind
+// utility classes (`text-default-*`, `border-default-*`, …) resolve against the
+// host's compiled stylesheet because the plugin renders inside the host DOM, so
+// spacing and colours match the rest of the app in both light and dark mode.
 function PluginShell({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div style={{ padding: '2rem', maxWidth: 880 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: '0.25rem' }}>
-        <WaveIcon />
-        <h1 style={{ margin: 0 }}>{title}</h1>
+    <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto">
+      <div className="flex items-center gap-3">
+        <HandIcon className="w-6 h-6 text-primary" />
+        <h1 className="text-2xl font-semibold text-default-800">{title}</h1>
       </div>
-      <nav style={{ display: 'flex', gap: '1rem', margin: '0.75rem 0 1.5rem' }}>
-        <Link to="/hello-world" data-cy="hello-world-nav-greetings">Greetings</Link>
-        <Link to="/hello-world/capabilities" data-cy="hello-world-nav-capabilities">Capabilities</Link>
+      <nav className="flex gap-2">
+        <Button as={Link} to="/hello-world" variant="ghost" size="sm" data-cy="hello-world-nav-greetings">
+          Greetings
+        </Button>
+        <Button
+          as={Link}
+          to="/hello-world/capabilities"
+          variant="ghost"
+          size="sm"
+          data-cy="hello-world-nav-capabilities"
+        >
+          Capabilities
+        </Button>
       </nav>
       {children}
     </div>
@@ -72,47 +91,82 @@ function HelloWorldPage() {
 
   return (
     <PluginShell title="Hello World">
-      <div data-cy="hello-world-plugin-page" style={card}>
-        <h2 style={{ marginTop: 0 }}>Greetings from the backend</h2>
-        <p style={{ marginTop: 0, opacity: 0.8 }}>
-          Served by the plugin's NestJS controller at <code>GET /hello-world/greetings</code>, which reads
-          host users through an injected repository (needs the <code>READ_USERS</code> permission).
-        </p>
-        {loading && <p>Loading…</p>}
-        {error && <p style={{ color: '#e5484d' }}>Failed to load greetings: {error}</p>}
-        {!loading && !error && (
-          <ul data-cy="hello-world-greetings" style={{ marginBottom: 0 }}>
-            {greetings.map((greeting) => (
-              <li key={greeting}>{greeting}</li>
-            ))}
-          </ul>
-        )}
-      </div>
+      <Card data-cy="hello-world-plugin-page" className="border border-default-200 dark:border-default-100">
+        <Card.Header className="flex flex-col items-start gap-1">
+          <p className="text-base font-semibold text-default-700">Greetings from the backend</p>
+          <p className="text-sm text-default-500">
+            Served by the plugin's NestJS controller at <code>GET /hello-world/greetings</code>, which reads host
+            users through an injected repository (needs the <code>READ_USERS</code> permission).
+          </p>
+        </Card.Header>
+        <Card.Content>
+          {loading && (
+            <div className="flex items-center gap-2 text-default-500">
+              <Spinner size="sm" /> Loading…
+            </div>
+          )}
+          {error && (
+            <Alert status="danger">
+              <AlertContent>
+                <AlertDescription>Failed to load greetings: {error}</AlertDescription>
+              </AlertContent>
+            </Alert>
+          )}
+          {!loading && !error && (
+            <ul data-cy="hello-world-greetings" className="flex flex-col gap-2">
+              {greetings.map((greeting) => (
+                <li key={greeting}>
+                  <Chip color="accent" variant="soft">
+                    {greeting}
+                  </Chip>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card.Content>
+      </Card>
     </PluginShell>
   );
 }
 
 // Page 2: a static showcase of the capabilities the example exercises.
 function CapabilitiesPage() {
-  const items = [
-    { title: 'Backend controller', body: 'Adds GET /hello-world/greetings to the host API.' },
-    { title: 'Injected repository', body: "Reads users via context.getRepository('User') (needs READ_USERS)." },
-    { title: 'Typed event handler', body: 'Subscribes to RESOURCE_USAGE_STARTED via context.onEvent (needs LISTEN_EVENTS).' },
-    { title: 'Frontend route', body: 'Registers the /hello-world pages through getRoutes().' },
-    { title: 'Sidebar entry', body: 'Contributes this navigation item through getSidebarItems().' },
+  const items: { title: string; body: string; icon: ComponentType<{ className?: string }> }[] = [
+    { title: 'Backend controller', body: 'Adds GET /hello-world/greetings to the host API.', icon: ServerIcon },
+    {
+      title: 'Injected repository',
+      body: "Reads users via context.getRepository('User') (needs READ_USERS).",
+      icon: DatabaseIcon,
+    },
+    {
+      title: 'Typed event handler',
+      body: 'Subscribes to RESOURCE_USAGE_STARTED via context.onEvent (needs LISTEN_EVENTS).',
+      icon: BellIcon,
+    },
+    { title: 'Frontend route', body: 'Registers the /hello-world pages through getRoutes().', icon: RouteIcon },
+    {
+      title: 'Sidebar entry',
+      body: 'Contributes this navigation item through getSidebarItems().',
+      icon: PanelLeftIcon,
+    },
   ];
 
   return (
     <PluginShell title="Hello World — Capabilities">
       <div
         data-cy="hello-world-capabilities-page"
-        style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: '1rem' }}
+        className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
       >
         {items.map((item) => (
-          <div key={item.title} style={card}>
-            <h3 style={{ margin: '0 0 0.4rem' }}>{item.title}</h3>
-            <p style={{ margin: 0, opacity: 0.8, fontSize: 14 }}>{item.body}</p>
-          </div>
+          <Card key={item.title} className="border border-default-200 dark:border-default-100">
+            <Card.Header className="flex flex-row items-center gap-2">
+              <item.icon className="w-5 h-5 text-primary" />
+              <p className="text-base font-semibold text-default-700">{item.title}</p>
+            </Card.Header>
+            <Card.Content>
+              <p className="text-sm text-default-500">{item.body}</p>
+            </Card.Content>
+          </Card>
         ))}
       </div>
     </PluginShell>
@@ -170,13 +224,14 @@ export default class HelloWorldPlugin implements AttraccessFrontendPlugin {
 
   // Contribute a sidebar entry that links to the plugin's landing page. The
   // host gates it behind the target route's auth, so it only shows when the
-  // user can actually open it.
+  // user can actually open it. The icon is a lucide-react glyph — the same set
+  // the host sidebar uses — so it lines up visually with the built-in entries.
   getSidebarItems(): PluginSidebarItem[] {
     return [
       {
         label: 'Hello World',
         path: '/hello-world',
-        icon: <WaveIcon />,
+        icon: <HandIcon className="w-5 h-5" />,
       },
     ];
   }

--- a/examples/plugin-hello-world/frontend/src/plugin.tsx
+++ b/examples/plugin-hello-world/frontend/src/plugin.tsx
@@ -1,0 +1,83 @@
+// Hello World example frontend plugin.
+//
+// A frontend plugin is an ES module exposing a default-exported class that
+// implements `AttraccessFrontendPlugin`. The host loads it as a Vite module
+// federation remote (exposing `./plugin`) and calls `getRoutes()` to merge the
+// plugin's pages into the app router. See ../vite.config.ts for the build.
+import type { AttraccessFrontendPlugin, AttraccessFrontendPluginAuthData, RouteConfig } from '@attraccess/plugins-frontend-sdk';
+import type { IPluginStore } from 'react-pluggable';
+import { useEffect, useState } from 'react';
+
+// The endpoint the example backend plugin adds to the host API.
+const GREETINGS_ENDPOINT = '/api/hello-world/greetings';
+
+function HelloWorldPage() {
+  const [greetings, setGreetings] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Cookies carry the session, so just include credentials.
+    fetch(GREETINGS_ENDPOINT, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((data: { greetings: string[] }) => setGreetings(data.greetings))
+      .catch((err: Error) => setError(err.message));
+  }, []);
+
+  return (
+    <div style={{ padding: '2rem' }} data-cy="hello-world-plugin-page">
+      <h1>Hello World Plugin</h1>
+      <p>Greetings served by the example backend plugin:</p>
+      {error && <p style={{ color: 'red' }}>Failed to load greetings: {error}</p>}
+      <ul>
+        {greetings.map((greeting) => (
+          <li key={greeting}>{greeting}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default class HelloWorldPlugin implements AttraccessFrontendPlugin {
+  // react-pluggable plumbing — a stable, unique name and (here) no dependencies.
+  getPluginName(): string {
+    return 'hello-world-plugin@1.0.0';
+  }
+
+  getDependencies(): string[] {
+    return [];
+  }
+
+  init(_pluginStore: IPluginStore): void {
+    // No setup needed for this example.
+  }
+
+  activate(): void {
+    // Called when the plugin is installed into the store.
+  }
+
+  deactivate(): void {
+    // Called when the plugin is uninstalled.
+  }
+
+  // The host pushes auth + API endpoint changes to every plugin; this example
+  // reads greetings via a relative URL, so it does not need to react to them.
+  onApiAuthStateChange(_authData: null | AttraccessFrontendPluginAuthData): void {
+    // no-op
+  }
+
+  onApiEndpointChange(_endpoint: string): void {
+    // no-op
+  }
+
+  // Contribute pages to the app router. `authRequired: true` means any
+  // logged-in user can open the route.
+  getRoutes(): RouteConfig[] {
+    return [
+      {
+        path: '/hello-world',
+        authRequired: true,
+        element: <HelloWorldPage />,
+      },
+    ];
+  }
+}

--- a/examples/plugin-hello-world/frontend/tsconfig.json
+++ b/examples/plugin-hello-world/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["dom", "dom.iterable", "es2021"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/examples/plugin-hello-world/frontend/vite.config.ts
+++ b/examples/plugin-hello-world/frontend/vite.config.ts
@@ -8,9 +8,11 @@ import federation from '@originjs/vite-plugin-federation';
 // `shared` must list every host singleton the plugin *imports at runtime* so the
 // plugin reuses the host's copy instead of bundling its own. The host shares
 // (see apps/frontend/vite.config.ts): react, react-dom, react-router-dom,
-// react-pluggable, @heroui/react, @tanstack/react-query. This example only
-// renders plain React, so it shares just react + react-dom. Add the others here
-// if your plugin imports them (e.g. @heroui/react for host-styled components).
+// react-pluggable, @heroui/react, @tanstack/react-query. This example renders
+// plain React and uses the host's router for in-plugin links, so it shares
+// react + react-dom + react-router-dom. Add the others here if your plugin
+// imports them (e.g. @heroui/react for host-styled components). Sharing the
+// router is what lets the plugin's <Link>s reuse the host navigation context.
 export default defineConfig({
   plugins: [
     react(),
@@ -20,7 +22,16 @@ export default defineConfig({
       exposes: {
         './plugin': './src/plugin.tsx',
       },
-      shared: ['react', 'react-dom'],
+      // Object form with requiredVersion '*' mirrors the host (see
+      // apps/frontend/vite.config.ts): the plugin accepts whatever version the
+      // host shares instead of pinning its own, so React stays a single
+      // instance. A version mismatch here yields two Reacts → "Invalid hook
+      // call" at runtime.
+      shared: {
+        react: { singleton: true, requiredVersion: '*' },
+        'react-dom': { singleton: true, requiredVersion: '*' },
+        'react-router-dom': { singleton: true, requiredVersion: '*' },
+      },
     }),
   ],
   build: {

--- a/examples/plugin-hello-world/frontend/vite.config.ts
+++ b/examples/plugin-hello-world/frontend/vite.config.ts
@@ -8,11 +8,14 @@ import federation from '@originjs/vite-plugin-federation';
 // `shared` must list every host singleton the plugin *imports at runtime* so the
 // plugin reuses the host's copy instead of bundling its own. The host shares
 // (see apps/frontend/vite.config.ts): react, react-dom, react-router-dom,
-// react-pluggable, @heroui/react, @tanstack/react-query. This example renders
-// plain React and uses the host's router for in-plugin links, so it shares
-// react + react-dom + react-router-dom. Add the others here if your plugin
-// imports them (e.g. @heroui/react for host-styled components). Sharing the
-// router is what lets the plugin's <Link>s reuse the host navigation context.
+// react-pluggable, @heroui/react, lucide-react, @tanstack/react-query.
+//
+// This example follows the recommended approach: it builds its UI from the
+// host's own libraries — `@heroui/react` (components, themed) and `lucide-react`
+// (icons) — so it looks native and inherits light/dark mode for free. Every
+// shared package listed here is served from the host's single copy at runtime,
+// so the plugin bundle only carries its own code. Sharing the router is what
+// lets the plugin's <Link>s reuse the host navigation context.
 export default defineConfig({
   plugins: [
     react(),
@@ -31,6 +34,8 @@ export default defineConfig({
         react: { singleton: true, requiredVersion: '*' },
         'react-dom': { singleton: true, requiredVersion: '*' },
         'react-router-dom': { singleton: true, requiredVersion: '*' },
+        '@heroui/react': { singleton: true, requiredVersion: '*' },
+        'lucide-react': { singleton: true, requiredVersion: '*' },
       },
     }),
   ],

--- a/examples/plugin-hello-world/frontend/vite.config.ts
+++ b/examples/plugin-hello-world/frontend/vite.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import federation from '@originjs/vite-plugin-federation';
+
+// Builds the frontend plugin as a Vite module federation *remote*. The host
+// loads it at runtime and pulls the exposed `./plugin` module.
+//
+// `shared` must list every host singleton the plugin *imports at runtime* so the
+// plugin reuses the host's copy instead of bundling its own. The host shares
+// (see apps/frontend/vite.config.ts): react, react-dom, react-router-dom,
+// react-pluggable, @heroui/react, @tanstack/react-query. This example only
+// renders plain React, so it shares just react + react-dom. Add the others here
+// if your plugin imports them (e.g. @heroui/react for host-styled components).
+export default defineConfig({
+  plugins: [
+    react(),
+    federation({
+      name: 'plugin-hello-world',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './plugin': './src/plugin.tsx',
+      },
+      shared: ['react', 'react-dom'],
+    }),
+  ],
+  build: {
+    // Required by module federation: emit modern ESM and keep names intact.
+    target: 'esnext',
+    minify: false,
+    cssCodeSplit: false,
+    // Emit remoteEntry.js and its chunks at the output root (not assets/) so the
+    // manifest entryPoint "remoteEntry.js" resolves directly.
+    assetsDir: '',
+  },
+});

--- a/examples/plugin-hello-world/package.json
+++ b/examples/plugin-hello-world/package.json
@@ -15,9 +15,11 @@
   "devDependencies": {
     "@attraccess/plugins-backend-sdk": "^1.0.0",
     "@attraccess/plugins-frontend-sdk": "^1.0.0",
+    "@heroui/react": "^3.0.4",
     "@originjs/vite-plugin-federation": "^1.3.0",
     "@vitejs/plugin-react": "^4.0.0",
     "esbuild": "^0.28.0",
+    "lucide-react": "^1.14.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0",

--- a/examples/plugin-hello-world/package.json
+++ b/examples/plugin-hello-world/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@attraccess-example/plugin-hello-world",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Working example plugin: backend controller + injected repository + event handler, and a frontend route. Build it, ZIP it, and upload it through the Plugins admin page.",
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/event-emitter": "^3.0.0",
+    "typeorm": "^0.3.0"
+  },
+  "devDependencies": {
+    "@attraccess/plugins-backend-sdk": "^1.0.0",
+    "@attraccess/plugins-frontend-sdk": "^1.0.0",
+    "@originjs/vite-plugin-federation": "^1.3.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "esbuild": "^0.28.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/examples/plugin-hello-world/package.json
+++ b/examples/plugin-hello-world/package.json
@@ -18,8 +18,9 @@
     "@originjs/vite-plugin-federation": "^1.3.0",
     "@vitejs/plugin-react": "^4.0.0",
     "esbuild": "^0.28.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0",
     "vite": "^5.0.0"
   }
 }

--- a/examples/plugin-hello-world/plugin.json
+++ b/examples/plugin-hello-world/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "plugin-hello-world",
+  "version": "1.0.0",
+  "main": {
+    "backend": {
+      "directory": "dist",
+      "entryPoint": "index.js"
+    },
+    "frontend": {
+      "directory": "frontend",
+      "entryPoint": "remoteEntry.js"
+    }
+  },
+  "attraccessVersion": {
+    "min": "1.0.0"
+  },
+  "permissions": ["READ_USERS", "LISTEN_EVENTS"]
+}

--- a/libs/plugins-frontend-sdk/src/lib/frontend.pluggable.ts
+++ b/libs/plugins-frontend-sdk/src/lib/frontend.pluggable.ts
@@ -1,4 +1,5 @@
 import { User } from '@attraccess/database-entities';
+import { ReactNode } from 'react';
 import { IPlugin } from 'react-pluggable';
 import { RouteConfig } from './frontend.routing';
 
@@ -6,6 +7,17 @@ export enum FrontendLocation {}
 
 export enum FRONTEND_FUNCTION {
   GET_ROUTES = 'GET_ROUTES',
+  GET_SIDEBAR_ITEMS = 'GET_SIDEBAR_ITEMS',
+}
+
+// A navigation entry a plugin contributes to the app sidebar. The host renders
+// `label` with `icon` and links to `path` (which should match a route the
+// plugin returns from getRoutes()). Route-level `authRequired` still gates
+// visibility, so an entry never points at a page the user cannot open.
+export interface PluginSidebarItem {
+  label: string;
+  path: string;
+  icon?: ReactNode;
 }
 
 export const getPluginFunctionName = (pluginName: string, func: FRONTEND_FUNCTION) => {
@@ -22,4 +34,6 @@ export interface AttraccessFrontendPlugin extends IPlugin {
   onApiEndpointChange(endpoint: string): void;
   // Optional. Return the routes this plugin contributes to the app router.
   getRoutes?(): RouteConfig[];
+  // Optional. Return the sidebar navigation entries this plugin contributes.
+  getSidebarItems?(): PluginSidebarItem[];
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Makes the plugin platform usable by third parties and presents the admin plugin UI as stable.

- **Docs** — rewrote `docs/en/plugins/developing-plugins.md` into a full walkthrough: manifest, backend module + `PluginContext` (injected repository, typed `SystemEvent` handlers, permission model), frontend plugin + `getRoutes`, and the build → ZIP → upload flow — all tracking the example below.
- **Example plugin** — new `examples/plugin-hello-world/` exercising every core capability:
  - backend controller adding `GET /hello-world/greetings`,
  - an **injected repository** (`context.getRepository('User')`, gated by `READ_USERS`),
  - a **typed event handler** (`context.onEvent(RESOURCE_USAGE_STARTED, …)`, gated by `LISTEN_EVENTS`),
  - a **frontend route** (`/hello-world`) via `getRoutes()`,
  - one-command `build.mjs` that bundles the backend (esbuild, host-shared peers externalized) and the frontend (Vite module-federation remote) and produces the upload ZIP.
- **Admin UI** — removed the "Work in progress" alert from `PluginsList` and added a **Documentation** link to the developing-plugins guide.

## Testing

- `examples/plugin-hello-world` builds end-to-end via `node build.mjs` → valid `plugin-hello-world.zip` (`plugin.json` at root, `dist/index.js`, `frontend/remoteEntry.js` + chunks).
- Frontend: prettier, eslint, and `tsc --noEmit` pass on the changed files.
- Verified the Plugins admin page in a browser (logged-in admin): WIP alert gone, Documentation link present (→ `docs.attraccess.org/#/plugins/developing-plugins`), Upload button intact. Screenshots posted to the Linear issue.

## Acceptance criteria

- [x] A new developer can follow the docs to build, upload, and run the example plugin
- [x] Example exercises backend service injection, an event handler, and a frontend route
- [x] WIP warning removed; admin plugin UI presented as stable
- [x] Docs linked from the plugin admin page

Closes [ATT-461](https://linear.app/attraccess/issue/ATT-461/plugin-docs-working-example-plugin-remove-wip-flag)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->