### PR TITLE
fix(ATT-470): recover from display driver init failure (infinite while(1))

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.6"'
+	-D FIRMWARE_VERSION='"1.3.7"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/display/display.cpp
+++ b/apps/attractap/firmware/src/display/display.cpp
@@ -1,5 +1,8 @@
 #include "display.hpp"
 
+#include <Wire.h>
+#include "../utils.hpp"
+
 #ifdef HAS_IO_EXPANDER
 #include "../ioexpander/ioexpander.hpp"
 #endif
@@ -143,13 +146,38 @@ void Display::setup()
     Display::driver = nullptr;
 #endif
 
-    if (!Display::driver || !Display::driver->begin())
+    // Bounded retry: a transient I2C glitch at boot (the GT911/RGB panel shares the
+    // I2C bus with the PN532/IO-expander) can make begin() fail. Recover the bus and
+    // retry a few times; if it still fails, reboot rather than hang forever.
+    const uint8_t MAX_DISPLAY_INIT_ATTEMPTS = 5;
+    bool driverReady = false;
+    for (uint8_t attempt = 1; attempt <= MAX_DISPLAY_INIT_ATTEMPTS; attempt++)
     {
-        Display::logger.error("Display driver init failed");
-        while (1)
+        if (Display::driver && Display::driver->begin())
         {
-            delay(1000);
+            driverReady = true;
+            break;
         }
+
+        Display::logger.errorf("Display driver init failed (attempt %u/%u)", attempt, MAX_DISPLAY_INIT_ATTEMPTS);
+
+        if (attempt < MAX_DISPLAY_INIT_ATTEMPTS)
+        {
+#if defined(DISPLAY_DRIVER_GT911) && defined(PIN_TOUCH_I2C_SDA) && defined(PIN_TOUCH_I2C_SCL)
+            // Free any I2C slave stuck mid-transaction before the next attempt.
+            recoverI2CBus(PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
+            Wire.begin(PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
+            Wire.setTimeOut(50);
+#endif
+            delay(200);
+        }
+    }
+
+    if (!driverReady)
+    {
+        Display::logger.error("Display driver init exhausted retries; restarting");
+        delay(100); // let the serial buffer flush before reset
+        esp_restart();
     }
 
     Display::screenWidth = Display::driver->width();

--- a/apps/attractap/firmware/src/main.cpp
+++ b/apps/attractap/firmware/src/main.cpp
@@ -6,6 +6,7 @@
 #include "freertos/task.h"
 
 #include "application/application.hpp"
+#include "utils.hpp"
 
 SET_LOOP_TASK_STACK_SIZE(16 * 1024); // 16KB
 
@@ -38,35 +39,6 @@ void setup()
     mainLogger.infof("Firmware: %s, Variant: %s, Version: %s", FIRMWARE_FRIENDLY_NAME, FIRMWARE_VARIANT_FRIENDLY_NAME, FIRMWARE_VERSION);
 
     mainLogger.info("Serial initialized");
-
-// Bit-bang 9 SCL clock pulses to release any I2C slave stuck mid-transaction.
-    // This handles the common case where a firmware flash (or a crash) resets the ESP32
-    // (I2C master) without power-cycling I2C slaves; the slaves may still be holding SDA
-    // low waiting for more clock edges or an ACK that never arrives.
-    // After 9 pulses a STOP condition is generated, then Wire.begin() takes over normally.
-    auto recoverI2CBus = [](int sda, int scl)
-    {
-        pinMode(scl, OUTPUT);
-        pinMode(sda, INPUT_PULLUP); // sense SDA without driving it
-        for (int i = 0; i < 9; i++)
-        {
-            digitalWrite(scl, LOW);
-            delayMicroseconds(10);
-            digitalWrite(scl, HIGH);
-            delayMicroseconds(10);
-            if (digitalRead(sda))
-                break; // slave released SDA — bus is free
-        }
-        // STOP condition: SDA LOW → SCL HIGH → SDA HIGH
-        pinMode(sda, OUTPUT);
-        digitalWrite(sda, LOW);
-        delayMicroseconds(10);
-        digitalWrite(scl, HIGH);
-        delayMicroseconds(10);
-        digitalWrite(sda, HIGH);
-        delayMicroseconds(10);
-        // Pins will be reclaimed by Wire.begin() immediately after
-    };
 
 #if defined(PIN_NFC_I2C_SDA) && defined(PIN_NFC_I2C_SCL)
     mainLogger.infof("I2C init: SDA=%d, SCL=%d", PIN_NFC_I2C_SDA, PIN_NFC_I2C_SCL);

--- a/apps/attractap/firmware/src/utils.cpp
+++ b/apps/attractap/firmware/src/utils.cpp
@@ -1,5 +1,29 @@
 #include "utils.hpp"
 
+void recoverI2CBus(int sda, int scl)
+{
+    pinMode(scl, OUTPUT);
+    pinMode(sda, INPUT_PULLUP); // sense SDA without driving it
+    for (int i = 0; i < 9; i++)
+    {
+        digitalWrite(scl, LOW);
+        delayMicroseconds(10);
+        digitalWrite(scl, HIGH);
+        delayMicroseconds(10);
+        if (digitalRead(sda))
+            break; // slave released SDA — bus is free
+    }
+    // STOP condition: SDA LOW → SCL HIGH → SDA HIGH
+    pinMode(sda, OUTPUT);
+    digitalWrite(sda, LOW);
+    delayMicroseconds(10);
+    digitalWrite(scl, HIGH);
+    delayMicroseconds(10);
+    digitalWrite(sda, HIGH);
+    delayMicroseconds(10);
+    // Pins will be reclaimed by Wire.begin() immediately after
+}
+
 static inline int8_t hexCharToNibble(char c)
 {
     if (c >= '0' && c <= '9')

--- a/apps/attractap/firmware/src/utils.hpp
+++ b/apps/attractap/firmware/src/utils.hpp
@@ -6,6 +6,18 @@ String hexToString(uint8_t *uid, uint8_t uidLength);
 bool stringToHexArray(String hexString, uint8_t *array, uint8_t arrayLength);
 
 /**
+ * @brief Recover a stuck I2C bus by bit-banging 9 SCL clock pulses then a STOP.
+ *
+ * Releases any I2C slave that is holding SDA low mid-transaction (common after a
+ * firmware flash or crash resets the ESP32 master without power-cycling slaves).
+ * Pins are left ready for Wire.begin() to reclaim immediately after.
+ *
+ * @param sda SDA GPIO number
+ * @param scl SCL GPIO number
+ */
+void recoverI2CBus(int sda, int scl);
+
+/**
  * @brief Convert milliseconds to a time string in the format "HH:MM:SS"
  * @param millis The milliseconds to convert
  * @return The time string


### PR DESCRIPTION
Assignee: [Jan Jaap](https://linear.app/attraccess/profile/jan-jaap)

## Summary

`Display::setup()` previously entered `while (1) { delay(1000); }` forever when `driver->begin()` failed. Because `delay()` yields to IDLE (feeding the IDLE watchdog), no auto-reboot occurred — a transient I2C glitch at boot on the GT911/RGB panel (shared bus with PN532/IO-expander) left the device permanently dark until a power cycle.

## Changes

- **Bounded retry**: replace the infinite loop with up to 5 attempts of `driver->begin()`. Between attempts, recover the shared I2C bus and re-init `Wire` (GT911 builds), then `delay(200)`.
- **Fail-safe reboot**: if all attempts are exhausted, `esp_restart()` instead of hanging forever.
- **Refactor**: extract `recoverI2CBus()` from a `main.cpp` lambda into `utils.{hpp,cpp}` so both `main.cpp` and `display.cpp` reuse it.
- **Version bump**: firmware `1.3.6` → `1.3.7` (OTA).

## Testing

- `pio run -e attractap-touch-v2` compiles cleanly (SUCCESS).
- Manual repro per issue: forcing `begin()` failure now retries N times then resets (serial shows reboot) rather than staying dark; with the display working, normal boot is unaffected and transient glitches recover within the retry budget.

Closes [ATT-470](https://linear.app/attraccess/issue/ATT-470/fixattractap-recover-from-display-driver-init-failure-infinite-while1). Stacked on the ATT-462 parent branch alongside ATT-464/465/466/468.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->