### PR TITLE
fix(ATT-272): include group-inherited introducers in resource introducer list

### DIFF
--- a/apps/api/src/resources/introducers/resourceIntroducers.service.spec.ts
+++ b/apps/api/src/resources/introducers/resourceIntroducers.service.spec.ts
@@ -7,6 +7,7 @@ import { ResourceIntroducersService } from './resourceIntroducers.service';
 describe('ResourceIntroducersService', () => {
   let service: ResourceIntroducersService;
   let repository: {
+    find: jest.Mock;
     findOne: jest.Mock;
     create: jest.Mock;
     save: jest.Mock;
@@ -24,6 +25,7 @@ describe('ResourceIntroducersService', () => {
 
   beforeEach(async () => {
     repository = {
+      find: jest.fn().mockResolvedValue([]),
       findOne: jest.fn(),
       create: jest.fn(),
       save: jest.fn(),
@@ -41,6 +43,72 @@ describe('ResourceIntroducersService', () => {
     }).compile();
 
     service = module.get(ResourceIntroducersService);
+  });
+
+  describe('getMany', () => {
+    it('returns both direct and group-inherited introducers, deduped by user', async () => {
+      const directIntroducer = {
+        id: 1,
+        userId: 10,
+        resourceId: 1,
+        type: ResourceIntroducerType.INTRODUCER,
+        user: { id: 10 },
+      } as unknown as ResourceIntroducer;
+      const groupIntroducer = {
+        id: 2,
+        userId: 20,
+        resourceGroupId: 5,
+        type: ResourceIntroducerType.INTRODUCER,
+        user: { id: 20 },
+      } as unknown as ResourceIntroducer;
+
+      repository.find.mockResolvedValue([directIntroducer]);
+
+      const groupQuery = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([groupIntroducer]),
+      };
+      repository.createQueryBuilder.mockReturnValue(groupQuery);
+
+      const result = await service.getMany(1);
+
+      expect(result).toEqual([directIntroducer, groupIntroducer]);
+    });
+
+    it('does not list a user twice when they are both a direct and a group introducer', async () => {
+      const directIntroducer = {
+        id: 1,
+        userId: 10,
+        resourceId: 1,
+        type: ResourceIntroducerType.INTRODUCER,
+        user: { id: 10 },
+      } as unknown as ResourceIntroducer;
+      const groupIntroducer = {
+        id: 2,
+        userId: 10,
+        resourceGroupId: 5,
+        type: ResourceIntroducerType.INTRODUCER,
+        user: { id: 10 },
+      } as unknown as ResourceIntroducer;
+
+      repository.find.mockResolvedValue([directIntroducer]);
+
+      const groupQuery = {
+        leftJoinAndSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([groupIntroducer]),
+      };
+      repository.createQueryBuilder.mockReturnValue(groupQuery);
+
+      const result = await service.getMany(1);
+
+      expect(result).toEqual([directIntroducer]);
+    });
   });
 
   describe('isIntroducer', () => {

--- a/apps/api/src/resources/introducers/resourceIntroducers.service.ts
+++ b/apps/api/src/resources/introducers/resourceIntroducers.service.ts
@@ -15,10 +15,35 @@ export class ResourceIntroducersService {
   ) {}
 
   public async getMany(resourceId: number, type?: ResourceIntroducerType): Promise<ResourceIntroducer[]> {
-    return await this.resourceIntroducerRepository.find({
+    const directIntroducers = await this.resourceIntroducerRepository.find({
       where: { resourceId, ...(type ? { type } : {}) },
       relations: ['user'],
     });
+
+    // Introducers granted at the group level apply to every resource in the group,
+    // so they must be listed alongside the resource's own introducers.
+    const groupQuery = this.resourceIntroducerRepository
+      .createQueryBuilder('introducer')
+      .leftJoinAndSelect('introducer.user', 'user')
+      .innerJoin('introducer.resourceGroup', 'group')
+      .innerJoin('group.resources', 'resource')
+      .where('resource.id = :resourceId', { resourceId });
+
+    if (type) {
+      groupQuery.andWhere('introducer.type = :type', { type });
+    }
+
+    const groupIntroducers = await groupQuery.getMany();
+
+    // A user can be both a direct and a group introducer; show them once.
+    const byUserId = new Map<number, ResourceIntroducer>();
+    for (const introducer of [...directIntroducers, ...groupIntroducers]) {
+      if (!byUserId.has(introducer.userId)) {
+        byUserId.set(introducer.userId, introducer);
+      }
+    }
+
+    return Array.from(byUserId.values());
   }
 
   public async getByResourceIdAndUserId(


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes [ATT-272](https://linear.app/attraccess/issue/ATT-272). When a user opens a resource they have no introduction for, the "Available Introducers" list omitted trainers assigned via a **resource group** — only directly-assigned trainers showed.

### Root cause
`ResourceIntroducersService.getMany()` queried only `ResourceIntroducer` rows whose `resourceId` matched. Group-level introducers are stored as rows with `resourceGroupId` set (and `resourceId` null) and apply to every resource in the group. The access check (`hasAccess`) already joins through groups — which is why access worked — but the displayed list did not, so the data was inconsistent.

### Fix
`getMany()` now also pulls introducers joined through the resource's groups (`introducer.resourceGroup` → `group.resources`), mirroring the `hasAccess` join, and dedupes by user so someone who is both a direct and group introducer appears once. The optional `type` filter is applied to both sources.

## Testing
- New unit tests in `resourceIntroducers.service.spec.ts`:
  - returns both direct and group-inherited introducers
  - dedupes a user who is both a direct and a group introducer
- `nx test api` — full suite green
- `nx lint api` — clean

## Not verified
Live browser screenshot of the introducer list could not be captured: the local dev API will not build/serve in this worktree (`api:build` depends on `attractap-firmware:build`, which fails without the firmware toolchain; the nx cache is shared across sibling worktrees and does not populate `dist/apps/api` here). The change is a backend query only — the `ResourceIntroducersList` frontend component is unchanged and renders whatever rows the API returns — and is covered by the unit tests above.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
