### PR TITLE
fix(attractap): NFC card reset/deletion + align screen with enrollment (ATT-506)

### DIFF
--- a/apps/api/src/attractap/websockets/handlers/card.handler.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/card.handler.spec.ts
@@ -12,6 +12,7 @@ describe('AttractapCardHandler', () => {
     generateNTAG424Key: jest.Mock;
     uint8ArrayToHexString: jest.Mock;
     createNFCCard: jest.Mock;
+    deleteNFCCard: jest.Mock;
   };
   let usersService: { findOne: jest.Mock };
   let resourceUsageService: { canControllResource: jest.Mock };
@@ -31,6 +32,7 @@ describe('AttractapCardHandler', () => {
       state: {
         lastAuthenticatedUserId: null,
         enrollNewCardData: null,
+        resetNfcCardData: null,
         ...(overrides.state || {}),
       },
       sendMessage: jest.fn().mockResolvedValue(undefined),
@@ -52,10 +54,13 @@ describe('AttractapCardHandler', () => {
     attractapService = {
       findReaderById: jest.fn().mockResolvedValue(mockReaderWithEnrollment),
       getNFCCardByUID: jest.fn().mockResolvedValue(null),
-      getNFCCardByID: jest.fn().mockResolvedValue({ id: 7 }),
+      getNFCCardByID: jest
+        .fn()
+        .mockResolvedValue({ id: 7, key: 'aabbccddeeff00112233445566778899', keyNo: 1, user: mockUser }),
       generateNTAG424Key: jest.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
       uint8ArrayToHexString: jest.fn().mockReturnValue('deadbeef'),
       createNFCCard: jest.fn().mockResolvedValue(undefined),
+      deleteNFCCard: jest.fn().mockResolvedValue({ affected: 1 }),
     };
     usersService = { findOne: jest.fn().mockResolvedValue(mockUser) };
     resourceUsageService = { canControllResource: jest.fn().mockResolvedValue(true) };
@@ -135,6 +140,63 @@ describe('AttractapCardHandler', () => {
       expect((handler as any).logger.debug).toHaveBeenCalledWith(
         expect.stringContaining('Failed to send ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO to client socket-1'),
       );
+    });
+  });
+
+  describe('onResetNfcCard', () => {
+    it('sends RESET_NFC_CARD_DATA_NOT_SET when no reset state', async () => {
+      const socket = createMockSocket();
+      const data = { payload: { success: true } } as AttractapEvent['data'];
+
+      await handler.onResetNfcCard(socket, data);
+
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESET_NFC_CARD,
+            payload: { error: 'RESET_NFC_CARD_DATA_NOT_SET' },
+          }),
+        }),
+      );
+      expect(attractapService.deleteNFCCard).not.toHaveBeenCalled();
+    });
+
+    it('does not delete and keeps state when the reader reports failure', async () => {
+      const socket = createMockSocket({ state: { resetNfcCardData: { cardId: 7, key: 'x', keyNo: 1 } } });
+      const data = { payload: { success: false } } as AttractapEvent['data'];
+
+      await handler.onResetNfcCard(socket, data);
+
+      expect(attractapService.deleteNFCCard).not.toHaveBeenCalled();
+      expect(socket.state.resetNfcCardData).toEqual({ cardId: 7, key: 'x', keyNo: 1 });
+    });
+
+    it('deletes the card and clears state on success', async () => {
+      const socket = createMockSocket({ state: { resetNfcCardData: { cardId: 7, key: 'x', keyNo: 1 } } });
+      const data = { payload: { success: true } } as AttractapEvent['data'];
+
+      await handler.onResetNfcCard(socket, data);
+
+      expect(attractapService.deleteNFCCard).toHaveBeenCalledWith(7);
+      expect(socket.state.resetNfcCardData).toBeNull();
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESET_NFC_CARD,
+            payload: { success: true },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('onResetNfcCardCancel', () => {
+    it('clears reset state', async () => {
+      const socket = createMockSocket({ state: { resetNfcCardData: { cardId: 7, key: 'x', keyNo: 1 } } });
+
+      await handler.onResetNfcCardCancel(socket);
+
+      expect(socket.state.resetNfcCardData).toBeNull();
     });
   });
 
@@ -393,7 +455,7 @@ describe('AttractapCardHandler', () => {
       ).rejects.toThrow('NFC card not found: 7');
     });
 
-    it('resolves and performs all lookups on the happy path', async () => {
+    it('stores reset state and sends RESET_NFC_CARD with the stored key material on the happy path', async () => {
       const socket = createMockSocket();
       websocketService.sockets.set('socket-1', socket);
 
@@ -404,6 +466,19 @@ describe('AttractapCardHandler', () => {
       expect(attractapService.findReaderById).toHaveBeenCalledWith(42);
       expect(usersService.findOne).toHaveBeenCalledWith({ id: 1 });
       expect(attractapService.getNFCCardByID).toHaveBeenCalledWith(7);
+      expect(socket.state.resetNfcCardData).toEqual({
+        cardId: 7,
+        key: 'aabbccddeeff00112233445566778899',
+        keyNo: 1,
+      });
+      expect(socket.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: AttractapEventType.RESET_NFC_CARD,
+            payload: { username: mockUser.username, keyNo: 1, key: 'aabbccddeeff00112233445566778899' },
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/attractap/websockets/handlers/card.handler.ts
+++ b/apps/api/src/attractap/websockets/handlers/card.handler.ts
@@ -192,7 +192,57 @@ export class AttractapCardHandler {
       throw new Error(`NFC card not found: ${data.cardId}`);
     }
 
-    // TODO: implement this
+    // Hand the reader everything it needs to reset the card in one go: the
+    // stored key + slot let it authenticate the card and write the factory key
+    // back, so — unlike enrollment — no extra key round-trip is required. The
+    // cardId is kept in socket state so we know which DB record to delete once
+    // the reader confirms the on-card reset succeeded.
+    socket.state.resetNfcCardData = {
+      cardId: nfcCard.id,
+      key: nfcCard.key,
+      keyNo: nfcCard.keyNo,
+    };
+
+    await socket.sendMessage(
+      new AttractapEvent(AttractapEventType.RESET_NFC_CARD, {
+        username: nfcCard.user.username,
+        keyNo: nfcCard.keyNo,
+        key: nfcCard.key,
+      }),
+    );
+  }
+
+  public async onResetNfcCard(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {
+    if (!socket.state.resetNfcCardData) {
+      await socket.sendMessage(
+        new AttractapEvent(AttractapEventType.RESET_NFC_CARD, { error: 'RESET_NFC_CARD_DATA_NOT_SET' }),
+      );
+      return;
+    }
+
+    const { success } = data.payload as { success: boolean };
+    if (!success) {
+      this.logger.error('Reset of NFC card failed on reader');
+      // Keep the reset data: the reader stays on its screen and may retry the
+      // write with the same card within the timeout.
+      return;
+    }
+
+    const { cardId } = socket.state.resetNfcCardData;
+
+    // The card was wiped back to the factory key on the reader; drop the DB
+    // record so the (now blank) card is no longer recognised.
+    await this.attractapService.deleteNFCCard(cardId);
+
+    socket.state.resetNfcCardData = null;
+    socket.sendMessage(new AttractapEvent(AttractapEventType.RESET_NFC_CARD, { success: true }));
+  }
+
+  // Reader actively cancelled (user pressed cancel) or the reset timed out.
+  // Clear the reset state so a stale cardId can't leak into a later flow.
+  public async onResetNfcCardCancel(socket: AuthenticatedWebSocket) {
+    this.logger.log('Reset of NFC card cancelled by reader');
+    socket.state.resetNfcCardData = null;
   }
 
   public async handleCardAuthenticationRequest(socket: AuthenticatedWebSocket, data: AttractapEvent['data']) {

--- a/apps/api/src/attractap/websockets/websocket.gateway.spec.ts
+++ b/apps/api/src/attractap/websockets/websocket.gateway.spec.ts
@@ -56,6 +56,7 @@ function createMockSocket(overrides: Partial<AuthenticatedWebSocket> = {}): Auth
     state: {
       lastAuthenticatedUserId: null,
       enrollNewCardData: null,
+      resetNfcCardData: null,
       ota: null,
     },
     ...overrides,
@@ -189,6 +190,7 @@ describe('AttractapGateway', () => {
         state: {
           lastAuthenticatedUserId: null,
           enrollNewCardData: null,
+          resetNfcCardData: null,
           ota: { path: '/tmp/test', size: 1024, fd: 999 },
         },
       });

--- a/apps/api/src/attractap/websockets/websocket.gateway.ts
+++ b/apps/api/src/attractap/websockets/websocket.gateway.ts
@@ -229,6 +229,7 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
       state: {
         lastAuthenticatedUserId: null,
         enrollNewCardData: null,
+        resetNfcCardData: null,
         ota: null,
       },
     });
@@ -440,6 +441,13 @@ export class AttractapGateway implements OnGatewayConnection, OnGatewayDisconnec
         break;
       case AttractapEventType.ENROLL_NEW_CARD_CANCEL:
         await this.cardHandler.onEnrollNewCardCancel(socket);
+        break;
+
+      case AttractapEventType.RESET_NFC_CARD:
+        await this.cardHandler.onResetNfcCard(socket, eventData);
+        break;
+      case AttractapEventType.RESET_NFC_CARD_CANCEL:
+        await this.cardHandler.onResetNfcCardCancel(socket);
         break;
 
       case AttractapEventType.PROJECTS_OF_USER:

--- a/apps/api/src/attractap/websockets/websocket.types.ts
+++ b/apps/api/src/attractap/websockets/websocket.types.ts
@@ -31,6 +31,8 @@ export enum AttractapEventType {
   ENROLL_NEW_CARD_REQUEST_NFC_KEY = 'ENROLL_NEW_CARD_REQUEST_NFC_KEY',
   ENROLL_NEW_CARD = 'ENROLL_NEW_CARD',
   ENROLL_NEW_CARD_CANCEL = 'ENROLL_NEW_CARD_CANCEL',
+  RESET_NFC_CARD = 'RESET_NFC_CARD',
+  RESET_NFC_CARD_CANCEL = 'RESET_NFC_CARD_CANCEL',
   TRIGGER_FLOW_BUTTON = 'TRIGGER_FLOW_BUTTON',
   BILLING_REQUEST_TOPUP = 'BILLING_REQUEST_TOPUP',
   PROJECTS_OF_USER = 'PROJECTS_OF_USER',
@@ -92,6 +94,11 @@ export interface AuthenticatedWebSocket extends Omit<WebSocket, 'send'> {
       key: string;
       keyNo: number;
       cardUID: string;
+    } | null;
+    resetNfcCardData: {
+      cardId: number;
+      key: string;
+      keyNo: number;
     } | null;
     ota?: {
       path: string;

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts =
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.21"'
+	-D FIRMWARE_VERSION='"1.3.22"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/api/api.cpp
+++ b/apps/attractap/firmware/src/api/api.cpp
@@ -161,6 +161,10 @@ void API::processIncomingMessage(const char *buf, size_t len)
         // path responds with ENROLL_NEW_CARD instead.
         this->onEnrollNewCardRequestNFCKeyError(inboundDoc["data"].as<JsonObject>());
     }
+    else if (strcmp(eventType, "RESET_NFC_CARD") == 0)
+    {
+        this->onResetNfcCard(inboundDoc["data"].as<JsonObject>());
+    }
     else if (
         strcmp(eventType, "START_RESOURCE_USAGE_SESSION") == 0 ||
         strcmp(eventType, "STOP_RESOURCE_USAGE_SESSION") == 0 ||

--- a/apps/attractap/firmware/src/api/api.hpp
+++ b/apps/attractap/firmware/src/api/api.hpp
@@ -227,6 +227,13 @@ public:
     void sendEnrollNewCard(bool success);
     void sendEnrollNewCardCancel();
 
+    // Card reset/deletion. The server already knows the card's stored key + slot
+    // (it is being deleted from the DB), so it hands them to the reader in a
+    // single RESET_NFC_CARD event — no key round-trip like enrollment.
+    void setResetNfcCardCallback(std::function<void(String username, uint8_t keyNo, String key)> callback);
+    void sendResetNfcCard(bool success);
+    void sendResetNfcCardCancel();
+
     void startResourceUsageSession(uint32_t resourceId, uint32_t projectId = 0);
     void stopResourceUsageSession(uint32_t resourceId);
     void requestFormFields(uint32_t resourceId, ResourceUsageFormActionType action, uint32_t formId, uint32_t offset, uint32_t limit);
@@ -340,6 +347,9 @@ private:
     // Server reuses the ENROLL_NEW_CARD_REQUEST_NFC_KEY event to report errors
     // back to the reader (e.g. CARD_ALREADY_ENROLLED).
     void onEnrollNewCardRequestNFCKeyError(JsonObject data);
+
+    std::function<void(String username, uint8_t keyNo, String key)> resetNfcCardCallback;
+    void onResetNfcCard(JsonObject data);
 
     std::function<void(const char *title, const char *message)> errorCallback;
     std::function<void(const char *type, bool success)> actionResultCallback;

--- a/apps/attractap/firmware/src/api/api_cards.cpp
+++ b/apps/attractap/firmware/src/api/api_cards.cpp
@@ -110,6 +110,57 @@ void API::setEnrollNewCardErrorCallback(std::function<void(String error)> callba
     this->enrollNewCardErrorCallback = callback;
 }
 
+void API::setResetNfcCardCallback(std::function<void(String username, uint8_t keyNo, String key)> callback)
+{
+    this->resetNfcCardCallback = callback;
+}
+
+void API::sendResetNfcCard(bool success)
+{
+    JsonDocument doc;
+    JsonObject payload = doc.to<JsonObject>();
+    payload["success"] = success;
+    this->sendMessage("RESET_NFC_CARD", payload);
+}
+
+void API::sendResetNfcCardCancel()
+{
+    JsonDocument doc;
+    JsonObject payload = doc.to<JsonObject>();
+    this->sendMessage("RESET_NFC_CARD_CANCEL", payload);
+}
+
+void API::onResetNfcCard(JsonObject data)
+{
+    this->logger.info("Received reset nfc card");
+    if (this->resetNfcCardCallback == nullptr)
+    {
+        this->logger.error("Reset nfc card callback is not set");
+        return;
+    }
+
+    JsonObject payload = data["payload"].as<JsonObject>();
+    if (payload["error"].is<String>() && payload["error"].as<String>().length() > 0)
+    {
+        this->logger.error(("Reset nfc card error from server: " + payload["error"].as<String>()).c_str());
+        return;
+    }
+
+    // The server hands over the card's stored key material so the reader can
+    // authenticate the card and write the factory key back.
+    if (!(payload["key"].is<String>() && payload["key"].as<String>().length() == 32 && payload["keyNo"].is<uint8_t>()))
+    {
+        this->logger.info("Reset nfc card payload does not contain key material; ignoring.");
+        return;
+    }
+
+    String username = payload["username"].is<String>() ? payload["username"].as<String>() : String("");
+    uint8_t keyNo = payload["keyNo"].as<uint8_t>();
+    String key = payload["key"].as<String>();
+
+    this->resetNfcCardCallback(username, keyNo, key);
+}
+
 void API::onEnrollNewCardRequestNFCKeyError(JsonObject data)
 {
     JsonObject payload = data["payload"].as<JsonObject>();

--- a/apps/attractap/firmware/src/application/application.cpp
+++ b/apps/attractap/firmware/src/application/application.cpp
@@ -358,6 +358,23 @@ void Application::setup() {
   Display::enrollmentScreen.setOnCancelCallback(
       [this]() { this->enrollCancelRequested = true; });
 
+  this->api.setResetNfcCardCallback(
+      [this](String username, uint8_t keyNo, String key) {
+        uint8_t keyBytes[16] = {0};
+        stringToHexArray(key, keyBytes, 16);
+
+        this->apiResetNfcCardData.username = username;
+        this->apiResetNfcCardData.keyNo = keyNo;
+        memset(this->apiResetNfcCardData.keyBytes, 0, 16);
+        memcpy(this->apiResetNfcCardData.keyBytes, keyBytes, 16);
+
+        // The reset state machine takes over on the main loop (beginReset()).
+        this->externalState = EXTERNAL_STATE_RESET_NFC_CARD;
+      });
+
+  Display::resetScreen.setOnCancelCallback(
+      [this]() { this->resetCancelRequested = true; });
+
   this->api.setProjectsOfUserResponseCallback(
       [this](const API::ProjectsOfUserResponse &projectsOfUserResponse) {
         this->projectsOfUserResponse = projectsOfUserResponse;
@@ -451,6 +468,14 @@ void Application::setup() {
       // ride the normal detection loop here precisely because it re-arms the
       // reader reliably across removals/re-presentations (ATT-503).
       this->enrollCardDetected = true;
+      return;
+    }
+
+    if (this->state == APPLICATION_STATE_RESET) {
+      // A card entered the field while waiting to reset. Same rationale as
+      // enrollment: flag it and let the reset state machine authenticate + write
+      // the factory key back on the main loop.
+      this->resetCardDetected = true;
       return;
     }
 #endif

--- a/apps/attractap/firmware/src/application/application.hpp
+++ b/apps/attractap/firmware/src/application/application.hpp
@@ -67,6 +67,7 @@ private:
         EXTERNAL_STATE_NONE,
 #ifdef HAS_LVGL_DISPLAY
         EXTERNAL_STATE_ENROLL_NEW_CARD_GET_AVAILABLE_KEY_NO,
+        EXTERNAL_STATE_RESET_NFC_CARD,
 #endif
         EXTERNAL_STATE_AUTHENTICATE_CARD,
         EXTERNAL_STATE_FIRMWARE_UPDATE,
@@ -125,6 +126,42 @@ private:
     void beginEnrollment();
     void processEnrollment();
     void exitEnrollment();
+
+    // Card reset/deletion. Mirrors the sticky, poll-driven enrollment sub-flow:
+    // once started it owns the display until success, cancel or timeout. Unlike
+    // enrollment there is no key round-trip — the server hands over the stored
+    // key + slot up front, so the reader can authenticate the card and write the
+    // factory key back as soon as a card is presented.
+    struct ApiResetNfcCardData_t
+    {
+        String username;
+        uint8_t keyNo;
+        uint8_t keyBytes[16];
+    };
+    ApiResetNfcCardData_t apiResetNfcCardData;
+
+    enum ResetPhase_t
+    {
+        RESET_PHASE_NONE,
+        RESET_PHASE_WAIT_FOR_CARD, // screen up, waiting for a card to reset
+        RESET_PHASE_WRITING,       // authenticating + writing the factory key back
+        RESET_PHASE_SUCCESS,       // success shown, dwelling before exit
+        RESET_PHASE_ERROR,         // error shown, dwelling before retry
+    };
+    ResetPhase_t resetPhase = RESET_PHASE_NONE;
+    // Set by the card-detection callback when a card enters the field during
+    // RESET_PHASE_WAIT_FOR_CARD; consumed on the main loop. Rides the proven
+    // handleCardDetection loop for reliable re-arm across removals (like ATT-503).
+    volatile bool resetCardDetected = false;
+    volatile bool resetCancelRequested = false;
+    uint32_t resetStartTimeMs = 0;
+    uint32_t resetPhaseChangedMs = 0;
+    static constexpr uint32_t RESET_TIMEOUT_MS = 30000;
+    static constexpr uint32_t RESET_SUCCESS_DWELL_MS = 1500;
+    static constexpr uint32_t RESET_ERROR_DWELL_MS = 1800;
+    void beginReset();
+    void processReset();
+    void exitReset();
 #endif
 
     API::CardAuthenticationDetailsResponse cardAuthenticationData;
@@ -272,6 +309,7 @@ private:
         APPLICATION_STATE_RESOURCE_LIST,
         APPLICATION_STATE_UNLOCKED,
         APPLICATION_STATE_ENROLLMENT,
+        APPLICATION_STATE_RESET,
 #else
         APPLICATION_STATE_WAIT_FOR_CARD,
 #endif

--- a/apps/attractap/firmware/src/application/application_state.cpp
+++ b/apps/attractap/firmware/src/application/application_state.cpp
@@ -77,6 +77,13 @@ void Application::processState() {
       this->externalState = EXTERNAL_STATE_NONE;
       this->enrollPhase = ENROLL_PHASE_NONE;
     }
+    // Same rationale for a pending/active reset: a stale trigger would relaunch
+    // a dead reset screen on reconnect (the server session is gone).
+    if (this->externalState == EXTERNAL_STATE_RESET_NFC_CARD ||
+        this->resetPhase != RESET_PHASE_NONE) {
+      this->externalState = EXTERNAL_STATE_NONE;
+      this->resetPhase = RESET_PHASE_NONE;
+    }
 #endif
         if (this->state == APPLICATION_STATE_INIT)
         {
@@ -113,6 +120,20 @@ void Application::processState() {
 
   if (this->state == APPLICATION_STATE_ENROLLMENT) {
     this->processEnrollment();
+    return;
+  }
+
+  // Card reset is a sticky, self-contained sub-flow just like enrollment — it
+  // owns the screen until success, cancel or timeout so the generic routing
+  // below can never steal the reset screen.
+  if (this->externalState == EXTERNAL_STATE_RESET_NFC_CARD &&
+      this->state != APPLICATION_STATE_RESET) {
+    this->beginReset();
+    return;
+  }
+
+  if (this->state == APPLICATION_STATE_RESET) {
+    this->processReset();
     return;
   }
 #endif
@@ -499,6 +520,123 @@ void Application::processEnrollment() {
       Display::enrollmentScreen.setStatus(EnrollmentScreen::STATUS_WAITING);
       this->enrollPhase = ENROLL_PHASE_WAIT_FOR_CARD;
       this->enrollCardDetected = false;
+      this->nfc.resetCardPresence();
+      this->nfc.enableCardDetection();
+    }
+    break;
+  }
+
+  default:
+    break;
+  }
+}
+
+void Application::beginReset() {
+  // Mirrors beginEnrollment(): WAIT_FOR_CARD rides the normal card-detection
+  // loop (reliable re-arm across removals); detection is disabled only for the
+  // authenticate + write once a card is actually picked.
+  this->resetCardDetected = false;
+  this->nfc.resetCardPresence();
+  this->nfc.enableCardDetection();
+  this->resetPhase = RESET_PHASE_WAIT_FOR_CARD;
+  this->resetCancelRequested = false;
+  this->resetStartTimeMs = millis();
+  this->resetPhaseChangedMs = this->resetStartTimeMs;
+
+  Display::resetScreen.setUserName(this->apiResetNfcCardData.username);
+  Display::resetScreen.setTimeoutTime(this->resetStartTimeMs + RESET_TIMEOUT_MS);
+  Display::resetScreen.setStatus(ResetScreen::STATUS_WAITING);
+  Display::transitionToScreen(&Display::resetScreen);
+
+  this->state = APPLICATION_STATE_RESET;
+  this->externalState = EXTERNAL_STATE_NONE;
+}
+
+void Application::exitReset() {
+  this->resetPhase = RESET_PHASE_NONE;
+  this->externalState = EXTERNAL_STATE_NONE;
+  this->unlocked = false;
+  // Hand back to the generic screen routing; next processState() iteration
+  // re-evaluates and transitions to the correct idle screen.
+  this->state = APPLICATION_STATE_INIT;
+}
+
+void Application::processReset() {
+  uint32_t now = millis();
+
+  // Explicit cancel (device touch button) wins over everything else.
+  if (this->resetCancelRequested) {
+    this->resetCancelRequested = false;
+    this->logger.debug("Reset cancelled by user");
+    this->api.sendResetNfcCardCancel();
+    this->exitReset();
+    return;
+  }
+
+  // Overall timeout — but never interrupt the brief success confirmation.
+  if (this->resetPhase != RESET_PHASE_SUCCESS &&
+      now - this->resetStartTimeMs > RESET_TIMEOUT_MS) {
+    this->logger.error("Reset timeout reached");
+    this->api.sendResetNfcCardCancel();
+    this->exitReset();
+    return;
+  }
+
+  switch (this->resetPhase) {
+  case RESET_PHASE_WAIT_FOR_CARD: {
+    // The detection loop flags a card via the card-detection callback; until
+    // then there is nothing to do but keep the screen up.
+    if (!this->resetCardDetected) {
+      break;
+    }
+    this->resetCardDetected = false;
+
+    // Take exclusive control of the PN532 for the authenticate + write that
+    // follow, so the detection loop doesn't probe the card underneath us.
+    this->nfc.disableCardDetection();
+    Display::resetScreen.setStatus(ResetScreen::STATUS_WRITING);
+    this->resetPhase = RESET_PHASE_WRITING;
+    this->resetPhaseChangedMs = now;
+    break;
+  }
+
+  case RESET_PHASE_WRITING: {
+    // Authenticate as the (still factory) application master key, then change
+    // the stored slot from the card's current key back to the factory key.
+    bool ok = this->nfc.changeKey(this->apiResetNfcCardData.keyNo,
+                                  this->nfc.FACTORY_KEY,
+                                  this->apiResetNfcCardData.keyBytes,
+                                  this->nfc.FACTORY_KEY);
+    this->api.sendResetNfcCard(ok);
+    if (ok) {
+      this->beeper.successBeep();
+      Display::resetScreen.setStatus(ResetScreen::STATUS_SUCCESS);
+      this->resetPhase = RESET_PHASE_SUCCESS;
+    } else {
+      this->beeper.errorBeep();
+      Display::resetScreen.setStatus(ResetScreen::STATUS_ERROR);
+      Display::resetScreen.setStatusMessage(
+          "Karte konnte nicht\nzurueckgesetzt werden");
+      this->resetPhase = RESET_PHASE_ERROR;
+    }
+    this->resetPhaseChangedMs = now;
+    break;
+  }
+
+  case RESET_PHASE_SUCCESS: {
+    if (now - this->resetPhaseChangedMs > RESET_SUCCESS_DWELL_MS) {
+      this->exitReset();
+    }
+    break;
+  }
+
+  case RESET_PHASE_ERROR: {
+    // Keep the screen up briefly, then drop back to waiting so the user can
+    // re-present the card. Re-arm detection so the next card is picked cleanly.
+    if (now - this->resetPhaseChangedMs > RESET_ERROR_DWELL_MS) {
+      Display::resetScreen.setStatus(ResetScreen::STATUS_WAITING);
+      this->resetPhase = RESET_PHASE_WAIT_FOR_CARD;
+      this->resetCardDetected = false;
       this->nfc.resetCardPresence();
       this->nfc.enableCardDetection();
     }

--- a/apps/attractap/firmware/src/display/display.cpp
+++ b/apps/attractap/firmware/src/display/display.cpp
@@ -46,6 +46,7 @@ NoResourcesScreen Display::noResourcesScreen;
 ResourceListScreen Display::resourceListScreen;
 ResourceDetailsScreen Display::resourceDetailsScreen;
 EnrollmentScreen Display::enrollmentScreen;
+ResetScreen Display::resetScreen;
 FirmwareUpdateScreen Display::firmwareUpdateScreen;
 
 std::function<void(int16_t, int16_t)> Display::touchCallback = nullptr;

--- a/apps/attractap/firmware/src/display/display.hpp
+++ b/apps/attractap/firmware/src/display/display.hpp
@@ -16,6 +16,7 @@
 #include "screens/resourceList/resourceListScreen.hpp"
 #include "screens/resourceDetails/resourceDetailsScreen.hpp"
 #include "screens/enrollment/enrollmentScreen.hpp"
+#include "screens/reset/resetScreen.hpp"
 #include "screens/firmwareUpdate/firmwareUpdateScreen.hpp"
 #include "driver/display_driver.hpp"
 
@@ -45,6 +46,7 @@ public:
     static ResourceListScreen resourceListScreen;
     static ResourceDetailsScreen resourceDetailsScreen;
     static EnrollmentScreen enrollmentScreen;
+    static ResetScreen resetScreen;
     static FirmwareUpdateScreen firmwareUpdateScreen;
 
     static void setTouchCallback(std::function<void(int16_t, int16_t)> callback);

--- a/apps/attractap/firmware/src/display/screens/reset/resetScreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/reset/resetScreen.cpp
@@ -1,0 +1,247 @@
+#include "resetScreen.hpp"
+
+// Palette — shared with EnrollmentScreen for visual consistency (ATT-506).
+// Dark, neutral background with explicit high-contrast white text.
+#define RESET_COLOR_BG 0x14142A
+#define RESET_COLOR_TEXT 0xFFFFFF
+#define RESET_COLOR_TITLE 0xB9B9D6
+#define RESET_COLOR_ACCENT 0x7C4DFF
+#define RESET_COLOR_BAR_BG 0x2A2A40
+#define RESET_COLOR_WAITING 0xE6E6F0
+#define RESET_COLOR_WRITING 0xFFC107
+#define RESET_COLOR_SUCCESS 0x4CD964
+#define RESET_COLOR_ERROR 0xFF5252
+#define RESET_COLOR_CANCEL_BG 0x3A3A57
+
+void ResetScreen::init()
+{
+   if (this->screen)
+   {
+      return;
+   }
+
+   this->screen = lv_obj_create(NULL);
+   lv_obj_remove_flag(this->screen, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_flex_flow(this->screen, LV_FLEX_FLOW_COLUMN);
+   lv_obj_set_flex_align(this->screen, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+   lv_obj_set_style_bg_color(this->screen, lv_color_hex(RESET_COLOR_BG), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(this->screen, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_left(this->screen, 24, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_right(this->screen, 24, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_top(this->screen, 18, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_bottom(this->screen, 18, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_row(this->screen, 16, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   // Countdown bar — full width, clearly coloured so the remaining time reads
+   // at a glance.
+   this->timeoutBar = lv_bar_create(this->screen);
+   lv_bar_set_range(this->timeoutBar, 0, 30);
+   lv_bar_set_value(this->timeoutBar, 30, LV_ANIM_OFF);
+   lv_obj_set_height(this->timeoutBar, 12);
+   lv_obj_set_width(this->timeoutBar, lv_pct(100));
+   lv_obj_set_style_radius(this->timeoutBar, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_color(this->timeoutBar, lv_color_hex(RESET_COLOR_BAR_BG), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(this->timeoutBar, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_color(this->timeoutBar, lv_color_hex(RESET_COLOR_ACCENT), LV_PART_INDICATOR | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(this->timeoutBar, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
+   lv_obj_set_style_radius(this->timeoutBar, 6, LV_PART_INDICATOR | LV_STATE_DEFAULT);
+
+   // Title
+   lv_obj_t *title = lv_label_create(this->screen);
+   lv_obj_set_width(title, lv_pct(100));
+   lv_obj_set_height(title, LV_SIZE_CONTENT);
+   lv_label_set_text(title, "Karte zuruecksetzen");
+   lv_obj_set_style_text_align(title, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_color(title, lv_color_hex(RESET_COLOR_TITLE), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_font(title, &lv_font_montserrat_28, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   // Username — the person the card belongs to. Most prominent line.
+   this->userNameLabel = lv_label_create(this->screen);
+   lv_obj_set_width(this->userNameLabel, lv_pct(100));
+   lv_obj_set_height(this->userNameLabel, LV_SIZE_CONTENT);
+   lv_label_set_long_mode(this->userNameLabel, LV_LABEL_LONG_WRAP);
+   const char *initialName = this->userNameCache.length() > 0 ? this->userNameCache.c_str() : "...";
+   lv_label_set_text(this->userNameLabel, initialName);
+   lv_obj_set_style_text_align(this->userNameLabel, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_color(this->userNameLabel, lv_color_hex(RESET_COLOR_TEXT), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_font(this->userNameLabel, &lv_font_montserrat_36, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   // Status line — colour + text reflect the current reset phase.
+   this->statusLabel = lv_label_create(this->screen);
+   lv_obj_set_width(this->statusLabel, lv_pct(100));
+   lv_obj_set_height(this->statusLabel, LV_SIZE_CONTENT);
+   lv_label_set_long_mode(this->statusLabel, LV_LABEL_LONG_WRAP);
+   lv_obj_set_style_text_align(this->statusLabel, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_font(this->statusLabel, &lv_font_montserrat_32, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   // Cancel button — lets the user actively abort the reset.
+   this->cancelButton = lv_button_create(this->screen);
+   lv_obj_set_width(this->cancelButton, lv_pct(80));
+   lv_obj_set_height(this->cancelButton, 56);
+   lv_obj_remove_flag(this->cancelButton, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_style_bg_color(this->cancelButton, lv_color_hex(RESET_COLOR_CANCEL_BG), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(this->cancelButton, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_radius(this->cancelButton, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_add_event_cb(this->cancelButton, &ResetScreen::onCancelButtonEvent, LV_EVENT_CLICKED, this);
+
+   lv_obj_t *cancelLabel = lv_label_create(this->cancelButton);
+   lv_obj_set_align(cancelLabel, LV_ALIGN_CENTER);
+   lv_label_set_text(cancelLabel, "Abbrechen");
+   lv_obj_set_style_text_color(cancelLabel, lv_color_hex(RESET_COLOR_TEXT), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_font(cancelLabel, &lv_font_montserrat_24, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   this->updateTimeoutBar();
+   this->applyStatus();
+}
+
+void ResetScreen::loop()
+{
+   this->updateTimeoutBar();
+}
+
+void ResetScreen::updateTimeoutBar()
+{
+   if (!this->timeoutBar)
+   {
+      return;
+   }
+   uint32_t now = millis();
+   int32_t remainingSeconds = 0;
+   if (this->timeoutTime > now)
+   {
+      remainingSeconds = (int32_t)((this->timeoutTime - now) / 1000);
+   }
+   if (remainingSeconds > 30)
+   {
+      remainingSeconds = 30;
+   }
+   lv_bar_set_value(this->timeoutBar, remainingSeconds, LV_ANIM_ON);
+}
+
+void ResetScreen::applyStatus()
+{
+   if (!this->statusLabel)
+   {
+      return;
+   }
+
+   const char *text = "";
+   uint32_t color = RESET_COLOR_WAITING;
+   switch (this->status)
+   {
+   case STATUS_WAITING:
+      text = "Karte an den Leser halten";
+      color = RESET_COLOR_WAITING;
+      break;
+   case STATUS_WRITING:
+      text = "Karte wird zurueckgesetzt...\nbitte nicht bewegen";
+      color = RESET_COLOR_WRITING;
+      break;
+   case STATUS_SUCCESS:
+      text = "Karte zurueckgesetzt!";
+      color = RESET_COLOR_SUCCESS;
+      break;
+   case STATUS_ERROR:
+      text = this->statusMessageOverride.length() > 0 ? this->statusMessageOverride.c_str() : "Fehler";
+      color = RESET_COLOR_ERROR;
+      break;
+   }
+
+   lv_label_set_text(this->statusLabel, text);
+   lv_obj_set_style_text_color(this->statusLabel, lv_color_hex(color), LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   // Hide the cancel button once the reset has succeeded — nothing left to
+   // cancel, and it auto-dismisses shortly after.
+   if (this->cancelButton)
+   {
+      if (this->status == STATUS_SUCCESS)
+      {
+         lv_obj_add_flag(this->cancelButton, LV_OBJ_FLAG_HIDDEN);
+      }
+      else
+      {
+         lv_obj_remove_flag(this->cancelButton, LV_OBJ_FLAG_HIDDEN);
+      }
+   }
+}
+
+lv_obj_t *ResetScreen::getScreen()
+{
+   return this->screen;
+}
+
+void ResetScreen::setTimeoutTime(uint32_t timeoutTime)
+{
+   this->timeoutTime = timeoutTime;
+   this->updateTimeoutBar();
+}
+
+void ResetScreen::setUserName(String userName)
+{
+   this->userNameCache = userName;
+   if (this->userNameLabel)
+   {
+      lv_label_set_text(this->userNameLabel, userName.c_str());
+   }
+}
+
+void ResetScreen::setStatus(Status status)
+{
+   this->status = status;
+   if (status != STATUS_ERROR)
+   {
+      this->statusMessageOverride = "";
+   }
+   this->applyStatus();
+}
+
+void ResetScreen::setStatusMessage(const String &message)
+{
+   this->statusMessageOverride = message;
+   this->applyStatus();
+}
+
+void ResetScreen::setOnCancelCallback(std::function<void()> callback)
+{
+   this->onCancelCallback = callback;
+}
+
+void ResetScreen::onCancelButtonEvent(lv_event_t *e)
+{
+   ResetScreen *self = static_cast<ResetScreen *>(lv_event_get_user_data(e));
+   if (!self)
+   {
+      return;
+   }
+   if (lv_event_get_code(e) != LV_EVENT_CLICKED)
+   {
+      return;
+   }
+   if (self->onCancelCallback)
+   {
+      self->onCancelCallback();
+   }
+}
+
+String ResetScreen::getName()
+{
+   return "ResetScreen";
+}
+
+void ResetScreen::onScreenLeave()
+{
+}
+
+void ResetScreen::destroy()
+{
+   if (!this->screen)
+   {
+      return;
+   }
+   lv_obj_del(this->screen);
+   this->screen = nullptr;
+   this->timeoutBar = nullptr;
+   this->userNameLabel = nullptr;
+   this->statusLabel = nullptr;
+   this->cancelButton = nullptr;
+}

--- a/apps/attractap/firmware/src/display/screens/reset/resetScreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/reset/resetScreen.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "../IScreen.hpp"
+#include "../../../logger/logger.hpp"
+#include "../../../utils.hpp"
+#include "../../images/logo_400w_png.hpp"
+
+// Card reset/deletion screen. Visually + behaviourally mirrors EnrollmentScreen
+// (ATT-503): sticky until success/cancel/timeout, explicit high-contrast white
+// text, phase-driven status line, prominent username, styled countdown bar and
+// a cancel button — so the two card-management flows feel consistent (ATT-506).
+class ResetScreen : public IScreen
+{
+public:
+    ResetScreen() : logger("ResetScreen") {}
+    void init();
+    void onScreenLeave();
+    void loop() override;
+    lv_obj_t *getScreen() override;
+    String getName() override;
+    void destroy() override;
+
+    // Visual phase of the reset flow. Drives the status line text + color so the
+    // user always knows what the reader is doing.
+    enum Status
+    {
+        STATUS_WAITING, // hold the card on the reader
+        STATUS_WRITING, // resetting the key, hold still
+        STATUS_SUCCESS, // card reset
+        STATUS_ERROR,   // something went wrong
+    };
+
+    void setTimeoutTime(uint32_t timeoutTime);
+    void setUserName(String userName);
+    void setStatus(Status status);
+    // Override the status line text (used for specific error messages). Cleared
+    // automatically on the next setStatus() call that isn't STATUS_ERROR.
+    void setStatusMessage(const String &message);
+    void setOnCancelCallback(std::function<void()> callback);
+
+private:
+    Logger logger;
+    lv_obj_t *screen = nullptr;
+
+    lv_obj_t *timeoutBar = nullptr;
+    lv_obj_t *userNameLabel = nullptr;
+    lv_obj_t *statusLabel = nullptr;
+    lv_obj_t *cancelButton = nullptr;
+    String userNameCache;
+    String statusMessageOverride;
+    Status status = STATUS_WAITING;
+
+    std::function<void()> onCancelCallback;
+    static void onCancelButtonEvent(lv_event_t *e);
+
+    uint32_t timeoutTime = 0;
+    void updateTimeoutBar();
+    void applyStatus();
+};


### PR DESCRIPTION
Assignee: @jappyjan ([Jan Jaap](https://linear.app/attraccess/profiles))

## Summary

Fixes ATT-506: NFC card deletion/reset never worked, and aligns the reset screen with the ATT-503 enrollment redesign.

The reader-side reset flow was an unimplemented stub — `AttractapCardHandler.startResetOfNfcCard` ended with `// TODO: implement this` and never sent an event to the reader. This implements the full end-to-end reset flow and a matching firmware screen.

Follow-up to ATT-503 (#1228 — enrollment reliability + screen redesign).

## Changes

**Backend (`apps/api`)**
- Add `RESET_NFC_CARD` + `RESET_NFC_CARD_CANCEL` events and socket reset state.
- `startResetOfNfcCard` now hands the reader the card's stored key + slot in a single `RESET_NFC_CARD` event (no key round-trip — server already knows the key).
- `onResetNfcCard` deletes the DB card once the reader confirms the on-card reset; `onResetNfcCardCancel` clears state on cancel/timeout.

**Firmware (`apps/attractap/firmware`)**
- Sticky, poll-driven reset sub-state machine owned by `APPLICATION_STATE_RESET` (`WAIT_FOR_CARD -> WRITING -> SUCCESS/ERROR`), mirroring enrollment. On card tap it authenticates as the (still-factory) app master key and changes the stored slot back to the factory key via `changeKey(keyNo, FACTORY_KEY, storedKey, FACTORY_KEY)`, then confirms with the backend.
- Drop a stale reset trigger on disconnect so it can't relaunch a dead session on reconnect.
- New `ResetScreen` mirrors `EnrollmentScreen` (sticky until success/cancel/timeout, explicit white text, phase-driven status line, prominent username, styled countdown bar, cancel button).
- Bump `FIRMWARE_VERSION` 1.3.21 -> 1.3.22 (OTA).

## Acceptance criteria
- [x] Card deletion/reset works end-to-end (backend reset events + firmware reset sub-flow).
- [x] Reset screen design aligned with enrollment screen.

## Testing
- `nx test api` — 1303 tests pass (116 suites), incl. new `card.handler.spec.ts` reset coverage.
- `nx lint api` — clean.
- Firmware C++ is not built in CI (PlatformIO/ESP32 toolchain); on-device behavior mirrors the verified ATT-503 enrollment flow.

## Linear
https://linear.app/attraccess/issue/ATT-506/attractap-nfc-card-deletion-does-not-work-align-screen-design-with

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
