### PR TITLE
fix(attractap): recover from fragmented-heap websocket reconnect lockup (ATT-508)

### DIFF
--- a/apps/api/src/attractap/attractap.service.ts
+++ b/apps/api/src/attractap/attractap.service.ts
@@ -244,6 +244,7 @@ export class AttractapService {
     const report = await this.crashReportRepository.save({
       attractapId: readerId,
       resetReason: payload.resetReason,
+      rebootReason: payload.rebootReason || null,
       heapFreeBytes: this.toNullableInt(payload.heapFreeBytes),
       largestFreeBlockBytes: this.toNullableInt(payload.largestFreeBlockBytes),
       uptimeBeforeResetMs: this.toNullableInt(payload.uptimeBeforeResetMs),

--- a/apps/api/src/attractap/websockets/handlers/crash-report.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/crash-report.handler.ts
@@ -33,6 +33,7 @@ export class AttractapCrashReportHandler {
       const report = await this.attractapService.createCrashReport(socket.readerId, payload);
       this.logger.warn(
         `Stored crash report ${report.id} for reader ${socket.readerId}: reason=${report.resetReason} ` +
+          `rebootReason=${report.rebootReason ?? 'n/a'} ` +
           `heapFree=${report.heapFreeBytes ?? 'n/a'} largestBlock=${report.largestFreeBlockBytes ?? 'n/a'} ` +
           `uptimeMs=${report.uptimeBeforeResetMs ?? 'n/a'} ws=${report.wsState ?? 'n/a'} wifi=${report.wifiState ?? 'n/a'}`,
       );

--- a/apps/api/src/attractap/websockets/websocket.types.ts
+++ b/apps/api/src/attractap/websockets/websocket.types.ts
@@ -42,6 +42,7 @@ export enum AttractapEventType {
 
 export interface ReaderCrashReportPayload {
   resetReason: string;
+  rebootReason?: string | null;
   heapFreeBytes?: number | null;
   largestFreeBlockBytes?: number | null;
   uptimeBeforeResetMs?: number | null;

--- a/apps/api/src/database/migrations/1781300000000-attractap-crash-report-reboot-reason.ts
+++ b/apps/api/src/database/migrations/1781300000000-attractap-crash-report-reboot-reason.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AttractapCrashReportRebootReason1781300000000 implements MigrationInterface {
+  name = 'AttractapCrashReportRebootReason1781300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "attractap_crash_report" ADD COLUMN "rebootReason" text`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "attractap_crash_report" DROP COLUMN "rebootReason"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -122,3 +122,4 @@ export * from './1781000000000-maintenance-requests';
 export * from './1781100000000-message-email-fallback';
 export * from './1780200000000-attractap-crash-report-symbolication';
 export * from './1781200000000-resource-usage-note-email-template';
+export * from './1781300000000-attractap-crash-report-reboot-reason';

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts =
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.18"'
+	-D FIRMWARE_VERSION='"1.3.19"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/api/api_diag.cpp
+++ b/apps/attractap/firmware/src/api/api_diag.cpp
@@ -28,6 +28,7 @@ struct CrashBootRecord
 
 #define BOOT_DIAG_NAMESPACE "bootdiag"
 #define BOOT_DIAG_PENDING_KEY "pending"
+#define BOOT_DIAG_REBOOT_REASON_KEY "rebootreason"
 #define BOOT_DIAG_MAGIC 0x41545431
 
 // Cap the coredump we are willing to base64-encode and hold in RAM at once.
@@ -149,26 +150,44 @@ void API::sendPendingCrashReport()
     // live reset reason is the correct label to pair with the pre-freeze snapshot.
     const char *resetStr = crashResetReasonToString((uint8_t)esp_reset_reason());
 
+    // Optional deliberate-reboot reason left behind by the firmware before it
+    // rebooted itself (e.g. the websocket reconnect heap-recovery reboot). Absent
+    // for ordinary/unexpected resets, in which case the field is omitted.
+    char rebootReason[64] = {0};
+    {
+        Preferences reasonPrefs;
+        reasonPrefs.begin(BOOT_DIAG_NAMESPACE, true);
+        reasonPrefs.getString(BOOT_DIAG_REBOOT_REASON_KEY, rebootReason, sizeof(rebootReason));
+        reasonPrefs.end();
+    }
+
     size_t b64Len = 0;
     std::unique_ptr<char[]> coredump = readCoredumpBase64(this->logger, b64Len);
     this->crashReportSentCoredump = (bool)coredump;
 
-    this->logger.infof("Uploading crash report: reset=%s uptime=%ums heap=%u coredump=%s",
-                       resetStr, rec.uptimeMs, rec.freeInternalHeap, coredump ? "yes" : "no");
+    this->logger.infof("Uploading crash report: reset=%s rebootReason=%s uptime=%ums heap=%u coredump=%s",
+                       resetStr, rebootReason[0] ? rebootReason : "(none)", rec.uptimeMs,
+                       rec.freeInternalHeap, coredump ? "yes" : "no");
 
     // Build the event manually into a single heap buffer: an oversized coredump
     // base64 string would otherwise be copied several times through ArduinoJson.
     const char *ws = rec.websocketConnected ? "CONNECTED" : "DISCONNECTED";
     const char *wifi = rec.wifiConnected ? "CONNECTED" : "DISCONNECTED";
 
-    char head[320];
+    char rebootReasonField[96] = {0};
+    if (rebootReason[0] != '\0')
+    {
+        snprintf(rebootReasonField, sizeof(rebootReasonField), ",\"rebootReason\":\"%s\"", rebootReason);
+    }
+
+    char head[416];
     int headLen = snprintf(
         head, sizeof(head),
         "{\"event\":\"EVENT\",\"data\":{\"type\":\"READER_CRASH_REPORT\",\"payload\":{"
         "\"resetReason\":\"%s\",\"heapFreeBytes\":%u,\"largestFreeBlockBytes\":%u,"
-        "\"uptimeBeforeResetMs\":%u,\"wsState\":\"%s\",\"wifiState\":\"%s\",\"firmwareVersion\":\"%s\"",
+        "\"uptimeBeforeResetMs\":%u,\"wsState\":\"%s\",\"wifiState\":\"%s\",\"firmwareVersion\":\"%s\"%s",
         resetStr, (unsigned)rec.freeInternalHeap, (unsigned)rec.largestFreeBlock,
-        (unsigned)rec.uptimeMs, ws, wifi, FIRMWARE_VERSION);
+        (unsigned)rec.uptimeMs, ws, wifi, FIRMWARE_VERSION, rebootReasonField);
     if (headLen <= 0 || headLen >= (int)sizeof(head))
     {
         this->logger.error("Failed to format crash report header");
@@ -234,6 +253,7 @@ void API::onCrashReportResponse(JsonObject data)
     Preferences prefs;
     prefs.begin(BOOT_DIAG_NAMESPACE, false);
     prefs.remove(BOOT_DIAG_PENDING_KEY);
+    prefs.remove(BOOT_DIAG_REBOOT_REASON_KEY);
     prefs.end();
 
     if (this->crashReportSentCoredump)

--- a/apps/attractap/firmware/src/websocket/websocket.cpp
+++ b/apps/attractap/firmware/src/websocket/websocket.cpp
@@ -1,6 +1,13 @@
 #include "websocket.hpp"
 #include "esp_heap_caps.h"
 #include "esp_system.h"
+#include <Preferences.h>
+
+// Deliberate-reboot reason handed to the crash reporter across the SW reset (see
+// api_diag.cpp). Lives in the same NVS namespace as the boot diagnostics record
+// so the API layer can pick it up and attach it to the uploaded crash report.
+#define BOOT_DIAG_NAMESPACE "bootdiag"
+#define BOOT_DIAG_REBOOT_REASON_KEY "rebootreason"
 
 void Websocket::setup()
 {
@@ -293,6 +300,17 @@ void Websocket::handleConnectFailure(const char *reason)
     if (this->consecutiveConnectFailures >= MAX_CONSECUTIVE_CONNECT_FAILURES)
     {
         this->logger.error("WebSocket client could not be started repeatedly (heap likely fragmented); rebooting to recover");
+
+        // Record why we are rebooting so the next boot's crash report carries the
+        // real cause instead of a bare "SW" reset reason. The API layer reads and
+        // clears this key once the report is acknowledged (see api_diag.cpp).
+        Preferences prefs;
+        if (prefs.begin(BOOT_DIAG_NAMESPACE, false))
+        {
+            prefs.putString(BOOT_DIAG_REBOOT_REASON_KEY, "WEBSOCKET_RECONNECT_HEAP_EXHAUSTION");
+            prefs.end();
+        }
+
         delay(200);
         esp_restart();
     }

--- a/apps/attractap/firmware/src/websocket/websocket.cpp
+++ b/apps/attractap/firmware/src/websocket/websocket.cpp
@@ -1,5 +1,6 @@
 #include "websocket.hpp"
 #include "esp_heap_caps.h"
+#include "esp_system.h"
 
 void Websocket::setup()
 {
@@ -198,6 +199,7 @@ void Websocket::connectWebSocket()
         if (restartRet == ESP_OK)
         {
             logger.info("connectWebSocket: WebSocket restarted");
+            this->consecutiveConnectFailures = 0;
             return;
         }
         logger.error((String("Failed to restart WebSocket client: ") + esp_err_to_name(restartRet)).c_str());
@@ -247,9 +249,7 @@ void Websocket::connectWebSocket()
     esp_websocket_client_handle_t newClient = esp_websocket_client_init(&websocket_cfg);
     if (!newClient)
     {
-        logger.error("Failed to initialize WebSocket client");
-        setState(INIT);
-
+        handleConnectFailure("esp_websocket_client_init returned null");
         return;
     }
 
@@ -260,10 +260,8 @@ void Websocket::connectWebSocket()
     esp_err_t ret = esp_websocket_client_start(newClient);
     if (ret != ESP_OK)
     {
-        logger.error((String("Failed to start WebSocket client: ") + esp_err_to_name(ret)).c_str());
         esp_websocket_client_destroy(newClient);
-        setState(INIT);
-
+        handleConnectFailure((String("esp_websocket_client_start: ") + esp_err_to_name(ret)).c_str());
         return;
     }
 
@@ -271,7 +269,33 @@ void Websocket::connectWebSocket()
     ws_client = newClient;
     unlockWsClient();
 
+    this->consecutiveConnectFailures = 0;
     logger.info("connectWebSocket: WebSocket started");
+}
+
+// A failed (re)connect that gets this far means the websocket client could not be
+// created/started at all -- almost always because the internal heap is too
+// fragmented to allocate the client task's stack ("Error create websocket task" /
+// ESP_FAIL from the IDF). That state does not heal on its own: every subsequent
+// attempt fails the same way and the device sits forever on the connecting screen.
+// Reboot after a few consecutive failures so the heap is defragmented and the
+// device reconnects cleanly once the server is reachable again.
+void Websocket::handleConnectFailure(const char *reason)
+{
+    this->consecutiveConnectFailures++;
+    this->logger.errorf("Failed to start WebSocket client (%s); consecutive=%u heap_free=%u heap_largest=%u",
+                        reason,
+                        (unsigned)this->consecutiveConnectFailures,
+                        (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+                        (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
+    setState(INIT);
+
+    if (this->consecutiveConnectFailures >= MAX_CONSECUTIVE_CONNECT_FAILURES)
+    {
+        this->logger.error("WebSocket client could not be started repeatedly (heap likely fragmented); rebooting to recover");
+        delay(200);
+        esp_restart();
+    }
 }
 
 bool Websocket::shouldReconnect()
@@ -316,6 +340,7 @@ void Websocket::processWebSocketEvent(esp_event_base_t base, int32_t event_id, v
     {
     case WEBSOCKET_EVENT_CONNECTED:
         logger.info("WebSocket connected");
+        this->consecutiveConnectFailures = 0;
         {
             this->_certManager.markSuccess();
         }

--- a/apps/attractap/firmware/src/websocket/websocket.hpp
+++ b/apps/attractap/firmware/src/websocket/websocket.hpp
@@ -59,6 +59,19 @@ private:
     const uint32_t HEAP_LOG_INTERVAL_MS = 30000;
     void logHeapStats();
 
+    // Recovery from a fragmented internal heap: once esp_websocket_client_start()
+    // can no longer carve out a contiguous block for its ~10 KB task stack it logs
+    // "Error create websocket task" and returns ESP_FAIL on every attempt, leaving
+    // the device permanently stuck on the connecting screen even after the server
+    // returns. Repeated stop/start cycles during an outage are what fragments the
+    // heap in the first place, and a reboot is the only reliable way to defragment
+    // it. We count consecutive start failures (which only happen when the client
+    // truly cannot be created, never during a normal refused connection) and reboot
+    // once the threshold is hit to force a clean reconnect.
+    uint8_t consecutiveConnectFailures = 0;
+    static constexpr uint8_t MAX_CONSECUTIVE_CONNECT_FAILURES = 5;
+    void handleConnectFailure(const char *reason);
+
     uint32_t lastInboundFrameTime = 0;
     const uint32_t INBOUND_LIVENESS_TIMEOUT_MS = 20000;
     const int PINGPONG_TIMEOUT_SEC = 10;

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.tsx
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.tsx
@@ -168,6 +168,11 @@ export function AttractapDiagnostics(props: Readonly<Props>) {
                   <Chip color="warning" variant="soft" size="sm">
                     {report.resetReason}
                   </Chip>
+                  {report.rebootReason && (
+                    <Chip color="danger" variant="soft" size="sm" data-cy="attractap-diagnostics-reboot-reason">
+                      {report.rebootReason}
+                    </Chip>
+                  )}
                   {report.symbolicationStatus && (
                     <Chip
                       color={symbolicationChipColor(report.symbolicationStatus)}

--- a/libs/database-entities/src/lib/entities/attractapCrashReport.entity.ts
+++ b/libs/database-entities/src/lib/entities/attractapCrashReport.entity.ts
@@ -29,6 +29,15 @@ export class AttractapCrashReport {
   })
   resetReason!: string;
 
+  @Column({ type: 'text', nullable: true })
+  @ApiProperty({
+    description:
+      'Deliberate reboot reason set by the firmware before a self-triggered restart (e.g. websocket reconnect heap recovery). Null for ordinary/unexpected resets.',
+    example: 'WEBSOCKET_RECONNECT_HEAP_EXHAUSTION',
+    nullable: true,
+  })
+  rebootReason!: string | null;
+
   @Column({ type: 'integer', nullable: true })
   @ApiProperty({
     description: 'Free heap in bytes captured before the freeze/reset',


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes a lockup where, after the server is stopped and restarted, an Attractap reader stays stuck forever on the connecting screen. Serial log repeats:

```
E (226204) WEBSOCKET_CLIENT: Error create websocket task
[Websocket] ERROR: Failed to start WebSocket client: ESP_FAIL
```

## Root cause

`Error create websocket task` is the ESP-IDF websocket client logging that `xTaskCreate()` failed to allocate its task stack (`task_stack = 9830` bytes). The only reason that fails is insufficient **contiguous** internal heap.

The self-managed reconnect loop repeatedly stop/starts (and on failure destroy/recreates) the client during an outage. Each cycle frees and re-allocates the ~10 KB task stack; interleaved with other allocations this **fragments the internal heap** until no contiguous block large enough remains. Once fragmented the state never heals on its own — every subsequent `esp_websocket_client_start()` fails identically, so the reader never reconnects even after the server comes back.

## Fix

- Count **consecutive** client start/init failures. These only occur when the client genuinely cannot be created (heap), never on a normally refused connection — so the counter stays at 0 during ordinary outages where `start()` succeeds and the connection is merely refused.
- After `MAX_CONSECUTIVE_CONNECT_FAILURES` (5) consecutive failures, `esp_restart()` to defragment the heap and force a clean reconnect. A reboot is the only reliable cure for a fragmented heap, and this matches the existing watchdog-style hardening (#1179).
- Reset the counter on any successful start and on `WEBSOCKET_EVENT_CONNECTED`.
- Failure logging now includes free/largest internal heap for field diagnosis.
- Bump `FIRMWARE_VERSION` 1.3.18 → 1.3.19 (required for OTA).

## Testing

- `pio run -e attractap-touch` → SUCCESS (RAM 47.2%, Flash 81.6%).
- No firmware unit-test suite exists; verified via compile + code review. Hardware reproduction (stop server → wait → restart server) recommended before release.

Closes ATT-508 — https://linear.app/attraccess/issue/ATT-508/attractap-websocket-reconnect-issue

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->