### PR TITLE
fix(ATT-465): synchronize cross-task State access (heap-corruption race)

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.4"'
+	-D FIRMWARE_VERSION='"1.3.5"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/state/state.cpp
+++ b/apps/attractap/firmware/src/state/state.cpp
@@ -1,6 +1,31 @@
+// Thread-safe global device state guarded by a FreeRTOS mutex
+// FEATURE: Cross-task state synchronization for network and API status
+
 #include "state.hpp"
 
-// Static member definitions
+struct StateLock
+{
+    StateLock(SemaphoreHandle_t mutex) : handle(mutex)
+    {
+        if (handle)
+        {
+            xSemaphoreTakeRecursive(handle, portMAX_DELAY);
+        }
+    }
+
+    ~StateLock()
+    {
+        if (handle)
+        {
+            xSemaphoreGiveRecursive(handle);
+        }
+    }
+
+    SemaphoreHandle_t handle;
+};
+
+SemaphoreHandle_t State::state_mutex = xSemaphoreCreateRecursiveMutex();
+
 esp_ip4_addr_t State::wifi_ip = {};
 bool State::wifi_connected = false;
 String State::wifi_ssid = "";
@@ -15,12 +40,14 @@ String State::api_device_name = "";
 
 void State::setEthernetState(bool connected, esp_ip4_addr_t ip)
 {
+    StateLock lock(state_mutex);
     ethernet_ip = ip;
     ethernet_connected = connected;
 }
 
 void State::setWifiState(bool connected, esp_ip4_addr_t ip, String ssid)
 {
+    StateLock lock(state_mutex);
     wifi_connected = connected;
     wifi_ip = ip;
     wifi_ssid = ssid;
@@ -28,6 +55,7 @@ void State::setWifiState(bool connected, esp_ip4_addr_t ip, String ssid)
 
 State::NetworkState State::getNetworkState()
 {
+    StateLock lock(state_mutex);
     NetworkState state;
     state.wifi_connected = wifi_connected;
     state.wifi_ip = wifi_ip;
@@ -41,6 +69,7 @@ State::NetworkState State::getNetworkState()
 
 void State::setWebsocketState(bool connected, String hostname, uint16_t port, bool useSSL)
 {
+    StateLock lock(state_mutex);
     websocket_connected = connected;
     websocket_hostname = hostname;
     websocket_port = port;
@@ -49,7 +78,7 @@ void State::setWebsocketState(bool connected, String hostname, uint16_t port, bo
 
 State::WebsocketState State::getWebsocketState()
 {
-
+    StateLock lock(state_mutex);
     WebsocketState state;
     state.connected = websocket_connected;
     state.hostname = websocket_hostname;
@@ -61,14 +90,14 @@ State::WebsocketState State::getWebsocketState()
 
 void State::setApiState(bool authenticated, String deviceName)
 {
-
+    StateLock lock(state_mutex);
     api_authenticated = authenticated;
     api_device_name = deviceName;
 }
 
 State::ApiState State::getApiState()
 {
-
+    StateLock lock(state_mutex);
     ApiState state;
     state.authenticated = api_authenticated;
     state.deviceName = api_device_name;

--- a/apps/attractap/firmware/src/state/state.hpp
+++ b/apps/attractap/firmware/src/state/state.hpp
@@ -3,6 +3,8 @@
 #include <esp_netif.h>
 #include <Arduino.h>
 #include <ArduinoJson.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 
 class State
 {
@@ -39,6 +41,8 @@ public:
 
 private:
     State() = delete;
+
+    static SemaphoreHandle_t state_mutex;
 
     static esp_ip4_addr_t wifi_ip;
     static bool wifi_connected;


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes a heap-corruption race (Finding B1 of ATT-462 — best match for the "every few days" crash/hang).

`State` held heap-backed Arduino `String` members (`wifi_ssid`, `websocket_hostname`, `api_device_name`) as plain statics with **no lock**. Writers run on the **networkTask** and the **ESP-IDF system event task** (`Wifi`/`Ethernet` event handlers); readers run on the **main loopTask**, websocket, api, and serial handler. On dual-core ESP32 this is true parallel access — Arduino `String` assignment does a non-atomic free/realloc of its buffer, so a concurrent read-copy or two concurrent writers could read a freed/half-updated buffer or double-free → heap allocator corruption. The write window aligns with WiFi/Ethernet connect/disconnect churn → "every few days" panic-reboot or hang.

## Approach

- Added a recursive FreeRTOS mutex (`SemaphoreHandle_t State::state_mutex`), created at static-init time.
- Every `State` setter/getter now takes the mutex through an RAII `StateLock` guard, so reads snapshot the `String` members under the lock and writes are serialized against each other and against readers.
- Bumped firmware `1.3.4` → `1.3.5` (required for OTA).

## Testing

- `pio run -e attractap-touch-v2` — **SUCCESS** (RAM 45.6%, Flash 79.7%).
- Manual overnight heap-poisoning + WiFi-churn soak per the issue's repro is recommended before merge (no on-device run performed here).

Linear: [ATT-465](https://linear.app/attraccess/issue/ATT-465/fixattractap-synchronize-cross-task-state-access-heap-corruption-race)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
