### PR TITLE
fix(ATT-468): WAITING_FOR_IP timeout — DHCP-failure wedge

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.5"'
+	-D FIRMWARE_VERSION='"1.3.6"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/network/wifi/wifi.cpp
+++ b/apps/attractap/firmware/src/network/wifi/wifi.cpp
@@ -9,7 +9,9 @@ String Wifi::_lastSSID;
 
 uint8_t Wifi::current_reconnect_attempts_count = 0;
 uint32_t Wifi::last_reconnect_attempt_time_ms = 0;
+uint32_t Wifi::waiting_for_ip_since_ms = 0;
 const uint32_t Wifi::RECONNECT_INTERVAL_MS = 10000;
+const uint32_t Wifi::WAITING_FOR_IP_TIMEOUT_MS = 15000;
 
 bool Wifi::is_scanning = false;
 Wifi::WifiNetwork Wifi::knownWifiNetworks[MAX_KNOWN_WIFI_NETWORKS];
@@ -243,6 +245,10 @@ void Wifi::setState(WifiState state)
 {
     WifiState previous = _state;
     _state = state;
+    if (state == WIFI_STATE_CONNECTED_WAITING_FOR_IP && previous != WIFI_STATE_CONNECTED_WAITING_FOR_IP)
+    {
+        waiting_for_ip_since_ms = millis();
+    }
     State::setWifiState(state == WIFI_STATE_CONNECTED, Wifi::getIPAddress(), _lastSSID);
     if (previous != state)
     {
@@ -533,6 +539,17 @@ void Wifi::handleScanComplete()
 
 void Wifi::handleTimeout()
 {
+    if (_state == WIFI_STATE_CONNECTED_WAITING_FOR_IP)
+    {
+        if (millis() - waiting_for_ip_since_ms > WAITING_FOR_IP_TIMEOUT_MS)
+        {
+            logger.info("DHCP timeout - no IP acquired, forcing reconnect");
+            esp_wifi_disconnect();
+            setState(WIFI_STATE_CONNECT_FAILED);
+        }
+        return;
+    }
+
     if (isConnected())
     {
         return;

--- a/apps/attractap/firmware/src/network/wifi/wifi.hpp
+++ b/apps/attractap/firmware/src/network/wifi/wifi.hpp
@@ -57,7 +57,9 @@ private:
     static bool is_scanning;
     static uint8_t current_reconnect_attempts_count;
     static uint32_t last_reconnect_attempt_time_ms;
+    static uint32_t waiting_for_ip_since_ms;
     static const uint32_t RECONNECT_INTERVAL_MS;
+    static const uint32_t WAITING_FOR_IP_TIMEOUT_MS;
     static void tryAutoConnect();
     static bool hasSavedCredentials();
     static WifiNetwork knownWifiNetworks[MAX_KNOWN_WIFI_NETWORKS];


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes a DHCP-failure wedge on attractap (ATT-468, child of ATT-462 / finding C1).

On AP association the device enters `WIFI_STATE_CONNECTED_WAITING_FOR_IP`. If DHCP never delivers an IP, `ipEventHandler` never fires. In that state `loop()` calls only `handleTimeout()`, which short-circuited on `isConnected()` — and `isConnected()` returns true as soon as the device is L2-associated, regardless of IP. So the 15s timeout → `esp_wifi_disconnect()` → `CONNECT_FAILED` path was unreachable, and `WAITING_FOR_IP` had no `ensureConnection()` reconnect case. With a stable association but persistently failing DHCP (server down / pool exhausted / VLAN-firewall block), the device wedged until a power cycle.

## Implementation

- `handleTimeout()`: handle `WIFI_STATE_CONNECTED_WAITING_FOR_IP` **before** the `isConnected()` short-circuit. Measure time since entering the state; after 15s with no IP, force `esp_wifi_disconnect()` → `CONNECT_FAILED` → `ensureConnection()` retry. Mirrors the existing `CONNECTING`-timeout path.
- Stamp `waiting_for_ip_since_ms` in `setState()` on transition into `WAITING_FOR_IP`.
- New members `waiting_for_ip_since_ms` and `WAITING_FOR_IP_TIMEOUT_MS` (15000).
- Bump `FIRMWARE_VERSION` 1.3.5 → 1.3.6 (required for OTA).

Normal-DHCP path is untouched: IP arrives → `CONNECTED` well before 15s, no spurious disconnect. AP-disassociation recovery (existing `DISCONNECTED` path) is unchanged.

## Testing

- `pio run -e attractap-touch-v2` → **SUCCESS** (Flash 79.7%, RAM 45.6%).
- Manual hardware test (broken-DHCP AP) per issue steps recommended before merge.

Closes [ATT-468](https://linear.app/attraccess/issue/ATT-468/fixattractap-waiting-for-ip-timeout-dhcp-failure-wedge)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
