### PR TITLE
fix(ci): short-form depends_on so balena push accepts compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,10 +155,8 @@ services:
       - prometheus-config:/etc/prometheus:ro
       - prometheus-data:/prometheus
     depends_on:
-      config-ui:
-        condition: service_started
-      monitoring-init:
-        condition: service_completed_successfully
+      - config-ui
+      - monitoring-init
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=30d'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,8 +178,7 @@ services:
       - grafana-dashboards:/var/lib/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
     depends_on:
-      monitoring-init:
-        condition: service_completed_successfully
+      - monitoring-init
 
   # fail2ban is opt-in via the `fail2ban` Compose profile to keep developers
   # from getting their own IP banned during local testing. Enable with:


### PR DESCRIPTION
## Problem

`balena-push` CI job fails:

```
data/services/prometheus/depends_on should be array, data/services/prometheus/depends_on/monitoring-init/condition should be equal to one of the allowed values
```

Balena's compose schema does not support the long-form `depends_on` condition map — it requires the short-form array.

## Fix

Convert `prometheus` and `grafana` `depends_on` to short-form arrays. Standard docker compose still honors start ordering; `restart: unless-stopped` + the fast one-shot `monitoring-init` cover the config-copy race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)