### PR TITLE
feat(ATT-174): notify introducers/maintainers about usage notes

### DIFF
--- a/apps/api/src/database/migrations/1781200000000-resource-usage-note-email-template.ts
+++ b/apps/api/src/database/migrations/1781200000000-resource-usage-note-email-template.ts
@@ -1,0 +1,85 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const RESOURCE_USAGE_NOTE_ADDED_MJML = `
+<mjml>
+  <mj-head>
+    <mj-attributes>
+      <mj-all font-family="Helvetica, Arial, sans-serif" />
+      <mj-text font-size="16px" line-height="1.5" />
+      <mj-button background-color="#2563EB" color="#FFFFFF" font-size="16px" font-weight="bold" padding="12px 24px" border-radius="4px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#F3F7FB" width="600px">
+    <mj-section background-color="#2563EB" padding="20px 0">
+      <mj-column>
+        <mj-text align="center" font-size="22px" color="#FFFFFF" font-weight="bold" padding="0">
+          New usage note: {{resource.name}}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#FFFFFF" padding="20px">
+      <mj-column>
+        <mj-text>Hello {{user.username}},</mj-text>
+        <mj-text>
+          <strong>{{note.authorName}}</strong> left a note when {{note.phaseAction}} <strong>{{resource.name}}</strong>.
+        </mj-text>
+        <mj-text font-size="14px" color="#111827" background-color="#F3F4F6" padding="12px" border-radius="4px">
+          {{note.content}}
+        </mj-text>
+        <mj-button href="{{resource.url}}" align="left">
+          View Resource
+        </mj-button>
+        <mj-text font-size="14px" color="#4B5563" padding="20px 0 0 0">
+          If the button does not work, paste this into your browser:
+          <br />
+          <a href="{{resource.url}}">{{resource.url}}</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#FFFFFF" padding="0 20px 20px 20px">
+      <mj-column>
+        <mj-text font-size="12px" color="#6B7280" align="center">
+          You received this email because you are an introducer, maintainer or administrator for this resource.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>
+`;
+
+const RESOURCE_USAGE_NOTE_ADDED_VARIABLES = [
+  'user.username',
+  'user.email',
+  'user.id',
+  'host.frontend',
+  'host.backend',
+  'resource.id',
+  'resource.name',
+  'resource.url',
+  'note.authorName',
+  'note.content',
+  'note.phase',
+  'note.phaseAction',
+].join(',');
+
+export class ResourceUsageNoteEmailTemplate1781200000000 implements MigrationInterface {
+  name = 'ResourceUsageNoteEmailTemplate1781200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT OR IGNORE INTO "email_templates" ("type", "subject", "body", "variables") VALUES ($1, $2, $3, $4)`,
+      [
+        'resource-usage-note-added',
+        'New usage note: {{resource.name}}',
+        RESOURCE_USAGE_NOTE_ADDED_MJML,
+        RESOURCE_USAGE_NOTE_ADDED_VARIABLES,
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM "email_templates" WHERE "type" = 'resource-usage-note-added'`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -121,3 +121,4 @@ export * from './1780100000000-notification-preferences';
 export * from './1781000000000-maintenance-requests';
 export * from './1781100000000-message-email-fallback';
 export * from './1780200000000-attractap-crash-report-symbolication';
+export * from './1781200000000-resource-usage-note-email-template';

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -357,6 +357,37 @@ export class EmailService {
     await this.sendEmail(recipient, EmailTemplateType.MAINTENANCE_REQUEST_CREATED, context);
   }
 
+  async sendResourceUsageNoteEmail(
+    recipient: User,
+    resource: Pick<Resource, 'id' | 'name'>,
+    note: { content: string; phase: 'start' | 'end'; authorName: string },
+  ) {
+    if (!recipient?.email) {
+      return;
+    }
+
+    const base = await this.getBaseContext(recipient);
+    const resourceUrl = `${base.host.frontend}/resources/${resource.id}`;
+    const phaseAction = note.phase === 'start' ? 'starting' : 'finishing';
+
+    const context = {
+      ...base,
+      resource: {
+        id: resource.id,
+        name: resource.name,
+        url: resourceUrl,
+      },
+      note: {
+        content: note.content,
+        phase: note.phase,
+        phaseAction,
+        authorName: note.authorName,
+      },
+    };
+
+    await this.sendEmail(recipient, EmailTemplateType.RESOURCE_USAGE_NOTE_ADDED, context);
+  }
+
   async sendNewMessageEmail(
     recipient: User,
     message: { conversationId: number; senderName: string; preview: string },

--- a/apps/api/src/resources/flows/resource-flows-executor.service.spec.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.spec.ts
@@ -445,7 +445,7 @@ describe('ResourceFlowsExecutorService.runFlow', () => {
       {
         notes: 'Ended by bob',
       },
-      true,
+      { skipFormSubmissions: true, skipNoteNotification: true },
     );
   });
 

--- a/apps/api/src/resources/flows/resource-flows-executor.service.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.ts
@@ -962,7 +962,10 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
       finalNotes = compiled && compiled.trim().length > 0 ? compiled : notes;
     }
 
-    await this.resourceUsageService.endSession(node.resourceId, activeUsage.user, { notes: finalNotes }, true, true);
+    await this.resourceUsageService.endSession(node.resourceId, activeUsage.user, { notes: finalNotes }, {
+      skipFormSubmissions: true,
+      skipNoteNotification: true,
+    });
 
     return { payload: input };
   }

--- a/apps/api/src/resources/flows/resource-flows-executor.service.ts
+++ b/apps/api/src/resources/flows/resource-flows-executor.service.ts
@@ -962,7 +962,7 @@ export class ResourceFlowsExecutorService implements OnModuleInit, OnModuleDestr
       finalNotes = compiled && compiled.trim().length > 0 ? compiled : notes;
     }
 
-    await this.resourceUsageService.endSession(node.resourceId, activeUsage.user, { notes: finalNotes }, true);
+    await this.resourceUsageService.endSession(node.resourceId, activeUsage.user, { notes: finalNotes }, true, true);
 
     return { payload: input };
   }

--- a/apps/api/src/resources/usage/events/resource-usage.events.ts
+++ b/apps/api/src/resources/usage/events/resource-usage.events.ts
@@ -20,3 +20,18 @@ export class ResourceUsageTakenOverEvent {
     public readonly previousUser: User | null // Previous user might not exist if resource was free
   ) {}
 }
+
+/**
+ * Emitted when a user attaches a note to a usage session (on start or end).
+ * Drives notifications to the resource's introducers, maintainers and admins.
+ */
+export class ResourceUsageNoteAddedEvent {
+  public static readonly EVENT_NAME = 'resource.usage.note_added';
+
+  constructor(
+    public readonly resourceId: number,
+    public readonly note: string,
+    public readonly phase: 'start' | 'end',
+    public readonly author: Pick<User, 'id' | 'username'>
+  ) {}
+}

--- a/apps/api/src/resources/usage/resource-usage-note-notification.listener.spec.ts
+++ b/apps/api/src/resources/usage/resource-usage-note-notification.listener.spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Resource, ResourceIntroducer, User } from '@attraccess/database-entities';
+import { ResourceUsageNoteNotificationListener } from './resource-usage-note-notification.listener';
+import { ResourceUsageNoteAddedEvent } from './events/resource-usage.events';
+import { EmailService } from '../../email/email.service';
+
+describe('ResourceUsageNoteNotificationListener', () => {
+  let listener: ResourceUsageNoteNotificationListener;
+  let resourceRepository: { findOne: jest.Mock };
+  let introducerRepository: { find: jest.Mock };
+  let userRepository: { createQueryBuilder: jest.Mock };
+  let emailService: { sendResourceUsageNoteEmail: jest.Mock };
+
+  const RESOURCE_ID = 7;
+  const AUTHOR_ID = 1;
+
+  const buildResource = (overrides: Partial<Resource> = {}): Resource =>
+    ({ id: RESOURCE_ID, name: 'Laser Cutter', groups: [], ...overrides } as Resource);
+
+  const buildEvent = (overrides: Partial<ResourceUsageNoteAddedEvent> = {}): ResourceUsageNoteAddedEvent =>
+    new ResourceUsageNoteAddedEvent(
+      overrides.resourceId ?? RESOURCE_ID,
+      overrides.note ?? 'Bed needs leveling',
+      overrides.phase ?? 'end',
+      overrides.author ?? { id: AUTHOR_ID, username: 'alice' },
+    );
+
+  const setAdmins = (admins: User[]) => {
+    userRepository.createQueryBuilder.mockReturnValue({
+      where: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(admins),
+    });
+  };
+
+  beforeEach(async () => {
+    resourceRepository = { findOne: jest.fn().mockResolvedValue(buildResource()) };
+    introducerRepository = { find: jest.fn().mockResolvedValue([]) };
+    userRepository = { createQueryBuilder: jest.fn() };
+    emailService = { sendResourceUsageNoteEmail: jest.fn().mockResolvedValue(undefined) };
+    setAdmins([]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceUsageNoteNotificationListener,
+        { provide: getRepositoryToken(Resource), useValue: resourceRepository },
+        { provide: getRepositoryToken(ResourceIntroducer), useValue: introducerRepository },
+        { provide: getRepositoryToken(User), useValue: userRepository },
+        { provide: EmailService, useValue: emailService },
+      ],
+    }).compile();
+
+    listener = module.get(ResourceUsageNoteNotificationListener);
+  });
+
+  it('emails introducers and admins, excluding the note author and deduping', async () => {
+    setAdmins([
+      { id: 2, email: 'admin@example.com' } as User,
+      { id: AUTHOR_ID, email: 'alice@example.com' } as User, // author also admin -> excluded
+    ]);
+    introducerRepository.find.mockResolvedValue([
+      { user: { id: 3, email: 'intro@example.com' } as User },
+      { user: { id: 2, email: 'admin@example.com' } as User }, // dup of admin -> deduped
+    ]);
+
+    await listener.handleNoteAdded(buildEvent());
+
+    const ids = emailService.sendResourceUsageNoteEmail.mock.calls.map((c) => c[0].id).sort();
+    expect(ids).toEqual([2, 3]);
+    expect(emailService.sendResourceUsageNoteEmail).toHaveBeenCalledTimes(2);
+    expect(emailService.sendResourceUsageNoteEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 2 }),
+      { id: RESOURCE_ID, name: 'Laser Cutter' },
+      { content: 'Bed needs leveling', phase: 'end', authorName: 'alice' },
+    );
+  });
+
+  it('skips users without an email', async () => {
+    introducerRepository.find.mockResolvedValue([{ user: { id: 3, email: null } as User }]);
+
+    await listener.handleNoteAdded(buildEvent());
+
+    expect(emailService.sendResourceUsageNoteEmail).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the resource is missing', async () => {
+    resourceRepository.findOne.mockResolvedValue(null);
+
+    await listener.handleNoteAdded(buildEvent());
+
+    expect(emailService.sendResourceUsageNoteEmail).not.toHaveBeenCalled();
+  });
+
+  it('includes group introducers when the resource belongs to groups', async () => {
+    resourceRepository.findOne.mockResolvedValue(buildResource({ groups: [{ id: 9 } as Resource['groups'][number]] }));
+    introducerRepository.find.mockResolvedValue([{ user: { id: 4, email: 'group@example.com' } as User }]);
+
+    await listener.handleNoteAdded(buildEvent());
+
+    const whereArg = introducerRepository.find.mock.calls[0][0].where;
+    expect(whereArg).toEqual(expect.arrayContaining([{ resourceId: RESOURCE_ID }]));
+    expect(emailService.sendResourceUsageNoteEmail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/resources/usage/resource-usage-note-notification.listener.ts
+++ b/apps/api/src/resources/usage/resource-usage-note-notification.listener.ts
@@ -1,0 +1,102 @@
+// Emails introducers, maintainers and admins when a user attaches a note to a usage session.
+// FEATURE: inform introducers/maintainers about usage notes (ATT-174)
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Resource, ResourceIntroducer, User } from '@attraccess/database-entities';
+import { ResourceUsageNoteAddedEvent } from './events/resource-usage.events';
+import { EmailService } from '../../email/email.service';
+
+@Injectable()
+export class ResourceUsageNoteNotificationListener {
+  private readonly logger = new Logger(ResourceUsageNoteNotificationListener.name);
+
+  constructor(
+    @InjectRepository(Resource)
+    private readonly resourceRepository: Repository<Resource>,
+    @InjectRepository(ResourceIntroducer)
+    private readonly resourceIntroducerRepository: Repository<ResourceIntroducer>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly emailService: EmailService,
+  ) {}
+
+  @OnEvent(ResourceUsageNoteAddedEvent.EVENT_NAME)
+  async handleNoteAdded(event: ResourceUsageNoteAddedEvent): Promise<void> {
+    try {
+      const resource = await this.resourceRepository.findOne({
+        where: { id: event.resourceId },
+        relations: ['groups'],
+      });
+      if (!resource) {
+        this.logger.warn(`Usage note for missing resource ${event.resourceId}; skipping notifications`);
+        return;
+      }
+
+      const recipients = await this.collectRecipients(resource, event.author.id);
+      if (recipients.length === 0) {
+        return;
+      }
+
+      this.logger.log(
+        `Dispatching usage-note emails to ${recipients.length} user(s) for resource ${resource.id}`,
+      );
+
+      await Promise.all(
+        recipients.map((recipient) =>
+          this.emailService
+            .sendResourceUsageNoteEmail(
+              recipient,
+              { id: resource.id, name: resource.name },
+              { content: event.note, phase: event.phase, authorName: event.author.username ?? 'A user' },
+            )
+            .catch((error) => {
+              this.logger.error(
+                `Failed to send usage-note email to user ${recipient.id} for resource ${resource.id}: ${error.message}`,
+                error.stack,
+              );
+            }),
+        ),
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to process usage-note notification for resource ${event.resourceId}: ${error.message}`,
+        error.stack,
+      );
+    }
+  }
+
+  // Introducers/maintainers of the resource (or its groups) plus admins, excluding the note author.
+  private async collectRecipients(resource: Resource, authorId: number): Promise<User[]> {
+    const groupIds = (resource.groups ?? []).map((group) => group.id);
+
+    const admins = await this.userRepository
+      .createQueryBuilder('user')
+      .where('user.canManageResources = :value', { value: true })
+      .getMany();
+
+    const introducerWhere: Array<Record<string, unknown>> = [{ resourceId: resource.id }];
+    if (groupIds.length > 0) {
+      introducerWhere.push({ resourceGroupId: In(groupIds) });
+    }
+    const introducerRows = await this.resourceIntroducerRepository.find({
+      where: introducerWhere,
+      relations: ['user'],
+    });
+
+    const byId = new Map<number, User>();
+    for (const admin of admins) {
+      if (admin.email && admin.id !== authorId) {
+        byId.set(admin.id, admin);
+      }
+    }
+    for (const row of introducerRows) {
+      if (row.user?.email && row.user.id !== authorId && !byId.has(row.user.id)) {
+        byId.set(row.user.id, row.user);
+      }
+    }
+
+    return Array.from(byId.values());
+  }
+}

