### PR TITLE
refactor(ATT-426): split attractap websocket gateway into per-domain handlers

### DIFF
--- a/apps/api/src/attractap/attractap.module.ts
+++ b/apps/api/src/attractap/attractap.module.ts
@@ -8,6 +8,16 @@ import { AttractapNfcCardsController } from './card.controller';
 import 'sqlite3';
 import '@nestjs/common';
 import { WebSocketEventService } from './websockets/websocket-event.service';
+import { ResourceListService } from './websockets/handlers/resource-list.service';
+import { ResourceActionGuard } from './websockets/handlers/resource-action.guard';
+import { AttractapAuthHandler } from './websockets/handlers/auth.handler';
+import { AttractapFirmwareHandler } from './websockets/handlers/firmware.handler';
+import { AttractapCrashReportHandler } from './websockets/handlers/crash-report.handler';
+import { AttractapCardHandler } from './websockets/handlers/card.handler';
+import { AttractapFormsHandler } from './websockets/handlers/forms.handler';
+import { AttractapSessionHandler } from './websockets/handlers/session.handler';
+import { AttractapBillingHandler } from './websockets/handlers/billing.handler';
+import { AttractapProjectsHandler } from './websockets/handlers/projects.handler';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { Attractap, AttractapCrashReport, NFCCard, Resource, User } from '@attraccess/database-entities';
 import { UsersAndAuthModule } from '../users-and-auth/users-and-auth.module';
@@ -48,6 +58,16 @@ import { ResourceFormsModule } from '../resources/forms/forms.module';
     WebSocketEventService,
     AttractapFirmwareService,
     CoredumpSymbolicationService,
+    ResourceListService,
+    ResourceActionGuard,
+    AttractapAuthHandler,
+    AttractapFirmwareHandler,
+    AttractapCrashReportHandler,
+    AttractapCardHandler,
+    AttractapFormsHandler,
+    AttractapSessionHandler,
+    AttractapBillingHandler,
+    AttractapProjectsHandler,
   ],
   controllers: [AttractapController, AttractapNfcCardsController, AttractapFirmwareController],
 })

