### PR TITLE
ci(release): use GitHub App token to bypass main ruleset (ATT-513)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,24 +14,42 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived GitHub App installation token. The App is added as a
+      # bypass actor on the `main` ruleset, so its pushes skip the PR-required
+      # and required-signatures rules that block nx release's direct push.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: ./.github/actions/setup
 
+      - name: Resolve App bot user id
+        id: bot-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          user_id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)
+          echo "id=$user_id" >> "$GITHUB_OUTPUT"
+
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.bot-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Build publishable libraries
         run: pnpm nx run-many -t build,lint,typecheck
@@ -39,13 +57,13 @@ jobs:
       - name: Run NX Release (dry run)
         if: inputs.dry-run
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm nx release ${{ inputs.specifier }} --dry-run --yes
 
       - name: Run NX Release
         if: ${{ !inputs.dry-run }}
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm nx release ${{ inputs.specifier }} --yes


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

Fixes the `Create Release` workflow, which failed pushing the version commit + tag to `main`:

```
GH013: Repository rule violations found for refs/heads/main
- Changes must be made through a pull request.
- Commits must have verified signatures.
```

## Root cause
`nx release` commits, tags, and pushes **directly to `main`**. The `main` ruleset (id `6592584`) requires a PR *and* signed commits, and its only bypass actor is the Admin repository role. `RELEASE_PAT`'s user isn't an admin, so the push is rejected.

## Fix
Mint a short-lived **GitHub App installation token** (`actions/create-github-app-token@v2`) and use it for checkout, git identity, and `nx release`. The App is added as a **ruleset bypass actor** (`always`), so its direct push skips both the PR-required and required-signatures rules — no need to sign commits or open a release PR.

- Replaces `RELEASE_PAT` with `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY`.
- git identity set to the App's bot user (`<app-slug>[bot]`) so the release commit is attributed correctly.
- `permissions` narrowed to `contents: read` (the App token carries write).

## Required repo-admin setup before this works
1. Create an org-owned **GitHub App**, permission **Contents: Read & write**, and install it on this repo.
2. Add repo secrets **`RELEASE_APP_ID`** and **`RELEASE_APP_PRIVATE_KEY`** (the App's private key).
3. Add the App as a **bypass actor** on ruleset `6592584` with bypass mode `always`.

## Testing
- Workflow YAML validated (`js-yaml`).
- End-to-end requires the App + secrets + bypass actor above; recommend a `--dry-run` dispatch first.

[ATT-513](https://linear.app/attraccess/issue/ATT-513/github-actions-create-release-broken-git-push-permissions)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Update the release workflow to use a GitHub App installation token so releases can push directly to main while complying with repository rules.

CI:
- Replace personal access token usage in the create-release workflow with a short-lived GitHub App installation token for checkout and nx release operations.
- Set the workflow’s git user identity to the GitHub App bot user to attribute release commits correctly and narrow declared contents permissions to read.