### PR TITLE
fix(ATT-466): serialize ws_client lifecycle — use-after-free on reconnect

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.3"'
+	-D FIRMWARE_VERSION='"1.3.4"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/websocket/websocket.cpp
+++ b/apps/attractap/firmware/src/websocket/websocket.cpp
@@ -3,7 +3,27 @@
 void Websocket::setup()
 {
     logger.info("Websocket setup");
+    if (!ws_client_mutex)
+    {
+        ws_client_mutex = xSemaphoreCreateMutex();
+    }
     this->_certManager.begin();
+}
+
+void Websocket::lockWsClient()
+{
+    if (ws_client_mutex)
+    {
+        xSemaphoreTake(ws_client_mutex, portMAX_DELAY);
+    }
+}
+
+void Websocket::unlockWsClient()
+{
+    if (ws_client_mutex)
+    {
+        xSemaphoreGive(ws_client_mutex);
+    }
 }
 
 void Websocket::loop()
@@ -75,10 +95,13 @@ void Websocket::connectWebSocket()
     _lastApiConfig = apiConfig;
     setState(CONNECTING);
 
-    if (ws_client)
+    lockWsClient();
+    esp_websocket_client_handle_t oldClient = ws_client;
+    ws_client = nullptr;
+    unlockWsClient();
+    if (oldClient)
     {
-        esp_websocket_client_destroy(ws_client);
-        ws_client = nullptr;
+        esp_websocket_client_destroy(oldClient);
     }
 
     String serverHostname = apiConfig.hostname;
@@ -125,8 +148,8 @@ void Websocket::connectWebSocket()
         }
     }
 
-    ws_client = esp_websocket_client_init(&websocket_cfg);
-    if (!ws_client)
+    esp_websocket_client_handle_t newClient = esp_websocket_client_init(&websocket_cfg);
+    if (!newClient)
     {
         logger.error("Failed to initialize WebSocket client");
         setState(INIT);
@@ -135,17 +158,22 @@ void Websocket::connectWebSocket()
     }
 
     // Register event handler
-    esp_websocket_register_events(ws_client, WEBSOCKET_EVENT_ANY, websocket_event_handler, this);
+    esp_websocket_register_events(newClient, WEBSOCKET_EVENT_ANY, websocket_event_handler, this);
 
     // Start connection
-    esp_err_t ret = esp_websocket_client_start(ws_client);
+    esp_err_t ret = esp_websocket_client_start(newClient);
     if (ret != ESP_OK)
     {
         logger.error((String("Failed to start WebSocket client: ") + esp_err_to_name(ret)).c_str());
+        esp_websocket_client_destroy(newClient);
         setState(INIT);
 
         return;
     }
+
+    lockWsClient();
+    ws_client = newClient;
+    unlockWsClient();
 
     logger.info("connectWebSocket: WebSocket started");
 }
@@ -226,7 +254,16 @@ void Websocket::processWebSocketEvent(esp_event_base_t base, int32_t event_id, v
 void Websocket::sendMessage(const String &message)
 {
     this->logger.debug(("sendMessage: " + message).c_str());
+
+    lockWsClient();
+    if (!ws_client)
+    {
+        unlockWsClient();
+        logger.error("sendMessage: ws_client not initialized");
+        return;
+    }
     int ret = esp_websocket_client_send_text(ws_client, message.c_str(), message.length(), pdMS_TO_TICKS(5000));
+    unlockWsClient();
 
     if (ret == -1)
     {
@@ -236,12 +273,15 @@ void Websocket::sendMessage(const String &message)
 
 void Websocket::sendMessage(const char *message, size_t length)
 {
+    lockWsClient();
     if (!ws_client)
     {
+        unlockWsClient();
         logger.error("sendMessage(raw): ws_client not initialized");
         return;
     }
     int ret = esp_websocket_client_send_text(ws_client, message, static_cast<int>(length), pdMS_TO_TICKS(5000));
+    unlockWsClient();
     if (ret == -1)
     {
         logger.error("sendMessage(raw): failed");
@@ -274,10 +314,13 @@ void Websocket::disableConnectionAttempts()
 {
     this->connectionAttemptsEnabled = false;
 
-    if (ws_client)
+    lockWsClient();
+    esp_websocket_client_handle_t oldClient = ws_client;
+    ws_client = nullptr;
+    unlockWsClient();
+    if (oldClient)
     {
-        esp_websocket_client_destroy(ws_client);
-        ws_client = nullptr;
+        esp_websocket_client_destroy(oldClient);
     }
 
     setState(INIT);

--- a/apps/attractap/firmware/src/websocket/websocket.hpp
+++ b/apps/attractap/firmware/src/websocket/websocket.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Arduino.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "esp_websocket_client.h"
 #include "../settings/settings.hpp"
 #include <functional>
@@ -50,7 +52,10 @@ private:
     ConnectionState _state = INIT;
     void setState(ConnectionState state);
 
-    esp_websocket_client_handle_t ws_client;
+    esp_websocket_client_handle_t ws_client = nullptr;
+    SemaphoreHandle_t ws_client_mutex = nullptr;
+    void lockWsClient();
+    void unlockWsClient();
 
     static void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
     void processWebSocketEvent(esp_event_base_t base, int32_t event_id, void *event_data);


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes **Finding B2** of ATT-462: a use-after-free on `ws_client` during reconnect churn.

`Websocket::sendMessage(const String&)` read the bare `ws_client` member and called `esp_websocket_client_send_text` with no null-check, while `connectWebSocket`/`disableConnectionAttempts` destroy and reassign `ws_client` on the loopTask. The strongest concurrent writer is the inbound-ACK send running on the ESP websocket client's internal event task. A destroy interleaving a send dereferenced a freed handle → `LoadProhibited`/`StoreProhibited` panic, or a hang if a TLS/websocket mutex got corrupted.

## Approach

- **Mutex (`ws_client_mutex`) guards every `ws_client` read/write** via `lockWsClient`/`unlockWsClient` helpers, created in `setup()`.
- **Null-check added** to `sendMessage(const String&)` (the raw overload already had one); both sends now hold the mutex across the `send_text` call, so the handle can't be freed mid-send.
- **Atomic swap-then-destroy outside the lock.** `connectWebSocket` and `disableConnectionAttempts` copy `ws_client` to a local, null the member under the lock, release, *then* `destroy()`. This is critical: `esp_websocket_client_destroy` joins the internal event task, so holding the mutex across destroy would deadlock against an in-flight send blocked on that same mutex. Swapping to null first means future sends cleanly no-op while destroy runs lock-free.
- New client is built/started on a local handle and only published to `ws_client` under the lock once started.
- `ws_client` member initialized to `nullptr` (was uninitialized — garbage on first `if (ws_client)`).
- Firmware version bumped `1.3.3` → `1.3.4` for OTA.

## Testing

- `pio run -e attractap-touch-v2` → **SUCCESS** (clean compile).
- Manual UAF-repro test (high inbound rate + aggressive network flapping) per the issue still needs a hardware run on the bench unit.

Closes ATT-466 — https://linear.app/attraccess/issue/ATT-466

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