--- a/apps/api/src/resources/usage/resourceUsage.module.ts
+++ b/apps/api/src/resources/usage/resourceUsage.module.ts
@@ -2,7 +2,9 @@ import { Module, forwardRef } from '@nestjs/common';
 import { ResourceUsageController } from './resourceUsage.controller';
 import { ResourceUsageService } from './resourceUsage.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Resource, ResourceUsage } from '@attraccess/database-entities';
+import { Resource, ResourceIntroducer, ResourceUsage, User } from '@attraccess/database-entities';
+import { ResourceUsageNoteNotificationListener } from './resource-usage-note-notification.listener';
+import { EmailModule } from '../../email/email.module';
 import { ResourceIntroducersModule } from '../introducers/resourceIntroducers.module';
 import { ResourceIntroductionsModule } from '../introductions/resourceIntroductions.module';
 import { ResourceGroupsModule } from '../groups/resourceGroups.module';
@@ -16,7 +18,8 @@ import { ResourceRetrainingModule } from '../retraining/resourceRetraining.modul
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ResourceUsage, Resource]),
+    TypeOrmModule.forFeature([ResourceUsage, Resource, ResourceIntroducer, User]),
+    EmailModule,
     ResourceIntroducersModule,
     ResourceIntroductionsModule,
     ResourceGroupsModule,