--- a/apps/api/src/attractap/websockets/handlers/auth.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/auth.handler.spec.ts
@@ -1,0 +1,203 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AttractapAuthHandler } from './auth.handler';
+import { AttractapEvent, AttractapEventType } from '../websocket.types';
+import { verifyToken } from '../websocket.utils';
+
+jest.mock('../websocket.utils', () => ({
+  verifyToken: jest.fn(),
+}));
+
+const mockVerifyToken = verifyToken as jest.Mock;
+
+describe('AttractapAuthHandler', () => {
+  let handler: AttractapAuthHandler;
+  let mockSocket: {
+    id: string;
+    readerId: number | null;
+    state: Record<string, unknown>;
+    sendMessage: jest.Mock;
+    sendBinaryData: jest.Mock;
+  };
+  let mockAttractapService: { createNewReader: jest.Mock; findReaderById: jest.Mock };
+  let mockResourceListService: { sendResourceListToSocket: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    handler = Object.create(AttractapAuthHandler.prototype);
+    (handler as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockSocket = {
+      id: 'socket-1',
+      readerId: null,
+      state: {},
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+    };
+
+    mockAttractapService = {
+      createNewReader: jest.fn(),
+      findReaderById: jest.fn(),
+    };
+
+    mockResourceListService = {
+      sendResourceListToSocket: jest.fn().mockResolvedValue(undefined),
+    };
+
+    (handler as any).attractapService = mockAttractapService;
+    (handler as any).resourceListService = mockResourceListService;
+  });
+
+  describe('handleReaderRegister', () => {
+    it('creates a new reader with the firmware payload and sends READER_REGISTER response', async () => {
+      const data = { payload: { firmware: 'fw-1.2.3' } } as AttractapEvent['data'];
+      mockAttractapService.createNewReader.mockResolvedValue({
+        reader: { id: 99 },
+        token: 'tok-abc',
+      });
+
+      await handler.handleReaderRegister(mockSocket as any, data);
+
+      expect(mockAttractapService.createNewReader).toHaveBeenCalledWith('fw-1.2.3');
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_REGISTER,
+            payload: { id: 99, token: 'tok-abc' },
+          }),
+        }),
+      );
+    });
+
+    it('forwards the created reader id and token exactly', async () => {
+      const data = { payload: { firmware: undefined } } as AttractapEvent['data'];
+      mockAttractapService.createNewReader.mockResolvedValue({
+        reader: { id: 7 },
+        token: 'another-token',
+      });
+
+      await handler.handleReaderRegister(mockSocket as any, data);
+
+      expect(mockAttractapService.createNewReader).toHaveBeenCalledWith(undefined);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_REGISTER,
+            payload: { id: 7, token: 'another-token' },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('handleAuthentication', () => {
+    const data = { payload: { id: 42, token: 'client-token' } } as AttractapEvent['data'];
+
+    it('sends READER_UNAUTHORIZED and does not set readerId when reader is not found', async () => {
+      mockAttractapService.findReaderById.mockResolvedValue(null);
+
+      await handler.handleAuthentication(mockSocket as any, data);
+
+      expect(mockAttractapService.findReaderById).toHaveBeenCalledWith(42);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_UNAUTHORIZED,
+            payload: { message: 'PLEASE_REREGISTER' },
+          }),
+        }),
+      );
+      expect(mockSocket.readerId).toBeNull();
+      expect(mockVerifyToken).not.toHaveBeenCalled();
+      expect(mockResourceListService.sendResourceListToSocket).not.toHaveBeenCalled();
+    });
+
+    it('sends READER_UNAUTHORIZED and does not set readerId when token is invalid', async () => {
+      mockAttractapService.findReaderById.mockResolvedValue({
+        id: 42,
+        name: 'Reader A',
+        apiTokenHash: 'hashed',
+      });
+      mockVerifyToken.mockResolvedValue(false);
+
+      await handler.handleAuthentication(mockSocket as any, data);
+
+      expect(mockVerifyToken).toHaveBeenCalledWith('client-token', 'hashed');
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_UNAUTHORIZED,
+            payload: { message: 'PLEASE_REREGISTER' },
+          }),
+        }),
+      );
+      expect(mockSocket.readerId).toBeNull();
+      expect(mockResourceListService.sendResourceListToSocket).not.toHaveBeenCalled();
+    });
+
+    it('sets readerId, sends READER_AUTHENTICATED, and pushes the resource list on a valid token', async () => {
+      mockAttractapService.findReaderById.mockResolvedValue({
+        id: 42,
+        name: 'Reader A',
+        apiTokenHash: 'hashed',
+      });
+      mockVerifyToken.mockResolvedValue(true);
+
+      await handler.handleAuthentication(mockSocket as any, data);
+
+      expect(mockVerifyToken).toHaveBeenCalledWith('client-token', 'hashed');
+      expect(mockSocket.readerId).toBe(42);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_AUTHENTICATED,
+            payload: { name: 'Reader A' },
+          }),
+        }),
+      );
+      expect(mockResourceListService.sendResourceListToSocket).toHaveBeenCalledWith(mockSocket);
+    });
+
+    it('sends READER_AUTHENTICATED before pushing the resource list', async () => {
+      mockAttractapService.findReaderById.mockResolvedValue({
+        id: 42,
+        name: 'Reader A',
+        apiTokenHash: 'hashed',
+      });
+      mockVerifyToken.mockResolvedValue(true);
+
+      const callOrder: string[] = [];
+      mockSocket.sendMessage.mockImplementation(async () => {
+        callOrder.push('sendMessage');
+      });
+      mockResourceListService.sendResourceListToSocket.mockImplementation(async () => {
+        callOrder.push('sendResourceList');
+      });
+
+      await handler.handleAuthentication(mockSocket as any, data);
+
+      expect(callOrder).toEqual(['sendMessage', 'sendResourceList']);
+    });
+
+    it('does not send the unauthorized response on the happy path', async () => {
+      mockAttractapService.findReaderById.mockResolvedValue({
+        id: 42,
+        name: 'Reader A',
+        apiTokenHash: 'hashed',
+      });
+      mockVerifyToken.mockResolvedValue(true);
+
+      await handler.handleAuthentication(mockSocket as any, data);
+
+      const unauthorizedCall = mockSocket.sendMessage.mock.calls.find(
+        ([msg]) => msg.data.type === AttractapEventType.READER_UNAUTHORIZED,
+      );
+      expect(unauthorizedCall).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/auth.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/auth.handler.ts
@@ -1,0 +1,63 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { AttractapService } from '../../attractap.service';
+import { verifyToken } from '../websocket.utils';
+import { ResourceListService } from './resource-list.service';
+import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
+
+@Injectable()
+export class AttractapAuthHandler {
+  private readonly logger = new Logger(AttractapAuthHandler.name);
+
+  @Inject(AttractapService)
+  private attractapService: AttractapService;
+
+  @Inject(ResourceListService)
+  private resourceListService: ResourceListService;
+
+  public async handleReaderRegister(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    this.logger.debug('Received REGISTER event');
+    const response = await this.attractapService.createNewReader(data.payload.firmware);
+
+    this.logger.debug(
+      `Sending REGISTER response to client. Reader ID: ${response.reader.id}, Token: ${response.token}`,
+    );
+
+    await socket.sendMessage(
+      new AttractapEvent(AttractapEventType.READER_REGISTER, {
+        id: response.reader.id,
+        token: response.token,
+      }),
+    );
+  }
+
+  public async handleAuthentication(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    this.logger.debug('processing READER_AUTHENTICATE event', data);
+
+    const unauthorizedResponse = new AttractapEvent(AttractapEventType.READER_UNAUTHORIZED, {
+      message: 'PLEASE_REREGISTER',
+    });
+
+    this.logger.debug('Checking if reader exists');
+    const reader = await this.attractapService.findReaderById(data.payload.id);
+    if (!reader) {
+      this.logger.error('No reader-config found for socket, sending UNAUTHORIZED response to client');
+      return await socket.sendMessage(unauthorizedResponse);
+    }
+
+    this.logger.debug('Checking if token is valid');
+    const isValidToken = await verifyToken(data.payload.token, reader.apiTokenHash);
+    if (!isValidToken) {
+      this.logger.error('Invalid token, sending UNAUTHORIZED response to client');
+      return await socket.sendMessage(unauthorizedResponse);
+    }
+
+    socket.readerId = reader.id;
+
+    const authenticatedResponse = new AttractapEvent(AttractapEventType.READER_AUTHENTICATED, {
+      name: reader.name,
+    });
+    await socket.sendMessage(authenticatedResponse);
+
+    await this.resourceListService.sendResourceListToSocket(socket);
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/billing.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/billing.handler.spec.ts
@@ -1,0 +1,226 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AttractapBillingHandler } from './billing.handler';
+import { AttractapEventType, AttractapEvent } from '../websocket.types';
+
+describe('AttractapBillingHandler', () => {
+  let handler: AttractapBillingHandler;
+  let mockSocket: {
+    id: string;
+    readerId: number;
+    state: { lastAuthenticatedUserId: number | null };
+    sendMessage: jest.Mock;
+    sendBinaryData: jest.Mock;
+  };
+  let mockSumUpService: {
+    getIsEnabled: jest.Mock;
+    getReaders: jest.Mock;
+    topUpWithReader: jest.Mock;
+  };
+
+  const expectErrorResponse = (error: string, extra: Record<string, unknown> = {}) => {
+    expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: AttractapEventType.BILLING_REQUEST_TOPUP,
+          payload: { error, ...extra },
+        }),
+      }),
+    );
+  };
+
+  beforeEach(() => {
+    handler = Object.create(AttractapBillingHandler.prototype);
+    (handler as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockSumUpService = {
+      getIsEnabled: jest.fn().mockResolvedValue(true),
+      getReaders: jest.fn().mockResolvedValue([{ id: 'reader-1', status: 'paired' }]),
+      topUpWithReader: jest.fn().mockResolvedValue(undefined),
+    };
+
+    (handler as any).sumUpService = mockSumUpService;
+
+    mockSocket = {
+      id: 'test-id',
+      readerId: 42,
+      state: { lastAuthenticatedUserId: 7 },
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+    };
+  });
+
+  const callHandler = (payload: unknown) =>
+    (handler as any).handleBillingRequestTopup(mockSocket, { payload } as AttractapEvent['data']);
+
+  describe('SumUp disabled', () => {
+    it('sends SUMUP_NOT_ENABLED and does not proceed', async () => {
+      mockSumUpService.getIsEnabled.mockResolvedValue(false);
+
+      await callHandler({ amountCents: 1000 });
+
+      expectErrorResponse('SUMUP_NOT_ENABLED');
+      expect((handler as any).logger.warn).toHaveBeenCalled();
+      expect(mockSumUpService.getReaders).not.toHaveBeenCalled();
+      expect(mockSumUpService.topUpWithReader).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('user not authenticated', () => {
+    it('sends USER_NOT_AUTHENTICATED when lastAuthenticatedUserId is null', async () => {
+      mockSocket.state.lastAuthenticatedUserId = null;
+
+      await callHandler({ amountCents: 1000 });
+
+      expectErrorResponse('USER_NOT_AUTHENTICATED');
+      expect((handler as any).logger.warn).toHaveBeenCalled();
+      expect(mockSumUpService.getReaders).not.toHaveBeenCalled();
+      expect(mockSumUpService.topUpWithReader).not.toHaveBeenCalled();
+    });
+
+    it('sends USER_NOT_AUTHENTICATED when lastAuthenticatedUserId is 0 (falsy)', async () => {
+      mockSocket.state.lastAuthenticatedUserId = 0;
+
+      await callHandler({ amountCents: 1000 });
+
+      expectErrorResponse('USER_NOT_AUTHENTICATED');
+    });
+  });
+
+  describe('invalid amount', () => {
+    it('sends INVALID_AMOUNT for non-number (string)', async () => {
+      await callHandler({ amountCents: '1000' });
+
+      expectErrorResponse('INVALID_AMOUNT');
+      expect(mockSumUpService.getReaders).not.toHaveBeenCalled();
+    });
+
+    it('sends INVALID_AMOUNT for non-number (undefined)', async () => {
+      await callHandler({});
+
+      expectErrorResponse('INVALID_AMOUNT');
+    });
+
+    it('sends INVALID_AMOUNT for non-integer (1.5)', async () => {
+      await callHandler({ amountCents: 1.5 });
+
+      expectErrorResponse('INVALID_AMOUNT');
+    });
+
+    it('sends INVALID_AMOUNT for zero', async () => {
+      await callHandler({ amountCents: 0 });
+
+      expectErrorResponse('INVALID_AMOUNT');
+    });
+
+    it('sends INVALID_AMOUNT for negative amount', async () => {
+      await callHandler({ amountCents: -500 });
+
+      expectErrorResponse('INVALID_AMOUNT');
+    });
+
+    it('sends INVALID_AMOUNT for NaN', async () => {
+      await callHandler({ amountCents: NaN });
+
+      expectErrorResponse('INVALID_AMOUNT');
+    });
+
+    it('logs a warning and does not call topUpWithReader on invalid amount', async () => {
+      await callHandler({ amountCents: -1 });
+
+      expect((handler as any).logger.warn).toHaveBeenCalled();
+      expect(mockSumUpService.topUpWithReader).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('no readers available', () => {
+    it('sends NO_SUMUP_TERMINALS_AVAILABLE when getReaders returns null', async () => {
+      mockSumUpService.getReaders.mockResolvedValue(null);
+
+      await callHandler({ amountCents: 1000 });
+
+      expectErrorResponse('NO_SUMUP_TERMINALS_AVAILABLE');
+      expect(mockSumUpService.topUpWithReader).not.toHaveBeenCalled();
+      expect((handler as any).logger.warn).toHaveBeenCalled();
+    });
+
+    it('sends NO_SUMUP_TERMINALS_AVAILABLE when getReaders returns empty array', async () => {
+      mockSumUpService.getReaders.mockResolvedValue([]);
+
+      await callHandler({ amountCents: 1000 });
+
+      expectErrorResponse('NO_SUMUP_TERMINALS_AVAILABLE');
+      expect(mockSumUpService.topUpWithReader).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success', () => {
+    it('prefers a paired reader and forwards userId, readerId, amountCents', async () => {
+      mockSumUpService.getReaders.mockResolvedValue([
+        { id: 'unpaired-1', status: 'pending' },
+        { id: 'paired-1', status: 'paired' },
+      ]);
+
+      await callHandler({ amountCents: 2500 });
+
+      expect(mockSumUpService.topUpWithReader).toHaveBeenCalledWith(7, 'paired-1', 2500);
+      expect(mockSumUpService.topUpWithReader).toHaveBeenCalledTimes(1);
+      expect((handler as any).logger.debug).toHaveBeenCalled();
+      // No error message sent on success.
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('falls back to readers[0] when no paired reader exists', async () => {
+      mockSumUpService.getReaders.mockResolvedValue([
+        { id: 'first', status: 'pending' },
+        { id: 'second', status: 'offline' },
+      ]);
+
+      await callHandler({ amountCents: 999 });
+
+      expect(mockSumUpService.topUpWithReader).toHaveBeenCalledWith(7, 'first', 999);
+    });
+
+    it('uses readers[0] when it is the paired reader', async () => {
+      mockSumUpService.getReaders.mockResolvedValue([{ id: 'only', status: 'paired' }]);
+
+      await callHandler({ amountCents: 100 });
+
+      expect(mockSumUpService.topUpWithReader).toHaveBeenCalledWith(7, 'only', 100);
+    });
+  });
+
+  describe('topUpWithReader failure', () => {
+    it('sends SUMUP_TOPUP_FAILED with error message details and logs error', async () => {
+      mockSumUpService.topUpWithReader.mockRejectedValue(new Error('terminal offline'));
+
+      await callHandler({ amountCents: 1000 });
+
+      expectErrorResponse('SUMUP_TOPUP_FAILED', { details: 'terminal offline' });
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('terminal offline'),
+      );
+    });
+
+    it('catches errors thrown by getIsEnabled and sends SUMUP_TOPUP_FAILED', async () => {
+      mockSumUpService.getIsEnabled.mockRejectedValue(new Error('config read failed'));
+
+      await callHandler({ amountCents: 1000 });
+
+      expectErrorResponse('SUMUP_TOPUP_FAILED', { details: 'config read failed' });
+      expect((handler as any).logger.error).toHaveBeenCalled();
+    });
+
+    it('catches errors thrown by getReaders and sends SUMUP_TOPUP_FAILED', async () => {
+      mockSumUpService.getReaders.mockRejectedValue(new Error('readers fetch failed'));
+
+      await callHandler({ amountCents: 1000 });
+
+      expectErrorResponse('SUMUP_TOPUP_FAILED', { details: 'readers fetch failed' });
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/billing.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/billing.handler.ts
@@ -1,0 +1,64 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { SumUpService } from '../../../billing/sumup.service';
+import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
+
+@Injectable()
+export class AttractapBillingHandler {
+  private readonly logger = new Logger(AttractapBillingHandler.name);
+
+  @Inject(SumUpService)
+  private sumUpService: SumUpService;
+
+  public async handleBillingRequestTopup(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    try {
+      const enabled = await this.sumUpService.getIsEnabled();
+      if (!enabled) {
+        this.logger.warn('BILLING_REQUEST_TOPUP received but SumUp is not enabled');
+        await socket.sendMessage(
+          new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, { error: 'SUMUP_NOT_ENABLED' }),
+        );
+        return;
+      }
+
+      const userId = socket.state.lastAuthenticatedUserId;
+      if (!userId) {
+        this.logger.warn('BILLING_REQUEST_TOPUP received but no authenticated user is set on socket');
+        await socket.sendMessage(
+          new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, { error: 'USER_NOT_AUTHENTICATED' }),
+        );
+        return;
+      }
+
+      const { amountCents } = data.payload as { amountCents: number };
+      if (typeof amountCents !== 'number' || !Number.isInteger(amountCents) || amountCents <= 0) {
+        this.logger.warn(`BILLING_REQUEST_TOPUP invalid amount: ${JSON.stringify(data.payload)}`);
+        await socket.sendMessage(
+          new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, { error: 'INVALID_AMOUNT' }),
+        );
+        return;
+      }
+
+      const readers = await this.sumUpService.getReaders();
+      if (!readers || readers.length === 0) {
+        this.logger.warn('BILLING_REQUEST_TOPUP requested but no SumUp readers are linked');
+        await socket.sendMessage(
+          new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, { error: 'NO_SUMUP_TERMINALS_AVAILABLE' }),
+        );
+        return;
+      }
+
+      // Prefer a paired/active reader if available, otherwise first one
+      const preferred = readers.find((r) => r.status === 'paired') || readers[0];
+      await this.sumUpService.topUpWithReader(userId, preferred.id, amountCents);
+      this.logger.debug(`Started SumUp top-up for user ${userId} on reader ${preferred.id} amount ${amountCents}`);
+    } catch (err) {
+      this.logger.error(`handleBillingRequestTopup error: ${(err as Error).message}`);
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, {
+          error: 'SUMUP_TOPUP_FAILED',
+          details: (err as Error).message,
+        }),
+      );
+    }
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/card.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/card.handler.spec.ts
@@ -1,0 +1,512 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AttractapCardHandler } from './card.handler';
+import { AttractapEvent, AttractapEventType } from '../websocket.types';
+
+describe('AttractapCardHandler', () => {
+  let handler: AttractapCardHandler;
+  let websocketService: { sockets: Map<string, any> };
+  let attractapService: {
+    findReaderById: jest.Mock;
+    getNFCCardByUID: jest.Mock;
+    getNFCCardByID: jest.Mock;
+    generateNTAG424Key: jest.Mock;
+    uint8ArrayToHexString: jest.Mock;
+    createNFCCard: jest.Mock;
+  };
+  let usersService: { findOne: jest.Mock };
+  let resourceUsageService: { canControllResource: jest.Mock };
+  let resourceIntroducersService: { isIntroducer: jest.Mock };
+  let metricsService: { attractapNfcTapsTotal: { inc: jest.Mock } };
+
+  const mockUser = { id: 1, username: 'testuser' };
+  const mockReaderWithEnrollment = {
+    id: 42,
+    firmware: { capabilities: { cardEnrollment: true } },
+  };
+
+  function createMockSocket(overrides: any = {}): any {
+    return {
+      id: 'socket-1',
+      readerId: 42,
+      state: {
+        lastAuthenticatedUserId: null,
+        enrollNewCardData: null,
+        ...(overrides.state || {}),
+      },
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    handler = Object.create(AttractapCardHandler.prototype);
+    (handler as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    websocketService = { sockets: new Map() };
+    attractapService = {
+      findReaderById: jest.fn().mockResolvedValue(mockReaderWithEnrollment),
+      getNFCCardByUID: jest.fn().mockResolvedValue(null),
+      getNFCCardByID: jest.fn().mockResolvedValue({ id: 7 }),
+      generateNTAG424Key: jest.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+      uint8ArrayToHexString: jest.fn().mockReturnValue('deadbeef'),
+      createNFCCard: jest.fn().mockResolvedValue(undefined),
+    };
+    usersService = { findOne: jest.fn().mockResolvedValue(mockUser) };
+    resourceUsageService = { canControllResource: jest.fn().mockResolvedValue(true) };
+    resourceIntroducersService = { isIntroducer: jest.fn().mockResolvedValue(false) };
+    metricsService = { attractapNfcTapsTotal: { inc: jest.fn() } };
+
+    (handler as any).websocketService = websocketService;
+    (handler as any).attractapService = attractapService;
+    (handler as any).usersService = usersService;
+    (handler as any).resourceUsageService = resourceUsageService;
+    (handler as any).resourceIntroducersService = resourceIntroducersService;
+    (handler as any).metricsService = metricsService;
+  });
+
+  describe('startEnrollOfNewNfcCard', () => {
+    it('throws when the reader is not found', async () => {
+      attractapService.findReaderById.mockResolvedValueOnce(null);
+
+      await expect(handler.startEnrollOfNewNfcCard({ readerId: 42, userId: 1 })).rejects.toThrow(
+        'Reader not found: 42',
+      );
+    });
+
+    it('throws when the reader does not support card enrollment', async () => {
+      attractapService.findReaderById.mockResolvedValueOnce({
+        id: 42,
+        firmware: { capabilities: { cardEnrollment: false } },
+      });
+
+      await expect(handler.startEnrollOfNewNfcCard({ readerId: 42, userId: 1 })).rejects.toThrow(
+        'Reader does not support card enrollment: 42',
+      );
+    });
+
+    it('throws when the user is not found', async () => {
+      usersService.findOne.mockResolvedValueOnce(null);
+
+      await expect(handler.startEnrollOfNewNfcCard({ readerId: 42, userId: 1 })).rejects.toThrow(
+        'User not found: 1',
+      );
+    });
+
+    it('throws when there is no connected socket for the reader', async () => {
+      const otherSocket = createMockSocket({ id: 'other', readerId: 99 });
+      websocketService.sockets.set('other', otherSocket);
+
+      await expect(handler.startEnrollOfNewNfcCard({ readerId: 42, userId: 1 })).rejects.toThrow(
+        'Reader not connected: 42',
+      );
+    });
+
+    it('sets lastAuthenticatedUserId and sends ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO', async () => {
+      const socket = createMockSocket();
+      websocketService.sockets.set('socket-1', socket);
+
+      await handler.startEnrollOfNewNfcCard({ readerId: 42, userId: 1 });
+
+      expect(socket.state.lastAuthenticatedUserId).toBe(mockUser.id);
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO,
+            payload: { username: mockUser.username },
+          }),
+        }),
+      );
+    });
+
+    it('swallows a sendMessage rejection (Promise.allSettled) and logs it', async () => {
+      const socket = createMockSocket();
+      socket.sendMessage.mockRejectedValueOnce(new Error('send failed'));
+      websocketService.sockets.set('socket-1', socket);
+
+      await expect(handler.startEnrollOfNewNfcCard({ readerId: 42, userId: 1 })).resolves.toBeUndefined();
+
+      expect(socket.state.lastAuthenticatedUserId).toBe(mockUser.id);
+      expect((handler as any).logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to send ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO to client socket-1'),
+      );
+    });
+  });
+
+  describe('onEnrollNewCardRequestNFCKey', () => {
+    it('sends USER_NOT_SET when no lastAuthenticatedUserId', async () => {
+      const socket = createMockSocket();
+      const data = { payload: { uid: 'abc', keyNo: 1 } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCardRequestNFCKey(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY,
+            payload: { error: 'USER_NOT_SET' },
+          }),
+        }),
+      );
+      expect(attractapService.getNFCCardByUID).not.toHaveBeenCalled();
+    });
+
+    it('sends INVALID_PARAMS when uid is missing', async () => {
+      const socket = createMockSocket({ state: { lastAuthenticatedUserId: 1 } });
+      const data = { payload: { uid: '', keyNo: 1 } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCardRequestNFCKey(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY,
+            payload: { error: 'INVALID_PARAMS' },
+          }),
+        }),
+      );
+    });
+
+    it('sends INVALID_PARAMS when keyNo is missing', async () => {
+      const socket = createMockSocket({ state: { lastAuthenticatedUserId: 1 } });
+      const data = { payload: { uid: 'abc', keyNo: 0 } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCardRequestNFCKey(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY,
+            payload: { error: 'INVALID_PARAMS' },
+          }),
+        }),
+      );
+    });
+
+    it('sends CARD_ALREADY_ENROLLED when a card with the uid already exists', async () => {
+      const socket = createMockSocket({ state: { lastAuthenticatedUserId: 1 } });
+      attractapService.getNFCCardByUID.mockResolvedValueOnce({ id: 9 });
+      const data = { payload: { uid: 'abc', keyNo: 1 } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCardRequestNFCKey(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY,
+            payload: { error: 'CARD_ALREADY_ENROLLED' },
+          }),
+        }),
+      );
+      expect(attractapService.generateNTAG424Key).not.toHaveBeenCalled();
+    });
+
+    it('generates a key, stores enrollNewCardData and sends ENROLL_NEW_CARD on success', async () => {
+      const socket = createMockSocket({ state: { lastAuthenticatedUserId: 1 } });
+      const data = { payload: { uid: 'abc', keyNo: 2 } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCardRequestNFCKey(socket, data);
+
+      expect(attractapService.generateNTAG424Key).toHaveBeenCalledWith({
+        userId: 1,
+        keyNo: 2,
+        cardUID: 'abc',
+      });
+      expect(attractapService.uint8ArrayToHexString).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+      expect(socket.state.enrollNewCardData).toEqual({
+        keyNo: 2,
+        key: 'deadbeef',
+        cardUID: 'abc',
+      });
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD,
+            payload: { key: 'deadbeef', keyNo: 2 },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('onEnrollNewCard', () => {
+    it('sends ENROLL_NEW_CARD_DATA_NOT_SET when no enrollNewCardData', async () => {
+      const socket = createMockSocket();
+      const data = { payload: { success: true } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCard(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD,
+            payload: { error: 'ENROLL_NEW_CARD_DATA_NOT_SET' },
+          }),
+        }),
+      );
+    });
+
+    it('logs error and returns without a message when payload.success is false', async () => {
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          enrollNewCardData: { key: 'deadbeef', keyNo: 1, cardUID: 'abc' },
+        },
+      });
+      const data = { payload: { success: false } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCard(socket, data);
+
+      expect((handler as any).logger.error).toHaveBeenCalledWith('Enroll new card failed');
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends KEY_NOT_SET when stored data has no key', async () => {
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          enrollNewCardData: { key: '', keyNo: 1, cardUID: 'abc' },
+        },
+      });
+      const data = { payload: { success: true } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCard(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD,
+            payload: { error: 'KEY_NOT_SET' },
+          }),
+        }),
+      );
+    });
+
+    it('sends KEY_NOT_SET when stored data has no keyNo', async () => {
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          enrollNewCardData: { key: 'deadbeef', keyNo: 0, cardUID: 'abc' },
+        },
+      });
+      const data = { payload: { success: true } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCard(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD,
+            payload: { error: 'KEY_NOT_SET' },
+          }),
+        }),
+      );
+    });
+
+    it('sends USER_NOT_FOUND when the user does not exist', async () => {
+      usersService.findOne.mockResolvedValueOnce(null);
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          enrollNewCardData: { key: 'deadbeef', keyNo: 1, cardUID: 'abc' },
+        },
+      });
+      const data = { payload: { success: true } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCard(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD,
+            payload: { error: 'USER_NOT_FOUND' },
+          }),
+        }),
+      );
+      expect(attractapService.createNFCCard).not.toHaveBeenCalled();
+    });
+
+    it('creates the card, clears state and sends success', async () => {
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          enrollNewCardData: { key: 'deadbeef', keyNo: 1, cardUID: 'abc' },
+        },
+      });
+      const data = { payload: { success: true } } as AttractapEvent['data'];
+
+      await handler.onEnrollNewCard(socket, data);
+
+      expect(attractapService.createNFCCard).toHaveBeenCalledWith(mockUser, {
+        key: 'deadbeef',
+        keyNo: 1,
+        uid: 'abc',
+      });
+      expect(socket.state.enrollNewCardData).toBeNull();
+      expect(socket.state.lastAuthenticatedUserId).toBeNull();
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.ENROLL_NEW_CARD,
+            payload: { success: true },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('startResetOfNfcCard', () => {
+    it('throws when the reader is not found', async () => {
+      attractapService.findReaderById.mockResolvedValueOnce(null);
+
+      await expect(
+        handler.startResetOfNfcCard({ readerId: 42, userId: 1, cardId: 7 }),
+      ).rejects.toThrow('Reader not found: 42');
+    });
+
+    it('throws when the user is not found', async () => {
+      usersService.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        handler.startResetOfNfcCard({ readerId: 42, userId: 1, cardId: 7 }),
+      ).rejects.toThrow('User not found: 1');
+    });
+
+    it('throws when there is no connected socket', async () => {
+      await expect(
+        handler.startResetOfNfcCard({ readerId: 42, userId: 1, cardId: 7 }),
+      ).rejects.toThrow('Reader not connected: 42');
+    });
+
+    it('throws when the nfc card is not found', async () => {
+      const socket = createMockSocket();
+      websocketService.sockets.set('socket-1', socket);
+      attractapService.getNFCCardByID.mockResolvedValueOnce(null);
+
+      await expect(
+        handler.startResetOfNfcCard({ readerId: 42, userId: 1, cardId: 7 }),
+      ).rejects.toThrow('NFC card not found: 7');
+    });
+
+    it('resolves and performs all lookups on the happy path', async () => {
+      const socket = createMockSocket();
+      websocketService.sockets.set('socket-1', socket);
+
+      await expect(
+        handler.startResetOfNfcCard({ readerId: 42, userId: 1, cardId: 7 }),
+      ).resolves.toBeUndefined();
+
+      expect(attractapService.findReaderById).toHaveBeenCalledWith(42);
+      expect(usersService.findOne).toHaveBeenCalledWith({ id: 1 });
+      expect(attractapService.getNFCCardByID).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('handleCardAuthenticationRequest', () => {
+    const activeCard = {
+      keyNo: 3,
+      key: 'cardkey',
+      isActive: true,
+      user: {
+        id: 5,
+        username: 'carduser',
+        systemPermissions: { canManageResources: true },
+      },
+    };
+
+    it('always increments attractapNfcTapsTotal', async () => {
+      const socket = createMockSocket();
+      const data = { payload: { uid: '', resourceId: 10 } } as AttractapEvent['data'];
+
+      await handler.handleCardAuthenticationRequest(socket, data);
+
+      expect(metricsService.attractapNfcTapsTotal.inc).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends INVALID_UID when uid is invalid', async () => {
+      const socket = createMockSocket();
+      const data = { payload: { uid: '', resourceId: 10 } } as AttractapEvent['data'];
+
+      await handler.handleCardAuthenticationRequest(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.CARD_AUTHENTICATION_DATA,
+            payload: { error: 'INVALID_UID' },
+          }),
+        }),
+      );
+      expect(attractapService.getNFCCardByUID).not.toHaveBeenCalled();
+    });
+
+    it('sends CARD_NOT_FOUND when the card does not exist', async () => {
+      const socket = createMockSocket();
+      attractapService.getNFCCardByUID.mockResolvedValueOnce(null);
+      const data = { payload: { uid: 'abc', resourceId: 10 } } as AttractapEvent['data'];
+
+      await handler.handleCardAuthenticationRequest(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.CARD_AUTHENTICATION_DATA,
+            payload: { error: 'CARD_NOT_FOUND' },
+          }),
+        }),
+      );
+    });
+
+    it('sends CARD_NOT_ACTIVE when the card is inactive', async () => {
+      const socket = createMockSocket();
+      attractapService.getNFCCardByUID.mockResolvedValueOnce({ ...activeCard, isActive: false });
+      const data = { payload: { uid: 'abc', resourceId: 10 } } as AttractapEvent['data'];
+
+      await handler.handleCardAuthenticationRequest(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.CARD_AUTHENTICATION_DATA,
+            payload: { error: 'CARD_NOT_ACTIVE' },
+          }),
+        }),
+      );
+      expect(resourceUsageService.canControllResource).not.toHaveBeenCalled();
+    });
+
+    it('sets lastAuthenticatedUserId and sends CARD_AUTHENTICATION_DATA on success', async () => {
+      const socket = createMockSocket();
+      attractapService.getNFCCardByUID.mockResolvedValueOnce(activeCard);
+      resourceUsageService.canControllResource.mockResolvedValueOnce(true);
+      resourceIntroducersService.isIntroducer.mockResolvedValueOnce(true);
+      const data = { payload: { uid: 'abc', resourceId: 10 } } as AttractapEvent['data'];
+
+      await handler.handleCardAuthenticationRequest(socket, data);
+
+      expect(socket.state.lastAuthenticatedUserId).toBe(activeCard.user.id);
+      expect(resourceUsageService.canControllResource).toHaveBeenCalledWith(10, activeCard.user);
+      expect(resourceIntroducersService.isIntroducer).toHaveBeenCalledWith(10, activeCard.user.id, true);
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.CARD_AUTHENTICATION_DATA,
+            payload: {
+              keyNo: activeCard.keyNo,
+              key: activeCard.key,
+              username: activeCard.user.username,
+              canManageResource: true,
+              hasIntroduction: true,
+              isIntroducer: true,
+            },
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/card.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/card.handler.ts
@@ -1,0 +1,235 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { WebsocketService } from '../websocket.service';
+import { AttractapService } from '../../attractap.service';
+import { UsersService } from '../../../users-and-auth/users/users.service';
+import { ResourceUsageService } from '../../../resources/usage/resourceUsage.service';
+import { ResourceIntroducersService } from '../../../resources/introducers/resourceIntroducers.service';
+import { MetricsService } from '../../../metrics/metrics.service';
+import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
+
+@Injectable()
+export class AttractapCardHandler {
+  private readonly logger = new Logger(AttractapCardHandler.name);
+
+  @Inject(WebsocketService)
+  private websocketService: WebsocketService;
+
+  @Inject(AttractapService)
+  private attractapService: AttractapService;
+
+  @Inject(UsersService)
+  private usersService: UsersService;
+
+  @Inject(ResourceUsageService)
+  private resourceUsageService: ResourceUsageService;
+
+  @Inject(ResourceIntroducersService)
+  private resourceIntroducersService: ResourceIntroducersService;
+
+  @Inject(MetricsService)
+  private metricsService: MetricsService;
+
+  public async startEnrollOfNewNfcCard(data: { readerId: number; userId: number }) {
+    const reader = await this.attractapService.findReaderById(data.readerId);
+
+    if (!reader) {
+      throw new Error(`Reader not found: ${data.readerId}`);
+    }
+
+    if (!reader.firmware.capabilities.cardEnrollment) {
+      throw new Error(`Reader does not support card enrollment: ${data.readerId}`);
+    }
+
+    const user = await this.usersService.findOne({ id: data.userId });
+
+    if (!user) {
+      throw new Error(`User not found: ${data.userId}`);
+    }
+
+    const sockets = Array.from(this.websocketService.sockets.values()).filter(
+      (socket) => socket.readerId === data.readerId,
+    );
+
+    if (sockets.length === 0) {
+      throw new Error(`Reader not connected: ${data.readerId}`);
+    }
+
+    // Send to all active sockets for this reader to avoid targeting a stale/disconnecting socket
+    const tasks = sockets.map(async (socket) => {
+      socket.state.lastAuthenticatedUserId = user.id;
+      try {
+        await socket.sendMessage(
+          new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO, {
+            username: user.username,
+          }),
+        );
+      } catch (error) {
+        // Log and continue; other sockets may still deliver the event
+        this.logger.debug(
+          `Failed to send ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO to client ${socket.id}: ${String(error)}`,
+        );
+      }
+    });
+
+    await Promise.allSettled(tasks);
+  }
+
+  public async onEnrollNewCardRequestNFCKey(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { uid, keyNo } = data.payload as { uid: string; keyNo: number };
+
+    if (!socket.state.lastAuthenticatedUserId) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY, { error: 'USER_NOT_SET' }),
+      );
+      return;
+    }
+
+    if (!uid || typeof uid !== 'string' || !keyNo || typeof keyNo !== 'number') {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY, { error: 'INVALID_PARAMS' }),
+      );
+      return;
+    }
+
+    const existingCard = await this.attractapService.getNFCCardByUID(uid);
+    if (existingCard) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY, { error: 'CARD_ALREADY_ENROLLED' }),
+      );
+      return;
+    }
+
+    const key = await this.attractapService.generateNTAG424Key({
+      userId: socket.state.lastAuthenticatedUserId,
+      keyNo,
+      cardUID: uid,
+    });
+
+    const keyString = this.attractapService.uint8ArrayToHexString(key);
+
+    socket.state.enrollNewCardData = {
+      keyNo,
+      key: keyString,
+      cardUID: uid,
+    };
+    await socket.sendMessage(new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { key: keyString, keyNo }));
+  }
+
+  public async onEnrollNewCard(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    if (!socket.state.enrollNewCardData) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { error: 'ENROLL_NEW_CARD_DATA_NOT_SET' }),
+      );
+      return;
+    }
+
+    const { success } = data.payload as { success: boolean };
+    if (!success) {
+      this.logger.error('Enroll new card failed');
+      return;
+    }
+
+    const { key, keyNo, cardUID } = socket.state.enrollNewCardData;
+
+    if (!key || typeof key !== 'string' || !keyNo || typeof keyNo !== 'number') {
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { error: 'KEY_NOT_SET' }));
+      return;
+    }
+
+    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
+    if (!user) {
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { error: 'USER_NOT_FOUND' }));
+      return;
+    }
+
+    await this.attractapService.createNFCCard(user, {
+      key,
+      keyNo,
+      uid: cardUID,
+    });
+
+    socket.state.enrollNewCardData = null;
+    socket.state.lastAuthenticatedUserId = null;
+    socket.sendMessage(new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { success: true }));
+  }
+
+  public async startResetOfNfcCard(data: { readerId: number; userId: number; cardId: number }) {
+    const reader = await this.attractapService.findReaderById(data.readerId);
+
+    if (!reader) {
+      throw new Error(`Reader not found: ${data.readerId}`);
+    }
+
+    const user = await this.usersService.findOne({ id: data.userId });
+
+    if (!user) {
+      throw new Error(`User not found: ${data.userId}`);
+    }
+
+    const socket = Array.from(this.websocketService.sockets.values()).find(
+      (socket) => socket.readerId === data.readerId,
+    );
+
+    if (!socket) {
+      throw new Error(`Reader not connected: ${data.readerId}`);
+    }
+
+    const nfcCard = await this.attractapService.getNFCCardByID(data.cardId);
+
+    if (!nfcCard) {
+      throw new Error(`NFC card not found: ${data.cardId}`);
+    }
+
+    // TODO: implement this
+  }
+
+  public async handleCardAuthenticationRequest(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    this.metricsService.attractapNfcTapsTotal.inc();
+    const { uid, resourceId } = data.payload as { uid: string; resourceId: number };
+
+    if (!uid || typeof uid !== 'string') {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.CARD_AUTHENTICATION_DATA, {
+          error: 'INVALID_UID',
+        }),
+      );
+      return;
+    }
+
+    const nfcCard = await this.attractapService.getNFCCardByUID(uid);
+
+    if (!nfcCard) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.CARD_AUTHENTICATION_DATA, {
+          error: 'CARD_NOT_FOUND',
+        }),
+      );
+      return;
+    }
+
+    if (!nfcCard.isActive) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.CARD_AUTHENTICATION_DATA, {
+          error: 'CARD_NOT_ACTIVE',
+        }),
+      );
+      return;
+    }
+
+    socket.state.lastAuthenticatedUserId = nfcCard.user.id;
+
+    const hasIntroduction = await this.resourceUsageService.canControllResource(resourceId, nfcCard.user);
+    const isIntroducer = await this.resourceIntroducersService.isIntroducer(resourceId, nfcCard.user.id, true);
+
+    await socket.sendMessage(
+      new AttractapEvent(AttractapEventType.CARD_AUTHENTICATION_DATA, {
+        keyNo: nfcCard.keyNo,
+        key: nfcCard.key,
+        username: nfcCard.user.username,
+        canManageResource: nfcCard.user.systemPermissions.canManageResources,
+        hasIntroduction,
+        isIntroducer,
+      }),
+    );
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/crash-report.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/crash-report.handler.spec.ts
@@ -1,0 +1,191 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AttractapCrashReportHandler } from './crash-report.handler';
+import { AttractapEvent, AttractapEventType } from '../websocket.types';
+
+describe('AttractapCrashReportHandler', () => {
+  let handler: AttractapCrashReportHandler;
+  let mockSocket: {
+    id: string;
+    readerId: number;
+    state: Record<string, unknown>;
+    sendMessage: jest.Mock;
+    sendBinaryData: jest.Mock;
+  };
+  let mockAttractapService: { createCrashReport: jest.Mock };
+  let mockMetricsService: { attractapCrashReportsTotal: { inc: jest.Mock } };
+
+  beforeEach(() => {
+    handler = Object.create(AttractapCrashReportHandler.prototype);
+    (handler as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockSocket = {
+      id: 'sock-1',
+      readerId: 42,
+      state: {},
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+    };
+
+    mockAttractapService = {
+      createCrashReport: jest.fn(),
+    };
+
+    mockMetricsService = {
+      attractapCrashReportsTotal: { inc: jest.fn() },
+    };
+
+    (handler as any).attractapService = mockAttractapService;
+    (handler as any).metricsService = mockMetricsService;
+  });
+
+  describe('handleCrashReport - invalid payload guard', () => {
+    it('rejects when payload is missing (undefined data.payload)', async () => {
+      const data = {} as AttractapEvent['data'];
+
+      await handler.handleCrashReport(mockSocket as any, data);
+
+      expect(mockAttractapService.createCrashReport).not.toHaveBeenCalled();
+      expect(mockMetricsService.attractapCrashReportsTotal.inc).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_CRASH_REPORT,
+            payload: { error: 'INVALID_CRASH_REPORT' },
+          }),
+        }),
+      );
+      expect((handler as any).logger.error).toHaveBeenCalled();
+    });
+
+    it('rejects when resetReason is undefined', async () => {
+      const data = { payload: { heapFreeBytes: 1234 } } as AttractapEvent['data'];
+
+      await handler.handleCrashReport(mockSocket as any, data);
+
+      expect(mockAttractapService.createCrashReport).not.toHaveBeenCalled();
+      expect(mockMetricsService.attractapCrashReportsTotal.inc).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_CRASH_REPORT,
+            payload: { error: 'INVALID_CRASH_REPORT' },
+          }),
+        }),
+      );
+    });
+
+    it('rejects when resetReason is a non-string (number)', async () => {
+      const data = { payload: { resetReason: 123 } } as unknown as AttractapEvent['data'];
+
+      await handler.handleCrashReport(mockSocket as any, data);
+
+      expect(mockAttractapService.createCrashReport).not.toHaveBeenCalled();
+      expect(mockMetricsService.attractapCrashReportsTotal.inc).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_CRASH_REPORT,
+            payload: { error: 'INVALID_CRASH_REPORT' },
+          }),
+        }),
+      );
+    });
+
+    it('rejects when resetReason is an empty string (falsy)', async () => {
+      const data = { payload: { resetReason: '' } } as unknown as AttractapEvent['data'];
+
+      await handler.handleCrashReport(mockSocket as any, data);
+
+      expect(mockAttractapService.createCrashReport).not.toHaveBeenCalled();
+      expect(mockMetricsService.attractapCrashReportsTotal.inc).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_CRASH_REPORT,
+            payload: { error: 'INVALID_CRASH_REPORT' },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('handleCrashReport - success', () => {
+    it('stores the report, increments the metric, and acks with received + id', async () => {
+      const payload = {
+        resetReason: 'PANIC',
+        heapFreeBytes: 1000,
+        largestFreeBlockBytes: 500,
+        uptimeBeforeResetMs: 5000,
+        wsState: 'CONNECTED',
+        wifiState: 'CONNECTED',
+      };
+      const report = { id: 'report-7', ...payload };
+      mockAttractapService.createCrashReport.mockResolvedValue(report);
+
+      const data = { payload } as unknown as AttractapEvent['data'];
+
+      await handler.handleCrashReport(mockSocket as any, data);
+
+      expect(mockAttractapService.createCrashReport).toHaveBeenCalledWith(42, payload);
+      expect(mockMetricsService.attractapCrashReportsTotal.inc).toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_CRASH_REPORT,
+            payload: { received: true, id: 'report-7' },
+          }),
+        }),
+      );
+    });
+
+    it('succeeds with minimal report (optional fields absent)', async () => {
+      const payload = { resetReason: 'WDT' };
+      const report = { id: 'report-min', resetReason: 'WDT' };
+      mockAttractapService.createCrashReport.mockResolvedValue(report);
+
+      const data = { payload } as unknown as AttractapEvent['data'];
+
+      await handler.handleCrashReport(mockSocket as any, data);
+
+      expect(mockAttractapService.createCrashReport).toHaveBeenCalledWith(42, payload);
+      expect(mockMetricsService.attractapCrashReportsTotal.inc).toHaveBeenCalledTimes(1);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_CRASH_REPORT,
+            payload: { received: true, id: 'report-min' },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('handleCrashReport - store failure', () => {
+    it('sends CRASH_REPORT_STORE_FAILED and logs the error when createCrashReport throws', async () => {
+      mockAttractapService.createCrashReport.mockRejectedValue(new Error('DB down'));
+
+      const data = { payload: { resetReason: 'PANIC' } } as unknown as AttractapEvent['data'];
+
+      await handler.handleCrashReport(mockSocket as any, data);
+
+      expect(mockAttractapService.createCrashReport).toHaveBeenCalledWith(42, { resetReason: 'PANIC' });
+      expect(mockMetricsService.attractapCrashReportsTotal.inc).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_CRASH_REPORT,
+            payload: { error: 'CRASH_REPORT_STORE_FAILED' },
+          }),
+        }),
+      );
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('DB down'),
+      );
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/crash-report.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/crash-report.handler.ts
@@ -1,0 +1,50 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { AttractapService } from '../../attractap.service';
+import { MetricsService } from '../../../metrics/metrics.service';
+import {
+  AuthenticatedWebSocket,
+  AttractapEvent,
+  AttractapEventType,
+  ReaderCrashReportPayload,
+} from '../websocket.types';
+
+@Injectable()
+export class AttractapCrashReportHandler {
+  private readonly logger = new Logger(AttractapCrashReportHandler.name);
+
+  @Inject(AttractapService)
+  private attractapService: AttractapService;
+
+  @Inject(MetricsService)
+  private metricsService: MetricsService;
+
+  public async handleCrashReport(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const payload = data.payload as ReaderCrashReportPayload;
+
+    if (!payload?.resetReason || typeof payload.resetReason !== 'string') {
+      this.logger.error(`READER_CRASH_REPORT from reader ${socket.readerId} missing resetReason; ignoring.`);
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.READER_CRASH_REPORT, { error: 'INVALID_CRASH_REPORT' }),
+      );
+      return;
+    }
+
+    try {
+      const report = await this.attractapService.createCrashReport(socket.readerId, payload);
+      this.logger.warn(
+        `Stored crash report ${report.id} for reader ${socket.readerId}: reason=${report.resetReason} ` +
+          `heapFree=${report.heapFreeBytes ?? 'n/a'} largestBlock=${report.largestFreeBlockBytes ?? 'n/a'} ` +
+          `uptimeMs=${report.uptimeBeforeResetMs ?? 'n/a'} ws=${report.wsState ?? 'n/a'} wifi=${report.wifiState ?? 'n/a'}`,
+      );
+      this.metricsService.attractapCrashReportsTotal.inc();
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.READER_CRASH_REPORT, { received: true, id: report.id }),
+      );
+    } catch (error) {
+      this.logger.error(`Failed to store crash report for reader ${socket.readerId}: ${(error as Error).message}`);
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.READER_CRASH_REPORT, { error: 'CRASH_REPORT_STORE_FAILED' }),
+      );
+    }
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/firmware.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/firmware.handler.spec.ts
@@ -1,0 +1,473 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AttractapFirmwareHandler } from './firmware.handler';
+import { AttractapEventType, AttractapEvent } from '../websocket.types';
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    existsSync: jest.fn(),
+    statSync: jest.fn(),
+    openSync: jest.fn(),
+    readSync: jest.fn(),
+  };
+});
+
+import { existsSync, statSync, openSync, readSync } from 'fs';
+
+const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+const mockStatSync = statSync as jest.MockedFunction<typeof statSync>;
+const mockOpenSync = openSync as jest.MockedFunction<typeof openSync>;
+const mockReadSync = readSync as jest.MockedFunction<typeof readSync>;
+
+describe('AttractapFirmwareHandler', () => {
+  let handler: AttractapFirmwareHandler;
+  let mockAttractapService: { updateReaderFirmware: jest.Mock };
+  let mockFirmwareService: { getFirmwareDefinition: jest.Mock };
+  let mockMetricsService: { attractapFirmwareUpdatesTotal: { inc: jest.Mock } };
+  let socket: any;
+
+  function makeSocket(overrides: any = {}): any {
+    return {
+      id: 'sock-1',
+      readerId: 42,
+      state: { ota: null },
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    handler = Object.create(AttractapFirmwareHandler.prototype);
+    (handler as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockAttractapService = { updateReaderFirmware: jest.fn().mockResolvedValue(undefined) };
+    mockFirmwareService = { getFirmwareDefinition: jest.fn() };
+    mockMetricsService = { attractapFirmwareUpdatesTotal: { inc: jest.fn() } };
+
+    (handler as any).attractapService = mockAttractapService;
+    (handler as any).firmwareService = mockFirmwareService;
+    (handler as any).metricsService = mockMetricsService;
+
+    socket = makeSocket();
+  });
+
+  describe('handleFirmwareChunkRequest', () => {
+    it('returns early and logs error when no OTA context set', async () => {
+      socket.state.ota = null;
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('no OTA context set'),
+      );
+    });
+
+    it('returns early when OTA path missing', async () => {
+      socket.state.ota = { size: 2048 };
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalled();
+    });
+
+    it('returns early when OTA size missing', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin' };
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalled();
+    });
+
+    it('returns early when offset is not a number', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048 };
+      const data = { payload: { offset: 'x', length: 100 } } as any;
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid chunk request'),
+      );
+    });
+
+    it('returns early when length is not a number', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048 };
+      const data = { payload: { offset: 0, length: 'y' } } as any;
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid chunk request'),
+      );
+    });
+
+    it('returns early when offset < 0', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048 };
+      const data = { payload: { offset: -1, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid chunk request'),
+      );
+    });
+
+    it('returns early when length <= 0', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048 };
+      const data = { payload: { offset: 0, length: 0 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid chunk request'),
+      );
+    });
+
+    it('returns early when offset >= total', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048 };
+      const data = { payload: { offset: 2048, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid chunk request'),
+      );
+    });
+
+    it('opens fd lazily via openSync when fd absent', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048 };
+      mockOpenSync.mockReturnValue(7 as any);
+      mockReadSync.mockReturnValue(100 as any);
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(mockOpenSync).toHaveBeenCalledWith('/tmp/fw.bin', 'r');
+      expect(socket.state.ota.fd).toBe(7);
+      expect(socket.sendBinaryData).toHaveBeenCalled();
+    });
+
+    it('returns early and logs error when openSync throws', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048 };
+      mockOpenSync.mockImplementation(() => {
+        throw new Error('open failed');
+      });
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to open firmware'),
+      );
+    });
+
+    it('does not call openSync when fd already present', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048, fd: 9 };
+      mockReadSync.mockReturnValue(100 as any);
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(mockOpenSync).not.toHaveBeenCalled();
+      expect(mockReadSync).toHaveBeenCalledWith(9, expect.any(Buffer), 0, 100, 0);
+      expect(socket.sendBinaryData).toHaveBeenCalled();
+    });
+
+    it('returns early and logs error when readSync throws', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048, fd: 9 };
+      mockReadSync.mockImplementation(() => {
+        throw new Error('read failed');
+      });
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to read firmware chunk'),
+      );
+    });
+
+    it('sends binary subarray on successful read with bytesRead>0', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048, fd: 9 };
+      mockReadSync.mockReturnValue(50 as any);
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).toHaveBeenCalledTimes(1);
+      const sentBuf = socket.sendBinaryData.mock.calls[0][0] as Buffer;
+      expect(Buffer.isBuffer(sentBuf)).toBe(true);
+      expect(sentBuf.length).toBe(50);
+    });
+
+    it('caps the read length at maxChunk (4096) and remaining bytes', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 100000, fd: 9 };
+      mockReadSync.mockReturnValue(4096 as any);
+      const data = { payload: { offset: 0, length: 999999 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      // safeLen = min(999999, 4096, 100000-0) = 4096
+      expect(mockReadSync).toHaveBeenCalledWith(9, expect.any(Buffer), 0, 4096, 0);
+    });
+
+    it('caps the read length at total-offset when near end', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048, fd: 9 };
+      mockReadSync.mockReturnValue(48 as any);
+      const data = { payload: { offset: 2000, length: 4096 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      // safeLen = min(4096, 4096, 2048-2000) = 48
+      expect(mockReadSync).toHaveBeenCalledWith(9, expect.any(Buffer), 0, 48, 2000);
+    });
+
+    it('does not send binary data when bytesRead is 0', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 2048, fd: 9 };
+      mockReadSync.mockReturnValue(0 as any);
+      const data = { payload: { offset: 0, length: 100 } } as AttractapEvent['data'];
+
+      await handler.handleFirmwareChunkRequest(socket, data);
+
+      expect(socket.sendBinaryData).not.toHaveBeenCalled();
+      expect((handler as any).logger.log).not.toHaveBeenCalled();
+    });
+
+    it('logs progress once per 10% bucket (lastLoggedPct gate)', async () => {
+      socket.state.ota = { path: '/tmp/fw.bin', size: 1000, fd: 9 };
+
+      // First read reaches 10% bucket
+      mockReadSync.mockReturnValue(100 as any);
+      await handler.handleFirmwareChunkRequest(socket, {
+        payload: { offset: 0, length: 100 },
+      } as AttractapEvent['data']);
+
+      expect(socket.state.ota.lastLoggedPct).toBe(10);
+      expect((handler as any).logger.log).toHaveBeenCalledTimes(1);
+      expect((handler as any).logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('10%'),
+      );
+
+      // Second read still within the 10% bucket -> no additional log
+      mockReadSync.mockReturnValue(50 as any);
+      await handler.handleFirmwareChunkRequest(socket, {
+        payload: { offset: 100, length: 50 },
+      } as AttractapEvent['data']);
+
+      // (100+50)/1000 = 15% -> bucket 10, not greater than lastLogged 10
+      expect((handler as any).logger.log).toHaveBeenCalledTimes(1);
+
+      // Third read crosses into 20% bucket -> logs again
+      mockReadSync.mockReturnValue(100 as any);
+      await handler.handleFirmwareChunkRequest(socket, {
+        payload: { offset: 100, length: 100 },
+      } as AttractapEvent['data']);
+
+      // (100+100)/1000 = 20% -> bucket 20 > 10
+      expect(socket.state.ota.lastLoggedPct).toBe(20);
+      expect((handler as any).logger.log).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses "unknown" reader label in progress log when readerId is absent', async () => {
+      socket.readerId = null;
+      socket.state.ota = { path: '/tmp/fw.bin', size: 1000, fd: 9 };
+      mockReadSync.mockReturnValue(100 as any);
+
+      await handler.handleFirmwareChunkRequest(socket, {
+        payload: { offset: 0, length: 100 },
+      } as AttractapEvent['data']);
+
+      expect((handler as any).logger.log).toHaveBeenCalledWith(
+        expect.stringContaining('reader unknown'),
+      );
+    });
+  });
+
+  describe('handleFirmwareInfo', () => {
+    const payload = { name: 'attractap', variant: 'touch', version: '1.0.0' };
+    const data = { payload } as AttractapEvent['data'];
+
+    it('always calls updateReaderFirmware with readerId and payload', async () => {
+      mockFirmwareService.getFirmwareDefinition.mockResolvedValue({ version: '1.0.0' });
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect(mockAttractapService.updateReaderFirmware).toHaveBeenCalledWith(42, payload);
+    });
+
+    it('does not send OTA message when firmware is already latest', async () => {
+      mockFirmwareService.getFirmwareDefinition.mockResolvedValue({ version: '1.0.0' });
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+      expect(mockMetricsService.attractapFirmwareUpdatesTotal.inc).not.toHaveBeenCalled();
+    });
+
+    it('warns and returns when firmware definition missing on second lookup', async () => {
+      // isFirmwareLatest first call returns a differing version (forces not-latest),
+      // then the handler body re-looks up and gets null.
+      mockFirmwareService.getFirmwareDefinition
+        .mockResolvedValueOnce({ version: '2.0.0' })
+        .mockResolvedValueOnce(null);
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect((handler as any).logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No firmware definition found'),
+      );
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+      expect(mockMetricsService.attractapFirmwareUpdatesTotal.inc).not.toHaveBeenCalled();
+    });
+
+    it('logs error when OTA binary file is missing (existsSync false)', async () => {
+      mockFirmwareService.getFirmwareDefinition.mockResolvedValue({
+        name: 'attractap',
+        variant: 'touch',
+        version: '2.0.0',
+        filename: 'fw.bin',
+        filenameOTA: 'fw-ota.bin',
+      });
+      mockExistsSync.mockReturnValue(false);
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('OTA firmware binary not found'),
+      );
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+      expect(mockMetricsService.attractapFirmwareUpdatesTotal.inc).not.toHaveBeenCalled();
+    });
+
+    it('logs error when OTA firmware size < 1024', async () => {
+      mockFirmwareService.getFirmwareDefinition.mockResolvedValue({
+        name: 'attractap',
+        variant: 'touch',
+        version: '2.0.0',
+        filename: 'fw.bin',
+        filenameOTA: 'fw-ota.bin',
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockReturnValue({ size: 512 } as any);
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('suspicious'),
+      );
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+      expect(mockMetricsService.attractapFirmwareUpdatesTotal.inc).not.toHaveBeenCalled();
+    });
+
+    it('logs error when OTA firmware size is 0/falsy', async () => {
+      mockFirmwareService.getFirmwareDefinition.mockResolvedValue({
+        name: 'attractap',
+        variant: 'touch',
+        version: '2.0.0',
+        filename: 'fw.bin',
+        filenameOTA: 'fw-ota.bin',
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockReturnValue({ size: 0 } as any);
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('suspicious'),
+      );
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('sets OTA state, sends READER_FIRMWARE_UPDATE_REQUIRED, and increments metric on valid update', async () => {
+      mockFirmwareService.getFirmwareDefinition.mockResolvedValue({
+        name: 'attractap',
+        variant: 'touch',
+        version: '2.0.0',
+        filename: 'fw.bin',
+        filenameOTA: 'fw-ota.bin',
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockReturnValue({ size: 4096 } as any);
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect(socket.state.ota).toEqual(
+        expect.objectContaining({ path: expect.stringContaining('fw-ota.bin'), size: 4096 }),
+      );
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.READER_FIRMWARE_UPDATE_REQUIRED,
+            payload: {
+              available: {
+                name: 'attractap',
+                variant: 'touch',
+                version: '2.0.0',
+                totalSize: 4096,
+              },
+            },
+          }),
+        }),
+      );
+      expect(mockMetricsService.attractapFirmwareUpdatesTotal.inc).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to filename when filenameOTA is absent', async () => {
+      mockFirmwareService.getFirmwareDefinition.mockResolvedValue({
+        name: 'attractap',
+        variant: 'touch',
+        version: '2.0.0',
+        filename: 'fw.bin',
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockReturnValue({ size: 2048 } as any);
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect(mockExistsSync).toHaveBeenCalledWith(expect.stringContaining('fw.bin'));
+      expect(socket.sendMessage).toHaveBeenCalled();
+    });
+
+    it('logs error when an exception is thrown while preparing the update', async () => {
+      mockFirmwareService.getFirmwareDefinition.mockResolvedValue({
+        name: 'attractap',
+        variant: 'touch',
+        version: '2.0.0',
+        filename: 'fw.bin',
+        filenameOTA: 'fw-ota.bin',
+      });
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockImplementation(() => {
+        throw new Error('stat boom');
+      });
+
+      await handler.handleFirmwareInfo(socket, data);
+
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to prepare firmware update notice'),
+      );
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/firmware.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/firmware.handler.ts
@@ -1,0 +1,137 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { existsSync, statSync, openSync, readSync } from 'fs';
+import { join } from 'path';
+import { AttractapService } from '../../attractap.service';
+import { AttractapFirmwareService } from '../../firmware.service';
+import { MetricsService } from '../../../metrics/metrics.service';
+import { AttractapFirmware } from '../../dtos/firmware.dto';
+import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
+
+@Injectable()
+export class AttractapFirmwareHandler {
+  private readonly logger = new Logger(AttractapFirmwareHandler.name);
+
+  @Inject(AttractapService)
+  private attractapService: AttractapService;
+
+  @Inject(AttractapFirmwareService)
+  private firmwareService: AttractapFirmwareService;
+
+  @Inject(MetricsService)
+  private metricsService: MetricsService;
+
+  public async handleFirmwareChunkRequest(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    try {
+      if (!socket.state.ota || !socket.state.ota.path || !socket.state.ota.size) {
+        this.logger.error(`FIRMWARE_REQUEST_CHUNK received but no OTA context set for client ${socket.id}`);
+        return;
+      }
+
+      const { offset, length } = data.payload;
+      const total = socket.state.ota.size;
+      if (typeof offset !== 'number' || typeof length !== 'number' || offset < 0 || length <= 0 || offset >= total) {
+        this.logger.error(`Invalid chunk request from client ${socket.id}: offset=${offset} length=${length}`);
+        return;
+      }
+
+      const maxChunk = 4096; // hard cap chunk size
+      const safeLen = Math.min(length, maxChunk, total - offset);
+
+      // Lazily open file descriptor
+      if (!socket.state.ota.fd) {
+        try {
+          socket.state.ota.fd = openSync(socket.state.ota.path, 'r');
+        } catch (e) {
+          this.logger.error(`Failed to open firmware for client ${socket.id}: ${(e as Error).message}`);
+          return;
+        }
+      }
+
+      const fd = socket.state.ota.fd as number;
+      const buffer = Buffer.allocUnsafe(safeLen);
+      let bytesRead = 0;
+      try {
+        bytesRead = readSync(fd, buffer, 0, safeLen, offset);
+      } catch (e) {
+        this.logger.error(`Failed to read firmware chunk for client ${socket.id}: ${(e as Error).message}`);
+        return;
+      }
+
+      if (bytesRead > 0) {
+        socket.sendBinaryData(buffer.subarray(0, bytesRead));
+        const progressPct = Math.round(((offset + bytesRead) / total) * 100);
+        const pctBucket = Math.floor(progressPct / 10) * 10;
+        const lastLogged = socket.state.ota.lastLoggedPct ?? -1;
+        if (pctBucket > lastLogged) {
+          socket.state.ota.lastLoggedPct = pctBucket;
+          this.logger.log(
+            `Attractap firmware update progress: ${pctBucket}% (reader ${socket.readerId ?? 'unknown'})`,
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.error(`handleFirmwareChunkRequest error: ${(err as Error).message}`);
+    }
+  }
+
+  public async handleFirmwareInfo(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    await this.attractapService.updateReaderFirmware(socket.readerId, data.payload);
+
+    const firmwareIsUpToDate = await this.isFirmwareLatest(data.payload);
+    if (!firmwareIsUpToDate) {
+      this.logger.debug('Firmware is not up to date, notifying client to start OTA');
+
+      try {
+        const current = data.payload as AttractapFirmware;
+        const latest = await this.firmwareService.getFirmwareDefinition(current.name, current.variant);
+        if (!latest) {
+          this.logger.warn(
+            `No firmware definition found for ${current.name}/${current.variant}; treating as up-to-date for now.`,
+          );
+          return;
+        }
+
+        const assetsDir = join(__dirname, 'assets', 'attractap-firmwares');
+        const otaFilename = latest.filenameOTA || latest.filename;
+        const firmwarePath = join(assetsDir, otaFilename);
+        if (!existsSync(firmwarePath)) {
+          this.logger.error(`OTA firmware binary not found at ${firmwarePath}`);
+          return;
+        }
+        const size = statSync(firmwarePath).size;
+        if (!size || size < 1024) {
+          this.logger.error(`OTA firmware size is suspicious (${size} bytes) for ${otaFilename}`);
+          return;
+        }
+
+        // Store OTA context for this socket
+        socket.state.ota = { path: firmwarePath, size } as AuthenticatedWebSocket['state']['ota'];
+
+        await socket.sendMessage(
+          new AttractapEvent(AttractapEventType.READER_FIRMWARE_UPDATE_REQUIRED, {
+            available: {
+              name: latest.name,
+              variant: latest.variant,
+              version: String(latest.version),
+              totalSize: size,
+            },
+          }),
+        );
+        this.metricsService.attractapFirmwareUpdatesTotal.inc();
+      } catch (err) {
+        this.logger.error(`Failed to prepare firmware update notice: ${(err as Error).message}`);
+      }
+      return;
+    }
+  }
+
+  private async isFirmwareLatest(firmware: AttractapFirmware): Promise<boolean> {
+    const firmwareDefinition = await this.firmwareService.getFirmwareDefinition(firmware.name, firmware.variant);
+
+    if (!firmwareDefinition) {
+      return true;
+    }
+
+    return String(firmwareDefinition.version) === String(firmware.version);
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/forms.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/forms.handler.spec.ts
@@ -1,0 +1,487 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ResourceFormAction } from '@attraccess/database-entities';
+import { AttractapFormsHandler } from './forms.handler';
+import { AttractapEventType, AttractapEvent } from '../websocket.types';
+
+describe('AttractapFormsHandler', () => {
+  let handler: AttractapFormsHandler;
+  let mockAttractapService: { findReaderById: jest.Mock };
+  let mockResourceFormsService: {
+    getFormsForAction: jest.Mock;
+    getFieldsWindow: jest.Mock;
+    validatePageAnswers: jest.Mock;
+  };
+  let mockResourceActionGuard: { validateResourceAction: jest.Mock };
+
+  function createMockSocket(overrides: any = {}): any {
+    return {
+      id: 'sock-1',
+      readerId: 42,
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+      state: {
+        lastAuthenticatedUserId: 1,
+        ...overrides.state,
+      },
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    handler = Object.create(AttractapFormsHandler.prototype);
+    (handler as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockAttractapService = {
+      findReaderById: jest.fn().mockResolvedValue(null),
+    };
+    mockResourceFormsService = {
+      getFormsForAction: jest.fn(),
+      getFieldsWindow: jest.fn(),
+      validatePageAnswers: jest.fn(),
+    };
+    mockResourceActionGuard = {
+      validateResourceAction: jest.fn(),
+    };
+
+    (handler as any).attractapService = mockAttractapService;
+    (handler as any).resourceFormsService = mockResourceFormsService;
+    (handler as any).resourceActionGuard = mockResourceActionGuard;
+  });
+
+  describe('formDraftKey', () => {
+    it('builds the key from resourceId and action', () => {
+      const key = (handler as any).formDraftKey(10, ResourceFormAction.START);
+      expect(key).toBe(`10:${ResourceFormAction.START}`);
+    });
+  });
+
+  describe('getFormDraft', () => {
+    it('returns empty object when no formDrafts present', () => {
+      const socket = createMockSocket();
+      expect(handler.getFormDraft(socket, 10, ResourceFormAction.START)).toEqual({});
+    });
+
+    it('returns empty object when formDrafts present but key missing', () => {
+      const socket = createMockSocket({ state: { lastAuthenticatedUserId: 1, formDrafts: {} } });
+      expect(handler.getFormDraft(socket, 10, ResourceFormAction.START)).toEqual({});
+    });
+
+    it('returns the stored draft for the key', () => {
+      const stored = { 1: 'a', 2: 'b' };
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          formDrafts: { [`10:${ResourceFormAction.START}`]: stored },
+        },
+      });
+      expect(handler.getFormDraft(socket, 10, ResourceFormAction.START)).toBe(stored);
+    });
+  });
+
+  describe('clearFormDraft', () => {
+    it('deletes the key when formDrafts present', () => {
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          formDrafts: {
+            [`10:${ResourceFormAction.START}`]: { 1: 'a' },
+            [`11:${ResourceFormAction.END}`]: { 2: 'b' },
+          },
+        },
+      });
+
+      handler.clearFormDraft(socket, 10, ResourceFormAction.START);
+
+      expect(socket.state.formDrafts).toEqual({ [`11:${ResourceFormAction.END}`]: { 2: 'b' } });
+    });
+
+    it('is a no-op when formDrafts absent', () => {
+      const socket = createMockSocket();
+      expect(() => handler.clearFormDraft(socket, 10, ResourceFormAction.START)).not.toThrow();
+      expect(socket.state.formDrafts).toBeUndefined();
+    });
+  });
+
+  describe('ensureFormsSatisfied', () => {
+    it('returns [] when there are no forms', async () => {
+      mockResourceFormsService.getFormsForAction.mockResolvedValue([]);
+      const socket = createMockSocket();
+
+      const result = await handler.ensureFormsSatisfied({
+        socket,
+        resourceId: 10,
+        action: ResourceFormAction.START,
+      });
+
+      expect(result).toEqual([]);
+      expect(mockResourceFormsService.getFormsForAction).toHaveBeenCalledWith(10, ResourceFormAction.START);
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns mapped submission DTOs when all required fields present (only fields with a draft value)', async () => {
+      mockResourceFormsService.getFormsForAction.mockResolvedValue([
+        {
+          id: 7,
+          name: 'Form A',
+          fields: [
+            { id: 1, isRequired: true },
+            { id: 2, isRequired: false },
+            { id: 3, isRequired: false },
+          ],
+        },
+      ]);
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          formDrafts: { [`10:${ResourceFormAction.START}`]: { 1: 'req-value', 2: 'opt-value' } },
+        },
+      });
+
+      const result = await handler.ensureFormsSatisfied({
+        socket,
+        resourceId: 10,
+        action: ResourceFormAction.START,
+      });
+
+      // field 3 has no draft value (undefined) -> omitted
+      expect(result).toEqual([
+        {
+          formId: 7,
+          answers: [
+            { fieldId: 1, value: 'req-value' },
+            { fieldId: 2, value: 'opt-value' },
+          ],
+        },
+      ]);
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends a form request and returns null when required fields incomplete, resolving resourceName via findReaderById', async () => {
+      mockResourceFormsService.getFormsForAction.mockResolvedValue([
+        {
+          id: 7,
+          name: 'Form A',
+          fields: [{ id: 1, isRequired: true }],
+        },
+      ]);
+      mockAttractapService.findReaderById.mockResolvedValue({
+        id: 42,
+        resources: [{ id: 10, name: 'Laser Cutter' }],
+      });
+      const socket = createMockSocket();
+
+      const result = await handler.ensureFormsSatisfied({
+        socket,
+        resourceId: 10,
+        action: ResourceFormAction.START,
+      });
+
+      expect(result).toBeNull();
+      expect(mockAttractapService.findReaderById).toHaveBeenCalledWith(42);
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESOURCE_USAGE_FORM_REQUEST,
+            payload: {
+              resourceId: 10,
+              resourceName: 'Laser Cutter',
+              action: ResourceFormAction.START,
+              forms: [{ id: 7, name: 'Form A', fieldCount: 1 }],
+            },
+          }),
+        }),
+      );
+    });
+
+    it('treats empty-string and null draft values as missing for required fields', async () => {
+      mockResourceFormsService.getFormsForAction.mockResolvedValue([
+        {
+          id: 7,
+          name: 'Form A',
+          fields: [
+            { id: 1, isRequired: true },
+            { id: 2, isRequired: true },
+          ],
+        },
+      ]);
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          formDrafts: { [`10:${ResourceFormAction.START}`]: { 1: '', 2: null } },
+        },
+      });
+
+      const result = await handler.ensureFormsSatisfied({
+        socket,
+        resourceId: 10,
+        action: ResourceFormAction.START,
+      });
+
+      expect(result).toBeNull();
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ type: AttractapEventType.RESOURCE_USAGE_FORM_REQUEST }),
+        }),
+      );
+    });
+
+    it('leaves resourceName undefined when reader has no matching resource', async () => {
+      mockResourceFormsService.getFormsForAction.mockResolvedValue([
+        { id: 7, name: 'Form A', fields: [{ id: 1, isRequired: true }] },
+      ]);
+      mockAttractapService.findReaderById.mockResolvedValue({ id: 42, resources: [{ id: 99, name: 'Other' }] });
+      const socket = createMockSocket();
+
+      await handler.ensureFormsSatisfied({ socket, resourceId: 10, action: ResourceFormAction.START });
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESOURCE_USAGE_FORM_REQUEST,
+            payload: expect.objectContaining({ resourceName: undefined }),
+          }),
+        }),
+      );
+    });
+
+    it('does not call findReaderById when socket has no readerId (resourceName undefined)', async () => {
+      mockResourceFormsService.getFormsForAction.mockResolvedValue([
+        { id: 7, name: 'Form A', fields: [{ id: 1, isRequired: true }] },
+      ]);
+      const socket = createMockSocket({ readerId: null });
+
+      const result = await handler.ensureFormsSatisfied({
+        socket,
+        resourceId: 10,
+        action: ResourceFormAction.START,
+      });
+
+      expect(result).toBeNull();
+      expect(mockAttractapService.findReaderById).not.toHaveBeenCalled();
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESOURCE_USAGE_FORM_REQUEST,
+            payload: expect.objectContaining({ resourceName: undefined }),
+          }),
+        }),
+      );
+    });
+
+    it('tolerates findReaderById throwing -> resourceName undefined and logs debug', async () => {
+      mockResourceFormsService.getFormsForAction.mockResolvedValue([
+        { id: 7, name: 'Form A', fields: [{ id: 1, isRequired: true }] },
+      ]);
+      mockAttractapService.findReaderById.mockRejectedValue(new Error('boom'));
+      const socket = createMockSocket();
+
+      const result = await handler.ensureFormsSatisfied({
+        socket,
+        resourceId: 10,
+        action: ResourceFormAction.START,
+      });
+
+      expect(result).toBeNull();
+      expect((handler as any).logger.debug).toHaveBeenCalledWith(expect.stringContaining('boom'));
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESOURCE_USAGE_FORM_REQUEST,
+            payload: expect.objectContaining({ resourceName: undefined }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('handleResourceUsageFormGetFields', () => {
+    const eventData = {
+      payload: { resourceId: 10, action: ResourceFormAction.START, formId: 7, offset: 0, limit: 5 },
+    } as AttractapEvent['data'];
+
+    it('returns early without fetching fields when guard fails', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValue(false);
+      const socket = createMockSocket();
+
+      await handler.handleResourceUsageFormGetFields(socket, eventData);
+
+      expect(mockResourceActionGuard.validateResourceAction).toHaveBeenCalledWith(
+        socket,
+        10,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      );
+      expect(mockResourceFormsService.getFieldsWindow).not.toHaveBeenCalled();
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('fetches a fields window and sends mapped fields when guard passes', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValue(true);
+      mockResourceFormsService.getFieldsWindow.mockResolvedValue({
+        totalFieldCount: 2,
+        fields: [
+          {
+            id: 1,
+            name: 'Name',
+            description: 'Your name',
+            type: 'text',
+            isRequired: true,
+            options: ['a', 'b'],
+          },
+          {
+            id: 2,
+            name: 'Extra',
+            // description and options undefined -> mapped to null
+            type: 'text',
+            isRequired: false,
+          },
+        ],
+      });
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          formDrafts: { [`10:${ResourceFormAction.START}`]: { 1: 'draft-1' } },
+        },
+      });
+
+      await handler.handleResourceUsageFormGetFields(socket, eventData);
+
+      expect(mockResourceFormsService.getFieldsWindow).toHaveBeenCalledWith(10, 7, 0, 5);
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESOURCE_USAGE_FORM_FIELDS,
+            payload: {
+              resourceId: 10,
+              action: ResourceFormAction.START,
+              formId: 7,
+              offset: 0,
+              totalFieldCount: 2,
+              fields: [
+                {
+                  id: 1,
+                  name: 'Name',
+                  description: 'Your name',
+                  type: 'text',
+                  isRequired: true,
+                  options: ['a', 'b'],
+                  value: 'draft-1',
+                },
+                {
+                  id: 2,
+                  name: 'Extra',
+                  description: null,
+                  type: 'text',
+                  isRequired: false,
+                  options: null,
+                  value: null,
+                },
+              ],
+            },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('handleResourceUsageFormSubmitPage', () => {
+    const answers = [
+      { fieldId: 1, value: 'v1' },
+      { fieldId: 2, value: 'v2' },
+    ];
+    const eventData = {
+      payload: { resourceId: 10, action: ResourceFormAction.START, formId: 7, offset: 0, answers },
+    } as AttractapEvent['data'];
+
+    it('returns early without validating when guard fails', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValue(false);
+      const socket = createMockSocket();
+
+      await handler.handleResourceUsageFormSubmitPage(socket, eventData);
+
+      expect(mockResourceActionGuard.validateResourceAction).toHaveBeenCalledWith(
+        socket,
+        10,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      );
+      expect(mockResourceFormsService.validatePageAnswers).not.toHaveBeenCalled();
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('stores the draft and sends a valid result when answers are valid', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValue(true);
+      mockResourceFormsService.validatePageAnswers.mockResolvedValue({ valid: true, errors: {} });
+      const socket = createMockSocket();
+
+      await handler.handleResourceUsageFormSubmitPage(socket, eventData);
+
+      expect(mockResourceFormsService.validatePageAnswers).toHaveBeenCalledWith(10, 7, answers);
+      expect(socket.state.formDrafts).toEqual({
+        [`10:${ResourceFormAction.START}`]: { 1: 'v1', 2: 'v2' },
+      });
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESOURCE_USAGE_FORM_PAGE_RESULT,
+            payload: {
+              resourceId: 10,
+              action: ResourceFormAction.START,
+              formId: 7,
+              offset: 0,
+              valid: true,
+              errors: {},
+            },
+          }),
+        }),
+      );
+    });
+
+    it('merges into an existing draft for the same key when valid', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValue(true);
+      mockResourceFormsService.validatePageAnswers.mockResolvedValue({ valid: true, errors: {} });
+      const socket = createMockSocket({
+        state: {
+          lastAuthenticatedUserId: 1,
+          formDrafts: { [`10:${ResourceFormAction.START}`]: { 9: 'existing' } },
+        },
+      });
+
+      await handler.handleResourceUsageFormSubmitPage(socket, eventData);
+
+      expect(socket.state.formDrafts).toEqual({
+        [`10:${ResourceFormAction.START}`]: { 9: 'existing', 1: 'v1', 2: 'v2' },
+      });
+    });
+
+    it('does not store a draft and sends an invalid result when answers are invalid', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValue(true);
+      const errors = { 1: 'Required' };
+      mockResourceFormsService.validatePageAnswers.mockResolvedValue({ valid: false, errors });
+      const socket = createMockSocket();
+
+      await handler.handleResourceUsageFormSubmitPage(socket, eventData);
+
+      expect(mockResourceFormsService.validatePageAnswers).toHaveBeenCalledWith(10, 7, answers);
+      expect(socket.state.formDrafts).toBeUndefined();
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESOURCE_USAGE_FORM_PAGE_RESULT,
+            payload: {
+              resourceId: 10,
+              action: ResourceFormAction.START,
+              formId: 7,
+              offset: 0,
+              valid: false,
+              errors,
+            },
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/forms.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/forms.handler.ts
@@ -1,0 +1,171 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ResourceFormAction } from '@attraccess/database-entities';
+import { AttractapService } from '../../attractap.service';
+import { ResourceFormsService } from '../../../resources/forms/forms.service';
+import { FormSubmissionRequestDto } from '../../../resources/forms/dto/form-submission-request.dto';
+import { ResourceActionGuard } from './resource-action.guard';
+import {
+  AuthenticatedWebSocket,
+  AttractapEvent,
+  AttractapEventType,
+  FormFieldAnswerValue,
+  ResourceUsageFormRequestPayload,
+  ResourceUsageFormGetFieldsPayload,
+  ResourceUsageFormFieldsPayload,
+  ResourceUsageFormSubmitPagePayload,
+  ResourceUsageFormPageResultPayload,
+} from '../websocket.types';
+
+@Injectable()
+export class AttractapFormsHandler {
+  private readonly logger = new Logger(AttractapFormsHandler.name);
+
+  @Inject(AttractapService)
+  private attractapService: AttractapService;
+
+  @Inject(ResourceFormsService)
+  private resourceFormsService: ResourceFormsService;
+
+  @Inject(ResourceActionGuard)
+  private resourceActionGuard: ResourceActionGuard;
+
+  private formDraftKey(resourceId: number, action: ResourceFormAction): string {
+    return `${resourceId}:${action}`;
+  }
+
+  public getFormDraft(
+    socket: AuthenticatedWebSocket,
+    resourceId: number,
+    action: ResourceFormAction,
+  ): Record<number, FormFieldAnswerValue> {
+    return socket.state.formDrafts?.[this.formDraftKey(resourceId, action)] ?? {};
+  }
+
+  public clearFormDraft(socket: AuthenticatedWebSocket, resourceId: number, action: ResourceFormAction): void {
+    if (socket.state.formDrafts) {
+      delete socket.state.formDrafts[this.formDraftKey(resourceId, action)];
+    }
+  }
+
+  public async ensureFormsSatisfied({
+    socket,
+    resourceId,
+    action,
+  }: {
+    socket: AuthenticatedWebSocket;
+    resourceId: number;
+    action: ResourceFormAction;
+  }): Promise<FormSubmissionRequestDto[] | null> {
+    const forms = await this.resourceFormsService.getFormsForAction(resourceId, action);
+    if (!forms.length) {
+      return [];
+    }
+
+    const draft = this.getFormDraft(socket, resourceId, action);
+    const hasValue = (fieldId: number) => {
+      const value = draft[fieldId];
+      return value !== undefined && value !== null && value !== '';
+    };
+
+    const complete = forms.every((form) =>
+      form.fields.filter((field) => field.isRequired).every((field) => hasValue(field.id)),
+    );
+
+    if (complete) {
+      return forms.map((form) => ({
+        formId: form.id,
+        answers: form.fields
+          .filter((field) => draft[field.id] !== undefined)
+          .map((field) => ({ fieldId: field.id, value: draft[field.id] })),
+      }));
+    }
+
+    let resourceName: string | undefined;
+    try {
+      const reader = socket.readerId ? await this.attractapService.findReaderById(socket.readerId) : null;
+      const resource = reader?.resources?.find((item) => item.id === resourceId);
+      resourceName = resource?.name;
+    } catch (error) {
+      this.logger.debug(`Failed to resolve resource name for form request: ${(error as Error).message}`);
+    }
+
+    const payload: ResourceUsageFormRequestPayload = {
+      resourceId,
+      resourceName,
+      action,
+      forms: forms.map((form) => ({ id: form.id, name: form.name, fieldCount: form.fields.length })),
+    };
+
+    await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_REQUEST, payload));
+    return null;
+  }
+
+  public async handleResourceUsageFormGetFields(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId, action, formId, offset, limit } = data.payload as ResourceUsageFormGetFieldsPayload;
+
+    if (
+      !(await this.resourceActionGuard.validateResourceAction(
+        socket,
+        resourceId,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      ))
+    ) {
+      return;
+    }
+
+    const { totalFieldCount, fields } = await this.resourceFormsService.getFieldsWindow(
+      resourceId,
+      formId,
+      offset,
+      limit,
+    );
+
+    const draft = this.getFormDraft(socket, resourceId, action);
+    const payload: ResourceUsageFormFieldsPayload = {
+      resourceId,
+      action,
+      formId,
+      offset,
+      totalFieldCount,
+      fields: fields.map((field) => ({
+        id: field.id,
+        name: field.name,
+        description: field.description ?? null,
+        type: field.type,
+        isRequired: field.isRequired,
+        options: field.options ?? null,
+        value: draft[field.id] ?? null,
+      })),
+    };
+
+    await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_FIELDS, payload));
+  }
+
+  public async handleResourceUsageFormSubmitPage(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId, action, formId, offset, answers } = data.payload as ResourceUsageFormSubmitPagePayload;
+
+    if (
+      !(await this.resourceActionGuard.validateResourceAction(
+        socket,
+        resourceId,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      ))
+    ) {
+      return;
+    }
+
+    const { valid, errors } = await this.resourceFormsService.validatePageAnswers(resourceId, formId, answers);
+
+    if (valid) {
+      const key = this.formDraftKey(resourceId, action);
+      socket.state.formDrafts ??= {};
+      socket.state.formDrafts[key] ??= {};
+      for (const answer of answers) {
+        socket.state.formDrafts[key][answer.fieldId] = answer.value;
+      }
+    }
+
+    const payload: ResourceUsageFormPageResultPayload = { resourceId, action, formId, offset, valid, errors };
+    await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_PAGE_RESULT, payload));
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/projects.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/projects.handler.spec.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AttractapProjectsHandler } from './projects.handler';
+import { AttractapEventType, AttractapEvent } from '../websocket.types';
+
+describe('AttractapProjectsHandler', () => {
+  let handler: AttractapProjectsHandler;
+  let mockProjectsService: { findMany: jest.Mock; getTotalCount: jest.Mock };
+  let mockSocket: {
+    id: string;
+    readerId: number;
+    state: { lastAuthenticatedUserId: number | null };
+    sendMessage: jest.Mock;
+    sendBinaryData: jest.Mock;
+  };
+
+  const mockProjects = [{ id: 1, name: 'Project A' }, { id: 2, name: 'Project B' }];
+
+  beforeEach(() => {
+    handler = Object.create(AttractapProjectsHandler.prototype);
+    (handler as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockProjectsService = {
+      findMany: jest.fn().mockResolvedValue(mockProjects),
+      getTotalCount: jest.fn().mockResolvedValue(2),
+    };
+    (handler as any).projectsService = mockProjectsService;
+
+    mockSocket = {
+      id: 'test-id',
+      readerId: 42,
+      state: { lastAuthenticatedUserId: 7 },
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+    };
+  });
+
+  describe('handleProjectsOfUserRequest', () => {
+    it('sends USER_NOT_AUTHENTICATED and makes no service calls when no authenticated user', async () => {
+      mockSocket.state.lastAuthenticatedUserId = null;
+      const data = { payload: {} } as AttractapEvent['data'];
+
+      await handler.handleProjectsOfUserRequest(mockSocket as any, data);
+
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.PROJECTS_OF_USER,
+            payload: { error: 'USER_NOT_AUTHENTICATED' },
+          }),
+        }),
+      );
+      expect(mockProjectsService.findMany).not.toHaveBeenCalled();
+      expect(mockProjectsService.getTotalCount).not.toHaveBeenCalled();
+    });
+
+    it('uses explicit page/limit and sends projects payload on success', async () => {
+      const data = { payload: { page: 3, limit: 25 } } as AttractapEvent['data'];
+
+      await handler.handleProjectsOfUserRequest(mockSocket as any, data);
+
+      expect(mockProjectsService.findMany).toHaveBeenCalledWith(7, { page: 3, limit: 25 });
+      expect(mockProjectsService.getTotalCount).toHaveBeenCalledWith(7);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.PROJECTS_OF_USER,
+            payload: { projects: mockProjects, page: 3, limit: 25, total: 2 },
+          }),
+        }),
+      );
+    });
+
+    it('defaults to page=1 and limit=10 when payload is empty', async () => {
+      const data = { payload: {} } as AttractapEvent['data'];
+
+      await handler.handleProjectsOfUserRequest(mockSocket as any, data);
+
+      expect(mockProjectsService.findMany).toHaveBeenCalledWith(7, { page: 1, limit: 10 });
+      expect(mockProjectsService.getTotalCount).toHaveBeenCalledWith(7);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.PROJECTS_OF_USER,
+            payload: { projects: mockProjects, page: 1, limit: 10, total: 2 },
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/projects.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/projects.handler.ts
@@ -1,0 +1,25 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ProjectsService } from '../../../projects/projects.service';
+import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
+
+@Injectable()
+export class AttractapProjectsHandler {
+  @Inject(ProjectsService)
+  private projectsService: ProjectsService;
+
+  public async handleProjectsOfUserRequest(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const userId = socket.state.lastAuthenticatedUserId;
+    if (!userId) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.PROJECTS_OF_USER, { error: 'USER_NOT_AUTHENTICATED' }),
+      );
+      return;
+    }
+
+    const { page = 1, limit = 10 } = data.payload as { page?: number; limit?: number };
+
+    const projects = await this.projectsService.findMany(userId, { page, limit });
+    const total = await this.projectsService.getTotalCount(userId);
+    await socket.sendMessage(new AttractapEvent(AttractapEventType.PROJECTS_OF_USER, { projects, page, limit, total }));
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/resource-action.guard.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/resource-action.guard.spec.ts
@@ -1,0 +1,273 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ResourceActionGuard } from './resource-action.guard';
+import { AttractapEventType } from '../websocket.types';
+
+describe('ResourceActionGuard', () => {
+  let guard: ResourceActionGuard;
+  let mockSocket: {
+    id: string;
+    readerId: number;
+    state: { lastAuthenticatedUserId: number | null };
+    sendMessage: jest.Mock;
+    sendBinaryData: jest.Mock;
+  };
+  let mockAttractapService: { findReaderById: jest.Mock };
+  let mockUsersService: { findOne: jest.Mock };
+
+  const mockUser = { id: 1, username: 'testuser' };
+  const mockReader = { id: 42, resources: [{ id: 10 }] };
+
+  beforeEach(() => {
+    guard = Object.create(ResourceActionGuard.prototype);
+
+    mockAttractapService = {
+      findReaderById: jest.fn().mockResolvedValue(mockReader),
+    };
+    mockUsersService = {
+      findOne: jest.fn().mockResolvedValue(mockUser),
+    };
+
+    (guard as any).attractapService = mockAttractapService;
+    (guard as any).usersService = mockUsersService;
+
+    mockSocket = {
+      id: 'test-id',
+      readerId: 42,
+      state: { lastAuthenticatedUserId: 1 },
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+    };
+  });
+
+  describe('invalid resourceId', () => {
+    it('sends START_RESOURCE_USAGE_SESSION INVALID_RESOURCE_ID and returns false when resourceId is 0', async () => {
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        0,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(false);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'INVALID_RESOURCE_ID' },
+          }),
+        }),
+      );
+      expect(mockAttractapService.findReaderById).not.toHaveBeenCalled();
+    });
+
+    it('sends START_RESOURCE_USAGE_SESSION INVALID_RESOURCE_ID and returns false when resourceId is undefined', async () => {
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        undefined as any,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(false);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'INVALID_RESOURCE_ID' },
+          }),
+        }),
+      );
+    });
+
+    it('always uses START type for invalid resourceId regardless of eventType', async () => {
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        0,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      );
+
+      expect(result).toBe(false);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'INVALID_RESOURCE_ID' },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('reader not found', () => {
+    it('sends eventType READER_NOT_FOUND and returns false', async () => {
+      mockAttractapService.findReaderById.mockResolvedValueOnce(null);
+
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        10,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(false);
+      expect(mockAttractapService.findReaderById).toHaveBeenCalledWith(42);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.LOCK_DOOR,
+            payload: { error: 'READER_NOT_FOUND' },
+          }),
+        }),
+      );
+    });
+
+    it('uses the START event type when given (fallback)', async () => {
+      mockAttractapService.findReaderById.mockResolvedValueOnce(null);
+
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        10,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      );
+
+      expect(result).toBe(false);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'READER_NOT_FOUND' },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('resource not associated with reader', () => {
+    it('sends RESOURCE_NOT_ASSOCIATED_WITH_READER and returns false', async () => {
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        999,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(false);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.LOCK_DOOR,
+            payload: { error: 'RESOURCE_NOT_ASSOCIATED_WITH_READER' },
+          }),
+        }),
+      );
+      expect(mockUsersService.findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('user not authenticated', () => {
+    it('sends USER_NOT_AUTHENTICATED and returns false when lastAuthenticatedUserId is null', async () => {
+      mockSocket.state.lastAuthenticatedUserId = null;
+
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        10,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(false);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.LOCK_DOOR,
+            payload: { error: 'USER_NOT_AUTHENTICATED' },
+          }),
+        }),
+      );
+      expect(mockUsersService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('sends USER_NOT_AUTHENTICATED when lastAuthenticatedUserId is undefined', async () => {
+      mockSocket.state.lastAuthenticatedUserId = undefined as any;
+
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        10,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(false);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.LOCK_DOOR,
+            payload: { error: 'USER_NOT_AUTHENTICATED' },
+          }),
+        }),
+      );
+    });
+
+    it('does NOT treat userId 0 as unauthenticated (== null check)', async () => {
+      // lastAuthenticatedUserId == null is false for 0, so it proceeds to findOne.
+      mockSocket.state.lastAuthenticatedUserId = 0;
+
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        10,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(true);
+      expect(mockUsersService.findOne).toHaveBeenCalledWith({ id: 0 });
+    });
+  });
+
+  describe('user not found', () => {
+    it('sends USER_NOT_FOUND and returns false', async () => {
+      mockUsersService.findOne.mockResolvedValueOnce(null);
+
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        10,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(false);
+      expect(mockUsersService.findOne).toHaveBeenCalledWith({ id: 1 });
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.LOCK_DOOR,
+            payload: { error: 'USER_NOT_FOUND' },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('success', () => {
+    it('returns true and sends no message when all checks pass', async () => {
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        10,
+        AttractapEventType.LOCK_DOOR,
+      );
+
+      expect(result).toBe(true);
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('forwards readerId and userId to the dependencies', async () => {
+      await guard.validateResourceAction(mockSocket as any, 10, AttractapEventType.LOCK_DOOR);
+
+      expect(mockAttractapService.findReaderById).toHaveBeenCalledWith(42);
+      expect(mockUsersService.findOne).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    it('returns true for the START fallback event type as well', async () => {
+      const result = await guard.validateResourceAction(
+        mockSocket as any,
+        10,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      );
+
+      expect(result).toBe(true);
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/resource-action.guard.ts
+++ b/apps/api/src/attractap/websockets/handlers/resource-action.guard.ts
@@ -1,0 +1,56 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { AttractapService } from '../../attractap.service';
+import { UsersService } from '../../../users-and-auth/users/users.service';
+import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
+
+@Injectable()
+export class ResourceActionGuard {
+  @Inject(AttractapService)
+  private attractapService: AttractapService;
+
+  @Inject(UsersService)
+  private usersService: UsersService;
+
+  public async validateResourceAction(
+    socket: AuthenticatedWebSocket,
+    resourceId: number,
+    eventType: AttractapEventType,
+  ): Promise<boolean> {
+    if (!resourceId) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'INVALID_RESOURCE_ID' }),
+      );
+      return false;
+    }
+
+    const reader = await this.attractapService.findReaderById(socket.readerId);
+    if (!reader) {
+      await socket.sendMessage(new AttractapEvent(eventType, { error: 'READER_NOT_FOUND' }));
+      return false;
+    }
+
+    const resource = reader.resources.find((resource) => resource.id === resourceId);
+    if (!resource) {
+      await socket.sendMessage(
+        new AttractapEvent(eventType, {
+          error: 'RESOURCE_NOT_ASSOCIATED_WITH_READER',
+        }),
+      );
+      return false;
+    }
+
+    const lastAuthenticatedUserId = socket.state.lastAuthenticatedUserId;
+    if (lastAuthenticatedUserId == null) {
+      await socket.sendMessage(new AttractapEvent(eventType, { error: 'USER_NOT_AUTHENTICATED' }));
+      return false;
+    }
+
+    const user = await this.usersService.findOne({ id: lastAuthenticatedUserId });
+    if (!user) {
+      await socket.sendMessage(new AttractapEvent(eventType, { error: 'USER_NOT_FOUND' }));
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/resource-list.service.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/resource-list.service.spec.ts
@@ -1,0 +1,253 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ResourceListService } from './resource-list.service';
+import { AttractapEvent, AttractapEventType } from '../websocket.types';
+import { ResourceFlowNodeType } from '@attraccess/database-entities';
+
+describe('ResourceListService', () => {
+  let service: ResourceListService;
+  let websocketService: { sockets: Map<string, any> };
+  let attractapService: { findReaderById: jest.Mock };
+  let resourceUsageService: { getActiveSession: jest.Mock };
+  let resourceMaintenanceService: { hasActiveMaintenance: jest.Mock };
+  let resourceFlowsService: { getNodes: jest.Mock };
+
+  function createMockSocket(overrides: Partial<any> = {}): any {
+    return {
+      id: 'socket-1',
+      readerId: 42,
+      state: { lastAuthenticatedUserId: null },
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  function createReaderFixture(overrides: Partial<any> = {}): any {
+    return {
+      id: 42,
+      name: 'Front Door Reader',
+      ledBrightness: 128,
+      resources: [
+        {
+          id: 10,
+          name: '3D Printer',
+          type: 'machine',
+          separateUnlockAndUnlatch: true,
+          description: 'A printer',
+          allowTakeOver: false,
+          introducers: [{ user: { username: 'introducer-a' } }],
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    service = Object.create(ResourceListService.prototype);
+
+    (service as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    websocketService = { sockets: new Map() };
+    attractapService = { findReaderById: jest.fn() };
+    resourceUsageService = { getActiveSession: jest.fn().mockResolvedValue(null) };
+    resourceMaintenanceService = { hasActiveMaintenance: jest.fn().mockResolvedValue(false) };
+    resourceFlowsService = { getNodes: jest.fn().mockResolvedValue([]) };
+
+    (service as any).websocketService = websocketService;
+    (service as any).attractapService = attractapService;
+    (service as any).resourceUsageService = resourceUsageService;
+    (service as any).resourceMaintenanceService = resourceMaintenanceService;
+    (service as any).resourceFlowsService = resourceFlowsService;
+  });
+
+  describe('sendResourceList', () => {
+    it('resolves without calling findReaderById when no sockets match the reader id', async () => {
+      websocketService.sockets.set('a', createMockSocket({ id: 'a', readerId: 1 }));
+      websocketService.sockets.set('b', createMockSocket({ id: 'b', readerId: 2 }));
+
+      const spy = jest.spyOn(service, 'sendResourceListToSocket').mockResolvedValue(undefined);
+
+      await expect(service.sendResourceList(999)).resolves.toBeUndefined();
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(attractapService.findReaderById).not.toHaveBeenCalled();
+    });
+
+    it('calls sendResourceListToSocket for each matching socket', async () => {
+      const matchA = createMockSocket({ id: 'a', readerId: 42 });
+      const matchB = createMockSocket({ id: 'b', readerId: 42 });
+      const other = createMockSocket({ id: 'c', readerId: 7 });
+      websocketService.sockets.set('a', matchA);
+      websocketService.sockets.set('b', matchB);
+      websocketService.sockets.set('c', other);
+
+      const spy = jest.spyOn(service, 'sendResourceListToSocket').mockResolvedValue(undefined);
+
+      await service.sendResourceList(42);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(matchA);
+      expect(spy).toHaveBeenCalledWith(matchB);
+      expect(spy).not.toHaveBeenCalledWith(other);
+    });
+  });
+
+  describe('sendResourceListToReadersWithResource', () => {
+    it('iterates ALL sockets calling sendResourceListToSocket with the resourceId filter', async () => {
+      const s1 = createMockSocket({ id: 's1', readerId: 42 });
+      const s2 = createMockSocket({ id: 's2', readerId: 7 });
+      websocketService.sockets.set('s1', s1);
+      websocketService.sockets.set('s2', s2);
+
+      const spy = jest.spyOn(service, 'sendResourceListToSocket').mockResolvedValue(undefined);
+
+      await service.sendResourceListToReadersWithResource(10);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(s1, { resourceId: 10 });
+      expect(spy).toHaveBeenCalledWith(s2, { resourceId: 10 });
+    });
+
+    it('resolves without error when there are no sockets', async () => {
+      const spy = jest.spyOn(service, 'sendResourceListToSocket').mockResolvedValue(undefined);
+
+      await expect(service.sendResourceListToReadersWithResource(10)).resolves.toBeUndefined();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendResourceListToSocket', () => {
+    it('throws "Reader not found" when the reader does not exist', async () => {
+      attractapService.findReaderById.mockResolvedValue(null);
+      const socket = createMockSocket({ readerId: 42 });
+
+      await expect(service.sendResourceListToSocket(socket)).rejects.toThrow('Reader not found: 42');
+
+      expect(attractapService.findReaderById).toHaveBeenCalledWith(42);
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns without sending when onlyIfResourceMatches.resourceId is not among reader.resources', async () => {
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      const socket = createMockSocket();
+
+      await service.sendResourceListToSocket(socket, { resourceId: 999 });
+
+      expect(socket.sendMessage).not.toHaveBeenCalled();
+      expect(resourceUsageService.getActiveSession).not.toHaveBeenCalled();
+    });
+
+    it('sends the resource list when onlyIfResourceMatches.resourceId matches a reader resource', async () => {
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      const socket = createMockSocket();
+
+      await service.sendResourceListToSocket(socket, { resourceId: 10 });
+
+      expect(socket.sendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('builds the full RESOURCE_LIST payload on the happy path', async () => {
+      const startTime = new Date('2026-06-04T10:00:00.000Z');
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      resourceUsageService.getActiveSession.mockResolvedValue({
+        user: { username: 'active-user' },
+        startTime,
+      });
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(true);
+      resourceFlowsService.getNodes.mockResolvedValue([
+        { id: 'node-1', data: { label: 'Start' } },
+      ]);
+
+      const socket = createMockSocket();
+
+      await service.sendResourceListToSocket(socket);
+
+      expect(attractapService.findReaderById).toHaveBeenCalledWith(42);
+      expect(resourceUsageService.getActiveSession).toHaveBeenCalledWith(10, true);
+      expect(resourceMaintenanceService.hasActiveMaintenance).toHaveBeenCalledWith(10);
+      expect(resourceFlowsService.getNodes).toHaveBeenCalledWith(10, ResourceFlowNodeType.INPUT_BUTTON);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESOURCE_LIST,
+            payload: {
+              readerName: 'Front Door Reader',
+              ledBrightness: 128,
+              resources: [
+                {
+                  id: 10,
+                  name: '3D Printer',
+                  type: 'machine',
+                  separateUnlockAndUnlatch: true,
+                  description: 'A printer',
+                  allowTakeOver: false,
+                  introducers: ['introducer-a'],
+                  isUnderMaintenance: true,
+                  activeUsageSession: {
+                    user: { username: 'active-user' },
+                    startTime: startTime.toISOString(),
+                  },
+                  flowButtons: [{ id: 'node-1', label: 'Start' }],
+                },
+              ],
+            },
+          }),
+        }),
+      );
+    });
+
+    it('emits activeUsageSession=null when there is no active session', async () => {
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      resourceUsageService.getActiveSession.mockResolvedValue(null);
+
+      const socket = createMockSocket();
+
+      await service.sendResourceListToSocket(socket);
+
+      const sent = (socket.sendMessage as jest.Mock).mock.calls[0][0] as AttractapEvent;
+      expect((sent.data.payload as any).resources[0].activeUsageSession).toBeNull();
+    });
+
+    it('falls back to node.id for the flowButton label when data.label is empty', async () => {
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      resourceFlowsService.getNodes.mockResolvedValue([{ id: 'fallback-id', data: { label: '' } }]);
+
+      const socket = createMockSocket();
+
+      await service.sendResourceListToSocket(socket);
+
+      const sent = (socket.sendMessage as jest.Mock).mock.calls[0][0] as AttractapEvent;
+      expect((sent.data.payload as any).resources[0].flowButtons).toEqual([
+        { id: 'fallback-id', label: 'fallback-id' },
+      ]);
+    });
+
+    it('logs a debug message before sending', async () => {
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      const socket = createMockSocket({ id: 'sock-debug' });
+
+      await service.sendResourceListToSocket(socket);
+
+      expect((service as any).logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Sending resource list to socket sock-debug'),
+        expect.any(AttractapEvent),
+      );
+    });
+
+    it('proceeds to send when onlyIfResourceMatches is provided without a resourceId', async () => {
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      const socket = createMockSocket();
+
+      await service.sendResourceListToSocket(socket, {});
+
+      expect(socket.sendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/resource-list.service.ts
+++ b/apps/api/src/attractap/websockets/handlers/resource-list.service.ts
@@ -1,0 +1,109 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ResourceFlowNodeType } from '@attraccess/database-entities';
+import { WebsocketService } from '../websocket.service';
+import { AttractapService } from '../../attractap.service';
+import { ResourceUsageService } from '../../../resources/usage/resourceUsage.service';
+import { ResourceMaintenanceService } from '../../../resources/maintenances/maintenance.service';
+import { ResourceFlowsService } from '../../../resources/flows/resource-flows.service';
+import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
+
+@Injectable()
+export class ResourceListService {
+  private readonly logger = new Logger(ResourceListService.name);
+
+  @Inject(WebsocketService)
+  private websocketService: WebsocketService;
+
+  @Inject(AttractapService)
+  private attractapService: AttractapService;
+
+  @Inject(ResourceUsageService)
+  private resourceUsageService: ResourceUsageService;
+
+  @Inject(ResourceMaintenanceService)
+  private resourceMaintenanceService: ResourceMaintenanceService;
+
+  @Inject(ResourceFlowsService)
+  private resourceFlowsService: ResourceFlowsService;
+
+  public async sendResourceList(readerId: number) {
+    const sockets = Array.from(this.websocketService.sockets.values()).filter((socket) => socket.readerId === readerId);
+    if (sockets.length === 0) {
+      return;
+    }
+
+    await Promise.all(sockets.map((socket) => this.sendResourceListToSocket(socket)));
+  }
+
+  public async sendResourceListToReadersWithResource(resourceId: number) {
+    const allSockets = Array.from(this.websocketService.sockets.values());
+    await Promise.all(allSockets.map((socket) => this.sendResourceListToSocket(socket, { resourceId })));
+  }
+
+  public async sendResourceListToSocket(
+    socket: AuthenticatedWebSocket,
+    onlyIfResourceMatches?: { resourceId?: number },
+  ) {
+    const reader = await this.attractapService.findReaderById(socket.readerId);
+    if (!reader) {
+      throw new Error(`Reader not found: ${socket.readerId}`);
+    }
+
+    const resources = reader.resources;
+
+    if (onlyIfResourceMatches?.resourceId) {
+      if (!resources.some((resource) => resource.id === onlyIfResourceMatches.resourceId)) {
+        return;
+      }
+    }
+
+    const resourcesWithUsageSession = await Promise.all(
+      resources.map(async (resource) => ({
+        ...resource,
+        activeUsageSession: await this.resourceUsageService.getActiveSession(resource.id, true),
+        isUnderMaintenance: await this.resourceMaintenanceService.hasActiveMaintenance(resource.id),
+      })),
+    );
+
+    const getFlowButtons = async (resourceId: number) => {
+      const nodes = await this.resourceFlowsService.getNodes(resourceId, ResourceFlowNodeType.INPUT_BUTTON);
+      return nodes.map((node) => ({
+        id: node.id,
+        label: node.data.label || node.id,
+      }));
+    };
+
+    const resourcesWithFlowButtons = await Promise.all(
+      resourcesWithUsageSession.map(async (resource) => ({
+        ...resource,
+        flowButtons: await getFlowButtons(resource.id),
+      })),
+    );
+
+    const resourceListResponse = new AttractapEvent(AttractapEventType.RESOURCE_LIST, {
+      readerName: reader.name,
+      ledBrightness: reader.ledBrightness,
+      resources: resourcesWithFlowButtons.map((resource) => ({
+        id: resource.id,
+        name: resource.name,
+        type: resource.type,
+        separateUnlockAndUnlatch: resource.separateUnlockAndUnlatch,
+        description: resource.description,
+        allowTakeOver: resource.allowTakeOver,
+        introducers: resource.introducers.map((introducer) => introducer.user.username),
+        isUnderMaintenance: resource.isUnderMaintenance,
+        activeUsageSession: resource.activeUsageSession
+          ? {
+            user: {
+              username: resource.activeUsageSession.user.username,
+            },
+            startTime: resource.activeUsageSession.startTime.toISOString(),
+          }
+          : null,
+        flowButtons: resource.flowButtons,
+      })),
+    });
+    this.logger.debug(`Sending resource list to socket ${socket.id}`, resourceListResponse);
+    await socket.sendMessage(resourceListResponse);
+  }
+}

--- a/apps/api/src/attractap/websockets/handlers/session.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/session.handler.spec.ts
@@ -1,0 +1,373 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AttractapSessionHandler } from './session.handler';
+import { AttractapEventType, AttractapEvent } from '../websocket.types';
+import { ResourceInUseError } from '../../../resources/usage/errors/resource-in-use.error';
+import { InsufficientBalanceError } from '../../../billing/errors/insufficient-balance.error';
+import { ResourceFormAction } from '@attraccess/database-entities';
+
+describe('AttractapSessionHandler – session + flow button', () => {
+  let handler: AttractapSessionHandler;
+  let mockSocket: {
+    id: string;
+    readerId: number;
+    state: { lastAuthenticatedUserId: number; readerId: number };
+    sendMessage: jest.Mock;
+    sendBinaryData: jest.Mock;
+  };
+  let mockUsersService: { findOne: jest.Mock };
+  let mockResourceUsageService: { startSession: jest.Mock; endSession: jest.Mock };
+  let mockResourceFlowsExecutorService: { pressButton: jest.Mock };
+  let mockSumUpService: { getIsEnabled: jest.Mock };
+  let mockResourceActionGuard: { validateResourceAction: jest.Mock };
+  let mockResourceListService: { sendResourceListToSocket: jest.Mock };
+  let mockFormsHandler: { ensureFormsSatisfied: jest.Mock; clearFormDraft: jest.Mock };
+
+  const mockUser = { id: 1, username: 'testuser' };
+
+  beforeEach(() => {
+    handler = Object.create(AttractapSessionHandler.prototype);
+    (handler as any).logger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    mockSocket = {
+      id: 'sock-1',
+      readerId: 42,
+      state: { lastAuthenticatedUserId: 1, readerId: 42 },
+      sendMessage: jest.fn().mockResolvedValue(undefined),
+      sendBinaryData: jest.fn(),
+    };
+
+    mockUsersService = {
+      findOne: jest.fn().mockResolvedValue(mockUser),
+    };
+
+    mockResourceUsageService = {
+      startSession: jest.fn().mockResolvedValue({}),
+      endSession: jest.fn().mockResolvedValue({}),
+    };
+
+    mockResourceFlowsExecutorService = {
+      pressButton: jest.fn().mockResolvedValue({}),
+    };
+
+    mockSumUpService = {
+      getIsEnabled: jest.fn().mockResolvedValue(true),
+    };
+
+    mockResourceActionGuard = {
+      validateResourceAction: jest.fn().mockResolvedValue(true),
+    };
+
+    mockResourceListService = {
+      sendResourceListToSocket: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockFormsHandler = {
+      ensureFormsSatisfied: jest.fn().mockResolvedValue([]),
+      clearFormDraft: jest.fn(),
+    };
+
+    (handler as any).usersService = mockUsersService;
+    (handler as any).resourceUsageService = mockResourceUsageService;
+    (handler as any).resourceFlowsExecutorService = mockResourceFlowsExecutorService;
+    (handler as any).sumUpService = mockSumUpService;
+    (handler as any).resourceActionGuard = mockResourceActionGuard;
+    (handler as any).resourceListService = mockResourceListService;
+    (handler as any).formsHandler = mockFormsHandler;
+  });
+
+  describe('handleStartResourceUsageSession', () => {
+    const eventData = { payload: { resourceId: 10, projectId: 7 } } as AttractapEvent['data'];
+
+    it('returns early and does not start a session when the guard rejects the action', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValueOnce(false);
+
+      await (handler as any).handleStartResourceUsageSession(mockSocket, eventData);
+
+      expect(mockResourceActionGuard.validateResourceAction).toHaveBeenCalledWith(
+        mockSocket,
+        10,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      );
+      expect(mockFormsHandler.ensureFormsSatisfied).not.toHaveBeenCalled();
+      expect(mockResourceUsageService.startSession).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns early when forms are not satisfied (ensureFormsSatisfied returns null)', async () => {
+      mockFormsHandler.ensureFormsSatisfied.mockResolvedValueOnce(null);
+
+      await (handler as any).handleStartResourceUsageSession(mockSocket, eventData);
+
+      expect(mockFormsHandler.ensureFormsSatisfied).toHaveBeenCalledWith({
+        socket: mockSocket,
+        resourceId: 10,
+        action: ResourceFormAction.START,
+      });
+      expect(mockUsersService.findOne).not.toHaveBeenCalled();
+      expect(mockResourceUsageService.startSession).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends USER_NOT_FOUND when the authenticated user does not exist', async () => {
+      mockUsersService.findOne.mockResolvedValueOnce(null);
+
+      await (handler as any).handleStartResourceUsageSession(mockSocket, eventData);
+
+      expect(mockUsersService.findOne).toHaveBeenCalledWith({ id: 1 });
+      expect(mockResourceUsageService.startSession).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'USER_NOT_FOUND' },
+          }),
+        }),
+      );
+    });
+
+    it('starts the session, clears the form draft and sends success', async () => {
+      const formSubmissions = [{ id: 99 }];
+      mockFormsHandler.ensureFormsSatisfied.mockResolvedValueOnce(formSubmissions);
+
+      await (handler as any).handleStartResourceUsageSession(mockSocket, eventData);
+
+      expect(mockResourceUsageService.startSession).toHaveBeenCalledWith(10, mockUser, {
+        projectId: 7,
+        formSubmissions,
+      });
+      expect(mockFormsHandler.clearFormDraft).toHaveBeenCalledWith(mockSocket, 10, ResourceFormAction.START);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { success: true },
+          }),
+        }),
+      );
+    });
+
+    describe('ResourceInUseError handling', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it('schedules a resource list refresh after 1000ms and sends no error message', async () => {
+        mockResourceUsageService.startSession.mockRejectedValueOnce(new ResourceInUseError());
+
+        await (handler as any).handleStartResourceUsageSession(mockSocket, eventData);
+
+        // No error message is sent to the socket and the draft is not cleared.
+        expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+        expect(mockFormsHandler.clearFormDraft).not.toHaveBeenCalled();
+        expect(mockResourceListService.sendResourceListToSocket).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(1000);
+        // Flush the microtask queue so the async setTimeout callback runs.
+        await Promise.resolve();
+
+        expect(mockResourceListService.sendResourceListToSocket).toHaveBeenCalledWith(mockSocket, {
+          resourceId: 10,
+        });
+      });
+    });
+
+    it('sends INSUFFICIENT_BALANCE with sumUpEnabled for InsufficientBalanceError', async () => {
+      mockResourceUsageService.startSession.mockRejectedValueOnce(new InsufficientBalanceError());
+      mockSumUpService.getIsEnabled.mockResolvedValueOnce(true);
+
+      await (handler as any).handleStartResourceUsageSession(mockSocket, eventData);
+
+      expect(mockSumUpService.getIsEnabled).toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'INSUFFICIENT_BALANCE', sumUpEnabled: true },
+          }),
+        }),
+      );
+    });
+
+    it('sends INSUFFICIENT_BALANCE for a plain error whose message is INSUFFICIENT_BALANCE', async () => {
+      mockResourceUsageService.startSession.mockRejectedValueOnce(new Error('INSUFFICIENT_BALANCE'));
+      mockSumUpService.getIsEnabled.mockResolvedValueOnce(false);
+
+      await (handler as any).handleStartResourceUsageSession(mockSocket, eventData);
+
+      expect(mockSumUpService.getIsEnabled).toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'INSUFFICIENT_BALANCE', sumUpEnabled: false },
+          }),
+        }),
+      );
+    });
+
+    it('sends the raw error message and logs for any other error', async () => {
+      mockResourceUsageService.startSession.mockRejectedValueOnce(new Error('boom'));
+
+      await (handler as any).handleStartResourceUsageSession(mockSocket, eventData);
+
+      expect(mockSumUpService.getIsEnabled).not.toHaveBeenCalled();
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to start resource usage session'),
+      );
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'boom' },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('handleStopResourceUsageSession', () => {
+    const eventData = { payload: { resourceId: 10 } } as AttractapEvent['data'];
+
+    it('returns early and does not end a session when the guard rejects the action', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValueOnce(false);
+
+      await (handler as any).handleStopResourceUsageSession(mockSocket, eventData);
+
+      expect(mockResourceActionGuard.validateResourceAction).toHaveBeenCalledWith(
+        mockSocket,
+        10,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      );
+      expect(mockFormsHandler.ensureFormsSatisfied).not.toHaveBeenCalled();
+      expect(mockResourceUsageService.endSession).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns early when forms are not satisfied (ensureFormsSatisfied returns null)', async () => {
+      mockFormsHandler.ensureFormsSatisfied.mockResolvedValueOnce(null);
+
+      await (handler as any).handleStopResourceUsageSession(mockSocket, eventData);
+
+      expect(mockFormsHandler.ensureFormsSatisfied).toHaveBeenCalledWith({
+        socket: mockSocket,
+        resourceId: 10,
+        action: ResourceFormAction.END,
+      });
+      expect(mockUsersService.findOne).not.toHaveBeenCalled();
+      expect(mockResourceUsageService.endSession).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('sends USER_NOT_FOUND when the authenticated user does not exist', async () => {
+      mockUsersService.findOne.mockResolvedValueOnce(null);
+
+      await (handler as any).handleStopResourceUsageSession(mockSocket, eventData);
+
+      expect(mockResourceUsageService.endSession).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.START_RESOURCE_USAGE_SESSION,
+            payload: { error: 'USER_NOT_FOUND' },
+          }),
+        }),
+      );
+    });
+
+    it('ends the session, clears the form draft and sends success', async () => {
+      const formSubmissions = [{ id: 5 }];
+      mockFormsHandler.ensureFormsSatisfied.mockResolvedValueOnce(formSubmissions);
+
+      await (handler as any).handleStopResourceUsageSession(mockSocket, eventData);
+
+      expect(mockResourceUsageService.endSession).toHaveBeenCalledWith(10, mockUser, { formSubmissions });
+      expect(mockFormsHandler.clearFormDraft).toHaveBeenCalledWith(mockSocket, 10, ResourceFormAction.END);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.STOP_RESOURCE_USAGE_SESSION,
+            payload: { success: true },
+          }),
+        }),
+      );
+    });
+
+    it('sends the error message and logs when ending the session fails', async () => {
+      mockResourceUsageService.endSession.mockRejectedValueOnce(new Error('stop failed'));
+
+      await (handler as any).handleStopResourceUsageSession(mockSocket, eventData);
+
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to stop resource usage session'),
+      );
+      expect(mockFormsHandler.clearFormDraft).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.STOP_RESOURCE_USAGE_SESSION,
+            payload: { error: 'stop failed' },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('handleTriggerFlowButton', () => {
+    const eventData = { payload: { resourceId: 10, buttonId: 'btn-1' } } as AttractapEvent['data'];
+
+    it('returns early and does not press the button when the guard rejects the action', async () => {
+      mockResourceActionGuard.validateResourceAction.mockResolvedValueOnce(false);
+
+      await (handler as any).handleTriggerFlowButton(mockSocket, eventData);
+
+      expect(mockResourceActionGuard.validateResourceAction).toHaveBeenCalledWith(
+        mockSocket,
+        10,
+        AttractapEventType.TRIGGER_FLOW_BUTTON,
+      );
+      expect(mockResourceFlowsExecutorService.pressButton).not.toHaveBeenCalled();
+      expect(mockSocket.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('presses the button and sends success', async () => {
+      await (handler as any).handleTriggerFlowButton(mockSocket, eventData);
+
+      expect(mockResourceFlowsExecutorService.pressButton).toHaveBeenCalledWith(10, 'btn-1', 1);
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.TRIGGER_FLOW_BUTTON,
+            payload: { success: true },
+          }),
+        }),
+      );
+    });
+
+    it('sends the error message and logs when pressing the button fails', async () => {
+      mockResourceFlowsExecutorService.pressButton.mockRejectedValueOnce(new Error('flow boom'));
+
+      await (handler as any).handleTriggerFlowButton(mockSocket, eventData);
+
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to trigger flow button'),
+      );
+      expect(mockSocket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.TRIGGER_FLOW_BUTTON,
+            payload: { error: 'flow boom' },
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/attractap/websockets/handlers/session.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/session.handler.ts
@@ -1,0 +1,260 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ResourceFormAction } from '@attraccess/database-entities';
+import { UsersService } from '../../../users-and-auth/users/users.service';
+import { ResourceUsageService } from '../../../resources/usage/resourceUsage.service';
+import { ResourceFlowsExecutorService } from '../../../resources/flows/resource-flows-executor.service';
+import { SumUpService } from '../../../billing/sumup.service';
+import { ResourceInUseError } from '../../../resources/usage/errors/resource-in-use.error';
+import { InsufficientBalanceError } from '../../../billing/errors/insufficient-balance.error';
+import { FlowExecutionError } from '../../../resources/flows/errors/flow-execution.error';
+import { ResourceActionGuard } from './resource-action.guard';
+import { ResourceListService } from './resource-list.service';
+import { AttractapFormsHandler } from './forms.handler';
+import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
+
+@Injectable()
+export class AttractapSessionHandler {
+  private readonly logger = new Logger(AttractapSessionHandler.name);
+
+  @Inject(UsersService)
+  private usersService: UsersService;
+
+  @Inject(ResourceUsageService)
+  private resourceUsageService: ResourceUsageService;
+
+  @Inject(ResourceFlowsExecutorService)
+  private resourceFlowsExecutorService: ResourceFlowsExecutorService;
+
+  @Inject(SumUpService)
+  private sumUpService: SumUpService;
+
+  @Inject(ResourceActionGuard)
+  private resourceActionGuard: ResourceActionGuard;
+
+  @Inject(ResourceListService)
+  private resourceListService: ResourceListService;
+
+  @Inject(AttractapFormsHandler)
+  private formsHandler: AttractapFormsHandler;
+
+  public async handleStartResourceUsageSession(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId, projectId } = data.payload as {
+      resourceId: number;
+      projectId?: number;
+    };
+
+    if (
+      !(await this.resourceActionGuard.validateResourceAction(
+        socket,
+        resourceId,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      ))
+    ) {
+      return;
+    }
+
+    const formSubmissions = await this.formsHandler.ensureFormsSatisfied({
+      socket,
+      resourceId,
+      action: ResourceFormAction.START,
+    });
+    if (formSubmissions === null) {
+      return;
+    }
+
+    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
+    if (!user) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
+      );
+      return;
+    }
+
+    try {
+      await this.resourceUsageService.startSession(resourceId, user, { projectId, formSubmissions });
+      this.formsHandler.clearFormDraft(socket, resourceId, ResourceFormAction.START);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { success: true }));
+    } catch (error) {
+      if (error instanceof ResourceInUseError) {
+        setTimeout(async () => {
+          await this.resourceListService.sendResourceListToSocket(socket, { resourceId });
+        }, 1000);
+        return;
+      }
+      if (error instanceof InsufficientBalanceError || error?.message === 'INSUFFICIENT_BALANCE') {
+        const sumUpEnabled = await this.sumUpService.getIsEnabled();
+        await socket.sendMessage(
+          new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, {
+            error: 'INSUFFICIENT_BALANCE',
+            sumUpEnabled,
+          }),
+        );
+        return;
+      }
+      this.logger.error(`Failed to start resource usage session: ${error.message}`);
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: error.message }),
+      );
+    }
+  }
+
+  public async handleStopResourceUsageSession(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId } = data.payload as {
+      resourceId: number;
+    };
+
+    if (
+      !(await this.resourceActionGuard.validateResourceAction(
+        socket,
+        resourceId,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      ))
+    ) {
+      return;
+    }
+
+    const formSubmissions = await this.formsHandler.ensureFormsSatisfied({
+      socket,
+      resourceId,
+      action: ResourceFormAction.END,
+    });
+    if (formSubmissions === null) {
+      return;
+    }
+
+    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
+    if (!user) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
+      );
+      return;
+    }
+
+    try {
+      await this.resourceUsageService.endSession(resourceId, user, { formSubmissions });
+      this.formsHandler.clearFormDraft(socket, resourceId, ResourceFormAction.END);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.STOP_RESOURCE_USAGE_SESSION, { success: true }));
+    } catch (error) {
+      this.logger.error(`Failed to stop resource usage session: ${error.message}`);
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.STOP_RESOURCE_USAGE_SESSION, { error: error.message }),
+      );
+    }
+  }
+
+  public async handleLockDoor(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId } = data.payload as { resourceId: number };
+
+    if (
+      !(await this.resourceActionGuard.validateResourceAction(
+        socket,
+        resourceId,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      ))
+    ) {
+      return;
+    }
+
+    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
+    if (!user) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
+      );
+      return;
+    }
+
+    try {
+      await this.resourceUsageService.lockDoor(resourceId, user);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.LOCK_DOOR, { success: true }));
+    } catch (error) {
+      const errorMessage = this.extractUserFacingError(error);
+      this.logger.error(`Failed to lock door: ${errorMessage}`);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.LOCK_DOOR, { error: errorMessage }));
+    }
+  }
+
+  public async handleUnlockDoor(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId } = data.payload as { resourceId: number };
+
+    if (
+      !(await this.resourceActionGuard.validateResourceAction(
+        socket,
+        resourceId,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      ))
+    ) {
+      return;
+    }
+
+    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
+    if (!user) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
+      );
+      return;
+    }
+
+    try {
+      await this.resourceUsageService.unlockDoor(resourceId, user);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.UNLOCK_DOOR, { success: true }));
+    } catch (error) {
+      const errorMessage = this.extractUserFacingError(error);
+      this.logger.error(`Failed to unlock door: ${errorMessage}`);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.UNLOCK_DOOR, { error: errorMessage }));
+    }
+  }
+
+  public async handleUnlatchDoor(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId } = data.payload as { resourceId: number };
+
+    if (
+      !(await this.resourceActionGuard.validateResourceAction(
+        socket,
+        resourceId,
+        AttractapEventType.START_RESOURCE_USAGE_SESSION,
+      ))
+    ) {
+      return;
+    }
+
+    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
+    if (!user) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
+      );
+      return;
+    }
+
+    try {
+      await this.resourceUsageService.unlatchDoor(resourceId, user);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.UNLATCH_DOOR, { success: true }));
+    } catch (error) {
+      const errorMessage = this.extractUserFacingError(error);
+      this.logger.error(`Failed to unlatch door: ${errorMessage}`);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.UNLATCH_DOOR, { error: errorMessage }));
+    }
+  }
+
+  public async handleTriggerFlowButton(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    const { resourceId, buttonId } = data.payload as { resourceId: number; buttonId: string };
+
+    if (!(await this.resourceActionGuard.validateResourceAction(socket, resourceId, AttractapEventType.TRIGGER_FLOW_BUTTON))) {
+      return;
+    }
+
+    try {
+      await this.resourceFlowsExecutorService.pressButton(resourceId, buttonId, socket.state.lastAuthenticatedUserId);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.TRIGGER_FLOW_BUTTON, { success: true }));
+    } catch (error) {
+      this.logger.error(`Failed to trigger flow button: ${error.message}`);
+      await socket.sendMessage(new AttractapEvent(AttractapEventType.TRIGGER_FLOW_BUTTON, { error: error.message }));
+    }
+  }
+
+  private extractUserFacingError(error: unknown): string {
+    if (error instanceof FlowExecutionError) {
+      return error.message.replace(/^FLOW_EXECUTION_ERROR:\s*/, '');
+    }
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/apps/api/src/attractap/websockets/websocket-gateway-door-error.spec.ts
+++ b/apps/api/src/attractap/websockets/websocket-gateway-door-error.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { AttractapGateway } from './websocket.gateway';
+import { AttractapSessionHandler } from './handlers/session.handler';
+import { ResourceActionGuard } from './handlers/resource-action.guard';
 import { AttractapEventType, AttractapEvent } from './websocket.types';
 import { FlowExecutionError } from '../../resources/flows/errors/flow-execution.error';
 import { BadRequestException } from '@nestjs/common';
 
-describe('AttractapGateway – door action error propagation', () => {
-  let gateway: AttractapGateway;
+describe('AttractapSessionHandler – door action error propagation', () => {
+  let handler: AttractapSessionHandler;
   let mockSocket: {
     readerId: number;
     state: { lastAuthenticatedUserId: number; readerId: number };
@@ -23,8 +24,8 @@ describe('AttractapGateway – door action error propagation', () => {
   const mockReader = { id: 42, resources: [{ id: 10 }] };
 
   beforeEach(() => {
-    gateway = Object.create(AttractapGateway.prototype);
-    (gateway as any).logger = {
+    handler = Object.create(AttractapSessionHandler.prototype);
+    (handler as any).logger = {
       log: jest.fn(),
       error: jest.fn(),
       warn: jest.fn(),
@@ -52,16 +53,23 @@ describe('AttractapGateway – door action error propagation', () => {
       getResourcesForReader: jest.fn().mockResolvedValue([{ id: 10 }]),
     };
 
-    (gateway as any).resourceUsageService = mockResourceUsageService;
-    (gateway as any).usersService = mockUsersService;
-    (gateway as any).attractapService = mockAttractapService;
+    // ResourceActionGuard runs the real validation logic against the mocks so the
+    // door handlers proceed exactly as they did when validateResourceAction lived
+    // on the gateway.
+    const guard: ResourceActionGuard = Object.create(ResourceActionGuard.prototype);
+    (guard as any).attractapService = mockAttractapService;
+    (guard as any).usersService = mockUsersService;
+
+    (handler as any).resourceUsageService = mockResourceUsageService;
+    (handler as any).usersService = mockUsersService;
+    (handler as any).resourceActionGuard = guard;
   });
 
   describe('handleLockDoor', () => {
     const eventData = { payload: { resourceId: 10 } } as AttractapEvent['data'];
 
     it('should send success on successful lock', async () => {
-      await (gateway as any).handleLockDoor(mockSocket, eventData);
+      await (handler as any).handleLockDoor(mockSocket, eventData);
 
       expect(mockResourceUsageService.lockDoor).toHaveBeenCalledWith(10, mockUser);
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
@@ -79,7 +87,7 @@ describe('AttractapGateway – door action error propagation', () => {
         new FlowExecutionError('Access denied for this user'),
       );
 
-      await (gateway as any).handleLockDoor(mockSocket, eventData);
+      await (handler as any).handleLockDoor(mockSocket, eventData);
 
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -96,7 +104,7 @@ describe('AttractapGateway – door action error propagation', () => {
         new BadRequestException('Resource is not a door'),
       );
 
-      await (gateway as any).handleLockDoor(mockSocket, eventData);
+      await (handler as any).handleLockDoor(mockSocket, eventData);
 
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -113,9 +121,9 @@ describe('AttractapGateway – door action error propagation', () => {
         new FlowExecutionError('Some error'),
       );
 
-      await (gateway as any).handleLockDoor(mockSocket, eventData);
+      await (handler as any).handleLockDoor(mockSocket, eventData);
 
-      expect((gateway as any).logger.error).toHaveBeenCalledWith(
+      expect((handler as any).logger.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to lock door'),
       );
     });
@@ -125,9 +133,9 @@ describe('AttractapGateway – door action error propagation', () => {
         new FlowExecutionError('Custom flow error'),
       );
 
-      await (gateway as any).handleLockDoor(mockSocket, eventData);
+      await (handler as any).handleLockDoor(mockSocket, eventData);
 
-      const logCall = (gateway as any).logger.error.mock.calls[0][0] as string;
+      const logCall = (handler as any).logger.error.mock.calls[0][0] as string;
       expect(logCall).not.toContain('FLOW_EXECUTION_ERROR');
       expect(logCall).toContain('Custom flow error');
     });
@@ -137,7 +145,7 @@ describe('AttractapGateway – door action error propagation', () => {
     const eventData = { payload: { resourceId: 10 } } as AttractapEvent['data'];
 
     it('should send success on successful unlock', async () => {
-      await (gateway as any).handleUnlockDoor(mockSocket, eventData);
+      await (handler as any).handleUnlockDoor(mockSocket, eventData);
 
       expect(mockResourceUsageService.unlockDoor).toHaveBeenCalledWith(10, mockUser);
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
@@ -155,7 +163,7 @@ describe('AttractapGateway – door action error propagation', () => {
         new FlowExecutionError('Unlock not permitted'),
       );
 
-      await (gateway as any).handleUnlockDoor(mockSocket, eventData);
+      await (handler as any).handleUnlockDoor(mockSocket, eventData);
 
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -170,7 +178,7 @@ describe('AttractapGateway – door action error propagation', () => {
     it('should send raw error message for non-FlowExecutionError', async () => {
       mockResourceUsageService.unlockDoor.mockRejectedValueOnce(new Error('DB timeout'));
 
-      await (gateway as any).handleUnlockDoor(mockSocket, eventData);
+      await (handler as any).handleUnlockDoor(mockSocket, eventData);
 
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -187,9 +195,9 @@ describe('AttractapGateway – door action error propagation', () => {
         new FlowExecutionError('Unlock denied'),
       );
 
-      await (gateway as any).handleUnlockDoor(mockSocket, eventData);
+      await (handler as any).handleUnlockDoor(mockSocket, eventData);
 
-      const logCall = (gateway as any).logger.error.mock.calls[0][0] as string;
+      const logCall = (handler as any).logger.error.mock.calls[0][0] as string;
       expect(logCall).toContain('Unlock denied');
       expect(logCall).not.toContain('FLOW_EXECUTION_ERROR');
     });
@@ -199,7 +207,7 @@ describe('AttractapGateway – door action error propagation', () => {
     const eventData = { payload: { resourceId: 10 } } as AttractapEvent['data'];
 
     it('should send success on successful unlatch', async () => {
-      await (gateway as any).handleUnlatchDoor(mockSocket, eventData);
+      await (handler as any).handleUnlatchDoor(mockSocket, eventData);
 
       expect(mockResourceUsageService.unlatchDoor).toHaveBeenCalledWith(10, mockUser);
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
@@ -217,7 +225,7 @@ describe('AttractapGateway – door action error propagation', () => {
         new FlowExecutionError('Unlatch blocked by flow'),
       );
 
-      await (gateway as any).handleUnlatchDoor(mockSocket, eventData);
+      await (handler as any).handleUnlatchDoor(mockSocket, eventData);
 
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -234,7 +242,7 @@ describe('AttractapGateway – door action error propagation', () => {
         new BadRequestException('Door does not support unlatching'),
       );
 
-      await (gateway as any).handleUnlatchDoor(mockSocket, eventData);
+      await (handler as any).handleUnlatchDoor(mockSocket, eventData);
 
       expect(mockSocket.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -250,35 +258,35 @@ describe('AttractapGateway – door action error propagation', () => {
   describe('extractUserFacingError', () => {
     it('should strip FLOW_EXECUTION_ERROR prefix from FlowExecutionError', () => {
       const error = new FlowExecutionError('User not allowed');
-      const result = (gateway as any).extractUserFacingError(error);
+      const result = (handler as any).extractUserFacingError(error);
       expect(result).toBe('User not allowed');
     });
 
     it('should return raw message for regular Error', () => {
       const error = new Error('Something went wrong');
-      const result = (gateway as any).extractUserFacingError(error);
+      const result = (handler as any).extractUserFacingError(error);
       expect(result).toBe('Something went wrong');
     });
 
     it('should return raw message for BadRequestException', () => {
       const error = new BadRequestException('Resource is not a door');
-      const result = (gateway as any).extractUserFacingError(error);
+      const result = (handler as any).extractUserFacingError(error);
       expect(result).toBe('Resource is not a door');
     });
 
     it('should stringify non-Error values', () => {
-      const result = (gateway as any).extractUserFacingError('string error');
+      const result = (handler as any).extractUserFacingError('string error');
       expect(result).toBe('string error');
     });
 
     it('should stringify non-Error object values', () => {
-      const result = (gateway as any).extractUserFacingError(42);
+      const result = (handler as any).extractUserFacingError(42);
       expect(result).toBe('42');
     });
 
     it('should handle FlowExecutionError with empty message', () => {
       const error = new FlowExecutionError('');
-      const result = (gateway as any).extractUserFacingError(error);
+      const result = (handler as any).extractUserFacingError(error);
       expect(result).toBe('');
     });
   });

--- a/apps/api/src/attractap/websockets/websocket.gateway.spec.ts
+++ b/apps/api/src/attractap/websockets/websocket.gateway.spec.ts
@@ -18,6 +18,16 @@ import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from './we
 import { MetricsService } from '../../metrics/metrics.service';
 import { MetricsToggleService } from '../../metrics/settings/metrics-toggle.service';
 import { WS_METRICS } from '../../metrics/definitions/tokens';
+import { ResourceListService } from './handlers/resource-list.service';
+import { ResourceActionGuard } from './handlers/resource-action.guard';
+import { AttractapAuthHandler } from './handlers/auth.handler';
+import { AttractapFirmwareHandler } from './handlers/firmware.handler';
+import { AttractapCrashReportHandler } from './handlers/crash-report.handler';
+import { AttractapCardHandler } from './handlers/card.handler';
+import { AttractapFormsHandler } from './handlers/forms.handler';
+import { AttractapSessionHandler } from './handlers/session.handler';
+import { AttractapBillingHandler } from './handlers/billing.handler';
+import { AttractapProjectsHandler } from './handlers/projects.handler';
 
 const mockMetricsService = {
   attractapDevicesConnected: { inc: jest.fn(), dec: jest.fn(), set: jest.fn() },
@@ -87,6 +97,16 @@ describe('AttractapGateway', () => {
         { provide: MetricsService, useValue: mockMetricsService },
         { provide: WS_METRICS, useValue: mockWsMetrics },
         { provide: MetricsToggleService, useValue: mockMetricsToggle },
+        ResourceListService,
+        ResourceActionGuard,
+        AttractapAuthHandler,
+        AttractapFirmwareHandler,
+        AttractapCrashReportHandler,
+        AttractapCardHandler,
+        AttractapFormsHandler,
+        AttractapSessionHandler,
+        AttractapBillingHandler,
+        AttractapProjectsHandler,
       ],
     }).compile();
 

--- a/apps/api/src/attractap/websockets/websocket.gateway.ts
+++ b/apps/api/src/attractap/websockets/websocket.gateway.ts
@@ -8,8 +8,7 @@ import {
   ConnectedSocket,
 } from '@nestjs/websockets';
 import { Server } from 'ws';
-import { existsSync, statSync, openSync, readSync, closeSync } from 'fs';
-import { join } from 'path';
+import { closeSync } from 'fs';
 import { Inject, Logger, UseInterceptors } from '@nestjs/common';
 import { WebsocketService } from './websocket.service';
 import {
@@ -17,43 +16,25 @@ import {
   AttractapEvent,
   AttractapMessage,
   AttractapEventType,
-  ReaderCrashReportPayload,
 } from './websocket.types';
 import { AttractapService } from '../attractap.service';
 import { randomBytes } from 'crypto';
-import { UsersService } from '../../users-and-auth/users/users.service';
-import { AttractapFirmwareService } from '../firmware.service';
-import { SumUpService } from '../../billing/sumup.service';
 import { Mutex } from 'async-mutex';
 import { LicenseModuleType, LicenseService } from '../../license/license.service';
-import { AttractapFirmware } from '../dtos/firmware.dto';
-import { verifyToken } from './websocket.utils';
-import { ResourceUsageService } from '../../resources/usage/resourceUsage.service';
-import { ResourceMaintenanceService } from '../../resources/maintenances/maintenance.service';
-import { ResourceIntroductionsService } from '../../resources/introductions/resouceIntroductions.service';
-import { ResourceIntroducersService } from '../../resources/introducers/resourceIntroducers.service';
-import { ResourceFlowsService } from '../../resources/flows/resource-flows.service';
-import { ResourceFlowsExecutorService } from '../../resources/flows/resource-flows-executor.service';
-import { ResourceInUseError } from '../../resources/usage/errors/resource-in-use.error';
-import { InsufficientBalanceError } from '../../billing/errors/insufficient-balance.error';
-import { FlowExecutionError } from '../../resources/flows/errors/flow-execution.error';
-import { ResourceFlowNodeType, ResourceFormAction } from '@attraccess/database-entities';
-import { ProjectsService } from '../../projects/projects.service';
-import { ResourceFormsService } from '../../resources/forms/forms.service';
-import { FormSubmissionRequestDto } from '../../resources/forms/dto/form-submission-request.dto';
-import {
-  ResourceUsageFormRequestPayload,
-  ResourceUsageFormGetFieldsPayload,
-  ResourceUsageFormFieldsPayload,
-  ResourceUsageFormSubmitPagePayload,
-  ResourceUsageFormPageResultPayload,
-  FormFieldAnswerValue,
-} from './websocket.types';
 import { MetricsService } from '../../metrics/metrics.service';
 import { MetricsToggleService } from '../../metrics/settings/metrics-toggle.service';
 import { WS_METRICS } from '../../metrics/definitions/tokens';
 import { ATTRACTAP_GATEWAY_LABEL, WsMetrics } from '../../metrics/definitions/ws.metrics';
 import { WsMetricsInterceptor } from '../../metrics/instrumentation/ws/ws.interceptor';
+import { ResourceListService } from './handlers/resource-list.service';
+import { AttractapAuthHandler } from './handlers/auth.handler';
+import { AttractapFirmwareHandler } from './handlers/firmware.handler';
+import { AttractapCrashReportHandler } from './handlers/crash-report.handler';
+import { AttractapCardHandler } from './handlers/card.handler';
+import { AttractapFormsHandler } from './handlers/forms.handler';
+import { AttractapSessionHandler } from './handlers/session.handler';
+import { AttractapBillingHandler } from './handlers/billing.handler';
+import { AttractapProjectsHandler } from './handlers/projects.handler';
 
 @WebSocketGateway({ path: '/api/attractap/websocket' })
 @UseInterceptors(WsMetricsInterceptor)
@@ -70,41 +51,8 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
   @Inject(AttractapService)
   private attractapService: AttractapService;
 
-  @Inject(UsersService)
-  private usersService: UsersService;
-
-  @Inject(AttractapFirmwareService)
-  private firmwareService: AttractapFirmwareService;
-
   @Inject(LicenseService)
   private licenseService: LicenseService;
-
-  @Inject(ResourceUsageService)
-  private resourceUsageService: ResourceUsageService;
-
-  @Inject(ResourceMaintenanceService)
-  private resourceMaintenanceService: ResourceMaintenanceService;
-
-  @Inject(ResourceIntroductionsService)
-  private resourceIntroductionService: ResourceIntroductionsService;
-
-  @Inject(ResourceIntroducersService)
-  private resourceIntroducersService: ResourceIntroducersService;
-
-  @Inject(ResourceFlowsService)
-  private resourceFlowsService: ResourceFlowsService;
-
-  @Inject(ResourceFlowsExecutorService)
-  private resourceFlowsExecutorService: ResourceFlowsExecutorService;
-
-  @Inject(SumUpService)
-  private sumUpService: SumUpService;
-
-  @Inject(ProjectsService)
-  private projectsService: ProjectsService;
-
-  @Inject(ResourceFormsService)
-  private resourceFormsService: ResourceFormsService;
 
   @Inject(MetricsService)
   private metricsService: MetricsService;
@@ -114,6 +62,33 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
 
   @Inject(MetricsToggleService)
   private metricsToggle: MetricsToggleService;
+
+  @Inject(ResourceListService)
+  private resourceListService: ResourceListService;
+
+  @Inject(AttractapAuthHandler)
+  private authHandler: AttractapAuthHandler;
+
+  @Inject(AttractapFirmwareHandler)
+  private firmwareHandler: AttractapFirmwareHandler;
+
+  @Inject(AttractapCrashReportHandler)
+  private crashReportHandler: AttractapCrashReportHandler;
+
+  @Inject(AttractapCardHandler)
+  private cardHandler: AttractapCardHandler;
+
+  @Inject(AttractapFormsHandler)
+  private formsHandler: AttractapFormsHandler;
+
+  @Inject(AttractapSessionHandler)
+  private sessionHandler: AttractapSessionHandler;
+
+  @Inject(AttractapBillingHandler)
+  private billingHandler: AttractapBillingHandler;
+
+  @Inject(AttractapProjectsHandler)
+  private projectsHandler: AttractapProjectsHandler;
 
   private readonly connectedAt = new WeakMap<object, bigint>();
 
@@ -412,62 +387,62 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     switch (eventData.type) {
       case AttractapEventType.READER_REGISTER:
-        await this.handleReaderRegister(socket, eventData);
+        await this.authHandler.handleReaderRegister(socket, eventData);
         break;
       case AttractapEventType.READER_AUTHENTICATE:
-        await this.handleAuthentication(socket, eventData);
+        await this.authHandler.handleAuthentication(socket, eventData);
         break;
       case AttractapEventType.READER_FIRMWARE_INFO:
-        await this.handleFirmwareInfo(socket, eventData);
+        await this.firmwareHandler.handleFirmwareInfo(socket, eventData);
         break;
       case AttractapEventType.READER_CRASH_REPORT:
-        await this.handleCrashReport(socket, eventData);
+        await this.crashReportHandler.handleCrashReport(socket, eventData);
         break;
       case AttractapEventType.REQUEST_CARD_AUTHENTICATION_DATA:
-        await this.handleCardAuthenticationRequest(socket, eventData);
+        await this.cardHandler.handleCardAuthenticationRequest(socket, eventData);
         break;
       case AttractapEventType.START_RESOURCE_USAGE_SESSION:
-        await this.handleStartResourceUsageSession(socket, eventData);
+        await this.sessionHandler.handleStartResourceUsageSession(socket, eventData);
         break;
       case AttractapEventType.STOP_RESOURCE_USAGE_SESSION:
-        await this.handleStopResourceUsageSession(socket, eventData);
+        await this.sessionHandler.handleStopResourceUsageSession(socket, eventData);
         break;
       case AttractapEventType.LOCK_DOOR:
-        await this.handleLockDoor(socket, eventData);
+        await this.sessionHandler.handleLockDoor(socket, eventData);
         break;
       case AttractapEventType.UNLOCK_DOOR:
-        await this.handleUnlockDoor(socket, eventData);
+        await this.sessionHandler.handleUnlockDoor(socket, eventData);
         break;
       case AttractapEventType.UNLATCH_DOOR:
-        await this.handleUnlatchDoor(socket, eventData);
+        await this.sessionHandler.handleUnlatchDoor(socket, eventData);
         break;
       case AttractapEventType.TRIGGER_FLOW_BUTTON:
-        await this.handleTriggerFlowButton(socket, eventData);
+        await this.sessionHandler.handleTriggerFlowButton(socket, eventData);
         break;
       case AttractapEventType.BILLING_REQUEST_TOPUP:
-        await this.handleBillingRequestTopup(socket, eventData);
+        await this.billingHandler.handleBillingRequestTopup(socket, eventData);
         break;
       case AttractapEventType.FIRMWARE_REQUEST_CHUNK:
-        await this.handleFirmwareChunkRequest(socket, eventData);
+        await this.firmwareHandler.handleFirmwareChunkRequest(socket, eventData);
         break;
       case AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY:
-        await this.onEnrollNewCardRequestNFCKey(socket, eventData);
+        await this.cardHandler.onEnrollNewCardRequestNFCKey(socket, eventData);
         break;
 
       case AttractapEventType.ENROLL_NEW_CARD:
-        await this.onEnrollNewCard(socket, eventData);
+        await this.cardHandler.onEnrollNewCard(socket, eventData);
         break;
 
       case AttractapEventType.PROJECTS_OF_USER:
-        await this.handleProjectsOfUserRequest(socket, eventData);
+        await this.projectsHandler.handleProjectsOfUserRequest(socket, eventData);
         break;
 
       case AttractapEventType.RESOURCE_USAGE_FORM_GET_FIELDS:
-        await this.handleResourceUsageFormGetFields(socket, eventData);
+        await this.formsHandler.handleResourceUsageFormGetFields(socket, eventData);
         break;
 
       case AttractapEventType.RESOURCE_USAGE_FORM_SUBMIT_PAGE:
-        await this.handleResourceUsageFormSubmitPage(socket, eventData);
+        await this.formsHandler.handleResourceUsageFormSubmitPage(socket, eventData);
         break;
 
       case AttractapEventType.READER_FIRMWARE_UPDATE_REQUIRED:
@@ -493,277 +468,12 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
     }
   }
 
-  private async handleFirmwareChunkRequest(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    try {
-      if (!socket.state.ota || !socket.state.ota.path || !socket.state.ota.size) {
-        this.logger.error(`FIRMWARE_REQUEST_CHUNK received but no OTA context set for client ${socket.id}`);
-        return;
-      }
-
-      const { offset, length } = data.payload;
-      const total = socket.state.ota.size;
-      if (typeof offset !== 'number' || typeof length !== 'number' || offset < 0 || length <= 0 || offset >= total) {
-        this.logger.error(`Invalid chunk request from client ${socket.id}: offset=${offset} length=${length}`);
-        return;
-      }
-
-      const maxChunk = 4096; // hard cap chunk size
-      const safeLen = Math.min(length, maxChunk, total - offset);
-
-      // Lazily open file descriptor
-      if (!socket.state.ota.fd) {
-        try {
-          socket.state.ota.fd = openSync(socket.state.ota.path, 'r');
-        } catch (e) {
-          this.logger.error(`Failed to open firmware for client ${socket.id}: ${(e as Error).message}`);
-          return;
-        }
-      }
-
-      const fd = socket.state.ota.fd as number;
-      const buffer = Buffer.allocUnsafe(safeLen);
-      let bytesRead = 0;
-      try {
-        bytesRead = readSync(fd, buffer, 0, safeLen, offset);
-      } catch (e) {
-        this.logger.error(`Failed to read firmware chunk for client ${socket.id}: ${(e as Error).message}`);
-        return;
-      }
-
-      if (bytesRead > 0) {
-        socket.sendBinaryData(buffer.subarray(0, bytesRead));
-        const progressPct = Math.round(((offset + bytesRead) / total) * 100);
-        const pctBucket = Math.floor(progressPct / 10) * 10;
-        const lastLogged = socket.state.ota.lastLoggedPct ?? -1;
-        if (pctBucket > lastLogged) {
-          socket.state.ota.lastLoggedPct = pctBucket;
-          this.logger.log(
-            `Attractap firmware update progress: ${pctBucket}% (reader ${socket.readerId ?? 'unknown'})`,
-          );
-        }
-      }
-    } catch (err) {
-      this.logger.error(`handleFirmwareChunkRequest error: ${(err as Error).message}`);
-    }
-  }
-
-  private async handleFirmwareInfo(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    await this.attractapService.updateReaderFirmware(socket.readerId, data.payload);
-
-    const firmwareIsUpToDate = await this.isFirmwareLatest(data.payload);
-    if (!firmwareIsUpToDate) {
-      this.logger.debug('Firmware is not up to date, notifying client to start OTA');
-
-      try {
-        const current = data.payload as AttractapFirmware;
-        const latest = await this.firmwareService.getFirmwareDefinition(current.name, current.variant);
-        if (!latest) {
-          this.logger.warn(
-            `No firmware definition found for ${current.name}/${current.variant}; treating as up-to-date for now.`,
-          );
-          return;
-        }
-
-        const assetsDir = join(__dirname, 'assets', 'attractap-firmwares');
-        const otaFilename = latest.filenameOTA || latest.filename;
-        const firmwarePath = join(assetsDir, otaFilename);
-        if (!existsSync(firmwarePath)) {
-          this.logger.error(`OTA firmware binary not found at ${firmwarePath}`);
-          return;
-        }
-        const size = statSync(firmwarePath).size;
-        if (!size || size < 1024) {
-          this.logger.error(`OTA firmware size is suspicious (${size} bytes) for ${otaFilename}`);
-          return;
-        }
-
-        // Store OTA context for this socket
-        socket.state.ota = { path: firmwarePath, size } as AuthenticatedWebSocket['state']['ota'];
-
-        await socket.sendMessage(
-          new AttractapEvent(AttractapEventType.READER_FIRMWARE_UPDATE_REQUIRED, {
-            available: {
-              name: latest.name,
-              variant: latest.variant,
-              version: String(latest.version),
-              totalSize: size,
-            },
-          }),
-        );
-        this.metricsService.attractapFirmwareUpdatesTotal.inc();
-      } catch (err) {
-        this.logger.error(`Failed to prepare firmware update notice: ${(err as Error).message}`);
-      }
-      return;
-    }
-  }
-
-  private async handleCrashReport(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const payload = data.payload as ReaderCrashReportPayload;
-
-    if (!payload?.resetReason || typeof payload.resetReason !== 'string') {
-      this.logger.error(`READER_CRASH_REPORT from reader ${socket.readerId} missing resetReason; ignoring.`);
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.READER_CRASH_REPORT, { error: 'INVALID_CRASH_REPORT' }),
-      );
-      return;
-    }
-
-    try {
-      const report = await this.attractapService.createCrashReport(socket.readerId, payload);
-      this.logger.warn(
-        `Stored crash report ${report.id} for reader ${socket.readerId}: reason=${report.resetReason} ` +
-          `heapFree=${report.heapFreeBytes ?? 'n/a'} largestBlock=${report.largestFreeBlockBytes ?? 'n/a'} ` +
-          `uptimeMs=${report.uptimeBeforeResetMs ?? 'n/a'} ws=${report.wsState ?? 'n/a'} wifi=${report.wifiState ?? 'n/a'}`,
-      );
-      this.metricsService.attractapCrashReportsTotal.inc();
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.READER_CRASH_REPORT, { received: true, id: report.id }),
-      );
-    } catch (error) {
-      this.logger.error(`Failed to store crash report for reader ${socket.readerId}: ${(error as Error).message}`);
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.READER_CRASH_REPORT, { error: 'CRASH_REPORT_STORE_FAILED' }),
-      );
-    }
-  }
-
-  private async isFirmwareLatest(firmware: AttractapFirmware): Promise<boolean> {
-    const firmwareDefinition = await this.firmwareService.getFirmwareDefinition(firmware.name, firmware.variant);
-
-    if (!firmwareDefinition) {
-      return true;
-    }
-
-    return String(firmwareDefinition.version) === String(firmware.version);
-  }
-
-  private async handleReaderRegister(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    this.logger.debug('Received REGISTER event');
-    const response = await this.attractapService.createNewReader(data.payload.firmware);
-
-    this.logger.debug(
-      `Sending REGISTER response to client. Reader ID: ${response.reader.id}, Token: ${response.token}`,
-    );
-
-    await socket.sendMessage(
-      new AttractapEvent(AttractapEventType.READER_REGISTER, {
-        id: response.reader.id,
-        token: response.token,
-      }),
-    );
-  }
-
-  private async handleAuthentication(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    this.logger.debug('processing READER_AUTHENTICATE event', data);
-
-    const unauthorizedResponse = new AttractapEvent(AttractapEventType.READER_UNAUTHORIZED, {
-      message: 'PLEASE_REREGISTER',
-    });
-
-    this.logger.debug('Checking if reader exists');
-    const reader = await this.attractapService.findReaderById(data.payload.id);
-    if (!reader) {
-      this.logger.error('No reader-config found for socket, sending UNAUTHORIZED response to client');
-      return await socket.sendMessage(unauthorizedResponse);
-    }
-
-    this.logger.debug('Checking if token is valid');
-    const isValidToken = await verifyToken(data.payload.token, reader.apiTokenHash);
-    if (!isValidToken) {
-      this.logger.error('Invalid token, sending UNAUTHORIZED response to client');
-      return await socket.sendMessage(unauthorizedResponse);
-    }
-
-    socket.readerId = reader.id;
-
-    const authenticatedResponse = new AttractapEvent(AttractapEventType.READER_AUTHENTICATED, {
-      name: reader.name,
-    });
-    await socket.sendMessage(authenticatedResponse);
-
-    await this.sendResourceListToSocket(socket);
-  }
-
   public async sendResourceList(readerId: number) {
-    const sockets = Array.from(this.websocketService.sockets.values()).filter((socket) => socket.readerId === readerId);
-    if (sockets.length === 0) {
-      return;
-    }
-
-    await Promise.all(sockets.map((socket) => this.sendResourceListToSocket(socket)));
+    return this.resourceListService.sendResourceList(readerId);
   }
 
   public async sendResourceListToReadersWithResource(resourceId: number) {
-    const allSockets = Array.from(this.websocketService.sockets.values());
-    await Promise.all(allSockets.map((socket) => this.sendResourceListToSocket(socket, { resourceId })));
-  }
-
-  private async sendResourceListToSocket(
-    socket: AuthenticatedWebSocket,
-    onlyIfResourceMatches?: { resourceId?: number },
-  ) {
-    const reader = await this.attractapService.findReaderById(socket.readerId);
-    if (!reader) {
-      throw new Error(`Reader not found: ${socket.readerId}`);
-    }
-
-    const resources = reader.resources;
-
-    if (onlyIfResourceMatches?.resourceId) {
-      if (!resources.some((resource) => resource.id === onlyIfResourceMatches.resourceId)) {
-        return;
-      }
-    }
-
-    const resourcesWithUsageSession = await Promise.all(
-      resources.map(async (resource) => ({
-        ...resource,
-        activeUsageSession: await this.resourceUsageService.getActiveSession(resource.id, true),
-        isUnderMaintenance: await this.resourceMaintenanceService.hasActiveMaintenance(resource.id),
-      })),
-    );
-
-    const getFlowButtons = async (resourceId: number) => {
-      const nodes = await this.resourceFlowsService.getNodes(resourceId, ResourceFlowNodeType.INPUT_BUTTON);
-      return nodes.map((node) => ({
-        id: node.id,
-        label: node.data.label || node.id,
-      }));
-    };
-
-    const resourcesWithFlowButtons = await Promise.all(
-      resourcesWithUsageSession.map(async (resource) => ({
-        ...resource,
-        flowButtons: await getFlowButtons(resource.id),
-      })),
-    );
-
-    const resourceListResponse = new AttractapEvent(AttractapEventType.RESOURCE_LIST, {
-      readerName: reader.name,
-      ledBrightness: reader.ledBrightness,
-      resources: resourcesWithFlowButtons.map((resource) => ({
-        id: resource.id,
-        name: resource.name,
-        type: resource.type,
-        separateUnlockAndUnlatch: resource.separateUnlockAndUnlatch,
-        description: resource.description,
-        allowTakeOver: resource.allowTakeOver,
-        introducers: resource.introducers.map((introducer) => introducer.user.username),
-        isUnderMaintenance: resource.isUnderMaintenance,
-        activeUsageSession: resource.activeUsageSession
-          ? {
-            user: {
-              username: resource.activeUsageSession.user.username,
-            },
-            startTime: resource.activeUsageSession.startTime.toISOString(),
-          }
-          : null,
-        flowButtons: resource.flowButtons,
-      })),
-    });
-    this.logger.debug(`Sending resource list to socket ${socket.id}`, resourceListResponse);
-    await socket.sendMessage(resourceListResponse);
+    return this.resourceListService.sendResourceListToReadersWithResource(resourceId);
   }
 
   public async disconnectReader(readerId: number) {
@@ -776,637 +486,10 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
   }
 
   public async startEnrollOfNewNfcCard(data: { readerId: number; userId: number }) {
-    const reader = await this.attractapService.findReaderById(data.readerId);
-
-    if (!reader) {
-      throw new Error(`Reader not found: ${data.readerId}`);
-    }
-
-    if (!reader.firmware.capabilities.cardEnrollment) {
-      throw new Error(`Reader does not support card enrollment: ${data.readerId}`);
-    }
-
-    const user = await this.usersService.findOne({ id: data.userId });
-
-    if (!user) {
-      throw new Error(`User not found: ${data.userId}`);
-    }
-
-    const sockets = Array.from(this.websocketService.sockets.values()).filter(
-      (socket) => socket.readerId === data.readerId,
-    );
-
-    if (sockets.length === 0) {
-      throw new Error(`Reader not connected: ${data.readerId}`);
-    }
-
-    // Send to all active sockets for this reader to avoid targeting a stale/disconnecting socket
-    const tasks = sockets.map(async (socket) => {
-      socket.state.lastAuthenticatedUserId = user.id;
-      try {
-        await socket.sendMessage(
-          new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO, {
-            username: user.username,
-          }),
-        );
-      } catch (error) {
-        // Log and continue; other sockets may still deliver the event
-        this.logger.debug(
-          `Failed to send ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO to client ${socket.id}: ${String(error)}`,
-        );
-      }
-    });
-
-    await Promise.allSettled(tasks);
-  }
-
-  private async onEnrollNewCardRequestNFCKey(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { uid, keyNo } = data.payload as { uid: string; keyNo: number };
-
-    if (!socket.state.lastAuthenticatedUserId) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY, { error: 'USER_NOT_SET' }),
-      );
-      return;
-    }
-
-    if (!uid || typeof uid !== 'string' || !keyNo || typeof keyNo !== 'number') {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY, { error: 'INVALID_PARAMS' }),
-      );
-      return;
-    }
-
-    const existingCard = await this.attractapService.getNFCCardByUID(uid);
-    if (existingCard) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD_REQUEST_NFC_KEY, { error: 'CARD_ALREADY_ENROLLED' }),
-      );
-      return;
-    }
-
-    const key = await this.attractapService.generateNTAG424Key({
-      userId: socket.state.lastAuthenticatedUserId,
-      keyNo,
-      cardUID: uid,
-    });
-
-    const keyString = this.attractapService.uint8ArrayToHexString(key);
-
-    socket.state.enrollNewCardData = {
-      keyNo,
-      key: keyString,
-      cardUID: uid,
-    };
-    await socket.sendMessage(new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { key: keyString, keyNo }));
-  }
-
-  private async onEnrollNewCard(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    if (!socket.state.enrollNewCardData) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { error: 'ENROLL_NEW_CARD_DATA_NOT_SET' }),
-      );
-      return;
-    }
-
-    const { success } = data.payload as { success: boolean };
-    if (!success) {
-      this.logger.error('Enroll new card failed');
-      return;
-    }
-
-    const { key, keyNo, cardUID } = socket.state.enrollNewCardData;
-
-    if (!key || typeof key !== 'string' || !keyNo || typeof keyNo !== 'number') {
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { error: 'KEY_NOT_SET' }));
-      return;
-    }
-
-    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
-    if (!user) {
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { error: 'USER_NOT_FOUND' }));
-      return;
-    }
-
-    await this.attractapService.createNFCCard(user, {
-      key,
-      keyNo,
-      uid: cardUID,
-    });
-
-    socket.state.enrollNewCardData = null;
-    socket.state.lastAuthenticatedUserId = null;
-    socket.sendMessage(new AttractapEvent(AttractapEventType.ENROLL_NEW_CARD, { success: true }));
+    return this.cardHandler.startEnrollOfNewNfcCard(data);
   }
 
   public async startResetOfNfcCard(data: { readerId: number; userId: number; cardId: number }) {
-    const reader = await this.attractapService.findReaderById(data.readerId);
-
-    if (!reader) {
-      throw new Error(`Reader not found: ${data.readerId}`);
-    }
-
-    const user = await this.usersService.findOne({ id: data.userId });
-
-    if (!user) {
-      throw new Error(`User not found: ${data.userId}`);
-    }
-
-    const socket = Array.from(this.websocketService.sockets.values()).find(
-      (socket) => socket.readerId === data.readerId,
-    );
-
-    if (!socket) {
-      throw new Error(`Reader not connected: ${data.readerId}`);
-    }
-
-    const nfcCard = await this.attractapService.getNFCCardByID(data.cardId);
-
-    if (!nfcCard) {
-      throw new Error(`NFC card not found: ${data.cardId}`);
-    }
-
-    // TODO: implement this
-  }
-
-  private async handleCardAuthenticationRequest(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    this.metricsService.attractapNfcTapsTotal.inc();
-    const { uid, resourceId } = data.payload as { uid: string; resourceId: number };
-
-    if (!uid || typeof uid !== 'string') {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.CARD_AUTHENTICATION_DATA, {
-          error: 'INVALID_UID',
-        }),
-      );
-      return;
-    }
-
-    const nfcCard = await this.attractapService.getNFCCardByUID(uid);
-
-    if (!nfcCard) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.CARD_AUTHENTICATION_DATA, {
-          error: 'CARD_NOT_FOUND',
-        }),
-      );
-      return;
-    }
-
-    if (!nfcCard.isActive) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.CARD_AUTHENTICATION_DATA, {
-          error: 'CARD_NOT_ACTIVE',
-        }),
-      );
-      return;
-    }
-
-    socket.state.lastAuthenticatedUserId = nfcCard.user.id;
-
-    const hasIntroduction = await this.resourceUsageService.canControllResource(resourceId, nfcCard.user);
-    const isIntroducer = await this.resourceIntroducersService.isIntroducer(resourceId, nfcCard.user.id, true);
-
-    await socket.sendMessage(
-      new AttractapEvent(AttractapEventType.CARD_AUTHENTICATION_DATA, {
-        keyNo: nfcCard.keyNo,
-        key: nfcCard.key,
-        username: nfcCard.user.username,
-        canManageResource: nfcCard.user.systemPermissions.canManageResources,
-        hasIntroduction,
-        isIntroducer,
-      }),
-    );
-  }
-
-  private async validateResourceAction(
-    socket: AuthenticatedWebSocket,
-    resourceId: number,
-    eventType: AttractapEventType,
-  ): Promise<boolean> {
-    if (!resourceId) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'INVALID_RESOURCE_ID' }),
-      );
-      return false;
-    }
-
-    const reader = await this.attractapService.findReaderById(socket.readerId);
-    if (!reader) {
-      await socket.sendMessage(new AttractapEvent(eventType, { error: 'READER_NOT_FOUND' }));
-      return false;
-    }
-
-    const resource = reader.resources.find((resource) => resource.id === resourceId);
-    if (!resource) {
-      await socket.sendMessage(
-        new AttractapEvent(eventType, {
-          error: 'RESOURCE_NOT_ASSOCIATED_WITH_READER',
-        }),
-      );
-      return false;
-    }
-
-    const lastAuthenticatedUserId = socket.state.lastAuthenticatedUserId;
-    if (lastAuthenticatedUserId == null) {
-      await socket.sendMessage(new AttractapEvent(eventType, { error: 'USER_NOT_AUTHENTICATED' }));
-      return false;
-    }
-
-    const user = await this.usersService.findOne({ id: lastAuthenticatedUserId });
-    if (!user) {
-      await socket.sendMessage(new AttractapEvent(eventType, { error: 'USER_NOT_FOUND' }));
-      return false;
-    }
-
-    return true;
-  }
-
-  private formDraftKey(resourceId: number, action: ResourceFormAction): string {
-    return `${resourceId}:${action}`;
-  }
-
-  private getFormDraft(
-    socket: AuthenticatedWebSocket,
-    resourceId: number,
-    action: ResourceFormAction,
-  ): Record<number, FormFieldAnswerValue> {
-    return socket.state.formDrafts?.[this.formDraftKey(resourceId, action)] ?? {};
-  }
-
-  private clearFormDraft(socket: AuthenticatedWebSocket, resourceId: number, action: ResourceFormAction): void {
-    if (socket.state.formDrafts) {
-      delete socket.state.formDrafts[this.formDraftKey(resourceId, action)];
-    }
-  }
-
-  private async ensureFormsSatisfied({
-    socket,
-    resourceId,
-    action,
-  }: {
-    socket: AuthenticatedWebSocket;
-    resourceId: number;
-    action: ResourceFormAction;
-  }): Promise<FormSubmissionRequestDto[] | null> {
-    const forms = await this.resourceFormsService.getFormsForAction(resourceId, action);
-    if (!forms.length) {
-      return [];
-    }
-
-    const draft = this.getFormDraft(socket, resourceId, action);
-    const hasValue = (fieldId: number) => {
-      const value = draft[fieldId];
-      return value !== undefined && value !== null && value !== '';
-    };
-
-    const complete = forms.every((form) =>
-      form.fields.filter((field) => field.isRequired).every((field) => hasValue(field.id)),
-    );
-
-    if (complete) {
-      return forms.map((form) => ({
-        formId: form.id,
-        answers: form.fields
-          .filter((field) => draft[field.id] !== undefined)
-          .map((field) => ({ fieldId: field.id, value: draft[field.id] })),
-      }));
-    }
-
-    let resourceName: string | undefined;
-    try {
-      const reader = socket.readerId ? await this.attractapService.findReaderById(socket.readerId) : null;
-      const resource = reader?.resources?.find((item) => item.id === resourceId);
-      resourceName = resource?.name;
-    } catch (error) {
-      this.logger.debug(`Failed to resolve resource name for form request: ${(error as Error).message}`);
-    }
-
-    const payload: ResourceUsageFormRequestPayload = {
-      resourceId,
-      resourceName,
-      action,
-      forms: forms.map((form) => ({ id: form.id, name: form.name, fieldCount: form.fields.length })),
-    };
-
-    await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_REQUEST, payload));
-    return null;
-  }
-
-  private async handleResourceUsageFormGetFields(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId, action, formId, offset, limit } = data.payload as ResourceUsageFormGetFieldsPayload;
-
-    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
-      return;
-    }
-
-    const { totalFieldCount, fields } = await this.resourceFormsService.getFieldsWindow(
-      resourceId,
-      formId,
-      offset,
-      limit,
-    );
-
-    const draft = this.getFormDraft(socket, resourceId, action);
-    const payload: ResourceUsageFormFieldsPayload = {
-      resourceId,
-      action,
-      formId,
-      offset,
-      totalFieldCount,
-      fields: fields.map((field) => ({
-        id: field.id,
-        name: field.name,
-        description: field.description ?? null,
-        type: field.type,
-        isRequired: field.isRequired,
-        options: field.options ?? null,
-        value: draft[field.id] ?? null,
-      })),
-    };
-
-    await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_FIELDS, payload));
-  }
-
-  private async handleResourceUsageFormSubmitPage(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId, action, formId, offset, answers } = data.payload as ResourceUsageFormSubmitPagePayload;
-
-    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
-      return;
-    }
-
-    const { valid, errors } = await this.resourceFormsService.validatePageAnswers(resourceId, formId, answers);
-
-    if (valid) {
-      const key = this.formDraftKey(resourceId, action);
-      socket.state.formDrafts ??= {};
-      socket.state.formDrafts[key] ??= {};
-      for (const answer of answers) {
-        socket.state.formDrafts[key][answer.fieldId] = answer.value;
-      }
-    }
-
-    const payload: ResourceUsageFormPageResultPayload = { resourceId, action, formId, offset, valid, errors };
-    await socket.sendMessage(new AttractapEvent(AttractapEventType.RESOURCE_USAGE_FORM_PAGE_RESULT, payload));
-  }
-
-  private async handleStartResourceUsageSession(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId, projectId } = data.payload as {
-      resourceId: number;
-      projectId?: number;
-    };
-
-    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
-      return;
-    }
-
-    const formSubmissions = await this.ensureFormsSatisfied({
-      socket,
-      resourceId,
-      action: ResourceFormAction.START,
-    });
-    if (formSubmissions === null) {
-      return;
-    }
-
-    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
-    if (!user) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
-      );
-      return;
-    }
-
-    try {
-      await this.resourceUsageService.startSession(resourceId, user, { projectId, formSubmissions });
-      this.clearFormDraft(socket, resourceId, ResourceFormAction.START);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { success: true }));
-    } catch (error) {
-      if (error instanceof ResourceInUseError) {
-        setTimeout(async () => {
-          await this.sendResourceListToSocket(socket, { resourceId });
-        }, 1000);
-        return;
-      }
-      if (error instanceof InsufficientBalanceError || error?.message === 'INSUFFICIENT_BALANCE') {
-        const sumUpEnabled = await this.sumUpService.getIsEnabled();
-        await socket.sendMessage(
-          new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, {
-            error: 'INSUFFICIENT_BALANCE',
-            sumUpEnabled,
-          }),
-        );
-        return;
-      }
-      this.logger.error(`Failed to start resource usage session: ${error.message}`);
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: error.message }),
-      );
-    }
-  }
-
-  private async handleStopResourceUsageSession(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId } = data.payload as {
-      resourceId: number;
-    };
-
-    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
-      return;
-    }
-
-    const formSubmissions = await this.ensureFormsSatisfied({
-      socket,
-      resourceId,
-      action: ResourceFormAction.END,
-    });
-    if (formSubmissions === null) {
-      return;
-    }
-
-    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
-    if (!user) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
-      );
-      return;
-    }
-
-    try {
-      await this.resourceUsageService.endSession(resourceId, user, { formSubmissions });
-      this.clearFormDraft(socket, resourceId, ResourceFormAction.END);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.STOP_RESOURCE_USAGE_SESSION, { success: true }));
-    } catch (error) {
-      this.logger.error(`Failed to stop resource usage session: ${error.message}`);
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.STOP_RESOURCE_USAGE_SESSION, { error: error.message }),
-      );
-    }
-  }
-
-  private async handleLockDoor(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId } = data.payload as { resourceId: number };
-
-    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
-      return;
-    }
-
-    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
-    if (!user) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
-      );
-      return;
-    }
-
-    try {
-      await this.resourceUsageService.lockDoor(resourceId, user);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.LOCK_DOOR, { success: true }));
-    } catch (error) {
-      const errorMessage = this.extractUserFacingError(error);
-      this.logger.error(`Failed to lock door: ${errorMessage}`);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.LOCK_DOOR, { error: errorMessage }));
-    }
-  }
-
-  private async handleUnlockDoor(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId } = data.payload as { resourceId: number };
-
-    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
-      return;
-    }
-
-    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
-    if (!user) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
-      );
-      return;
-    }
-
-    try {
-      await this.resourceUsageService.unlockDoor(resourceId, user);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.UNLOCK_DOOR, { success: true }));
-    } catch (error) {
-      const errorMessage = this.extractUserFacingError(error);
-      this.logger.error(`Failed to unlock door: ${errorMessage}`);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.UNLOCK_DOOR, { error: errorMessage }));
-    }
-  }
-
-  private async handleUnlatchDoor(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId } = data.payload as { resourceId: number };
-
-    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.START_RESOURCE_USAGE_SESSION))) {
-      return;
-    }
-
-    const user = await this.usersService.findOne({ id: socket.state.lastAuthenticatedUserId });
-    if (!user) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.START_RESOURCE_USAGE_SESSION, { error: 'USER_NOT_FOUND' }),
-      );
-      return;
-    }
-
-    try {
-      await this.resourceUsageService.unlatchDoor(resourceId, user);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.UNLATCH_DOOR, { success: true }));
-    } catch (error) {
-      const errorMessage = this.extractUserFacingError(error);
-      this.logger.error(`Failed to unlatch door: ${errorMessage}`);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.UNLATCH_DOOR, { error: errorMessage }));
-    }
-  }
-
-  private async handleTriggerFlowButton(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const { resourceId, buttonId } = data.payload as { resourceId: number; buttonId: string };
-
-    if (!(await this.validateResourceAction(socket, resourceId, AttractapEventType.TRIGGER_FLOW_BUTTON))) {
-      return;
-    }
-
-    try {
-      await this.resourceFlowsExecutorService.pressButton(resourceId, buttonId, socket.state.lastAuthenticatedUserId);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.TRIGGER_FLOW_BUTTON, { success: true }));
-    } catch (error) {
-      this.logger.error(`Failed to trigger flow button: ${error.message}`);
-      await socket.sendMessage(new AttractapEvent(AttractapEventType.TRIGGER_FLOW_BUTTON, { error: error.message }));
-    }
-  }
-
-  private async handleBillingRequestTopup(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    try {
-      const enabled = await this.sumUpService.getIsEnabled();
-      if (!enabled) {
-        this.logger.warn('BILLING_REQUEST_TOPUP received but SumUp is not enabled');
-        await socket.sendMessage(
-          new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, { error: 'SUMUP_NOT_ENABLED' }),
-        );
-        return;
-      }
-
-      const userId = socket.state.lastAuthenticatedUserId;
-      if (!userId) {
-        this.logger.warn('BILLING_REQUEST_TOPUP received but no authenticated user is set on socket');
-        await socket.sendMessage(
-          new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, { error: 'USER_NOT_AUTHENTICATED' }),
-        );
-        return;
-      }
-
-      const { amountCents } = data.payload as { amountCents: number };
-      if (typeof amountCents !== 'number' || !Number.isInteger(amountCents) || amountCents <= 0) {
-        this.logger.warn(`BILLING_REQUEST_TOPUP invalid amount: ${JSON.stringify(data.payload)}`);
-        await socket.sendMessage(
-          new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, { error: 'INVALID_AMOUNT' }),
-        );
-        return;
-      }
-
-      const readers = await this.sumUpService.getReaders();
-      if (!readers || readers.length === 0) {
-        this.logger.warn('BILLING_REQUEST_TOPUP requested but no SumUp readers are linked');
-        await socket.sendMessage(
-          new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, { error: 'NO_SUMUP_TERMINALS_AVAILABLE' }),
-        );
-        return;
-      }
-
-      // Prefer a paired/active reader if available, otherwise first one
-      const preferred = readers.find((r) => r.status === 'paired') || readers[0];
-      await this.sumUpService.topUpWithReader(userId, preferred.id, amountCents);
-      this.logger.debug(`Started SumUp top-up for user ${userId} on reader ${preferred.id} amount ${amountCents}`);
-    } catch (err) {
-      this.logger.error(`handleBillingRequestTopup error: ${(err as Error).message}`);
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.BILLING_REQUEST_TOPUP, {
-          error: 'SUMUP_TOPUP_FAILED',
-          details: (err as Error).message,
-        }),
-      );
-    }
-  }
-
-  private async handleProjectsOfUserRequest(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
-    const userId = socket.state.lastAuthenticatedUserId;
-    if (!userId) {
-      await socket.sendMessage(
-        new AttractapEvent(AttractapEventType.PROJECTS_OF_USER, { error: 'USER_NOT_AUTHENTICATED' }),
-      );
-      return;
-    }
-
-    const { page = 1, limit = 10 } = data.payload as { page?: number; limit?: number };
-
-    const projects = await this.projectsService.findMany(userId, { page, limit });
-    const total = await this.projectsService.getTotalCount(userId);
-    await socket.sendMessage(new AttractapEvent(AttractapEventType.PROJECTS_OF_USER, { projects, page, limit, total }));
-  }
-
-  private extractUserFacingError(error: unknown): string {
-    if (error instanceof FlowExecutionError) {
-      return error.message.replace(/^FLOW_EXECUTION_ERROR:\s*/, '');
-    }
-    return error instanceof Error ? error.message : String(error);
+    return this.cardHandler.startResetOfNfcCard(data);
   }
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Splits the ~1367-line `AttractapGateway` god class into focused, dependency-injected handler/service classes, leaving a thin gateway that owns only the socket lifecycle, the ACK-awaiter mechanism, and `EVENT` routing. Mirrors the firmware `api.cpp` modularization. **Wire protocol is unchanged.**

