### PR TITLE
feat(attractap): hidden pull-down drawer for settings and reboot (ATT-507)

### DIFF
--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts =
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.18"'
+	-D FIRMWARE_VERSION='"1.3.19"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/application/application.cpp
+++ b/apps/attractap/firmware/src/application/application.cpp
@@ -305,6 +305,15 @@ void Application::setup() {
     Display::transitionToScreen(&Display::connectionConfigurationScreen);
   });
 
+  // Hidden maintenance drawer (pull down from the top edge) reuses the same
+  // settings entry as the init screen, including the PIN lock.
+  Display::setOnOpenSettingsCallback([this]() {
+    this->state = APPLICATION_STATE_CONFIGURATION_REQUIRED;
+    this->api.disableConnectionAttempts();
+    Display::connectionConfigurationScreen.enablePinLock();
+    Display::transitionToScreen(&Display::connectionConfigurationScreen);
+  });
+
   Display::resourceListScreen.setResourceSelectionCallback(
       [this](const API::ResourceBrief &resource) {
         this->selectResource(resource);

--- a/apps/attractap/firmware/src/display/display.cpp
+++ b/apps/attractap/firmware/src/display/display.cpp
@@ -52,6 +52,14 @@ std::function<void(int16_t, int16_t)> Display::touchCallback = nullptr;
 lv_obj_t *Display::activePopup = nullptr;
 lv_timer_t *Display::popupAutoCloseTimer = nullptr;
 
+lv_obj_t *Display::drawerBackdrop = nullptr;
+lv_obj_t *Display::drawerPanel = nullptr;
+bool Display::drawerOpen = false;
+std::function<void()> Display::onOpenSettingsCallback = nullptr;
+bool Display::gestureCandidate = false;
+bool Display::gesturePrevPressed = false;
+int16_t Display::gestureStartY = 0;
+
 // Set during setup() if touch hardware was not found; popup is shown on the first loop() tick
 // to ensure LVGL is fully running before creating overlay objects.
 static bool s_touchWarningPending = false;
@@ -210,6 +218,7 @@ void Display::setup()
     lv_display_set_theme(disp, base_theme);
 
     Display::initDeviceOverlay();
+    Display::initDrawer();
 
     Display::transitionToScreen(&Display::bootScreen);
 

--- a/apps/attractap/firmware/src/display/display.hpp
+++ b/apps/attractap/firmware/src/display/display.hpp
@@ -59,6 +59,11 @@ public:
     static void showInsufficientBalancePopup(std::function<void(uint32_t amountCents)> onStart, std::function<void()> onCancel);
     static void hidePopup();
 
+    // Hidden maintenance drawer: pulled down from the top edge, exposes
+    // "Open Settings" and "Reboot" actions. The settings action is wired by the
+    // application; reboot is handled internally (esp_restart after a confirm).
+    static void setOnOpenSettingsCallback(std::function<void()> callback);
+
 private:
     static std::function<void(int16_t, int16_t)> touchCallback;
     static const int TRANSITION_DURATION = 500;
@@ -88,4 +93,21 @@ private:
 
     static lv_obj_t *activePopup;
     static lv_timer_t *popupAutoCloseTimer;
+
+    // Maintenance drawer (display_drawer.cpp)
+    static void initDrawer();
+    static void openDrawer();
+    static void closeDrawer();
+    static void showRebootConfirm();
+    // Fed every touch sample from touchpad_read to detect the top-edge pull-down
+    // gesture without intercepting touches destined for the active screen.
+    static void handleGestureSample(int16_t x, int16_t y, bool pressed);
+
+    static lv_obj_t *drawerBackdrop;
+    static lv_obj_t *drawerPanel;
+    static bool drawerOpen;
+    static std::function<void()> onOpenSettingsCallback;
+    static bool gestureCandidate;
+    static bool gesturePrevPressed;
+    static int16_t gestureStartY;
 };

--- a/apps/attractap/firmware/src/display/display_drawer.cpp
+++ b/apps/attractap/firmware/src/display/display_drawer.cpp
@@ -1,0 +1,288 @@
+#include "display.hpp"
+
+// Hidden maintenance drawer rendered on the LVGL top layer. It is revealed by a
+// pull-down gesture that starts at the very top edge of the screen and drags
+// downward (see handleGestureSample). The drawer exposes two admin actions:
+//   - "Settings": delegated to the application via onOpenSettingsCallback
+//                 (same path as the init screen's settings entry, incl. PIN lock)
+//   - "Reboot":   shows a confirmation, then esp_restart()
+//
+// Gesture detection is passive: it observes touch samples forwarded from
+// touchpad_read and never consumes them, so the active screen still receives
+// every touch normally. Only a deliberate top-edge downward drag opens the
+// drawer, which keeps it out of the way of regular screen interactions.
+
+namespace
+{
+    // Pull-down gesture tuning.
+    constexpr int16_t DRAWER_EDGE_BAND_PX = 45;       // press must start within this top band
+    constexpr int16_t DRAWER_OPEN_THRESHOLD_PX = 90;  // and drag down at least this far
+    constexpr int32_t DRAWER_HEIGHT = 230;            // panel height / off-screen offset
+
+    void anim_set_y_cb(void *obj, int32_t v)
+    {
+        lv_obj_set_y((lv_obj_t *)obj, (lv_coord_t)v);
+    }
+
+    lv_obj_t *makeDrawerButton(lv_obj_t *parent, const char *symbol, const char *text,
+                               lv_color_t color, lv_event_cb_t cb)
+    {
+        lv_obj_t *btn = lv_button_create(parent);
+        lv_obj_set_size(btn, lv_pct(44), 110);
+        lv_obj_set_style_bg_color(btn, color, LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_opa(btn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_radius(btn, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_flex_flow(btn, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_flex_align(btn, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+        lv_obj_set_style_pad_row(btn, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+        lv_obj_t *icon = lv_label_create(btn);
+        lv_label_set_text(icon, symbol);
+        lv_obj_set_style_text_color(icon, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_text_font(icon, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+        lv_obj_t *lbl = lv_label_create(btn);
+        lv_label_set_text(lbl, text);
+        lv_obj_set_style_text_color(lbl, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_text_font(lbl, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+        lv_obj_add_event_cb(btn, cb, LV_EVENT_CLICKED, NULL);
+        return btn;
+    }
+}
+
+void Display::setOnOpenSettingsCallback(std::function<void()> callback)
+{
+    Display::onOpenSettingsCallback = callback;
+}
+
+void Display::initDrawer()
+{
+    lv_obj_t *top = lv_layer_top();
+
+    // Dimming backdrop (created first so the panel renders above it). Hidden
+    // until the drawer opens; tapping it closes the drawer.
+    Display::drawerBackdrop = lv_obj_create(top);
+    lv_obj_remove_style_all(Display::drawerBackdrop);
+    lv_obj_set_size(Display::drawerBackdrop, lv_pct(100), lv_pct(100));
+    lv_obj_set_align(Display::drawerBackdrop, LV_ALIGN_CENTER);
+    lv_obj_set_style_bg_color(Display::drawerBackdrop, lv_color_black(), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(Display::drawerBackdrop, 140, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_remove_flag(Display::drawerBackdrop, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(Display::drawerBackdrop, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(Display::drawerBackdrop, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_event_cb(Display::drawerBackdrop, [](lv_event_t *e)
+                        {
+        if (lv_event_get_code(e) == LV_EVENT_CLICKED)
+        {
+            Display::closeDrawer();
+        } }, LV_EVENT_CLICKED, NULL);
+
+    // Sliding panel, parked off-screen above the top edge.
+    Display::drawerPanel = lv_obj_create(top);
+    lv_obj_remove_style_all(Display::drawerPanel);
+    lv_obj_set_width(Display::drawerPanel, lv_pct(100));
+    lv_obj_set_height(Display::drawerPanel, DRAWER_HEIGHT);
+    lv_obj_set_align(Display::drawerPanel, LV_ALIGN_TOP_MID);
+    lv_obj_set_y(Display::drawerPanel, -DRAWER_HEIGHT);
+    lv_obj_set_style_bg_color(Display::drawerPanel, lv_color_hex(0x1F2C47), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(Display::drawerPanel, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_radius(Display::drawerPanel, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_border_width(Display::drawerPanel, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_pad_all(Display::drawerPanel, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_pad_row(Display::drawerPanel, 14, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_flex_flow(Display::drawerPanel, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(Display::drawerPanel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_remove_flag(Display::drawerPanel, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(Display::drawerPanel, LV_OBJ_FLAG_HIDDEN);
+
+    lv_obj_t *titleLbl = lv_label_create(Display::drawerPanel);
+    lv_label_set_text(titleLbl, "Maintenance");
+    lv_obj_set_style_text_color(titleLbl, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(titleLbl, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+    lv_obj_t *row = lv_obj_create(Display::drawerPanel);
+    lv_obj_remove_style_all(row);
+    lv_obj_set_width(row, lv_pct(100));
+    lv_obj_set_height(row, LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(row, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_remove_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+
+    makeDrawerButton(row, LV_SYMBOL_SETTINGS, "Settings", lv_color_hex(0x2563EB),
+                     [](lv_event_t *e)
+                     {
+                         if (lv_event_get_code(e) != LV_EVENT_CLICKED)
+                             return;
+                         Display::logger.info("Drawer: open settings requested");
+                         Display::closeDrawer();
+                         if (Display::onOpenSettingsCallback)
+                             Display::onOpenSettingsCallback();
+                     });
+
+    makeDrawerButton(row, LV_SYMBOL_POWER, "Reboot", lv_color_hex(0xF31260),
+                     [](lv_event_t *e)
+                     {
+                         if (lv_event_get_code(e) != LV_EVENT_CLICKED)
+                             return;
+                         Display::closeDrawer();
+                         Display::showRebootConfirm();
+                     });
+
+    // Subtle top-edge grabber as an affordance for the otherwise hidden gesture.
+    lv_obj_t *grabber = lv_obj_create(top);
+    lv_obj_remove_style_all(grabber);
+    lv_obj_set_size(grabber, 46, 5);
+    lv_obj_set_align(grabber, LV_ALIGN_TOP_MID);
+    lv_obj_set_y(grabber, 4);
+    lv_obj_set_style_radius(grabber, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_color(grabber, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(grabber, 60, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_remove_flag(grabber, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_remove_flag(grabber, LV_OBJ_FLAG_SCROLLABLE);
+}
+
+void Display::openDrawer()
+{
+    if (Display::drawerOpen || !Display::drawerPanel || !Display::drawerBackdrop)
+        return;
+
+    Display::drawerOpen = true;
+    Display::logger.info("Maintenance drawer opened (top-edge pull-down)");
+    lv_obj_remove_flag(Display::drawerBackdrop, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_remove_flag(Display::drawerPanel, LV_OBJ_FLAG_HIDDEN);
+
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, Display::drawerPanel);
+    lv_anim_set_exec_cb(&a, anim_set_y_cb);
+    lv_anim_set_values(&a, -DRAWER_HEIGHT, 0);
+    lv_anim_set_time(&a, 250);
+    lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
+    lv_anim_start(&a);
+}
+
+void Display::closeDrawer()
+{
+    if (!Display::drawerOpen || !Display::drawerPanel || !Display::drawerBackdrop)
+        return;
+
+    Display::drawerOpen = false;
+    lv_obj_add_flag(Display::drawerBackdrop, LV_OBJ_FLAG_HIDDEN);
+
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, Display::drawerPanel);
+    lv_anim_set_exec_cb(&a, anim_set_y_cb);
+    lv_anim_set_values(&a, lv_obj_get_y(Display::drawerPanel), -DRAWER_HEIGHT);
+    lv_anim_set_time(&a, 200);
+    lv_anim_set_path_cb(&a, lv_anim_path_ease_in);
+    lv_anim_set_ready_cb(&a, [](lv_anim_t *)
+                         {
+        if (Display::drawerPanel)
+            lv_obj_add_flag(Display::drawerPanel, LV_OBJ_FLAG_HIDDEN); });
+    lv_anim_start(&a);
+}
+
+void Display::showRebootConfirm()
+{
+    lv_obj_t *top = lv_layer_top();
+    lv_obj_t *overlay = lv_obj_create(top);
+    lv_obj_remove_style_all(overlay);
+    lv_obj_set_size(overlay, lv_pct(100), lv_pct(100));
+    lv_obj_set_align(overlay, LV_ALIGN_CENTER);
+    lv_obj_set_style_bg_color(overlay, lv_color_black(), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(overlay, 160, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_remove_flag(overlay, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(overlay, LV_OBJ_FLAG_CLICKABLE);
+
+    lv_obj_t *dialog = lv_obj_create(overlay);
+    lv_obj_remove_style_all(dialog);
+    lv_obj_set_width(dialog, lv_pct(80));
+    lv_obj_set_height(dialog, LV_SIZE_CONTENT);
+    lv_obj_set_align(dialog, LV_ALIGN_CENTER);
+    lv_obj_set_style_bg_color(dialog, lv_color_hex(0x2A2A2A), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(dialog, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_radius(dialog, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_pad_all(dialog, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_pad_row(dialog, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_flex_flow(dialog, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(dialog, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
+
+    lv_obj_t *titleLbl = lv_label_create(dialog);
+    lv_label_set_text(titleLbl, "Reboot device?");
+    lv_obj_set_style_text_color(titleLbl, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(titleLbl, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+    lv_obj_t *msgLbl = lv_label_create(dialog);
+    lv_label_set_text(msgLbl, "The reader will restart now.");
+    lv_obj_set_style_text_color(msgLbl, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(msgLbl, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_width(msgLbl, lv_pct(100));
+
+    lv_obj_t *footer = lv_obj_create(dialog);
+    lv_obj_remove_style_all(footer);
+    lv_obj_set_width(footer, lv_pct(100));
+    lv_obj_set_height(footer, LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(footer, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
+    lv_obj_set_style_pad_column(footer, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+    lv_obj_t *cancelBtn = lv_button_create(footer);
+    lv_obj_set_height(cancelBtn, LV_SIZE_CONTENT);
+    lv_obj_set_width(cancelBtn, LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_color(cancelBtn, lv_color_hex(0x6B7280), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(cancelBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_t *cancelLbl = lv_label_create(cancelBtn);
+    lv_label_set_text(cancelLbl, "Cancel");
+    lv_obj_add_event_cb(cancelBtn, [](lv_event_t *e)
+                        {
+        if (lv_event_get_code(e) != LV_EVENT_CLICKED)
+            return;
+        lv_obj_t *ov = (lv_obj_t *)lv_event_get_user_data(e);
+        if (ov)
+            lv_obj_del(ov); }, LV_EVENT_CLICKED, overlay);
+
+    lv_obj_t *rebootBtn = lv_button_create(footer);
+    lv_obj_set_height(rebootBtn, LV_SIZE_CONTENT);
+    lv_obj_set_width(rebootBtn, LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_color(rebootBtn, lv_color_hex(0xF31260), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(rebootBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_t *rebootLbl = lv_label_create(rebootBtn);
+    lv_label_set_text(rebootLbl, "Reboot");
+    lv_obj_add_event_cb(rebootBtn, [](lv_event_t *e)
+                        {
+        if (lv_event_get_code(e) != LV_EVENT_CLICKED)
+            return;
+        Display::logger.info("Drawer: reboot confirmed, restarting");
+        esp_restart(); }, LV_EVENT_CLICKED, NULL);
+}
+
+void Display::handleGestureSample(int16_t x, int16_t y, bool pressed)
+{
+    (void)x;
+
+    if (!pressed)
+    {
+        Display::gesturePrevPressed = false;
+        Display::gestureCandidate = false;
+        return;
+    }
+
+    if (!Display::gesturePrevPressed)
+    {
+        // Rising edge: a new touch just started. It only counts as a drawer
+        // gesture if it began inside the top edge band and the drawer is closed.
+        Display::gesturePrevPressed = true;
+        Display::gestureStartY = y;
+        Display::gestureCandidate = !Display::drawerOpen && (y <= DRAWER_EDGE_BAND_PX);
+        return;
+    }
+
+    if (Display::gestureCandidate && !Display::drawerOpen &&
+        ((int)y - (int)Display::gestureStartY) >= DRAWER_OPEN_THRESHOLD_PX)
+    {
+        Display::gestureCandidate = false;
+        Display::openDrawer();
+    }
+}

--- a/apps/attractap/firmware/src/display/display_input.cpp
+++ b/apps/attractap/firmware/src/display/display_input.cpp
@@ -26,12 +26,15 @@ void Display::touchpad_read(lv_indev_t *indev_driver, lv_indev_data_t *data)
     if (!Display::driver->readTouch(point) || !point.pressed)
     {
         data->state = LV_INDEV_STATE_RELEASED;
+        Display::handleGestureSample(0, 0, false);
         return;
     }
 
     data->state = LV_INDEV_STATE_PRESSED;
     data->point.x = point.x;
     data->point.y = point.y;
+
+    Display::handleGestureSample(point.x, point.y, true);
 
     if (Display::touchCallback)
     {


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds a hidden maintenance drawer to the Attractap firmware. Pulling down from the **top edge** of the screen reveals a drawer with two admin actions:

- **Settings** — opens the connection-configuration screen via the same PIN-locked entry the init screen uses.
- **Reboot** — shows a confirm dialog, then `esp_restart()`.

Resolves [ATT-507](https://linear.app/attraccess/issue/ATT-507/attractap-hidden-menu-for-settings-and-reboot).

## Implementation

- New `src/display/display_drawer.cpp` builds the drawer (backdrop + sliding panel + buttons) on the LVGL **top layer**, so it is reachable from every screen — same layer pattern as the existing device-info overlay.
- Gesture detection is **passive**: `handleGestureSample()` observes touch samples forwarded from `touchpad_read` and only triggers when a press starts inside the top edge band (≤45px) and drags down ≥90px. It never consumes touches, so the active screen still receives every event normally (no blocking strip over top-aligned screen elements).
- A subtle top-center grabber hints at the otherwise-hidden gesture.
- Settings action wired in `application.cpp`, mirroring `initScreen.setOnOpenSettingsCallback` (state → `CONFIGURATION_REQUIRED`, disable connection attempts, enable PIN lock, transition). Reboot is handled internally with a confirmation dialog.
- `FIRMWARE_VERSION` bumped `1.3.18` → `1.3.19` (required for OTA).

## Testing

- Builds green for all three display/non-display envs: `attractap-touch`, `attractap-touch-v2`, `attractap-lite-ethernet`.
- On-device validation (bench unit, touch-v2) pending — info logs added (`Maintenance drawer opened …`, `Drawer: open settings requested`, `Drawer: reboot confirmed`) to confirm the gesture and actions over serial.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
