### PR TITLE
fix(ci): regenerate client libs before typecheck (fixes nightly main)

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -133,6 +133,7 @@
     },
     "typecheck": {
       "cache": true,
+      "dependsOn": ["generate", "^generate"],
       "inputs": [
         "production",
         "^production",


### PR DESCRIPTION
## Problem

Docker Nightly Latest (main) has failed on every push since `65c0971` (ATT-478). The **typecheck** job fails:

```
api-client/src/index.ts: TS2307 Cannot find module './generated/Api'
plugins-frontend-ui ... Module '@attraccess/react-query-client' has no exported member 'User' / 'useUsersServiceFindMany' ...
react-query-client/src/index.ts: TS2307 Cannot find module './lib/requests'
```

## Cause

ATT-478 untracked + gitignored the generated `api-client` and `react-query-client` sources and wired `generate` into frontend and api-client **lint/test/build** — but the **`typecheck`** target default was missed. On a cold runner the generated sources never get produced before typecheck runs:

- `api-client:typecheck` needs its own `generate` (`./generated/Api`)
- consumers (`plugins-frontend-ui`, `frontend`) typecheck against the react-query-client **source**, which is gitignored until `react-query-client:generate` runs

lint/test passed only because their per-project wiring + same-runner ordering happened to regenerate first; typecheck had no such guarantee and api-client had none at all.

## Fix

Add `dependsOn: ["generate", "^generate"]` to the `typecheck` target default in `nx.json`:
- `generate` → projects that own a generate target (api-client, react-query-client) regenerate themselves
- `^generate` → consumers wait for their dependencies' generate (covers plugins-frontend-ui, frontend, and any future consumer without per-project wiring)

nx ignores the dependency for projects lacking a `generate` target, so it's a no-op elsewhere.

## Verification

From a cold state (generated dirs removed, nx cache reset):

```
nx run-many --target=typecheck --parallel=5 --exclude=tag:scope:hardware
→ Successfully ran target typecheck for 5 projects and 9 tasks they depend on
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)