### PR TITLE
feat(ATT-494): show connection/cert-detection progress on connecting screen

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts = 
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.14"'
+	-D FIRMWARE_VERSION='"1.3.15"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/display/screens/init/initscreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/init/initscreen.cpp
@@ -22,6 +22,20 @@ void InitScreen::markStateAsError(lv_obj_t *spinner, lv_obj_t *label)
    this->finalizeState(spinner, label, lv_color_hex(0xFF0000));
 }
 
+void InitScreen::markStateAsWarning(lv_obj_t *spinner, lv_obj_t *label)
+{
+   // Amber: stage is actively working/retrying (e.g. sweeping CA certs) rather
+   // than cleanly succeeded or hard-failed.
+   this->finalizeState(spinner, label, lv_color_hex(0xFFA500));
+}
+
+String InitScreen::formatIp(esp_ip4_addr_t ip)
+{
+   char buf[16];
+   snprintf(buf, sizeof(buf), IPSTR, IP2STR(&ip));
+   return String(buf);
+}
+
 void InitScreen::resetState(lv_obj_t *spinner, lv_obj_t *label)
 {
    lv_obj_set_style_arc_color(spinner, lv_color_white(), LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -189,6 +203,42 @@ void InitScreen::init()
 
    this->resetState(this->apiAuthenticationSpinner, this->apiAuthenticationLabel);
 
+   // Connection / cert-detection progress detail block. Smaller font, left aligned,
+   // so users can see the configured target, which CA is being tried, the live
+   // connection phase and the countdown to the next attempt.
+   lv_obj_t *detailsContainer = lv_obj_create(statesContainer);
+   lv_obj_remove_style_all(detailsContainer);
+   lv_obj_set_width(detailsContainer, lv_pct(100));
+   lv_obj_set_height(detailsContainer, LV_SIZE_CONTENT);
+   lv_obj_set_align(detailsContainer, LV_ALIGN_CENTER);
+   lv_obj_set_flex_flow(detailsContainer, LV_FLEX_FLOW_COLUMN);
+   lv_obj_set_flex_align(detailsContainer, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+   lv_obj_remove_flag(detailsContainer, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_remove_flag(detailsContainer, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_style_pad_row(detailsContainer, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   this->serverTargetLabel = lv_label_create(detailsContainer);
+   lv_obj_set_width(this->serverTargetLabel, lv_pct(100));
+   lv_obj_set_height(this->serverTargetLabel, LV_SIZE_CONTENT);
+   lv_label_set_text(this->serverTargetLabel, "");
+   lv_obj_set_style_text_font(this->serverTargetLabel, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_color(this->serverTargetLabel, lv_color_white(), LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   this->certLabel = lv_label_create(detailsContainer);
+   lv_obj_set_width(this->certLabel, lv_pct(100));
+   lv_obj_set_height(this->certLabel, LV_SIZE_CONTENT);
+   lv_label_set_long_mode(this->certLabel, LV_LABEL_LONG_DOT);
+   lv_label_set_text(this->certLabel, "");
+   lv_obj_set_style_text_font(this->certLabel, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_color(this->certLabel, lv_color_white(), LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   this->connectionStateLabel = lv_label_create(detailsContainer);
+   lv_obj_set_width(this->connectionStateLabel, lv_pct(100));
+   lv_obj_set_height(this->connectionStateLabel, LV_SIZE_CONTENT);
+   lv_label_set_text(this->connectionStateLabel, "");
+   lv_obj_set_style_text_font(this->connectionStateLabel, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_color(this->connectionStateLabel, lv_color_white(), LV_PART_MAIN | LV_STATE_DEFAULT);
+
    lv_obj_t *openSettingsButton = lv_btn_create(statesContainer);
    lv_obj_set_width(openSettingsButton, LV_SIZE_CONTENT);
    lv_obj_set_height(openSettingsButton, LV_SIZE_CONTENT);
@@ -227,29 +277,43 @@ void InitScreen::loop()
    // TODO: extend network state and network interface classes to be more descriptive (in progress, success, error and maybe error reason)
    if (networkState.wifi_connected)
    {
+      lv_label_set_text(this->wifiLabel, ("WLAN  " + this->formatIp(networkState.wifi_ip)).c_str());
       this->markStateAsSuccess(this->wifiSpinner, this->wifiLabel);
    }
    else
    {
+      lv_label_set_text(this->wifiLabel, "verbinde WLAN");
       this->resetState(this->wifiSpinner, this->wifiLabel);
    }
 
    if (networkState.ethernet_connected)
    {
+      lv_label_set_text(this->ethernetLabel, ("Ethernet  " + this->formatIp(networkState.ethernet_ip)).c_str());
       this->markStateAsSuccess(this->ethernetSpinner, this->ethernetLabel);
    }
    else
    {
+      lv_label_set_text(this->ethernetLabel, "verbinde Ethernet");
       this->resetState(this->ethernetSpinner, this->ethernetLabel);
    }
 
    State::WebsocketState websocketState = State::getWebsocketState();
+   bool networkUp = networkState.wifi_connected || networkState.ethernet_connected;
+   // A repeating cert sweep or remembered-cert retry is the "stuck" signal.
+   bool sweeping = websocketState.useSSL && (websocketState.certIndex > 0 || websocketState.rememberedRetryCount > 0);
    if (websocketState.connected)
    {
+      lv_label_set_text(this->apiConnectionLabel, "API verbunden");
       this->markStateAsSuccess(this->apiConnectionSpinner, this->apiConnectionLabel);
+   }
+   else if (networkUp && sweeping)
+   {
+      lv_label_set_text(this->apiConnectionLabel, "suche Zertifikat");
+      this->markStateAsWarning(this->apiConnectionSpinner, this->apiConnectionLabel);
    }
    else
    {
+      lv_label_set_text(this->apiConnectionLabel, "verbinde API");
       this->resetState(this->apiConnectionSpinner, this->apiConnectionLabel);
    }
 
@@ -262,6 +326,61 @@ void InitScreen::loop()
    {
       this->resetState(this->apiAuthenticationSpinner, this->apiAuthenticationLabel);
    }
+
+   // Server target line
+   if (websocketState.hostname.isEmpty() || websocketState.port == 0)
+   {
+      lv_label_set_text(this->serverTargetLabel, "Server: nicht konfiguriert");
+   }
+   else
+   {
+      String target = "Server: " + websocketState.hostname + ":" + String(websocketState.port) +
+                      (websocketState.useSSL ? "  (SSL)" : "  (kein SSL)");
+      lv_label_set_text(this->serverTargetLabel, target.c_str());
+   }
+
+   // Cert evaluation line (only relevant while connecting over SSL)
+   if (websocketState.useSSL && !websocketState.connected && websocketState.certCount > 0)
+   {
+      String cert = "CA: " + websocketState.certName + "  (" +
+                    String(websocketState.certIndex + 1) + "/" + String(websocketState.certCount) + ")";
+      if (websocketState.rememberedRetryCount > 0)
+      {
+         cert += "  Wdh " + String(websocketState.rememberedRetryCount) + "/5";
+      }
+      lv_label_set_text(this->certLabel, cert.c_str());
+      lv_obj_remove_flag(this->certLabel, LV_OBJ_FLAG_HIDDEN);
+   }
+   else
+   {
+      lv_obj_add_flag(this->certLabel, LV_OBJ_FLAG_HIDDEN);
+   }
+
+   // Connection state + countdown line
+   const char *phaseText = "INIT";
+   switch (websocketState.phase)
+   {
+   case State::WS_CONNECTING:
+      phaseText = "CONNECTING";
+      break;
+   case State::WS_CONNECTED:
+      phaseText = "CONNECTED";
+      break;
+   case State::WS_INIT:
+   default:
+      phaseText = "INIT";
+      break;
+   }
+   String stateLine = String("Status: ") + phaseText;
+   if (!networkUp)
+   {
+      stateLine += "  warte auf Netzwerk";
+   }
+   else if (!websocketState.connected && websocketState.secondsUntilNextAttempt > 0)
+   {
+      stateLine += "  naechster Versuch in " + String(websocketState.secondsUntilNextAttempt) + "s";
+   }
+   lv_label_set_text(this->connectionStateLabel, stateLine.c_str());
 }
 
 void InitScreen::setOnOpenSettingsCallback(std::function<void()> onOpenSettingsCallback)
@@ -298,4 +417,7 @@ void InitScreen::destroy()
    this->apiConnectionLabel = nullptr;
    this->apiAuthenticationSpinner = nullptr;
    this->apiAuthenticationLabel = nullptr;
+   this->serverTargetLabel = nullptr;
+   this->certLabel = nullptr;
+   this->connectionStateLabel = nullptr;
 }

--- a/apps/attractap/firmware/src/display/screens/init/initscreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/init/initscreen.hpp
@@ -25,9 +25,12 @@ private:
     void finalizeState(lv_obj_t *spinner, lv_obj_t *label, lv_color_t color);
     void markStateAsSuccess(lv_obj_t *spinner, lv_obj_t *label);
     void markStateAsError(lv_obj_t *spinner, lv_obj_t *label);
+    void markStateAsWarning(lv_obj_t *spinner, lv_obj_t *label);
     void resetState(lv_obj_t *spinner, lv_obj_t *label);
 
     static void onOpenSettingsButtonEvent(lv_event_t *e);
+
+    static String formatIp(esp_ip4_addr_t ip);
 
     lv_obj_t *wifiSpinner = nullptr;
     lv_obj_t *wifiLabel = nullptr;
@@ -40,4 +43,9 @@ private:
 
     lv_obj_t *apiAuthenticationSpinner = nullptr;
     lv_obj_t *apiAuthenticationLabel = nullptr;
+
+    // Connection / cert-detection progress detail lines.
+    lv_obj_t *serverTargetLabel = nullptr;
+    lv_obj_t *certLabel = nullptr;
+    lv_obj_t *connectionStateLabel = nullptr;
 };

--- a/apps/attractap/firmware/src/state/state.cpp
+++ b/apps/attractap/firmware/src/state/state.cpp
@@ -10,6 +10,12 @@ String State::websocket_hostname = "";
 uint16_t State::websocket_port = 0;
 bool State::websocket_use_ssl = false;
 bool State::websocket_connected = false;
+State::WebsocketPhase State::websocket_phase = State::WS_INIT;
+String State::websocket_cert_name = "";
+int State::websocket_cert_index = 0;
+int State::websocket_cert_count = 0;
+int State::websocket_remembered_retry_count = 0;
+int State::websocket_next_attempt_seconds = 0;
 bool State::api_authenticated = false;
 String State::api_device_name = "";
 
@@ -47,6 +53,24 @@ void State::setWebsocketState(bool connected, String hostname, uint16_t port, bo
     websocket_use_ssl = useSSL;
 }
 
+void State::setWebsocketPhase(WebsocketPhase phase)
+{
+    websocket_phase = phase;
+}
+
+void State::setWebsocketCertProgress(String certName, int certIndex, int certCount, int rememberedRetryCount)
+{
+    websocket_cert_name = certName;
+    websocket_cert_index = certIndex;
+    websocket_cert_count = certCount;
+    websocket_remembered_retry_count = rememberedRetryCount;
+}
+
+void State::setWebsocketNextAttemptSeconds(int seconds)
+{
+    websocket_next_attempt_seconds = seconds;
+}
+
 State::WebsocketState State::getWebsocketState()
 {
 
@@ -55,6 +79,12 @@ State::WebsocketState State::getWebsocketState()
     state.hostname = websocket_hostname;
     state.port = websocket_port;
     state.useSSL = websocket_use_ssl;
+    state.phase = websocket_phase;
+    state.certName = websocket_cert_name;
+    state.certIndex = websocket_cert_index;
+    state.certCount = websocket_cert_count;
+    state.rememberedRetryCount = websocket_remembered_retry_count;
+    state.secondsUntilNextAttempt = websocket_next_attempt_seconds;
 
     return state;
 }

--- a/apps/attractap/firmware/src/state/state.hpp
+++ b/apps/attractap/firmware/src/state/state.hpp
@@ -19,13 +19,34 @@ public:
     };
     static NetworkState getNetworkState();
 
+    // Connection phase of the websocket client. Mirrors Websocket::ConnectionState
+    // so the connecting screen can show where the device is without depending on
+    // the websocket header.
+    enum WebsocketPhase
+    {
+        WS_INIT,
+        WS_CONNECTING,
+        WS_CONNECTED,
+    };
+
     static void setWebsocketState(bool connected, String hostname, uint16_t port, bool useSSL);
+    static void setWebsocketPhase(WebsocketPhase phase);
+    // Cert sweep progress (only meaningful while connecting over SSL).
+    static void setWebsocketCertProgress(String certName, int certIndex, int certCount, int rememberedRetryCount);
+    // Seconds until the next reconnect attempt (negative/zero means "now").
+    static void setWebsocketNextAttemptSeconds(int seconds);
     struct WebsocketState
     {
         bool connected;
         String hostname;
         uint16_t port;
         bool useSSL;
+        WebsocketPhase phase;
+        String certName;
+        int certIndex;
+        int certCount;
+        int rememberedRetryCount;
+        int secondsUntilNextAttempt;
     };
     static WebsocketState getWebsocketState();
 
@@ -51,6 +72,12 @@ private:
     static uint16_t websocket_port;
     static bool websocket_use_ssl;
     static bool websocket_connected;
+    static WebsocketPhase websocket_phase;
+    static String websocket_cert_name;
+    static int websocket_cert_index;
+    static int websocket_cert_count;
+    static int websocket_remembered_retry_count;
+    static int websocket_next_attempt_seconds;
 
     static bool api_authenticated;
     static String api_device_name;

--- a/apps/attractap/firmware/src/websocket/certManager/AdaptiveCertManager.cpp
+++ b/apps/attractap/firmware/src/websocket/certManager/AdaptiveCertManager.cpp
@@ -209,6 +209,16 @@ int AdaptiveCertManager::getCurrentCertIndex() const
     return currentCertIndex;
 }
 
+int AdaptiveCertManager::getCertCount() const
+{
+    return CA_CERT_COUNT;
+}
+
+int AdaptiveCertManager::getRememberedFailureCount() const
+{
+    return rememberedCertFailureCount;
+}
+
 void AdaptiveCertManager::loadSuccessfulCertIndexFromPreferences()
 {
     if (!initialized)

--- a/apps/attractap/firmware/src/websocket/certManager/AdaptiveCertManager.hpp
+++ b/apps/attractap/firmware/src/websocket/certManager/AdaptiveCertManager.hpp
@@ -31,6 +31,10 @@ public:
     // Get current certificate info
     const char *getCurrentCertName() const;
     int getCurrentCertIndex() const;
+    // Total number of available CA certificates.
+    int getCertCount() const;
+    // How many times the remembered certificate has failed in a row (0-5).
+    int getRememberedFailureCount() const;
 
 private:
     Preferences preferences;

--- a/apps/attractap/firmware/src/websocket/websocket.cpp
+++ b/apps/attractap/firmware/src/websocket/websocket.cpp
@@ -14,6 +14,7 @@ void Websocket::loop()
     }
 
     this->updateInfoFromAppState();
+    this->publishConnectionStatus();
 
     if (!network_is_connected)
     {
@@ -44,6 +45,43 @@ void Websocket::updateInfoFromAppState()
 {
     auto networkState = State::getNetworkState();
     this->network_is_connected = networkState.wifi_connected || networkState.ethernet_connected;
+}
+
+// Mirror the live connection / cert-sweep progress into State so the connecting
+// screen can surface where the device is (and where it is stuck). Cheap enough
+// to run every loop tick.
+void Websocket::publishConnectionStatus()
+{
+    AttraccessApiConfig apiConfig = Settings::getAttraccessApiConfig();
+
+    // Keep the configured server target fresh even before the first connect attempt.
+    State::setWebsocketState(_state == CONNECTED, apiConfig.hostname, apiConfig.port, apiConfig.useSSL);
+
+    // Cert sweep progress is only meaningful for SSL connections.
+    if (apiConfig.useSSL)
+    {
+        State::setWebsocketCertProgress(
+            String(this->_certManager.getCurrentCertName()),
+            this->_certManager.getCurrentCertIndex(),
+            this->_certManager.getCertCount(),
+            this->_certManager.getRememberedFailureCount());
+    }
+    else
+    {
+        State::setWebsocketCertProgress("", 0, 0, 0);
+    }
+
+    // Seconds until the next reconnect attempt (0 while connected or due now).
+    int secondsUntilNext = 0;
+    if (_state != CONNECTED && network_is_connected)
+    {
+        uint32_t elapsed = millis() - lastReconnectAttemptTime;
+        if (elapsed < RECONNECT_INTERVAL_MS)
+        {
+            secondsUntilNext = (int)((RECONNECT_INTERVAL_MS - elapsed + 999) / 1000);
+        }
+    }
+    State::setWebsocketNextAttemptSeconds(secondsUntilNext);
 }
 
 void Websocket::connectWebSocket()
@@ -260,6 +298,22 @@ void Websocket::sendMessage(const char *message, size_t length)
 void Websocket::setState(ConnectionState state)
 {
     _state = state;
+
+    State::WebsocketPhase phase = State::WS_INIT;
+    switch (state)
+    {
+    case CONNECTING:
+        phase = State::WS_CONNECTING;
+        break;
+    case CONNECTED:
+        phase = State::WS_CONNECTED;
+        break;
+    case INIT:
+    default:
+        phase = State::WS_INIT;
+        break;
+    }
+    State::setWebsocketPhase(phase);
 
     State::setWebsocketState(state == CONNECTED, this->_lastApiConfig.hostname, this->_lastApiConfig.port, this->_lastApiConfig.useSSL);
 }

--- a/apps/attractap/firmware/src/websocket/websocket.hpp
+++ b/apps/attractap/firmware/src/websocket/websocket.hpp
@@ -38,6 +38,7 @@ private:
     bool connectionAttemptsEnabled = true;
 
     void updateInfoFromAppState();
+    void publishConnectionStatus();
     void connectWebSocket();
     bool shouldReconnect();
     uint32_t lastReconnectAttemptTime;


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Surfaces live connection / cert-detection progress on the attractap connecting screen (`InitScreen`) so users can see what is happening and pinpoint where a device is stuck. With the adaptive CA-cert search iterating up to ~34 certificates plus network bring-up, a device could previously spend minutes with no visible feedback.

Follow-up from ATT-467 (review feedback).

## What it shows

- **Network stage** — assigned IP appended to the WiFi/Ethernet rows once link + DHCP are up (`WLAN  192.168.1.5`).
- **Server target** — configured `host:port` and SSL on/off.
- **Cert evaluation** — the CA currently being tried with `name (index/count)` (e.g. `CA: DigiCert Global Root G2  (12/34)`) plus the remembered-cert retry count (`Wdh 2/5`).
- **Connection state** — `INIT` / `CONNECTING` / `CONNECTED` plus a countdown to the next attempt (`naechster Versuch in 7s`), or `warte auf Netzwerk` when offline.
- **Stuck indicator** — the API stage turns amber and reads `suche Zertifikat` while a cert sweep / remembered-cert retry is repeating.

## Implementation

- `State`: added websocket phase, current cert name/index/count, remembered-cert retry count and seconds-until-next-attempt, with setters/getters.
- `Websocket`: publishes this status every loop tick and maps `ConnectionState` → phase.
- `AdaptiveCertManager`: exposes `getCertCount()` and `getRememberedFailureCount()`.
- `InitScreen`: renders the detail block and the per-stage highlighting.
- Bumped `FIRMWARE_VERSION` to `1.3.15` (frontend-visible firmware change → OTA).

## Testing

- `pio run -e attractap-touch-v2` builds clean (SUCCESS, Flash 81.6%).
- No umlauts used in new labels (LVGL Montserrat fonts are ASCII-only).
- Hardware/photo validation not done: no bench unit was attached to USB during this session. This is an embedded LVGL display (no browser), so `agent-browser` does not apply.

## Linear

https://linear.app/attraccess/issue/ATT-494

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
