### PR TITLE
feat(attractap): display resource health state on readers

### DIFF
--- a/apps/api/src/attractap/attractap.module.ts
+++ b/apps/api/src/attractap/attractap.module.ts
@@ -27,6 +27,7 @@ import { AttractapFirmwareController } from './firmware.controller';
 import { AttractapFirmwareService } from './firmware.service';
 import { CoredumpSymbolicationService } from './coredump-symbolication.service';
 import { ResourceMaintenanceModule } from '../resources/maintenances/maintenance.module';
+import { ResourceHealthModule } from '../resources/health/resource-health.module';
 import { LicenseModule } from '../license/license.module';
 import { ResourceIntroductionsModule } from '../resources/introductions/resourceIntroductions.module';
 import { ResourceIntroducersModule } from '../resources/introducers/resourceIntroducers.module';
@@ -43,6 +44,7 @@ import { ResourceFormsModule } from '../resources/forms/forms.module';
     ResourcesModule,
     ResourceUsageModule,
     ResourceMaintenanceModule,
+    ResourceHealthModule,
     LicenseModule,
     ResourceIntroductionsModule,
     ResourceIntroducersModule,

--- a/apps/api/src/attractap/websockets/handlers/resource-list.service.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/resource-list.service.spec.ts
@@ -9,6 +9,7 @@ describe('ResourceListService', () => {
   let attractapService: { findReaderById: jest.Mock };
   let resourceUsageService: { getActiveSession: jest.Mock };
   let resourceMaintenanceService: { hasActiveMaintenance: jest.Mock };
+  let resourceHealthService: { listForResource: jest.Mock };
   let resourceFlowsService: { getNodes: jest.Mock };
 
   function createMockSocket(overrides: Partial<any> = {}): any {
@@ -56,12 +57,14 @@ describe('ResourceListService', () => {
     attractapService = { findReaderById: jest.fn() };
     resourceUsageService = { getActiveSession: jest.fn().mockResolvedValue(null) };
     resourceMaintenanceService = { hasActiveMaintenance: jest.fn().mockResolvedValue(false) };
+    resourceHealthService = { listForResource: jest.fn().mockResolvedValue([]) };
     resourceFlowsService = { getNodes: jest.fn().mockResolvedValue([]) };
 
     (service as any).websocketService = websocketService;
     (service as any).attractapService = attractapService;
     (service as any).resourceUsageService = resourceUsageService;
     (service as any).resourceMaintenanceService = resourceMaintenanceService;
+    (service as any).resourceHealthService = resourceHealthService;
     (service as any).resourceFlowsService = resourceFlowsService;
   });
 
@@ -190,6 +193,8 @@ describe('ResourceListService', () => {
                   allowTakeOver: false,
                   introducers: ['introducer-a'],
                   isUnderMaintenance: true,
+                  isHealthy: true,
+                  healthReason: '',
                   activeUsageSession: {
                     user: { username: 'active-user' },
                     startTime: startTime.toISOString(),
@@ -201,6 +206,39 @@ describe('ResourceListService', () => {
           }),
         }),
       );
+    });
+
+    it('reports isHealthy=false with a combined reason when there are unhealthy entries', async () => {
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      resourceHealthService.listForResource.mockResolvedValue([
+        { identifier: 'temp', status: 'unhealthy', reason: 'overheating' },
+        { identifier: '', status: 'unhealthy', reason: 'not connected' },
+        { identifier: 'idle', status: 'healthy', reason: null },
+      ]);
+
+      const socket = createMockSocket();
+
+      await service.sendResourceListToSocket(socket);
+
+      expect(resourceHealthService.listForResource).toHaveBeenCalledWith(10);
+      const sent = (socket.sendMessage as jest.Mock).mock.calls[0][0] as AttractapEvent;
+      const resource = (sent.data.payload as any).resources[0];
+      expect(resource.isHealthy).toBe(false);
+      expect(resource.healthReason).toBe('temp: overheating\nnot connected');
+    });
+
+    it('reports isHealthy=true with an empty reason when all entries are healthy', async () => {
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      resourceHealthService.listForResource.mockResolvedValue([{ identifier: '', status: 'healthy', reason: null }]);
+
+      const socket = createMockSocket();
+
+      await service.sendResourceListToSocket(socket);
+
+      const sent = (socket.sendMessage as jest.Mock).mock.calls[0][0] as AttractapEvent;
+      const resource = (sent.data.payload as any).resources[0];
+      expect(resource.isHealthy).toBe(true);
+      expect(resource.healthReason).toBe('');
     });
 
     it('emits activeUsageSession=null when there is no active session', async () => {

--- a/apps/api/src/attractap/websockets/handlers/resource-list.service.ts
+++ b/apps/api/src/attractap/websockets/handlers/resource-list.service.ts
@@ -4,7 +4,9 @@ import { WebsocketService } from '../websocket.service';
 import { AttractapService } from '../../attractap.service';
 import { ResourceUsageService } from '../../../resources/usage/resourceUsage.service';
 import { ResourceMaintenanceService } from '../../../resources/maintenances/maintenance.service';
+import { ResourceHealthService } from '../../../resources/health/resource-health.service';
 import { ResourceFlowsService } from '../../../resources/flows/resource-flows.service';
+import { ResourceHealthStatus } from '@attraccess/database-entities';
 import { AuthenticatedWebSocket, AttractapEvent, AttractapEventType } from '../websocket.types';
 
 @Injectable()
@@ -22,6 +24,9 @@ export class ResourceListService {
 
   @Inject(ResourceMaintenanceService)
   private resourceMaintenanceService: ResourceMaintenanceService;
+
+  @Inject(ResourceHealthService)
+  private resourceHealthService: ResourceHealthService;
 
   @Inject(ResourceFlowsService)
   private resourceFlowsService: ResourceFlowsService;
@@ -58,11 +63,17 @@ export class ResourceListService {
     }
 
     const resourcesWithUsageSession = await Promise.all(
-      resources.map(async (resource) => ({
-        ...resource,
-        activeUsageSession: await this.resourceUsageService.getActiveSession(resource.id, true),
-        isUnderMaintenance: await this.resourceMaintenanceService.hasActiveMaintenance(resource.id),
-      })),
+      resources.map(async (resource) => {
+        const healthEntries = await this.resourceHealthService.listForResource(resource.id);
+        const unhealthyEntries = healthEntries.filter((entry) => entry.status === ResourceHealthStatus.UNHEALTHY);
+        return {
+          ...resource,
+          activeUsageSession: await this.resourceUsageService.getActiveSession(resource.id, true),
+          isUnderMaintenance: await this.resourceMaintenanceService.hasActiveMaintenance(resource.id),
+          isHealthy: unhealthyEntries.length === 0,
+          healthReason: this.buildHealthReason(unhealthyEntries),
+        };
+      }),
     );
 
     const getFlowButtons = async (resourceId: number) => {
@@ -92,6 +103,8 @@ export class ResourceListService {
         allowTakeOver: resource.allowTakeOver,
         introducers: resource.introducers.map((introducer) => introducer.user.username),
         isUnderMaintenance: resource.isUnderMaintenance,
+        isHealthy: resource.isHealthy,
+        healthReason: resource.healthReason,
         activeUsageSession: resource.activeUsageSession
           ? {
             user: {
@@ -105,5 +118,15 @@ export class ResourceListService {
     });
     this.logger.debug(`Sending resource list to socket ${socket.id}`, resourceListResponse);
     await socket.sendMessage(resourceListResponse);
+  }
+
+  private buildHealthReason(unhealthyEntries: { identifier: string; reason: string | null }[]): string {
+    return unhealthyEntries
+      .map((entry) => {
+        const reason = (entry.reason ?? '').trim() || 'Unhealthy';
+        const identifier = (entry.identifier ?? '').trim();
+        return identifier ? `${identifier}: ${reason}` : reason;
+      })
+      .join('\n');
   }
 }

--- a/apps/api/src/attractap/websockets/websocket.gateway.spec.ts
+++ b/apps/api/src/attractap/websockets/websocket.gateway.spec.ts
@@ -11,6 +11,7 @@ import { ResourceMaintenanceService } from '../../resources/maintenances/mainten
 import { ResourceIntroductionsService } from '../../resources/introductions/resouceIntroductions.service';
 import { ResourceIntroducersService } from '../../resources/introducers/resourceIntroducers.service';
 import { ResourceFlowsService } from '../../resources/flows/resource-flows.service';
+import { ResourceHealthService } from '../../resources/health/resource-health.service';
 import { ResourceFlowsExecutorService } from '../../resources/flows/resource-flows-executor.service';
 import { ProjectsService } from '../../projects/projects.service';
 import { ResourceFormsService } from '../../resources/forms/forms.service';
@@ -88,6 +89,7 @@ describe('AttractapGateway', () => {
         { provide: LicenseService, useValue: licenseService },
         { provide: ResourceUsageService, useValue: {} },
         { provide: ResourceMaintenanceService, useValue: { hasActiveMaintenance: jest.fn().mockResolvedValue(false) } },
+        { provide: ResourceHealthService, useValue: { listForResource: jest.fn().mockResolvedValue([]) } },
         { provide: ResourceIntroductionsService, useValue: {} },
         { provide: ResourceIntroducersService, useValue: {} },
         { provide: ResourceFlowsService, useValue: {} },

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts =
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.17"'
+	-D FIRMWARE_VERSION='"1.3.18"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/api/api.hpp
+++ b/apps/attractap/firmware/src/api/api.hpp
@@ -27,6 +27,7 @@ public:
     static constexpr size_t MAX_RESOURCE_NAME_LEN = 64;
     static constexpr size_t MAX_DESC_LEN = 128;
     static constexpr size_t MAX_USERNAME_LEN = 32;
+    static constexpr size_t MAX_HEALTH_REASON_LEN = 160;
     static constexpr size_t MAX_INTRODUCERS = 8;
     static constexpr size_t MAX_FLOW_BUTTONS = 7;
     static constexpr size_t MAX_FLOW_BUTTON_LABEL_LEN = 32;
@@ -51,6 +52,8 @@ public:
         char description[MAX_DESC_LEN];
         bool hasActiveUsage;
         bool isUnderMaintenance;
+        bool isHealthy;
+        char healthReason[MAX_HEALTH_REASON_LEN];
         char activeUser[MAX_USERNAME_LEN];
         uint32_t activeStartEpoch; // seconds since epoch
         uint8_t introducerCount;

--- a/apps/attractap/firmware/src/api/api_resources.cpp
+++ b/apps/attractap/firmware/src/api/api_resources.cpp
@@ -93,6 +93,11 @@ void API::onResourceList(JsonObject data)
 
         dst.isUnderMaintenance = resource["isUnderMaintenance"].is<bool>() ? resource["isUnderMaintenance"].as<bool>() : false;
 
+        // Health state: default to healthy when the field is absent (backwards compatible)
+        dst.isHealthy = resource["isHealthy"].is<bool>() ? resource["isHealthy"].as<bool>() : true;
+        const char *healthReason = resource["healthReason"].as<const char *>();
+        strlcpy(dst.healthReason, healthReason ? healthReason : "", sizeof(dst.healthReason));
+
         JsonObject aus = resource["activeUsageSession"].as<JsonObject>();
         if (!aus.isNull() && aus["user"]["username"].is<const char *>() && aus["startTime"].is<const char *>())
         {

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
@@ -416,6 +416,34 @@ void ResourceDetailsScreen::init()
    lv_obj_set_align(this->maintenanceIntroducersLabel, LV_ALIGN_CENTER);
    lv_label_set_text(this->maintenanceIntroducersLabel, "???");
 
+   this->healthPanel = lv_obj_create(this->screen);
+   lv_obj_set_width(this->healthPanel, lv_pct(100));
+   lv_obj_set_height(this->healthPanel, LV_SIZE_CONTENT);
+   lv_obj_set_align(this->healthPanel, LV_ALIGN_CENTER);
+   lv_obj_set_flex_flow(this->healthPanel, LV_FLEX_FLOW_COLUMN);
+   lv_obj_set_flex_align(this->healthPanel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+   lv_obj_remove_flag(this->healthPanel, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_style_bg_color(this->healthPanel, lv_color_hex(0xC20E4D), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(this->healthPanel, 200, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_add_flag(this->healthPanel, LV_OBJ_FLAG_HIDDEN);
+
+   lv_obj_t *healthInfoLabel = lv_label_create(this->healthPanel);
+   lv_obj_set_width(healthInfoLabel, lv_pct(100));
+   lv_obj_set_height(healthInfoLabel, LV_SIZE_CONTENT);
+   lv_obj_set_align(healthInfoLabel, LV_ALIGN_CENTER);
+   lv_label_set_text(healthInfoLabel, "Diese Ressource ist derzeit nicht betriebsbereit und kann nicht verwendet werden.");
+   lv_obj_set_style_text_color(healthInfoLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_opa(healthInfoLabel, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   this->healthReasonLabel = lv_label_create(this->healthPanel);
+   lv_obj_set_width(this->healthReasonLabel, lv_pct(100));
+   lv_obj_set_height(this->healthReasonLabel, LV_SIZE_CONTENT);
+   lv_obj_set_align(this->healthReasonLabel, LV_ALIGN_CENTER);
+   lv_label_set_long_mode(this->healthReasonLabel, LV_LABEL_LONG_WRAP);
+   lv_label_set_text(this->healthReasonLabel, "");
+   lv_obj_set_style_text_color(this->healthReasonLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_opa(this->healthReasonLabel, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+
    // action overlay is created lazily on lv_layer_top() when needed
    this->actionOverlay = nullptr;
    this->actionOverlayLabel = nullptr;
@@ -443,6 +471,13 @@ void ResourceDetailsScreen::setResourceAndUsageDetails(const API::ResourceBrief 
    if (this->maintenanceIntroducersLabel)
    {
       lv_label_set_text(this->maintenanceIntroducersLabel, introducersText.c_str());
+   }
+
+   // Update health banner reason text
+   if (this->healthReasonLabel)
+   {
+      const char *reason = (resource.healthReason[0] != '\0') ? resource.healthReason : "Kein Grund angegeben.";
+      lv_label_set_text(this->healthReasonLabel, reason);
    }
 
    // Toggle sections based on type and usage
@@ -535,10 +570,16 @@ String ResourceDetailsScreen::buildIntroducersText(const API::ResourceBrief &res
 void ResourceDetailsScreen::refreshAccessState()
 {
    bool underMaintenance = this->resourceCacheValid && this->resourceCache.isUnderMaintenance;
+   bool isUnhealthy = this->resourceCacheValid && !this->resourceCache.isHealthy;
 
    if (this->maintenancePanel)
    {
       lv_obj_set_flag(this->maintenancePanel, LV_OBJ_FLAG_HIDDEN, !underMaintenance);
+   }
+
+   if (this->healthPanel)
+   {
+      lv_obj_set_flag(this->healthPanel, LV_OBJ_FLAG_HIDDEN, !isUnhealthy);
    }
 
    if (!this->userDetailsInitialized)
@@ -549,16 +590,19 @@ void ResourceDetailsScreen::refreshAccessState()
    const UserDetails &user = this->userDetailsCache;
    bool isMaintainer = user.isIntroducer || user.canManageResource;
 
+   // Resource is blocked when it is under maintenance or reporting an unhealthy state.
+   bool blocked = underMaintenance || isUnhealthy;
+
    // No-introduction panel is shown only when the user is missing an introduction
-   // and the resource is not blocked by maintenance (maintenance panel takes priority).
+   // and the resource is not blocked (maintenance/health panels take priority).
    if (this->noIntroductionPanel)
    {
-      lv_obj_set_flag(this->noIntroductionPanel, LV_OBJ_FLAG_HIDDEN, user.hasIntroduction || underMaintenance);
+      lv_obj_set_flag(this->noIntroductionPanel, LV_OBJ_FLAG_HIDDEN, user.hasIntroduction || blocked);
    }
 
-   // Session controls require access; during maintenance only maintainers may use the resource.
+   // Session controls require access; while blocked only maintainers may use the resource.
    bool canUse = user.hasIntroduction || user.isIntroducer || user.canManageResource;
-   if (underMaintenance)
+   if (blocked)
    {
       canUse = isMaintainer;
    }
@@ -620,6 +664,8 @@ void ResourceDetailsScreen::destroy()
    this->introducersListLabel = nullptr;
    this->maintenancePanel = nullptr;
    this->maintenanceIntroducersLabel = nullptr;
+   this->healthPanel = nullptr;
+   this->healthReasonLabel = nullptr;
    this->actionOverlayLabel = nullptr;
    this->successToast = nullptr;
    this->formsModalMeta = nullptr;

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
@@ -202,6 +202,8 @@ private:
     lv_obj_t *introducersListLabel;
     lv_obj_t *maintenancePanel = nullptr;
     lv_obj_t *maintenanceIntroducersLabel = nullptr;
+    lv_obj_t *healthPanel = nullptr;
+    lv_obj_t *healthReasonLabel = nullptr;
     String buildIntroducersText(const API::ResourceBrief &resource);
     void refreshAccessState();
 


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Attractap NFC readers now surface resource **health state** ([ATT-274](https://linear.app/attraccess/issue/ATT-274/health-state-for-resources)). Previously a device could be flagged unhealthy and have usage blocked server-side, but the reader gave no indication until a user tried (and failed) to start it. This mirrors the existing maintenance-banner flow end-to-end.

### Changes
- **API** (`resource-list.service.ts`): the `RESOURCE_LIST` websocket payload now includes `isHealthy` and a combined `healthReason` string per resource, sourced from `ResourceHealthService`. `ResourceHealthModule` wired into `AttractapModule`.
- **Firmware** (`api.hpp` / `api_resources.cpp`): `ResourceBrief` gains `isHealthy` + `healthReason`; parser defaults to healthy when the field is absent (backwards compatible).
- **Firmware** (`resourceDetailsScreen`): a red banner shows the unhealthy reason; session controls (the start button) are hidden for users who are not introducers/maintainers, matching the backend gate that allows only maintenance-capable users to use an unhealthy resource.
- **Firmware version** bumped `1.3.17` → `1.3.18` (required for OTA).

### Testing
- `nx lint api` ✅, `nx build api` ✅ (also compiles all 4 firmware envs) ✅
- `nx test api` ✅ — updated `resource-list.service.spec.ts` and `websocket.gateway.spec.ts` for the new dependency; added unit tests for the healthy / unhealthy reason-string cases.

### Verification note
No browser/web UI is affected — the change targets the ESP32 reader display (LVGL) and the websocket payload that drives it. There is no firmware display simulator in the repo, so agent-browser verification does not apply. Firmware behavior was validated via compilation of all environments and backend unit tests of the payload.

Closes [ATT-505](https://linear.app/attraccess/issue/ATT-505/attractap-display-device-health-state)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->