### PR TITLE
fix(ATT-469): non-blocking WebSocket send off the main loopTask

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.5"'
+	-D FIRMWARE_VERSION='"1.3.6"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/websocket/websocket.cpp
+++ b/apps/attractap/firmware/src/websocket/websocket.cpp
@@ -7,6 +7,14 @@ void Websocket::setup()
     {
         ws_client_mutex = xSemaphoreCreateMutex();
     }
+    if (!tx_queue)
+    {
+        tx_queue = xQueueCreate(TX_QUEUE_DEPTH, sizeof(TxMessage));
+    }
+    if (!tx_task && tx_queue)
+    {
+        xTaskCreate(txTaskEntry, "ws_tx", TX_TASK_STACK, this, TX_TASK_PRIORITY, &tx_task);
+    }
     this->_certManager.begin();
 }
 
@@ -270,37 +278,82 @@ void Websocket::processWebSocketEvent(esp_event_base_t base, int32_t event_id, v
 void Websocket::sendMessage(const String &message)
 {
     this->logger.debug(("sendMessage: " + message).c_str());
-
-    lockWsClient();
-    if (!ws_client)
-    {
-        unlockWsClient();
-        logger.error("sendMessage: ws_client not initialized");
-        return;
-    }
-    int ret = esp_websocket_client_send_text(ws_client, message.c_str(), message.length(), pdMS_TO_TICKS(5000));
-    unlockWsClient();
-
-    if (ret == -1)
-    {
-        logger.error("sendMessage: failed");
-    }
+    enqueueMessage(message.c_str(), message.length());
 }
 
 void Websocket::sendMessage(const char *message, size_t length)
 {
-    lockWsClient();
-    if (!ws_client)
+    enqueueMessage(message, length);
+}
+
+void Websocket::enqueueMessage(const char *data, size_t length)
+{
+    if (!tx_queue)
     {
-        unlockWsClient();
-        logger.error("sendMessage(raw): ws_client not initialized");
+        logger.error("enqueueMessage: tx_queue not initialized");
         return;
     }
-    int ret = esp_websocket_client_send_text(ws_client, message, static_cast<int>(length), pdMS_TO_TICKS(5000));
-    unlockWsClient();
-    if (ret == -1)
+
+    char *copy = (char *)malloc(length);
+    if (!copy)
     {
-        logger.error("sendMessage(raw): failed");
+        logger.error("enqueueMessage: allocation failed");
+        return;
+    }
+    memcpy(copy, data, length);
+
+    TxMessage msg{copy, length};
+    if (xQueueSend(tx_queue, &msg, 0) != pdTRUE)
+    {
+        logger.error("enqueueMessage: tx queue full, dropping message");
+        free(copy);
+    }
+}
+
+void Websocket::txTaskEntry(void *arg)
+{
+    static_cast<Websocket *>(arg)->txTaskLoop();
+}
+
+void Websocket::txTaskLoop()
+{
+    TxMessage msg;
+    while (true)
+    {
+        if (xQueueReceive(tx_queue, &msg, portMAX_DELAY) != pdTRUE)
+        {
+            continue;
+        }
+
+        lockWsClient();
+        if (!ws_client)
+        {
+            unlockWsClient();
+            logger.error("ws tx: ws_client not initialized, dropping message");
+            free(msg.data);
+            continue;
+        }
+        int ret = esp_websocket_client_send_text(ws_client, msg.data, static_cast<int>(msg.length), SEND_TIMEOUT_TICKS);
+        unlockWsClient();
+
+        if (ret == -1)
+        {
+            logger.error("ws tx: send failed");
+        }
+        free(msg.data);
+    }
+}
+
+void Websocket::drainTxQueue()
+{
+    if (!tx_queue)
+    {
+        return;
+    }
+    TxMessage msg;
+    while (xQueueReceive(tx_queue, &msg, 0) == pdTRUE)
+    {
+        free(msg.data);
     }
 }
 
@@ -338,6 +391,8 @@ void Websocket::disableConnectionAttempts()
     {
         esp_websocket_client_destroy(oldClient);
     }
+
+    drainTxQueue();
 
     setState(INIT);
 }

--- a/apps/attractap/firmware/src/websocket/websocket.hpp
+++ b/apps/attractap/firmware/src/websocket/websocket.hpp
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
 #include "esp_websocket_client.h"
 #include "../settings/settings.hpp"
 #include <functional>
@@ -60,6 +62,25 @@ private:
     SemaphoreHandle_t ws_client_mutex = nullptr;
     void lockWsClient();
     void unlockWsClient();
+
+    // Dedicated TX path: all sends are copied onto a queue and drained by a single
+    // task so neither the main loopTask nor the WebSocket event task ever blocks on
+    // the (up to 5s) socket send under a congested link, and sends never overlap.
+    struct TxMessage
+    {
+        char *data;
+        size_t length;
+    };
+    static constexpr size_t TX_QUEUE_DEPTH = 8;
+    static constexpr uint32_t TX_TASK_STACK = 4096;
+    static constexpr UBaseType_t TX_TASK_PRIORITY = 5;
+    const TickType_t SEND_TIMEOUT_TICKS = pdMS_TO_TICKS(5000);
+    QueueHandle_t tx_queue = nullptr;
+    TaskHandle_t tx_task = nullptr;
+    static void txTaskEntry(void *arg);
+    void txTaskLoop();
+    void enqueueMessage(const char *data, size_t length);
+    void drainTxQueue();
 
     static void websocket_event_handler(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
     void processWebSocketEvent(esp_event_base_t base, int32_t event_id, void *event_data);


### PR DESCRIPTION
Assignee: [Jan Jaap](https://linear.app/attraccess/profile/jan-jaap)

## Summary

Fixes **ATT-469** (child of ATT-462 — *attractap freezes sometimes*). Finding C2: multi-second main-loop stalls under a congested link.

`sendMessage` called `esp_websocket_client_send_text(..., 5000ms)` directly. `sendHeartbeat()` runs on the **main loopTask**; inbound `sendAck`/responses run on the **WebSocket event task**. On a slow/congested link a loop-task send blocked up to 5s, freezing NFC/display/state — repeatedly — and concurrent sends from both tasks contended on the socket.

## Approach

- All sends now copy their payload onto a fixed-depth **TX queue** (`TX_QUEUE_DEPTH = 8`) and return immediately — the main loopTask and event task never block on the network.
- A single dedicated **TX task** (`ws_tx`) drains the queue and is the only caller of `esp_websocket_client_send_text`, so sends are **serialized** (one TX path) — removing the documented multi-task contention.
- Queue is drained and freed on connection teardown (`disableConnectionAttempts`).
- Bump firmware `1.3.5 → 1.3.6` for OTA.

## Testing

Manual test per issue (congested-link `netem` setup): main loop stays responsive (NFC/display smooth) while sends are slow/queued; no 5s loop stalls; heartbeats + ACKs delivered when link recovers. Normal-latency link unchanged.

Closes ATT-469
Linear: https://linear.app/attraccess/issue/ATT-469

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