## New units (`apps/api/src/attractap/websockets/handlers/`)

| Class | Responsibility |
|-------|----------------|
| `ResourceListService` | resource-list building + broadcast to sockets |
| `ResourceActionGuard` | shared `validateResourceAction` |
| `AttractapAuthHandler` | reader register / authenticate |
| `AttractapFirmwareHandler` | firmware info + OTA chunk streaming |
| `AttractapCrashReportHandler` | crash report ingestion |
| `AttractapCardHandler` | NFC card auth + enrollment/reset |
| `AttractapFormsHandler` | usage-form paging + draft state |
| `AttractapSessionHandler` | start/stop session, door lock/unlock/unlatch, flow buttons |
| `AttractapBillingHandler` | SumUp top-up |
| `AttractapProjectsHandler` | projects-of-user |

## Gateway after refactor

Keeps connection lifecycle (`handleConnection`/`handleDisconnect`/`onHeartbeat`), the LVGL sanitizer, the response-awaiter machinery, and the `onClientEvent` switch — now delegating each case to a handler. Its public surface (`sendResourceList`, `sendResourceListToReadersWithResource`, `disconnectReader`, `startEnrollOfNewNfcCard`, `startResetOfNfcCard`) is preserved as thin delegators, so `WebSocketEventService` and the controllers are untouched.

## Testing

- Full `api` Jest suite green (103 suites, 1126 tests).
- `nx lint api` and `tsc --noEmit` clean.
- `websocket-gateway-door-error.spec.ts` retargeted to `AttractapSessionHandler` (the door logic's new home); all assertions preserved.
- Handler providers registered in `attractap.module.ts` and added to the gateway spec's testing module.

## Linear

[ATT-426](https://linear.app/attraccess/issue/ATT-426/refactor-attractap-websocketgateway-god-class-api-1367-lines)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