@@ -29,7 +32,7 @@ import { ResourceRetrainingModule } from '../retraining/resourceRetraining.modul
     ResourceHealthModule,
   ],
   controllers: [ResourceUsageController],
-  providers: [ResourceUsageService],
+  providers: [ResourceUsageService, ResourceUsageNoteNotificationListener],
   exports: [ResourceUsageService],
 })
 export class ResourceUsageModule {}

--- a/apps/api/src/resources/usage/resourceUsage.service.spec.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.spec.ts
@@ -989,7 +989,7 @@ describe('ResourceUsageService', () => {
     it('does not emit the note event when skipNoteNotification is set (flow-ended session)', async () => {
       setupEndSession();
 
-      await service.endSession(1, mockUser, { notes: 'auto note' }, false, true);
+      await service.endSession(1, mockUser, { notes: 'auto note' }, { skipNoteNotification: true });
 
       const noteEmit = eventEmitter.emit.mock.calls.find((c) => c[0] === ResourceUsageNoteAddedEvent.EVENT_NAME);
       expect(noteEmit).toBeUndefined();

--- a/apps/api/src/resources/usage/resourceUsage.service.spec.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.spec.ts
@@ -25,7 +25,11 @@ import { ResourceRetrainingService } from '../retraining/resourceRetraining.serv
 import { ResourceMaintenanceService } from '../maintenances/maintenance.service';
 import { ResourceNotFoundException } from '../../exceptions/resource.notFound.exception';
 import { ResourceUsageImpossibleMaintenanceInProgressException } from '../../exceptions/resource.maintenance.inUse.exception';
-import { ResourceUsageEvent, ResourceUsageTakenOverEvent } from './events/resource-usage.events';
+import {
+  ResourceUsageEvent,
+  ResourceUsageTakenOverEvent,
+  ResourceUsageNoteAddedEvent,
+} from './events/resource-usage.events';
 import { BillingService } from '../../billing/billing.service';
 import { InsufficientBalanceError } from '../../billing/errors/insufficient-balance.error';
 import { ResourceInUseError } from './errors/resource-in-use.error';
@@ -949,6 +953,46 @@ describe('ResourceUsageService', () => {
       const eventPayload = emitted?.[1] as ResourceUsageEvent;
       expect(eventPayload).toBeInstanceOf(ResourceUsageEvent);
       expect(eventPayload.usage).toMatchObject({ id: 1, userId: 1, endNotes: 'Session completed' });
+    });
+
+    const setupEndSession = () => {
+      const mockActiveSession = {
+        id: 1,
+        resourceId: 1,
+        userId: 1,
+        startTime: new Date(),
+        user: { id: 1, username: 'owner' } as User,
+      } as ResourceUsage;
+      const mockUpdatedSession = { ...mockActiveSession, endTime: new Date(), endNotes: 'note text' };
+      resourceUsageRepository.findOne
+        .mockResolvedValueOnce(mockActiveSession)
+        .mockResolvedValueOnce(mockUpdatedSession)
+        .mockResolvedValueOnce(mockUpdatedSession);
+      const mockUpdateQueryBuilder = createMockQueryBuilder(null);
+      (mockUpdateQueryBuilder.update as jest.Mock).mockReturnValue(mockUpdateQueryBuilder);
+      resourceUsageRepository.createQueryBuilder.mockReturnValue(
+        mockUpdateQueryBuilder as unknown as SelectQueryBuilder<ResourceUsage>,
+      );
+    };
+
+    it('emits ResourceUsageNoteAddedEvent when a user note is present', async () => {
+      setupEndSession();
+
+      await service.endSession(1, mockUser, { notes: 'note text' });
+
+      const noteEmit = eventEmitter.emit.mock.calls.find((c) => c[0] === ResourceUsageNoteAddedEvent.EVENT_NAME);
+      expect(noteEmit).toBeDefined();
+      const payload = noteEmit?.[1] as ResourceUsageNoteAddedEvent;
+      expect(payload).toMatchObject({ resourceId: 1, note: 'note text', phase: 'end' });
+    });
+
+    it('does not emit the note event when skipNoteNotification is set (flow-ended session)', async () => {
+      setupEndSession();
+
+      await service.endSession(1, mockUser, { notes: 'auto note' }, false, true);
+
+      const noteEmit = eventEmitter.emit.mock.calls.find((c) => c[0] === ResourceUsageNoteAddedEvent.EVENT_NAME);
+      expect(noteEmit).toBeUndefined();
     });
 
     it('should throw error when no active session exists', async () => {

--- a/apps/api/src/resources/usage/resourceUsage.service.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.ts
@@ -18,7 +18,11 @@ import { ResourceUsageImpossibleMaintenanceInProgressException } from '../../exc
 import { ResourceUnhealthyException } from '../../exceptions/resource.unhealthy.exception';
 import { ResourceHealthService } from '../health/resource-health.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { ResourceUsageEvent, ResourceUsageTakenOverEvent } from './events/resource-usage.events';
+import {
+  ResourceUsageEvent,
+  ResourceUsageTakenOverEvent,
+  ResourceUsageNoteAddedEvent,
+} from './events/resource-usage.events';
 import { ResourceIntroductionsService } from '../introductions/resouceIntroductions.service';
 import { ResourceIntroducersService } from '../introducers/resourceIntroducers.service';
 import { ResourceGroupsIntroductionsService } from '../groups/introductions/resourceGroups.introductions.service';
@@ -461,6 +465,16 @@ export class ResourceUsageService {
     this.metricsService.resourceUsageSessionsTotal.inc({ action: 'start' });
     this.metricsService.resourceUsageSessionsActive.inc();
 
+    if (dto.notes?.trim()) {
+      this.eventEmitter.emit(
+        ResourceUsageNoteAddedEvent.EVENT_NAME,
+        new ResourceUsageNoteAddedEvent(resourceId, dto.notes.trim(), 'start', {
+          id: user.id,
+          username: user.username,
+        }),
+      );
+    }
+
     return newSession;
   }
 
@@ -575,6 +589,16 @@ export class ResourceUsageService {
     if (updatedUsage?.startTime && updatedUsage?.endTime) {
       const durationSeconds = (updatedUsage.endTime.getTime() - updatedUsage.startTime.getTime()) / 1000;
       this.metricsService.resourceUsageDurationSeconds.observe(durationSeconds);
+    }
+
+    if (dto.notes?.trim()) {
+      this.eventEmitter.emit(
+        ResourceUsageNoteAddedEvent.EVENT_NAME,
+        new ResourceUsageNoteAddedEvent(resourceId, dto.notes.trim(), 'end', {
+          id: user.id,
+          username: user.username,
+        }),
+      );
     }
 
     return updatedUsage;

--- a/apps/api/src/resources/usage/resourceUsage.service.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.ts
@@ -39,6 +39,13 @@ import { MetricsService } from '../../metrics/metrics.service';
 import { SystemEvent } from '@attraccess/plugins-backend-sdk';
 import { PluginEventsService } from '../../plugin-system/plugin-events.service';
 
+export interface EndSessionOptions {
+  /** Skip persisting required END-action form submissions (used by automated/flow paths). */
+  skipFormSubmissions?: boolean;
+  /** Skip emitting ResourceUsageNoteAddedEvent (used when the note is auto-generated, e.g. flow-ended). */
+  skipNoteNotification?: boolean;
+}
+
 @Injectable()
 export class ResourceUsageService {
   private readonly logger = new Logger(ResourceUsageService.name);
@@ -482,10 +489,11 @@ export class ResourceUsageService {
     resourceId: number,
     user: User,
     dto: EndUsageSessionDto,
-    skipFormSubmissions = false,
-    // Flow-ended sessions carry an auto-generated note, not a human one — skip personnel notification.
-    skipNoteNotification = false,
+    options: EndSessionOptions = {},
   ): Promise<ResourceUsage> {
+    // skipNoteNotification: flow-ended sessions carry an auto-generated note, not a human one — skip personnel notification.
+    const { skipFormSubmissions = false, skipNoteNotification = false } = options;
+
     this.logger.debug(`Ending session for resource ${resourceId} by user ${user.id}`, { dto });
 
     // Find active session

--- a/apps/api/src/resources/usage/resourceUsage.service.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.ts
@@ -483,6 +483,8 @@ export class ResourceUsageService {
     user: User,
     dto: EndUsageSessionDto,
     skipFormSubmissions = false,
+    // Flow-ended sessions carry an auto-generated note, not a human one — skip personnel notification.
+    skipNoteNotification = false,
   ): Promise<ResourceUsage> {
     this.logger.debug(`Ending session for resource ${resourceId} by user ${user.id}`, { dto });
 
@@ -591,7 +593,7 @@ export class ResourceUsageService {
       this.metricsService.resourceUsageDurationSeconds.observe(durationSeconds);
     }
 
-    if (dto.notes?.trim()) {
+    if (!skipNoteNotification && dto.notes?.trim()) {
       this.eventEmitter.emit(
         ResourceUsageNoteAddedEvent.EVENT_NAME,
         new ResourceUsageNoteAddedEvent(resourceId, dto.notes.trim(), 'end', {

--- a/libs/database-entities/src/lib/entities/email-template.entity.ts
+++ b/libs/database-entities/src/lib/entities/email-template.entity.ts
@@ -15,6 +15,7 @@ export enum EmailTemplateType {
   USER_RETRAINING_REQUIRED = 'user-retraining-required',
   MAINTENANCE_REQUEST_CREATED = 'maintenance-request-created',
   MESSAGE_RECEIVED = 'message-received',
+  RESOURCE_USAGE_NOTE_ADDED = 'resource-usage-note-added',
 }
 
 @Entity('email_templates')


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Notifies a resource's introducers, maintainers and admins by email when a user attaches a note while starting or ending a usage session.

## Approach

- New `ResourceUsageNoteAddedEvent`, emitted from `ResourceUsageService.startSession` (start note) and `endSession` (end note) only when the user supplied a non-empty note. Auto-generated takeover notes do not trigger it.
- New `ResourceUsageNoteNotificationListener` collects recipients — introducers/maintainers of the resource and its groups plus admins (`canManageResources`) — deduped and **excluding the note author** — and emails each via `EmailService.sendResourceUsageNoteEmail`.
- New `RESOURCE_USAGE_NOTE_ADDED` email template type + MJML template seeded by migration `1781200000000`.
- Wired the listener, `EmailModule`, and `User`/`ResourceIntroducer` repositories into `ResourceUsageModule`.

Mirrors the existing `MaintenanceRequestNotificationListener` pattern.

## Testing

- New unit spec `resource-usage-note-notification.listener.spec.ts` (4 tests): recipient collection, author exclusion, dedup, group introducers, missing-email skip, missing-resource skip. All pass.
- `tsc --noEmit` and ESLint clean.
- Pre-commit hook ran affected lint/typecheck/build/test/e2e — all green.

## Linear

https://linear.app/attraccess/issue/ATT-174/inform-introducersmaintainers-about-usage-notes

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
