### PR TITLE
fix(attractap): render session start time in server's timezone (ATT-516)

### DIFF
--- a/apps/api/src/attractap/websockets/handlers/resource-list.service.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/resource-list.service.spec.ts
@@ -198,6 +198,7 @@ describe('ResourceListService', () => {
                   activeUsageSession: {
                     user: { username: 'active-user' },
                     startTime: startTime.toISOString(),
+                    startTimeUtcOffsetMinutes: -startTime.getTimezoneOffset(),
                   },
                   flowButtons: [{ id: 'node-1', label: 'Start' }],
                 },
@@ -239,6 +240,25 @@ describe('ResourceListService', () => {
       const resource = (sent.data.payload as any).resources[0];
       expect(resource.isHealthy).toBe(true);
       expect(resource.healthReason).toBe('');
+    });
+
+    it('sends a per-instant UTC offset alongside the session start time so the reader renders local wall-clock time', async () => {
+      // Two timestamps the same Europe/Berlin day are on opposite sides of nothing, but a winter
+      // and a summer instant differ by the DST offset. Computing per-timestamp keeps both correct.
+      const summer = new Date('2026-07-01T10:00:00.000Z');
+      attractapService.findReaderById.mockResolvedValue(createReaderFixture());
+      resourceUsageService.getActiveSession.mockResolvedValue({
+        user: { username: 'active-user' },
+        startTime: summer,
+      });
+
+      const socket = createMockSocket();
+      await service.sendResourceListToSocket(socket);
+
+      const sent = (socket.sendMessage as jest.Mock).mock.calls[0][0] as AttractapEvent;
+      const session = (sent.data.payload as any).resources[0].activeUsageSession;
+      // Offset is the inverse of getTimezoneOffset() for that exact instant (DST-correct).
+      expect(session.startTimeUtcOffsetMinutes).toBe(-summer.getTimezoneOffset());
     });
 
     it('emits activeUsageSession=null when there is no active session', async () => {

--- a/apps/api/src/attractap/websockets/handlers/resource-list.service.ts
+++ b/apps/api/src/attractap/websockets/handlers/resource-list.service.ts
@@ -111,6 +111,10 @@ export class ResourceListService {
               username: resource.activeUsageSession.user.username,
             },
             startTime: resource.activeUsageSession.startTime.toISOString(),
+            // Offset (minutes east of UTC) of the API's effective timezone for this
+            // specific instant, so the reader can render local wall-clock time without
+            // a tz database. Computed per-timestamp, so it stays DST-correct.
+            startTimeUtcOffsetMinutes: -resource.activeUsageSession.startTime.getTimezoneOffset(),
           }
           : null,
         flowButtons: resource.flowButtons,

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -17,7 +17,7 @@ build_type = debug
 extra_scripts =
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
-	-D FIRMWARE_VERSION='"1.3.22"'
+	-D FIRMWARE_VERSION='"1.3.23"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/attractap/firmware/src/api/api.hpp
+++ b/apps/attractap/firmware/src/api/api.hpp
@@ -55,7 +55,8 @@ public:
         bool isHealthy;
         char healthReason[MAX_HEALTH_REASON_LEN];
         char activeUser[MAX_USERNAME_LEN];
-        uint32_t activeStartEpoch; // seconds since epoch
+        uint32_t activeStartEpoch;          // seconds since epoch (UTC)
+        int16_t activeStartUtcOffsetMinutes; // server tz offset (minutes east of UTC) for that instant
         uint8_t introducerCount;
         char introducers[MAX_INTRODUCERS][MAX_USERNAME_LEN];
         uint8_t flowButtonCount;

--- a/apps/attractap/firmware/src/api/api_resources.cpp
+++ b/apps/attractap/firmware/src/api/api_resources.cpp
@@ -106,12 +106,15 @@ void API::onResourceList(JsonObject data)
             strlcpy(dst.activeUser, username ? username : "", sizeof(dst.activeUser));
             const char *startIso = aus["startTime"].as<const char *>();
             dst.activeStartEpoch = parseIso8601ToTimeT(startIso);
+            // Offset is optional for backwards compatibility; absent -> 0 (render UTC as before)
+            dst.activeStartUtcOffsetMinutes = aus["startTimeUtcOffsetMinutes"].is<int>() ? (int16_t)aus["startTimeUtcOffsetMinutes"].as<int>() : 0;
         }
         else
         {
             dst.hasActiveUsage = false;
             dst.activeUser[0] = '\0';
             dst.activeStartEpoch = 0;
+            dst.activeStartUtcOffsetMinutes = 0;
         }
 
         // Parse introducers: array of strings (usernames)

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
@@ -487,7 +487,7 @@ void ResourceDetailsScreen::setResourceAndUsageDetails(const API::ResourceBrief 
    {
       // Persist the session start time so periodic updates can compute elapsed time correctly
       this->sessionStartTime = (time_t)resource.activeStartEpoch;
-      lv_label_set_text(this->sessionStartTimeLabel, timeToTimeString(this->sessionStartTime).c_str());
+      lv_label_set_text(this->sessionStartTimeLabel, timeToTimeString(this->sessionStartTime, resource.activeStartUtcOffsetMinutes).c_str());
       lv_label_set_text(this->currentUser, resource.activeUser);
    }
 

--- a/apps/attractap/firmware/src/utils.cpp
+++ b/apps/attractap/firmware/src/utils.cpp
@@ -113,9 +113,14 @@ String millisToTimeString(double millis)
     return hoursString + ":" + minutesString + ":" + secondsString;
 }
 
-String timeToTimeString(time_t time)
+String timeToTimeString(time_t time, int utcOffsetMinutes)
 {
-    struct tm *tm = localtime(&time);
+    // `time` is UTC. Shift by the server-provided offset, then render with gmtime so the
+    // result is independent of the device's own (unset) timezone. Offset 0 -> UTC.
+    time_t shifted = time + (time_t)utcOffsetMinutes * 60;
+    struct tm tmInfo;
+    gmtime_r(&shifted, &tmInfo);
+    struct tm *tm = &tmInfo;
     int month = tm->tm_mon + 1;
     int day = tm->tm_mday;
     int hours = tm->tm_hour;

--- a/apps/attractap/firmware/src/utils.hpp
+++ b/apps/attractap/firmware/src/utils.hpp
@@ -25,11 +25,12 @@ void recoverI2CBus(int sda, int scl);
 String millisToTimeString(double millis);
 
 /**
- * @brief Convert a time_t to a time string in the format "DD.MM. HH:MM"
- * @param time The time_t to convert
+ * @brief Convert a UTC time_t to a time string in the format "DD.MM. HH:MM"
+ * @param time The time_t (UTC) to convert
+ * @param utcOffsetMinutes Minutes east of UTC to apply before formatting (0 = render UTC)
  * @return The time string
  */
-String timeToTimeString(time_t time);
+String timeToTimeString(time_t time, int utcOffsetMinutes = 0);
 
 /**
  * @brief Parse an ISO8601 datetime string (e.g. "2025-10-16T12:34:56Z" or with offset) to time_t (UTC)


### PR DESCRIPTION
## Summary

Fixes ATT-516: Attractap reader showed session start time in UTC instead of the user's local time. A CEST 14:xx session rendered as 12:xx on the reader.

Root cause: the device's effective timezone is UTC (`configTime` with `gmtOffset=0`, no `TZ` set), so all timestamps rendered in UTC.

## Changes

- **Server**: sends a per-timestamp UTC offset (minutes east of UTC, computed for that instant so it's DST-correct) alongside `startTime`.
- **Firmware**: shifts the UTC `time_t` by the offset and formats via `gmtime`, making rendering independent of the unset device TZ. Offset is optional; absent → 0 → previous UTC behavior (backwards compatible).
- Firmware bumped 1.3.22 → 1.3.23 for OTA.

## Tests

- Added `resource-list.service.spec.ts` coverage for the offset computation.

🤖 Generated for ATT-516

<!-- generated-by-cyrus -->

## Summary by Sourcery

Render Attractap usage session start times in the server’s local timezone on readers while preserving backward compatibility with existing messages.

New Features:
- Include a per-session UTC offset with Attractap active usage session start times so readers can render local wall-clock time without a timezone database.

Bug Fixes:
- Correct the Attractap reader’s displayed session start time so it matches the server’s local time instead of always showing UTC.

Enhancements:
- Make the firmware’s time formatting utilities accept an explicit UTC offset and use timezone-agnostic UTC-based rendering for session start times.
- Extend the Attractap resource brief API model to carry the session start UTC offset from the backend to the display layer.

Build:
- Bump Attractap firmware version from 1.3.22 to 1.3.23 for OTA distribution.

Tests:
- Add unit coverage to verify the per-instant UTC offset is computed and sent correctly with session start times.