### PR TITLE
fix(frontend): make all tables horizontally scrollable on mobile (ATT-518)

### DIFF
--- a/apps/frontend/src/app/attractap/NfcCardList/index.tsx
+++ b/apps/frontend/src/app/attractap/NfcCardList/index.tsx
@@ -21,6 +21,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
   cn,
 } from '@heroui/react';
 import { StandardDrawer } from '../../../components/standardDrawer';
@@ -152,7 +153,8 @@ const NfcCardTableCell = (props: NfcCardTableCellProps) => {
                 variant="tertiary"
                 onPress={onOpen}
                 data-cy={`nfc-card-table-cell-deactivate-button-${props.card.id}`}
-              ><CheckIcon />
+              >
+                <CheckIcon />
                 <XIcon />
                 {t('nfcCardsTable.actions.deactivate')}
               </Button>
@@ -165,7 +167,8 @@ const NfcCardTableCell = (props: NfcCardTableCellProps) => {
                 variant="tertiary"
                 onPress={onOpen}
                 data-cy={`nfc-card-table-cell-activate-button-${props.card.id}`}
-              ><XIcon />
+              >
+                <XIcon />
                 <CheckIcon />
                 {t('nfcCardsTable.actions.activate')}
               </Button>
@@ -307,27 +310,27 @@ export function NfcCardList() {
     <>
       <PageHeader
         title={t('nfcCards')}
-        actions={[
-          {
-            key: 'enroll',
-            label: t('enroll'),
-            icon: <PlusIcon />,
-            variant: 'primary',
-            dataCy: 'enroll-nfc-card-button-trigger',
-            renderTrigger: (triggerProps) => (
-              <EnrollNfcCard>
-                {(onOpen) => <Button {...triggerProps} onPress={onOpen} />}
-              </EnrollNfcCard>
-            ),
-          },
-          {
-            key: 'readers',
-            label: t('readers'),
-            icon: <ServerIcon />,
-            isHidden: !hasPermission('canManageResources'),
-            onPress: () => navigate('/attractap/readers'),
-          },
-        ] satisfies PageAction[]}
+        actions={
+          [
+            {
+              key: 'enroll',
+              label: t('enroll'),
+              icon: <PlusIcon />,
+              variant: 'primary',
+              dataCy: 'enroll-nfc-card-button-trigger',
+              renderTrigger: (triggerProps) => (
+                <EnrollNfcCard>{(onOpen) => <Button {...triggerProps} onPress={onOpen} />}</EnrollNfcCard>
+              ),
+            },
+            {
+              key: 'readers',
+              label: t('readers'),
+              icon: <ServerIcon />,
+              isHidden: !hasPermission('canManageResources'),
+              onPress: () => navigate('/attractap/readers'),
+            },
+          ] satisfies PageAction[]
+        }
       />
 
       <Alert status="warning" className="mb-4">
@@ -345,30 +348,32 @@ export function NfcCardList() {
       />
 
       <Table data-cy="nfc-card-list-table">
-        <TableContent aria-label={t('nfcCards')}>
-        <TableHeader>
-          {headers.map((header, idx) => (
-            <TableColumn key={header} id={header} isRowHeader={idx === 0}>
-              {t('nfcCardsTable.headers.' + header)}
-            </TableColumn>
-          ))}
-        </TableHeader>
-        <TableBody items={cards ?? []} renderEmptyState={() => <EmptyState />}>
-          {(card) => (
-            <TableRow
-              key={card.id}
-              id={card.id}
-              className={cn('border-l-4', card.isActive ? 'border-l-success' : 'border-l-warning')}
-            >
-              {headers.map((header) => (
-                <TableCell key={header}>
-                  <NfcCardTableCell header={header} card={card} onDeleteClick={() => setCardToDeleteId(card.id)} />
-                </TableCell>
+        <TableScrollContainer>
+          <TableContent aria-label={t('nfcCards')}>
+            <TableHeader>
+              {headers.map((header, idx) => (
+                <TableColumn key={header} id={header} isRowHeader={idx === 0}>
+                  {t('nfcCardsTable.headers.' + header)}
+                </TableColumn>
               ))}
-            </TableRow>
-          )}
-        </TableBody>
-        </TableContent>
+            </TableHeader>
+            <TableBody items={cards ?? []} renderEmptyState={() => <EmptyState />}>
+              {(card) => (
+                <TableRow
+                  key={card.id}
+                  id={card.id}
+                  className={cn('border-l-4', card.isActive ? 'border-l-success' : 'border-l-warning')}
+                >
+                  {headers.map((header) => (
+                    <TableCell key={header}>
+                      <NfcCardTableCell header={header} card={card} onDeleteClick={() => setCardToDeleteId(card.id)} />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              )}
+            </TableBody>
+          </TableContent>
+        </TableScrollContainer>
       </Table>
     </>
   );

--- a/apps/frontend/src/app/billing/administration/sumup/readers/index.tsx
+++ b/apps/frontend/src/app/billing/administration/sumup/readers/index.tsx
@@ -1,7 +1,19 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import en from './en.json';
 import de from './de.json';
-import { Button, Card, CardProps, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import {
+  Button,
+  Card,
+  CardProps,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  TableScrollContainer,
+} from '@heroui/react';
 import { PageHeader } from '../../../../../components/pageHeader';
 import { SmartphoneNfcIcon, Trash2Icon } from 'lucide-react';
 import {
@@ -40,9 +52,7 @@ export function SumUpReadersCard(props: Omit<CardProps, 'children'>) {
               icon: <Trash2Icon className="w-4 h-4" />,
               variant: 'primary',
               renderTrigger: (triggerProps) => (
-                <SumUpReadersPairing>
-                  {(onOpen) => <Button {...triggerProps} onPress={onOpen} />}
-                </SumUpReadersPairing>
+                <SumUpReadersPairing>{(onOpen) => <Button {...triggerProps} onPress={onOpen} />}</SumUpReadersPairing>
               ),
             },
           ]}
@@ -51,39 +61,39 @@ export function SumUpReadersCard(props: Omit<CardProps, 'children'>) {
 
       <Card.Content>
         <Table>
-          <TableContent aria-label={t('table.ariaLabel')}>
-          <TableHeader>
-            <TableColumn isRowHeader>{t('table.columns.name')}</TableColumn>
-            <TableColumn>{t('table.columns.device')}</TableColumn>
-            <TableColumn>{t('table.columns.status')}</TableColumn>
-            <TableColumn>{t('table.columns.actions')}</TableColumn>
-          </TableHeader>
-          {/* the mapping of the language into the readers is to trick heroui to re-render when the language changes */}
-          <TableBody
-            items={(readers ?? []).map((reader) => ({ ...reader, language }))}
-            renderEmptyState={() => <EmptyState />}
-          >
-            {(reader) => (
-              <TableRow key={reader.id} id={reader.id}>
-                <TableCell>{reader.name}</TableCell>
-                <TableCell>{reader.device.model}</TableCell>
-                <TableCell>{reader.status}</TableCell>
-                <TableCell>
-                  <SumUpReaderDeleteModal readerId={reader.id} readerName={reader.name}>
-                    {(onOpen) => (
-                      <Button variant="danger-soft"
-
-                        onPress={onOpen}
-                      ><Trash2Icon className="w-4 h-4" />
-                        {t('table.actions.deleteReader')}
-                      </Button>
-                    )}
-                  </SumUpReaderDeleteModal>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-          </TableContent>
+          <TableScrollContainer>
+            <TableContent aria-label={t('table.ariaLabel')}>
+              <TableHeader>
+                <TableColumn isRowHeader>{t('table.columns.name')}</TableColumn>
+                <TableColumn>{t('table.columns.device')}</TableColumn>
+                <TableColumn>{t('table.columns.status')}</TableColumn>
+                <TableColumn>{t('table.columns.actions')}</TableColumn>
+              </TableHeader>
+              {/* the mapping of the language into the readers is to trick heroui to re-render when the language changes */}
+              <TableBody
+                items={(readers ?? []).map((reader) => ({ ...reader, language }))}
+                renderEmptyState={() => <EmptyState />}
+              >
+                {(reader) => (
+                  <TableRow key={reader.id} id={reader.id}>
+                    <TableCell>{reader.name}</TableCell>
+                    <TableCell>{reader.device.model}</TableCell>
+                    <TableCell>{reader.status}</TableCell>
+                    <TableCell>
+                      <SumUpReaderDeleteModal readerId={reader.id} readerName={reader.name}>
+                        {(onOpen) => (
+                          <Button variant="danger-soft" onPress={onOpen}>
+                            <Trash2Icon className="w-4 h-4" />
+                            {t('table.actions.deleteReader')}
+                          </Button>
+                        )}
+                      </SumUpReaderDeleteModal>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </TableContent>
+          </TableScrollContainer>
         </Table>
       </Card.Content>
     </Card>

--- a/apps/frontend/src/app/billing/dashboard/summary/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/index.tsx
@@ -1,5 +1,19 @@
 import { DateTimeDisplay, useNumberFormatter, useTranslations } from '@attraccess/plugins-frontend-ui';
-import { Button, Chip, cn, Skeleton, Spinner, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import {
+  Button,
+  Chip,
+  cn,
+  Skeleton,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  TableScrollContainer,
+} from '@heroui/react';
 import { PageHeader } from '../../../../components/pageHeader';
 import { EmptyState } from '../../../../components/emptyState';
 import de from './de.json';
@@ -44,9 +58,7 @@ export function SummaryCard(props: Props) {
 
   const [transactionsPage] = useState(1);
 
-  const {
-    data: transactions,
-  } = useBillingServiceGetBillingTransactions(
+  const { data: transactions } = useBillingServiceGetBillingTransactions(
     { userId: userId ?? 0, page: transactionsPage, limit: transactionsPerPage },
     undefined,
     {
@@ -163,52 +175,57 @@ export function SummaryCard(props: Props) {
       )}
 
       <Table>
-        <TableContent aria-label={t('transactions.table.ariaLabel')} onRowAction={(key) => openDetails(Number(key))}>
-          <TableHeader>
-            <TableColumn isRowHeader>{t('transactions.table.columns.id')}</TableColumn>
-            <TableColumn>{t('transactions.table.columns.dateTime')}</TableColumn>
-            <TableColumn>{t('transactions.table.columns.status')}</TableColumn>
-            <TableColumn className="w-full">{t('transactions.table.columns.details')}</TableColumn>
-            <TableColumn>{t('transactions.table.columns.amount')}</TableColumn>
-            <TableColumn>{t('transactions.table.columns.actions')}</TableColumn>
-          </TableHeader>
-          <TableBody items={transactions?.data ?? []} renderEmptyState={() => <EmptyState message={t('transactions.table.empty') as string} />}>
-            {(transaction) => (
-              <TableRow key={transaction.id} id={transaction.id} className="wrap-none cursor-pointer">
-                <TableCell>{transaction.id}</TableCell>
-                <TableCell className="whitespace-nowrap">
-                  <DateTimeDisplay date={transaction.createdAt} />
-                </TableCell>
-                <TableCell>
-                  <Chip color={statusColor(transaction.status)}>
-                    {t('transactions.table.cells.status.' + transaction.status)}
-                  </Chip>
-                </TableCell>
-                <TableCell className="max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap">
-                  {getDetailsCellContent(transaction)}
-                </TableCell>
-                <TableCell className={cn(transaction.amount < 0 ? 'text-danger' : 'text-success')}>
-                  {transaction.amount > 0 && '+'}
-                  {formatNumber(dbCurrencyToUserCurrency(transaction.amount, configuration.minorUnit))}
-                </TableCell>
-                <TableCell>
-                  <RefundModal transactionId={transaction.id}>
-                    {(onOpen) => (
-                      <Button
-                        isIconOnly
-                        variant="danger-soft"
-                        aria-label={t('transactions.table.actions.refund') as string}
-                        onPress={onOpen}
-                      >
-                        <RotateCcwIcon />
-                      </Button>
-                    )}
-                  </RefundModal>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </TableContent>
+        <TableScrollContainer>
+          <TableContent aria-label={t('transactions.table.ariaLabel')} onRowAction={(key) => openDetails(Number(key))}>
+            <TableHeader>
+              <TableColumn isRowHeader>{t('transactions.table.columns.id')}</TableColumn>
+              <TableColumn>{t('transactions.table.columns.dateTime')}</TableColumn>
+              <TableColumn>{t('transactions.table.columns.status')}</TableColumn>
+              <TableColumn className="w-full">{t('transactions.table.columns.details')}</TableColumn>
+              <TableColumn>{t('transactions.table.columns.amount')}</TableColumn>
+              <TableColumn>{t('transactions.table.columns.actions')}</TableColumn>
+            </TableHeader>
+            <TableBody
+              items={transactions?.data ?? []}
+              renderEmptyState={() => <EmptyState message={t('transactions.table.empty') as string} />}
+            >
+              {(transaction) => (
+                <TableRow key={transaction.id} id={transaction.id} className="wrap-none cursor-pointer">
+                  <TableCell>{transaction.id}</TableCell>
+                  <TableCell className="whitespace-nowrap">
+                    <DateTimeDisplay date={transaction.createdAt} />
+                  </TableCell>
+                  <TableCell>
+                    <Chip color={statusColor(transaction.status)}>
+                      {t('transactions.table.cells.status.' + transaction.status)}
+                    </Chip>
+                  </TableCell>
+                  <TableCell className="max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap">
+                    {getDetailsCellContent(transaction)}
+                  </TableCell>
+                  <TableCell className={cn(transaction.amount < 0 ? 'text-danger' : 'text-success')}>
+                    {transaction.amount > 0 && '+'}
+                    {formatNumber(dbCurrencyToUserCurrency(transaction.amount, configuration.minorUnit))}
+                  </TableCell>
+                  <TableCell>
+                    <RefundModal transactionId={transaction.id}>
+                      {(onOpen) => (
+                        <Button
+                          isIconOnly
+                          variant="danger-soft"
+                          aria-label={t('transactions.table.actions.refund') as string}
+                          onPress={onOpen}
+                        >
+                          <RotateCcwIcon />
+                        </Button>
+                      )}
+                    </RefundModal>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </TableContent>
+        </TableScrollContainer>
       </Table>
 
       {openedTransactionId && (

--- a/apps/frontend/src/app/billing/dashboard/summary/transactionDetailsModal/index.tsx
+++ b/apps/frontend/src/app/billing/dashboard/summary/transactionDetailsModal/index.tsx
@@ -15,6 +15,7 @@ import {
   TableColumn,
   TableContent,
   TableHeader,
+  TableScrollContainer,
   TableRow,
   useOverlayState,
 } from '@heroui/react';
@@ -189,46 +190,48 @@ export function TransactionDetailsModal(props: Props) {
                         <div>
                           <div className="mb-2 font-semibold">{t('items.title')}</div>
                           <Table>
-                            <TableContent aria-label="Transaction items">
-                            <TableHeader>
-                              <TableColumn isRowHeader>{t('items.columns.name')}</TableColumn>
-                              <TableColumn>{t('items.columns.description')}</TableColumn>
-                              <TableColumn>{t('items.columns.quantity')}</TableColumn>
-                              <TableColumn>{t('items.columns.unitPrice')}</TableColumn>
-                              <TableColumn>{t('items.columns.subtotal')}</TableColumn>
-                            </TableHeader>
-                            <TableBody renderEmptyState={() => t('items.empty')}>
-                              {(transaction.items ?? []).map((item) => (
-                                <TableRow key={item.id} id={item.id}>
-                                  <TableCell>
-                                    <div className="font-medium">
-                                      {tExists('items.system.' + item.name)
-                                        ? t('items.system.' + item.name)
-                                        : item.name}
-                                    </div>
-                                    {item.externalReference && (
-                                      <div className="text-tiny text-default-400">{item.externalReference}</div>
-                                    )}
-                                  </TableCell>
-                                  <TableCell className="max-w-[28ch] truncate">{item.description}</TableCell>
-                                  <TableCell className="text-right">{item.quantity}</TableCell>
-                                  <TableCell className="text-right">
-                                    {formatNumber(
-                                      dbCurrencyToUserCurrency(item.unitPrice, configuration?.minorUnit ?? 2),
-                                    )}
-                                  </TableCell>
-                                  <TableCell className="text-right">
-                                    {formatNumber(
-                                      dbCurrencyToUserCurrency(
-                                        item.unitPrice * item.quantity,
-                                        configuration?.minorUnit ?? 2,
-                                      ),
-                                    )}
-                                  </TableCell>
-                                </TableRow>
-                              ))}
-                            </TableBody>
-                            </TableContent>
+                            <TableScrollContainer>
+                              <TableContent aria-label="Transaction items">
+                                <TableHeader>
+                                  <TableColumn isRowHeader>{t('items.columns.name')}</TableColumn>
+                                  <TableColumn>{t('items.columns.description')}</TableColumn>
+                                  <TableColumn>{t('items.columns.quantity')}</TableColumn>
+                                  <TableColumn>{t('items.columns.unitPrice')}</TableColumn>
+                                  <TableColumn>{t('items.columns.subtotal')}</TableColumn>
+                                </TableHeader>
+                                <TableBody renderEmptyState={() => t('items.empty')}>
+                                  {(transaction.items ?? []).map((item) => (
+                                    <TableRow key={item.id} id={item.id}>
+                                      <TableCell>
+                                        <div className="font-medium">
+                                          {tExists('items.system.' + item.name)
+                                            ? t('items.system.' + item.name)
+                                            : item.name}
+                                        </div>
+                                        {item.externalReference && (
+                                          <div className="text-tiny text-default-400">{item.externalReference}</div>
+                                        )}
+                                      </TableCell>
+                                      <TableCell className="max-w-[28ch] truncate">{item.description}</TableCell>
+                                      <TableCell className="text-right">{item.quantity}</TableCell>
+                                      <TableCell className="text-right">
+                                        {formatNumber(
+                                          dbCurrencyToUserCurrency(item.unitPrice, configuration?.minorUnit ?? 2),
+                                        )}
+                                      </TableCell>
+                                      <TableCell className="text-right">
+                                        {formatNumber(
+                                          dbCurrencyToUserCurrency(
+                                            item.unitPrice * item.quantity,
+                                            configuration?.minorUnit ?? 2,
+                                          ),
+                                        )}
+                                      </TableCell>
+                                    </TableRow>
+                                  ))}
+                                </TableBody>
+                              </TableContent>
+                            </TableScrollContainer>
                           </Table>
                           <div className="mt-2 flex justify-end text-small text-default-500">
                             <div>

--- a/apps/frontend/src/app/csv-export/base-modal/preview-table.tsx
+++ b/apps/frontend/src/app/csv-export/base-modal/preview-table.tsx
@@ -10,6 +10,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
 } from '@heroui/react';
 import { QueryStatus } from '@tanstack/react-query';
 import { RotateCwIcon } from 'lucide-react';
@@ -38,8 +39,7 @@ interface Props {
 }
 
 export function PreviewTable(props: Props) {
-  const { columns, rows, totalCount, previewLimit, ariaLabel, titleLabel, rowCountLabel, refetch, queryStatus } =
-    props;
+  const { columns, rows, totalCount, previewLimit, ariaLabel, titleLabel, rowCountLabel, refetch, queryStatus } = props;
 
   const limited = rows.slice(0, previewLimit);
 
@@ -64,33 +64,35 @@ export function PreviewTable(props: Props) {
         </div>
       </div>
 
-      <div className="overflow-x-auto border border-default-100 rounded-md">
+      <div className="border border-default-100 rounded-md">
         {queryStatus === 'pending' ? (
           <div className="flex items-center justify-center py-12">
             <Spinner />
           </div>
         ) : (
           <Table data-cy="resource-usage-export-table">
-            <TableContent aria-label={ariaLabel}>
-              <TableHeader columns={columns}>
-                {(column) => (
-                  <TableColumn key={column.key} id={column.key} isRowHeader={column.key === columns[0]?.key}>
-                    {column.label}
-                  </TableColumn>
-                )}
-              </TableHeader>
-              <TableBody items={limited} renderEmptyState={() => <EmptyState />}>
-                {(row) => (
-                  <TableRow key={row.key} id={row.key}>
-                    {row.columns.map((column) => (
-                      <TableCell style={{ whiteSpace: 'nowrap' }} key={column.key}>
-                        {column.value}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                )}
-              </TableBody>
-            </TableContent>
+            <TableScrollContainer>
+              <TableContent aria-label={ariaLabel}>
+                <TableHeader columns={columns}>
+                  {(column) => (
+                    <TableColumn key={column.key} id={column.key} isRowHeader={column.key === columns[0]?.key}>
+                      {column.label}
+                    </TableColumn>
+                  )}
+                </TableHeader>
+                <TableBody items={limited} renderEmptyState={() => <EmptyState />}>
+                  {(row) => (
+                    <TableRow key={row.key} id={row.key}>
+                      {row.columns.map((column) => (
+                        <TableCell style={{ whiteSpace: 'nowrap' }} key={column.key}>
+                          {column.value}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  )}
+                </TableBody>
+              </TableContent>
+            </TableScrollContainer>
           </Table>
         )}
       </div>

--- a/apps/frontend/src/app/email-templates/EmailTemplatesPage.tsx
+++ b/apps/frontend/src/app/email-templates/EmailTemplatesPage.tsx
@@ -1,5 +1,15 @@
 import { useEmailTemplatesServiceEmailTemplateControllerFindAll } from '@attraccess/react-query-client';
-import { Table, TableContent, TableHeader, TableColumn, TableBody, TableRow, TableCell, Button } from '@heroui/react';
+import {
+  Table,
+  TableScrollContainer,
+  TableContent,
+  TableHeader,
+  TableColumn,
+  TableBody,
+  TableRow,
+  TableCell,
+  Button,
+} from '@heroui/react';
 import { Edit3, Mail } from 'lucide-react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useNavigate } from 'react-router-dom';
@@ -28,12 +38,7 @@ export function EmailTemplatesPage() {
       type: t(`templateTypes.${item.type}`),
       subject: item.subject,
       actions: (
-        <Button
-          variant="ghost"
-          isIconOnly
-          aria-label={t('editButton')}
-          onPress={() => openEditor(item.type)}
-        >
+        <Button variant="ghost" isIconOnly aria-label={t('editButton')} onPress={() => openEditor(item.type)}>
           <Edit3 size={18} />
         </Button>
       ),
@@ -45,30 +50,29 @@ export function EmailTemplatesPage() {
       <PageHeader title={t('title')} subtitle={t('subtitle')} icon={<Mail className="w-6 h-6" />} />
 
       <Table>
-        <TableContent aria-label="Email templates table">
-          <TableHeader>
-          <TableColumn isRowHeader>{t('columns.type')}</TableColumn>
-          <TableColumn>{t('columns.subject')}</TableColumn>
-          <TableColumn>{t('columns.actions')}</TableColumn>
-        </TableHeader>
-        <TableBody
-          items={tableItems}
-          renderEmptyState={() => <EmptyState />}
-        >
-          {(item) => (
-            <TableRow
-              key={item.key}
-              id={item.key}
-              className="cursor-pointer hover:bg-primary-50 transition-colors duration-300"
-              onAction={() => openEditor(item.key)}
-            >
-              <TableCell>{item.type}</TableCell>
-              <TableCell>{item.subject}</TableCell>
-              <TableCell>{item.actions}</TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-        </TableContent>
+        <TableScrollContainer>
+          <TableContent aria-label="Email templates table">
+            <TableHeader>
+              <TableColumn isRowHeader>{t('columns.type')}</TableColumn>
+              <TableColumn>{t('columns.subject')}</TableColumn>
+              <TableColumn>{t('columns.actions')}</TableColumn>
+            </TableHeader>
+            <TableBody items={tableItems} renderEmptyState={() => <EmptyState />}>
+              {(item) => (
+                <TableRow
+                  key={item.key}
+                  id={item.key}
+                  className="cursor-pointer hover:bg-primary-50 transition-colors duration-300"
+                  onAction={() => openEditor(item.key)}
+                >
+                  <TableCell>{item.type}</TableCell>
+                  <TableCell>{item.subject}</TableCell>
+                  <TableCell>{item.actions}</TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </TableContent>
+        </TableScrollContainer>
       </Table>
     </>
   );

--- a/apps/frontend/src/app/plugins/PluginsList.tsx
+++ b/apps/frontend/src/app/plugins/PluginsList.tsx
@@ -17,6 +17,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
   Tooltip,
   TooltipContent,
 } from '@heroui/react';
@@ -111,54 +112,56 @@ export function PluginsList() {
         ]}
       />
       <Table data-cy="plugins-list-table">
-        <TableContent aria-label="Plugins table">
-          <TableHeader>
-            <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
-            <TableColumn>{t('columns.version')}</TableColumn>
-            <TableColumn>{t('columns.directory')}</TableColumn>
-            <TableColumn>{t('columns.permissions')}</TableColumn>
-            <TableColumn>{t('columns.actions')}</TableColumn>
-          </TableHeader>
-          <TableBody items={plugins} renderEmptyState={() => <EmptyState />}>
-            {(plugin) => (
-              <TableRow key={plugin.name} id={plugin.name}>
-                <TableCell>{plugin.name}</TableCell>
-                <TableCell>
-                  <Chip variant="soft" color="accent">
-                    {plugin.version}
-                  </Chip>
-                </TableCell>
-                <TableCell>{plugin.pluginDirectory || '-'}</TableCell>
-                <TableCell>
-                  {plugin.permissions && plugin.permissions.length > 0 ? (
-                    <div className="flex flex-wrap gap-1" data-cy={`plugins-list-permissions-${plugin.id}`}>
-                      {plugin.permissions.map((permission) => (
-                        <Chip key={permission} variant="soft" color="warning">
-                          {permission}
-                        </Chip>
-                      ))}
-                    </div>
-                  ) : (
-                    <span className="text-default-400">{t('noPermissions')}</span>
-                  )}
-                </TableCell>
-                <TableCell>
-                  <Tooltip>
-                    <Button
-                      variant="danger-soft"
-                      isIconOnly
-                      onPress={() => handleDeleteClick(plugin.id)}
-                      data-cy={`plugins-list-delete-plugin-button-${plugin.id}`}
-                    >
-                      <Trash2 size={18} />
-                    </Button>
-                    <TooltipContent>{t('deleteTooltip')}</TooltipContent>
-                  </Tooltip>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </TableContent>
+        <TableScrollContainer>
+          <TableContent aria-label="Plugins table">
+            <TableHeader>
+              <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
+              <TableColumn>{t('columns.version')}</TableColumn>
+              <TableColumn>{t('columns.directory')}</TableColumn>
+              <TableColumn>{t('columns.permissions')}</TableColumn>
+              <TableColumn>{t('columns.actions')}</TableColumn>
+            </TableHeader>
+            <TableBody items={plugins} renderEmptyState={() => <EmptyState />}>
+              {(plugin) => (
+                <TableRow key={plugin.name} id={plugin.name}>
+                  <TableCell>{plugin.name}</TableCell>
+                  <TableCell>
+                    <Chip variant="soft" color="accent">
+                      {plugin.version}
+                    </Chip>
+                  </TableCell>
+                  <TableCell>{plugin.pluginDirectory || '-'}</TableCell>
+                  <TableCell>
+                    {plugin.permissions && plugin.permissions.length > 0 ? (
+                      <div className="flex flex-wrap gap-1" data-cy={`plugins-list-permissions-${plugin.id}`}>
+                        {plugin.permissions.map((permission) => (
+                          <Chip key={permission} variant="soft" color="warning">
+                            {permission}
+                          </Chip>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-default-400">{t('noPermissions')}</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Tooltip>
+                      <Button
+                        variant="danger-soft"
+                        isIconOnly
+                        onPress={() => handleDeleteClick(plugin.id)}
+                        data-cy={`plugins-list-delete-plugin-button-${plugin.id}`}
+                      >
+                        <Trash2 size={18} />
+                      </Button>
+                      <TooltipContent>{t('deleteTooltip')}</TooltipContent>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </TableContent>
+        </TableScrollContainer>
       </Table>
 
       <Modal

--- a/apps/frontend/src/app/projects/details/components/projectUsageCharts/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectUsageCharts/index.tsx
@@ -1,4 +1,15 @@
-import { Card, Skeleton, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import {
+  Card,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  TableScrollContainer,
+} from '@heroui/react';
 import { useMemo, useCallback, useEffect, useState } from 'react';
 import { useTranslations, useNumberFormatter, useDateTimeFormatter } from '@attraccess/plugins-frontend-ui';
 import { useProjectsServiceGetProjectUsageStats } from '@attraccess/react-query-client';
@@ -224,13 +235,11 @@ export function ProjectUsageCharts({ projectId }: ProjectUsageChartsProps) {
                         dataKey="sessions"
                         fill={BAR_COLORS.sessions.base}
                         name={t('tooltip.sessions')}
-
                         activeBar={
                           <Rectangle
                             fill={BAR_COLORS.sessions.active}
                             stroke={BAR_COLORS.sessions.base}
                             strokeWidth={2}
-
                           />
                         }
                       />
@@ -238,13 +247,11 @@ export function ProjectUsageCharts({ projectId }: ProjectUsageChartsProps) {
                         dataKey="minutes"
                         fill={BAR_COLORS.minutes.base}
                         name={t('tooltip.minutes')}
-
                         activeBar={
                           <Rectangle
                             fill={BAR_COLORS.minutes.active}
                             stroke={BAR_COLORS.minutes.base}
                             strokeWidth={2}
-
                           />
                         }
                       />
@@ -255,30 +262,32 @@ export function ProjectUsageCharts({ projectId }: ProjectUsageChartsProps) {
                 )}
               </div>
               <Table>
-                <TableContent aria-label={t('charts.topResources.table.ariaLabel')}>
-                <TableHeader>
-                  <TableColumn isRowHeader>{t('charts.topResources.columns.resource')}</TableColumn>
-                  <TableColumn>{t('charts.topResources.columns.sessions')}</TableColumn>
-                  <TableColumn>{t('charts.topResources.columns.minutes')}</TableColumn>
-                  <TableColumn>{t('charts.topResources.columns.spend')}</TableColumn>
-                </TableHeader>
-                <TableBody>
-                  {topResources.map((resource) => (
-                    <TableRow key={resource.resourceId} id={resource.resourceId}>
-                      <TableCell>{resource.resourceName}</TableCell>
-                      <TableCell>{formatNumber(resource.sessions)}</TableCell>
-                      <TableCell>{formatNumber(resource.minutes)}</TableCell>
-                      <TableCell>
-                        {data
-                          ? `${data.summary.currency} ${formatNumber(
-                              dbCurrencyToUserCurrency(resource.spend, data.summary.minorUnit),
-                            )}`
-                          : formatNumber(resource.spend)}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-                </TableContent>
+                <TableScrollContainer>
+                  <TableContent aria-label={t('charts.topResources.table.ariaLabel')}>
+                    <TableHeader>
+                      <TableColumn isRowHeader>{t('charts.topResources.columns.resource')}</TableColumn>
+                      <TableColumn>{t('charts.topResources.columns.sessions')}</TableColumn>
+                      <TableColumn>{t('charts.topResources.columns.minutes')}</TableColumn>
+                      <TableColumn>{t('charts.topResources.columns.spend')}</TableColumn>
+                    </TableHeader>
+                    <TableBody>
+                      {topResources.map((resource) => (
+                        <TableRow key={resource.resourceId} id={resource.resourceId}>
+                          <TableCell>{resource.resourceName}</TableCell>
+                          <TableCell>{formatNumber(resource.sessions)}</TableCell>
+                          <TableCell>{formatNumber(resource.minutes)}</TableCell>
+                          <TableCell>
+                            {data
+                              ? `${data.summary.currency} ${formatNumber(
+                                  dbCurrencyToUserCurrency(resource.spend, data.summary.minorUnit),
+                                )}`
+                              : formatNumber(resource.spend)}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </TableContent>
+                </TableScrollContainer>
               </Table>
             </>
           )}

--- a/apps/frontend/src/app/projects/details/components/projectUsageHistory/index.tsx
+++ b/apps/frontend/src/app/projects/details/components/projectUsageHistory/index.tsx
@@ -1,5 +1,15 @@
 import { useState, useCallback } from 'react';
-import { Card, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import {
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  TableScrollContainer,
+} from '@heroui/react';
 import { DateTimeDisplay, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { useProjectsServiceGetProjectUsageHistory, ResourceUsage } from '@attraccess/react-query-client';
 import en from './en.json';
@@ -53,43 +63,46 @@ export function ProjectUsageHistory({ projectId }: ProjectUsageHistoryProps) {
         </Card.Header>
         <Card.Content>
           <Table data-cy="project-usage-history-table">
-            <TableContent aria-label={t('history.title')}>
-            <TableHeader>
-              <TableColumn isRowHeader>{t('history.columns.resource')}</TableColumn>
-              <TableColumn>{t('history.columns.user')}</TableColumn>
-              <TableColumn>{t('history.columns.start')}</TableColumn>
-              <TableColumn>{t('history.columns.end')}</TableColumn>
-              <TableColumn>{t('history.columns.duration')}</TableColumn>
-            </TableHeader>
-            <TableBody
-              items={data?.data ?? []}
-              renderEmptyState={() => <EmptyState message={t('history.empty')} />}
-            >
-              {(session: ResourceUsage) => (
-                <TableRow
-                  key={session.id} id={session.id}
-                  className="cursor-pointer hover:bg-primary-50 transition-bg duration-300"
-                  onClick={() => handleRowAction(session)}
+            <TableScrollContainer>
+              <TableContent aria-label={t('history.title')}>
+                <TableHeader>
+                  <TableColumn isRowHeader>{t('history.columns.resource')}</TableColumn>
+                  <TableColumn>{t('history.columns.user')}</TableColumn>
+                  <TableColumn>{t('history.columns.start')}</TableColumn>
+                  <TableColumn>{t('history.columns.end')}</TableColumn>
+                  <TableColumn>{t('history.columns.duration')}</TableColumn>
+                </TableHeader>
+                <TableBody
+                  items={data?.data ?? []}
+                  renderEmptyState={() => <EmptyState message={t('history.empty')} />}
                 >
-                  <TableCell>{session.resource?.name ?? '—'}</TableCell>
-                  <TableCell>
-                    <AttraccessUser user={session.user} />
-                  </TableCell>
-                  <TableCell>
-                    <DateTimeDisplay date={session.startTime} />
-                  </TableCell>
-                  <TableCell>
-                    {session.endTime ? <DateTimeDisplay date={session.endTime} /> : t('history.inProgress')}
-                  </TableCell>
-                  <TableCell>
-                    {session.usageInMinutes >= 0
-                      ? t('history.minutes', { count: Math.round(session.usageInMinutes) })
-                      : t('history.inProgress')}
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-            </TableContent>
+                  {(session: ResourceUsage) => (
+                    <TableRow
+                      key={session.id}
+                      id={session.id}
+                      className="cursor-pointer hover:bg-primary-50 transition-bg duration-300"
+                      onClick={() => handleRowAction(session)}
+                    >
+                      <TableCell>{session.resource?.name ?? '—'}</TableCell>
+                      <TableCell>
+                        <AttraccessUser user={session.user} />
+                      </TableCell>
+                      <TableCell>
+                        <DateTimeDisplay date={session.startTime} />
+                      </TableCell>
+                      <TableCell>
+                        {session.endTime ? <DateTimeDisplay date={session.endTime} /> : t('history.inProgress')}
+                      </TableCell>
+                      <TableCell>
+                        {session.usageInMinutes >= 0
+                          ? t('history.minutes', { count: Math.round(session.usageInMinutes) })
+                          : t('history.inProgress')}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </TableContent>
+            </TableScrollContainer>
           </Table>
         </Card.Content>
       </Card>

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/index.tsx
@@ -3,7 +3,20 @@ import {
   useResourcesServiceGetAllResources,
   useResourcesServiceResourceGroupsGetOne,
 } from '@attraccess/react-query-client';
-import { Button, Card, CardProps, Skeleton, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import {
+  Button,
+  Card,
+  CardProps,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  TableScrollContainer,
+} from '@heroui/react';
 import { EmptyState } from '../../../components/emptyState';
 import { PageHeader } from '../../../components/pageHeader';
 import { useMemo, useState } from 'react';
@@ -134,53 +147,57 @@ export function ResourceGroupCard(props: Readonly<Props & Omit<CardProps, 'child
 
       <Card.Content>
         <Table>
-          <TableContent aria-label={tableAriaLabel}>
-          <TableHeader>
-            <TableColumn width="0">{t('columns.image')}</TableColumn>
-            <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
-            <TableColumn width="0" className="text-left">
-              {t('columns.status')}
-            </TableColumn>
-            <TableColumn width="0">{''}</TableColumn>
-          </TableHeader>
-          <TableBody
-            items={resources?.data ?? []}
-            renderEmptyState={() => <EmptyState />}
-          >
-            {(resource) => (
-              <TableRow key={resource.id} id={resource.id} className="cursor-pointer hover:bg-primary-50 transition-bg duration-300" onAction={() => navigate(`/resources/${resource.id}`)}>
-                <TableCell>
-                  {resource.imageFilename ? (
-                    <img
-                      height={48}
-                      width={48}
-                      src={filenameToUrl(resource.imageFilename)}
-                      alt=""
-                      aria-hidden="true"
-                      className="object-contain"
-                      style={{ height: 48, width: 48 }}
-                    />
-                  ) : (
-                    <div
-                      className="flex items-center justify-center text-default-400"
-                      style={{ height: 48, width: 48 }}
-                      aria-hidden="true"
-                    >
-                      <ShapesIcon className="w-6 h-6" />
-                    </div>
-                  )}
-                </TableCell>
-                <TableCell>{resource.name}</TableCell>
-                <TableCell className="text-right">
-                  <StatusChip resourceId={resource.id} />
-                </TableCell>
-                <TableCell>
-                  <ChevronRightIcon />
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-          </TableContent>
+          <TableScrollContainer>
+            <TableContent aria-label={tableAriaLabel}>
+              <TableHeader>
+                <TableColumn width="0">{t('columns.image')}</TableColumn>
+                <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
+                <TableColumn width="0" className="text-left">
+                  {t('columns.status')}
+                </TableColumn>
+                <TableColumn width="0">{''}</TableColumn>
+              </TableHeader>
+              <TableBody items={resources?.data ?? []} renderEmptyState={() => <EmptyState />}>
+                {(resource) => (
+                  <TableRow
+                    key={resource.id}
+                    id={resource.id}
+                    className="cursor-pointer hover:bg-primary-50 transition-bg duration-300"
+                    onAction={() => navigate(`/resources/${resource.id}`)}
+                  >
+                    <TableCell>
+                      {resource.imageFilename ? (
+                        <img
+                          height={48}
+                          width={48}
+                          src={filenameToUrl(resource.imageFilename)}
+                          alt=""
+                          aria-hidden="true"
+                          className="object-contain"
+                          style={{ height: 48, width: 48 }}
+                        />
+                      ) : (
+                        <div
+                          className="flex items-center justify-center text-default-400"
+                          style={{ height: 48, width: 48 }}
+                          aria-hidden="true"
+                        >
+                          <ShapesIcon className="w-6 h-6" />
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell>{resource.name}</TableCell>
+                    <TableCell className="text-right">
+                      <StatusChip resourceId={resource.id} />
+                    </TableCell>
+                    <TableCell>
+                      <ChevronRightIcon />
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </TableContent>
+          </TableScrollContainer>
         </Table>
       </Card.Content>
 

--- a/apps/frontend/src/app/resources/PeopleManagement/PeopleTable.tsx
+++ b/apps/frontend/src/app/resources/PeopleManagement/PeopleTable.tsx
@@ -7,6 +7,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
 } from '@heroui/react';
 import { AwardIcon, CheckIcon, WrenchIcon } from 'lucide-react';
 import { User } from '@attraccess/react-query-client';
@@ -50,79 +51,81 @@ export function PeopleTable(props: Readonly<PeopleTableProps>) {
 
   return (
     <Table>
-      <TableContent aria-label={t('title')}>
-        <TableHeader>
-          <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
-          <TableColumn>{t('columns.role')}</TableColumn>
-          <TableColumn>{t('columns.introduced')}</TableColumn>
-          <TableColumn>{t('columns.actions')}</TableColumn>
-        </TableHeader>
-        <TableBody
-          items={isLoading ? [] : rows}
-          renderEmptyState={() =>
-            isLoading ? (
-              <div className="flex justify-center py-12">
-                <Spinner data-cy="people-loading-spinner" />
-              </div>
-            ) : (
-              <EmptyState message={t('emptyState')} />
-            )
-          }
-        >
-          {(row) => (
-            <TableRow key={row.user.id} id={row.user.id}>
-              <TableCell className="w-full">
-                <AttraccessUser user={row.user} />
-              </TableCell>
-              <TableCell>
-                {row.isIntroducer ? (
-                  <span className="inline-flex items-center gap-1 text-success">
-                    <AwardIcon className="w-4 h-4" />
-                    {t('roles.introducer')}
-                  </span>
-                ) : row.isMaintainer ? (
-                  <span className="inline-flex items-center gap-1 text-primary">
-                    <WrenchIcon className="w-4 h-4" />
-                    {t('roles.maintainer')}
-                  </span>
-                ) : (
-                  <span className="text-foreground-400">{t('value.no')}</span>
-                )}
-              </TableCell>
-              <TableCell>
-                {row.hasValidIntroduction && row.introductionLastEventAt ? (
-                  <span className="inline-flex items-center gap-1 text-success">
-                    <CheckIcon className="w-4 h-4" />
-                    <DateTimeDisplay date={row.introductionLastEventAt} />
-                  </span>
-                ) : row.introduction && row.introductionLastEventAt ? (
-                  <span className="text-danger text-sm">
-                    <DateTimeDisplay date={row.introductionLastEventAt} />
-                  </span>
-                ) : (
-                  <span className="text-foreground-400">{t('value.no')}</span>
-                )}
-              </TableCell>
-              <TableCell>
-                <PeopleRowActions
-                  t={t}
-                  row={row}
-                  canManageIntroducers={canManageIntroducers}
-                  canManageIntroductions={canManageIntroductions}
-                  pendingIntroducerUserId={pendingIntroducerUserId}
-                  pendingIntroductionUserId={pendingIntroductionUserId}
-                  isRevokingIntroducer={isRevokingIntroducer}
-                  isGrantingIntroduction={isGrantingIntroduction}
-                  isRevokingIntroduction={isRevokingIntroduction}
-                  onOpenHistory={onOpenHistory}
-                  onToggleIntroduction={onToggleIntroduction}
-                  onRevokeIntroducer={onRevokeIntroducer}
-                />
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </TableContent>
+      <TableScrollContainer>
+        <TableContent aria-label={t('title')}>
+          <TableHeader>
+            <TableColumn isRowHeader>{t('columns.name')}</TableColumn>
+            <TableColumn>{t('columns.role')}</TableColumn>
+            <TableColumn>{t('columns.introduced')}</TableColumn>
+            <TableColumn>{t('columns.actions')}</TableColumn>
+          </TableHeader>
+          <TableBody
+            items={isLoading ? [] : rows}
+            renderEmptyState={() =>
+              isLoading ? (
+                <div className="flex justify-center py-12">
+                  <Spinner data-cy="people-loading-spinner" />
+                </div>
+              ) : (
+                <EmptyState message={t('emptyState')} />
+              )
+            }
+          >
+            {(row) => (
+              <TableRow key={row.user.id} id={row.user.id}>
+                <TableCell className="w-full">
+                  <AttraccessUser user={row.user} />
+                </TableCell>
+                <TableCell>
+                  {row.isIntroducer ? (
+                    <span className="inline-flex items-center gap-1 text-success">
+                      <AwardIcon className="w-4 h-4" />
+                      {t('roles.introducer')}
+                    </span>
+                  ) : row.isMaintainer ? (
+                    <span className="inline-flex items-center gap-1 text-primary">
+                      <WrenchIcon className="w-4 h-4" />
+                      {t('roles.maintainer')}
+                    </span>
+                  ) : (
+                    <span className="text-foreground-400">{t('value.no')}</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {row.hasValidIntroduction && row.introductionLastEventAt ? (
+                    <span className="inline-flex items-center gap-1 text-success">
+                      <CheckIcon className="w-4 h-4" />
+                      <DateTimeDisplay date={row.introductionLastEventAt} />
+                    </span>
+                  ) : row.introduction && row.introductionLastEventAt ? (
+                    <span className="text-danger text-sm">
+                      <DateTimeDisplay date={row.introductionLastEventAt} />
+                    </span>
+                  ) : (
+                    <span className="text-foreground-400">{t('value.no')}</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <PeopleRowActions
+                    t={t}
+                    row={row}
+                    canManageIntroducers={canManageIntroducers}
+                    canManageIntroductions={canManageIntroductions}
+                    pendingIntroducerUserId={pendingIntroducerUserId}
+                    pendingIntroductionUserId={pendingIntroductionUserId}
+                    isRevokingIntroducer={isRevokingIntroducer}
+                    isGrantingIntroduction={isGrantingIntroduction}
+                    isRevokingIntroduction={isRevokingIntroduction}
+                    onOpenHistory={onOpenHistory}
+                    onToggleIntroduction={onToggleIntroduction}
+                    onRevokeIntroducer={onRevokeIntroducer}
+                  />
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </TableContent>
+      </TableScrollContainer>
     </Table>
   );
 }

--- a/apps/frontend/src/app/resources/details/flows/variablesModal/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/variablesModal/index.tsx
@@ -15,6 +15,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -210,8 +211,8 @@ export function VariablesModal(props: Props) {
                       </Button>
                     </div>
 
-                    <div className="overflow-x-auto">
-                      <Table aria-label={t('title')}>
+                    <Table aria-label={t('title')}>
+                      <TableScrollContainer>
                         <TableContent>
                           <TableHeader>
                             <TableColumn isRowHeader>{t('table.key')}</TableColumn>
@@ -263,10 +264,7 @@ export function VariablesModal(props: Props) {
                                       </Button>
                                       {pendingDeleteKey === rowKey(row) ? (
                                         <>
-                                          <Button
-                                            variant="ghost"
-                                            onPress={() => setPendingDeleteKey(null)}
-                                          >
+                                          <Button variant="ghost" onPress={() => setPendingDeleteKey(null)}>
                                             {t('actions.confirmDeleteNo')}
                                           </Button>
                                           <Button
@@ -294,8 +292,8 @@ export function VariablesModal(props: Props) {
                             )}
                           </TableBody>
                         </TableContent>
-                      </Table>
-                    </div>
+                      </TableScrollContainer>
+                    </Table>
                   </div>
                 )}
               </ModalBody>

--- a/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
+++ b/apps/frontend/src/app/resources/details/maintenance-management/index.tsx
@@ -1,4 +1,16 @@
-import { Button, Card, cn, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow } from '@heroui/react';
+import {
+  Button,
+  Card,
+  cn,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  TableScrollContainer,
+} from '@heroui/react';
 import { PageAction, PageHeader } from '../../../../components/pageHeader';
 import { MaintenanceReasonDisplay } from '../../../../components/MaintenanceReasonDisplay';
 import { LabeledSwitch } from '../../../../components/labeledSwitch';
@@ -33,14 +45,18 @@ export function MaintenanceManagement(props: Props) {
 
   const [includePast, setIncludePast] = useState(false);
 
-  const { data: maintenances } = useResourceMaintenancesServiceFindMaintenances({
-    resourceId,
-    includePast,
-    includeActive: true,
-    includeUpcoming: true,
-  }, undefined, {
-    refetchInterval: 10000,
-  });
+  const { data: maintenances } = useResourceMaintenancesServiceFindMaintenances(
+    {
+      resourceId,
+      includePast,
+      includeActive: true,
+      includeUpcoming: true,
+    },
+    undefined,
+    {
+      refetchInterval: 10000,
+    },
+  );
 
   const now = useNow();
 
@@ -98,13 +114,7 @@ export function MaintenanceManagement(props: Props) {
       </LabeledSwitch>
       <ResourceMaintenanceUpsertModal resourceId={resourceId}>
         {(open) => (
-          <Button
-            variant="primary"
-            size="sm"
-            isIconOnly
-            onPress={open}
-            aria-label={t('actions.create.label')}
-          >
+          <Button variant="primary" size="sm" isIconOnly onPress={open} aria-label={t('actions.create.label')}>
             <PlusIcon className="w-4 h-4" />
           </Button>
         )}
@@ -122,7 +132,8 @@ export function MaintenanceManagement(props: Props) {
 
   const tableContent = (
     <Table>
-          <TableContent aria-label={t('table.ariaLabel')}>
+      <TableScrollContainer>
+        <TableContent aria-label={t('table.ariaLabel')}>
           <TableHeader>
             <TableColumn isRowHeader>{t('table.columns.start')}</TableColumn>
             <TableColumn>{t('table.columns.end')}</TableColumn>
@@ -158,21 +169,15 @@ export function MaintenanceManagement(props: Props) {
                   {(maintenance.completedByUser as { username?: string } | undefined)?.username ?? '—'}
                 </TableCell>
                 <TableCell>
-                  {maintenance.completedAt ? (
-                    <DateTimeDisplay date={maintenance.completedAt} />
-                  ) : (
-                    '—'
-                  )}
+                  {maintenance.completedAt ? <DateTimeDisplay date={maintenance.completedAt} /> : '—'}
                 </TableCell>
                 <TableCell>
                   {maintenance.isActive && (
                     <MarkDoneModal resourceId={resourceId} maintenanceId={maintenance.id}>
                       {(openMarkDone: () => void) => (
-                        <Button variant="tertiary"
-                          isIconOnly
-                         
-                          onPress={openMarkDone}
-                        ><CheckCircleIcon className="w-4 h-4" /></Button>
+                        <Button variant="tertiary" isIconOnly onPress={openMarkDone}>
+                          <CheckCircleIcon className="w-4 h-4" />
+                        </Button>
                       )}
                     </MarkDoneModal>
                   )}
@@ -180,8 +185,9 @@ export function MaintenanceManagement(props: Props) {
               </TableRow>
             )}
           </TableBody>
-          </TableContent>
-        </Table>
+        </TableContent>
+      </TableScrollContainer>
+    </Table>
   );
 
   if (variant === 'flat') {
@@ -240,12 +246,7 @@ export function MaintenanceManagement(props: Props) {
   return (
     <Card className={className} {...htmlProps}>
       <Card.Header>
-        <PageHeader
-          title={t('title')}
-          icon={<ConstructionIcon />}
-          noMargin
-          actions={cardActions}
-        />
+        <PageHeader title={t('title')} icon={<ConstructionIcon />} noMargin actions={cardActions} />
       </Card.Header>
 
       <Card.Content>

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Table, TableContent, TableHeader, TableBody, TableRow } from '@heroui/react';
+import { Table, TableScrollContainer, TableContent, TableHeader, TableBody, TableRow } from '@heroui/react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
 import { generateHeaderColumns } from './utils/tableHeaders';
 import { generateRowCells } from './utils/tableRows';
@@ -85,10 +85,7 @@ export const HistoryTable = ({
     setPage(newPage);
   }, []);
 
-  const {
-    data: usageHistory,
-    error,
-  } = useResourcesServiceResourceUsageGetHistory(
+  const { data: usageHistory, error } = useResourcesServiceResourceUsageGetHistory(
     {
       resourceId,
       page,
@@ -147,37 +144,38 @@ export const HistoryTable = ({
 
   return (
     <>
-    <Table data-cy="resource-usage-history-table">
-      <TableContent aria-label={t('table.ariaLabel')}>
-      <TableHeader>{headerColumns}</TableHeader>
-      <TableBody
-        renderEmptyState={() => <EmptyState />}
-      >
-        {filteredHistory.map((session: ResourceUsage) => (
-          <TableRow
-            key={session.id} id={session.id}
-            className="cursor-pointer hover:bg-primary-50 transition-bg duration-300"
-            onAction={() => onSessionClick(session)}
-          >
-            {resource
-              ? generateRowCells(session, t, resource, showAllUsers, canManageResources, (sessionToRender) => (
-                <ProjectAssignmentCell
-                  session={sessionToRender}
-                  canEdit={Boolean(sessionToRender.endTime) && sessionToRender.userId === user?.id}
-                  projectId={resolveProjectId(sessionToRender)}
-                  isUpdating={Boolean(updatingSessionIds[sessionToRender.id])}
-                  placeholder={projectPlaceholder}
-                  unassignedLabel={projectPlaceholder}
-                  onChange={(projectId) => onProjectChange(sessionToRender, projectId)}
-                />
-              ))
-              : []}
-          </TableRow>
-        ))}
-      </TableBody>
-      </TableContent>
-    </Table>
-    <SimplePagination total={totalPages} page={page} onChange={handlePageChange} />
+      <Table data-cy="resource-usage-history-table">
+        <TableScrollContainer>
+          <TableContent aria-label={t('table.ariaLabel')}>
+            <TableHeader>{headerColumns}</TableHeader>
+            <TableBody renderEmptyState={() => <EmptyState />}>
+              {filteredHistory.map((session: ResourceUsage) => (
+                <TableRow
+                  key={session.id}
+                  id={session.id}
+                  className="cursor-pointer hover:bg-primary-50 transition-bg duration-300"
+                  onAction={() => onSessionClick(session)}
+                >
+                  {resource
+                    ? generateRowCells(session, t, resource, showAllUsers, canManageResources, (sessionToRender) => (
+                        <ProjectAssignmentCell
+                          session={sessionToRender}
+                          canEdit={Boolean(sessionToRender.endTime) && sessionToRender.userId === user?.id}
+                          projectId={resolveProjectId(sessionToRender)}
+                          isUpdating={Boolean(updatingSessionIds[sessionToRender.id])}
+                          placeholder={projectPlaceholder}
+                          unassignedLabel={projectPlaceholder}
+                          onChange={(projectId) => onProjectChange(sessionToRender, projectId)}
+                        />
+                      ))
+                    : []}
+                </TableRow>
+              ))}
+            </TableBody>
+          </TableContent>
+        </TableScrollContainer>
+      </Table>
+      <SimplePagination total={totalPages} page={page} onChange={handlePageChange} />
     </>
   );
 };

--- a/apps/frontend/src/app/settings/password-policy/ConfirmDiffModal.tsx
+++ b/apps/frontend/src/app/settings/password-policy/ConfirmDiffModal.tsx
@@ -13,6 +13,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
 } from '@heroui/react';
 import { Button } from '../../../components/button';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -49,26 +50,28 @@ export function ConfirmDiffModal({ isOpen, diff, isConfirming, onClose, onConfir
                 <p className="text-sm text-default-500">{t('diff.noChanges')}</p>
               ) : (
                 <Table aria-label="changes" data-testid="policy-diff-table">
-                  <TableContent>
-                    <TableHeader>
-                      <TableColumn isRowHeader>{t('diff.field')}</TableColumn>
-                      <TableColumn>{t('diff.before')}</TableColumn>
-                      <TableColumn>{t('diff.after')}</TableColumn>
-                    </TableHeader>
-                    <TableBody>
-                      {diff.map((row) => (
-                        <TableRow key={row.field}>
-                          <TableCell className="font-medium">{row.field}</TableCell>
-                          <TableCell>
-                            <code>{row.before}</code>
-                          </TableCell>
-                          <TableCell>
-                            <code className="text-success-600">{row.after}</code>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </TableContent>
+                  <TableScrollContainer>
+                    <TableContent>
+                      <TableHeader>
+                        <TableColumn isRowHeader>{t('diff.field')}</TableColumn>
+                        <TableColumn>{t('diff.before')}</TableColumn>
+                        <TableColumn>{t('diff.after')}</TableColumn>
+                      </TableHeader>
+                      <TableBody>
+                        {diff.map((row) => (
+                          <TableRow key={row.field}>
+                            <TableCell className="font-medium">{row.field}</TableCell>
+                            <TableCell>
+                              <code>{row.before}</code>
+                            </TableCell>
+                            <TableCell>
+                              <code className="text-success-600">{row.after}</code>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </TableContent>
+                  </TableScrollContainer>
                 </Table>
               )}
             </ModalBody>

--- a/apps/frontend/src/app/settings/password-policy/OverridesSection.tsx
+++ b/apps/frontend/src/app/settings/password-policy/OverridesSection.tsx
@@ -22,6 +22,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
 } from '@heroui/react';
 import { Button } from '../../../components/button';
 import { LabeledSwitch } from '../../../components/labeledSwitch';
@@ -147,59 +148,58 @@ export function OverridesSection({ globalPolicy }: Props) {
           <Spinner size="sm" />
         ) : (
           <Table aria-label="overrides" data-testid="policy-overrides-table">
-            <TableContent>
-              <TableHeader>
-                <TableColumn isRowHeader>{t('overrides.role')}</TableColumn>
-                <TableColumn>{t('overrides.status')}</TableColumn>
-                <TableColumn>{t('overrides.actions')}</TableColumn>
-              </TableHeader>
-              <TableBody>
-                {ROLES.map((role) => {
-                  const row = overridesByRole.get(role);
-                  const count = countOverridden(row);
-                  return (
-                    <TableRow key={role} data-testid={`policy-override-row-${role}`}>
-                      <TableCell>{t(`overrides.roles.${role}`)}</TableCell>
-                      <TableCell>
-                        {count === 0 ? (
-                          <Chip variant="soft">{t('overrides.statusInherits')}</Chip>
-                        ) : (
-                          <Chip color="warning" variant="soft">
-                            {t('overrides.statusCustom', { count })}
-                          </Chip>
-                        )}
-                      </TableCell>
-                      <TableCell className="flex justify-end gap-2">
-                        <Button
-                          variant="ghost"
-                          onPress={() => setEditingRole(role)}
-                          data-testid={`policy-override-edit-${role}`}
-                        >
-                          {t('overrides.edit')}
-                        </Button>
-                        {row && (
+            <TableScrollContainer>
+              <TableContent>
+                <TableHeader>
+                  <TableColumn isRowHeader>{t('overrides.role')}</TableColumn>
+                  <TableColumn>{t('overrides.status')}</TableColumn>
+                  <TableColumn>{t('overrides.actions')}</TableColumn>
+                </TableHeader>
+                <TableBody>
+                  {ROLES.map((role) => {
+                    const row = overridesByRole.get(role);
+                    const count = countOverridden(row);
+                    return (
+                      <TableRow key={role} data-testid={`policy-override-row-${role}`}>
+                        <TableCell>{t(`overrides.roles.${role}`)}</TableCell>
+                        <TableCell>
+                          {count === 0 ? (
+                            <Chip variant="soft">{t('overrides.statusInherits')}</Chip>
+                          ) : (
+                            <Chip color="warning" variant="soft">
+                              {t('overrides.statusCustom', { count })}
+                            </Chip>
+                          )}
+                        </TableCell>
+                        <TableCell className="flex justify-end gap-2">
                           <Button
-                            variant="danger-soft"
-                            onPress={() => remove({ role })}
-                            data-testid={`policy-override-remove-${role}`}
+                            variant="ghost"
+                            onPress={() => setEditingRole(role)}
+                            data-testid={`policy-override-edit-${role}`}
                           >
-                            {t('overrides.remove')}
+                            {t('overrides.edit')}
                           </Button>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </TableContent>
+                          {row && (
+                            <Button
+                              variant="danger-soft"
+                              onPress={() => remove({ role })}
+                              data-testid={`policy-override-remove-${role}`}
+                            >
+                              {t('overrides.remove')}
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </TableContent>
+            </TableScrollContainer>
           </Table>
         )}
       </Card.Content>
 
-      <Modal
-        isOpen={editingRole !== null}
-        onOpenChange={(open) => !open && setEditingRole(null)}
-      >
+      <Modal isOpen={editingRole !== null} onOpenChange={(open) => !open && setEditingRole(null)}>
         <ModalBackdrop>
           <ModalContainer size="lg">
             <ModalDialog>
@@ -284,12 +284,7 @@ export function OverridesSection({ globalPolicy }: Props) {
                 <Button variant="ghost" onPress={() => setEditingRole(null)} isDisabled={isSaving}>
                   {t('overrides.cancel')}
                 </Button>
-                <Button
-                  variant="primary"
-                  onPress={handleSave}
-                  isPending={isSaving}
-                  data-testid="policy-override-save"
-                >
+                <Button variant="primary" onPress={handleSave} isPending={isSaving} data-testid="policy-override-save">
                   {t('overrides.save')}
                 </Button>
               </ModalFooter>

--- a/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
+++ b/apps/frontend/src/app/sso/providers/SSOProvidersList.tsx
@@ -1,5 +1,32 @@
 import React, { useState, forwardRef, useImperativeHandle, useCallback } from 'react';
-import { Description, Dropdown, DropdownItem, DropdownMenu, DropdownPopover, DropdownTrigger, DrawerBody, DrawerFooter, DrawerHeader, Input, InputGroup, Label, Link, Table, TableBody, TableCell, TableColumn, TableContent, TableHeader, TableRow, TextArea, TextField, Tooltip, TooltipContent, useOverlayState } from '@heroui/react';
+import {
+  Description,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownPopover,
+  DropdownTrigger,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
+  Input,
+  InputGroup,
+  Label,
+  Link,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  TableScrollContainer,
+  TextArea,
+  TextField,
+  Tooltip,
+  TooltipContent,
+  useOverlayState,
+} from '@heroui/react';
 import { Button } from '../../../components/button';
 import { StandardDrawer } from '../../../components/standardDrawer';
 import { buttonVariants } from '@heroui/styles';
@@ -613,56 +640,58 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
     <>
       {providers && providers.length > 0 ? (
         <Table data-cy="sso-providers-table">
-          <TableContent aria-label={t('table.ariaLabel')}>
-          <TableHeader>
-            <TableColumn isRowHeader>{t('id')}</TableColumn>
-            <TableColumn>{t('name')}</TableColumn>
-            <TableColumn>{t('type')}</TableColumn>
-            <TableColumn>{t('actions')}</TableColumn>
-          </TableHeader>
-          <TableBody items={providers} renderEmptyState={() => <EmptyState />}>
-            {(provider) => (
-              <TableRow key={provider.id} id={provider.id}>
-                <TableCell>
-                  <span className="font-mono text-sm">{provider.id}</span>
-                </TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2">
-                    <Key size={16} />
-                    {provider.name}
-                  </div>
-                </TableCell>
-                <TableCell>{provider.type}</TableCell>
-                <TableCell>
-                  <div className="flex items-center gap-2">
-                    <Tooltip>
-                      <Button
-                        variant="ghost"
-                        isIconOnly
-                        onPress={() => handleEdit(provider)}
-                        data-cy={`sso-provider-edit-button-${provider.id}`}
-                      >
-                        <Pencil size={16} />
-                      </Button>
-                      <TooltipContent>{t('edit')}</TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <Button
-                        variant="danger-soft"
-                        isIconOnly
-                        onPress={() => handleDelete(provider.id)}
-                        data-cy={`sso-provider-delete-button-${provider.id}`}
-                      >
-                        <Trash size={16} />
-                      </Button>
-                      <TooltipContent>{t('deleteText')}</TooltipContent>
-                    </Tooltip>
-                  </div>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-          </TableContent>
+          <TableScrollContainer>
+            <TableContent aria-label={t('table.ariaLabel')}>
+              <TableHeader>
+                <TableColumn isRowHeader>{t('id')}</TableColumn>
+                <TableColumn>{t('name')}</TableColumn>
+                <TableColumn>{t('type')}</TableColumn>
+                <TableColumn>{t('actions')}</TableColumn>
+              </TableHeader>
+              <TableBody items={providers} renderEmptyState={() => <EmptyState />}>
+                {(provider) => (
+                  <TableRow key={provider.id} id={provider.id}>
+                    <TableCell>
+                      <span className="font-mono text-sm">{provider.id}</span>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Key size={16} />
+                        {provider.name}
+                      </div>
+                    </TableCell>
+                    <TableCell>{provider.type}</TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Tooltip>
+                          <Button
+                            variant="ghost"
+                            isIconOnly
+                            onPress={() => handleEdit(provider)}
+                            data-cy={`sso-provider-edit-button-${provider.id}`}
+                          >
+                            <Pencil size={16} />
+                          </Button>
+                          <TooltipContent>{t('edit')}</TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <Button
+                            variant="danger-soft"
+                            isIconOnly
+                            onPress={() => handleDelete(provider.id)}
+                            data-cy={`sso-provider-delete-button-${provider.id}`}
+                          >
+                            <Trash size={16} />
+                          </Button>
+                          <TooltipContent>{t('deleteText')}</TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </TableContent>
+          </TableScrollContainer>
         </Table>
       ) : (
         <div className="text-center p-8 rounded-lg border dark:border-gray-700 border-gray-200">
@@ -673,433 +702,455 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
       {/* Main Provider Form Drawer */}
       <StandardDrawer isOpen={isOpen} onOpenChange={setOpen}>
         <div data-cy="sso-provider-form-modal" className="contents">
-        <DrawerHeader>
-          <h2 className="text-lg font-semibold">{editingProvider ? t('editProvider') : t('createNewProvider')}</h2>
-        </DrawerHeader>
-        <DrawerBody>
-          <div className="flex flex-col gap-8" data-cy="sso-provider-form">
-            <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-              <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                {t('sections.provider')}
-              </h3>
-              <TextField
-                isRequired
-                value={formValues.name}
-                onChange={(v) => setFormValues((prev) => ({ ...prev, name: v }))}
-              >
-                <Label>{t('name')}</Label>
-                <Input placeholder="e.g. Company OIDC" data-cy="sso-provider-form-name-input" />
-              </TextField>
-
-              <div className="flex flex-col gap-1">
-                <label className="text-sm font-medium">{t('type')}</label>
-                <Select
-                  items={Object.values(SSOProviderType).map((type) => ({ key: type, label: type }))}
-                  value={formValues.type}
-                  onChange={(key) => {
-                    if (key) handleSelectChange(key as SSOProviderType);
-                  }}
+          <DrawerHeader>
+            <h2 className="text-lg font-semibold">{editingProvider ? t('editProvider') : t('createNewProvider')}</h2>
+          </DrawerHeader>
+          <DrawerBody>
+            <div className="flex flex-col gap-8" data-cy="sso-provider-form">
+              <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                  {t('sections.provider')}
+                </h3>
+                <TextField
                   isRequired
-                  data-cy="sso-provider-form-type-select"
-                />
-              </div>
-            </section>
+                  value={formValues.name}
+                  onChange={(v) => setFormValues((prev) => ({ ...prev, name: v }))}
+                >
+                  <Label>{t('name')}</Label>
+                  <Input placeholder="e.g. Company OIDC" data-cy="sso-provider-form-name-input" />
+                </TextField>
 
-            {formValues.type === SSOProviderType.OIDC && (
-              <>
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <div className="flex items-center justify-between gap-2">
-                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                      {t('sections.oidcEndpoints')}
-                    </h3>
-                    <AuthentikDiscoveryDialog onDiscovery={onAutoDiscovery}>
-                      {(onOpenAuthentikDiscovery) => (
-                        <KeycloakDiscoveryDialog onDiscovery={onAutoDiscovery}>
-                          {(onOpenKeycloakDiscovery) => (
-                            <Dropdown>
-                              <DropdownTrigger className={buttonVariants({ variant: 'ghost' })}>
-                                <MoreVertical className="w-4 h-4" />
-                                {t('autoDiscovery.label')}
-                              </DropdownTrigger>
-                              <DropdownPopover>
-                                <DropdownMenu aria-label="OIDC auto discovery options">
-                                  <DropdownItem
-                                    key="authentik"
-                                    id="authentik"
-                                    onPress={onOpenAuthentikDiscovery}
-                                    data-cy="sso-provider-form-authentik-discovery-button"
-                                  >
-                                    {t('autoDiscovery.authentik')}
-                                  </DropdownItem>
-
-                                  <DropdownItem
-                                    key="keycloak"
-                                    id="keycloak"
-                                    onPress={onOpenKeycloakDiscovery}
-                                    data-cy="sso-provider-form-keycloak-discovery-button"
-                                  >
-                                    {t('autoDiscovery.keycloak')}
-                                  </DropdownItem>
-                                </DropdownMenu>
-                              </DropdownPopover>
-                            </Dropdown>
-                          )}
-                        </KeycloakDiscoveryDialog>
-                      )}
-                    </AuthentikDiscoveryDialog>
-                  </div>
-
-                  <TextField
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-medium">{t('type')}</label>
+                  <Select
+                    items={Object.values(SSOProviderType).map((type) => ({ key: type, label: type }))}
+                    value={formValues.type}
+                    onChange={(key) => {
+                      if (key) handleSelectChange(key as SSOProviderType);
+                    }}
                     isRequired
-                    value={formValues.oidcConfiguration?.issuer ?? ''}
-                    onChange={(v) => setOidc('issuer', v)}
-                  >
-                    <Label>{t('issuer')}</Label>
-                    <Input
-                      placeholder="https://sso.example.com/auth/realms/example"
-                      data-cy="sso-provider-form-oidc-issuer-input"
-                    />
-                  </TextField>
+                    data-cy="sso-provider-form-type-select"
+                  />
+                </div>
+              </section>
 
-                  <TextField
-                    isRequired
-                    value={formValues.oidcConfiguration?.authorizationURL ?? ''}
-                    onChange={(v) => setOidc('authorizationURL', v)}
-                  >
-                    <Label>{t('authorizationURL')}</Label>
-                    <Input
-                      placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/auth"
-                      data-cy="sso-provider-form-oidc-authorization-url-input"
-                    />
-                  </TextField>
+              {formValues.type === SSOProviderType.OIDC && (
+                <>
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <div className="flex items-center justify-between gap-2">
+                      <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                        {t('sections.oidcEndpoints')}
+                      </h3>
+                      <AuthentikDiscoveryDialog onDiscovery={onAutoDiscovery}>
+                        {(onOpenAuthentikDiscovery) => (
+                          <KeycloakDiscoveryDialog onDiscovery={onAutoDiscovery}>
+                            {(onOpenKeycloakDiscovery) => (
+                              <Dropdown>
+                                <DropdownTrigger className={buttonVariants({ variant: 'ghost' })}>
+                                  <MoreVertical className="w-4 h-4" />
+                                  {t('autoDiscovery.label')}
+                                </DropdownTrigger>
+                                <DropdownPopover>
+                                  <DropdownMenu aria-label="OIDC auto discovery options">
+                                    <DropdownItem
+                                      key="authentik"
+                                      id="authentik"
+                                      onPress={onOpenAuthentikDiscovery}
+                                      data-cy="sso-provider-form-authentik-discovery-button"
+                                    >
+                                      {t('autoDiscovery.authentik')}
+                                    </DropdownItem>
 
-                  <TextField
-                    isRequired
-                    value={formValues.oidcConfiguration?.tokenURL ?? ''}
-                    onChange={(v) => setOidc('tokenURL', v)}
-                  >
-                    <Label>{t('tokenURL')}</Label>
-                    <Input
-                      placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/token"
-                      data-cy="sso-provider-form-oidc-token-url-input"
-                    />
-                  </TextField>
+                                    <DropdownItem
+                                      key="keycloak"
+                                      id="keycloak"
+                                      onPress={onOpenKeycloakDiscovery}
+                                      data-cy="sso-provider-form-keycloak-discovery-button"
+                                    >
+                                      {t('autoDiscovery.keycloak')}
+                                    </DropdownItem>
+                                  </DropdownMenu>
+                                </DropdownPopover>
+                              </Dropdown>
+                            )}
+                          </KeycloakDiscoveryDialog>
+                        )}
+                      </AuthentikDiscoveryDialog>
+                    </div>
 
-                  <TextField
-                    isRequired
-                    value={formValues.oidcConfiguration?.userInfoURL ?? ''}
-                    onChange={(v) => setOidc('userInfoURL', v)}
-                  >
-                    <Label>{t('userInfoURL')}</Label>
-                    <Input
-                      placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/userinfo"
-                      data-cy="sso-provider-form-oidc-user-info-url-input"
-                    />
-                  </TextField>
-                </section>
-
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                    {t('sections.oidcCredentials')}
-                  </h3>
-                  <TextField
-                    isRequired
-                    value={formValues.oidcConfiguration?.clientId ?? ''}
-                    onChange={(v) => setOidc('clientId', v)}
-                  >
-                    <Label>{t('clientId')}</Label>
-                    <Input placeholder="your-client-id" data-cy="sso-provider-form-oidc-client-id-input" />
-                  </TextField>
-
-                  <TextField
-                    isRequired
-                    value={formValues.oidcConfiguration?.clientSecret ?? ''}
-                    onChange={(v) => setOidc('clientSecret', v)}
-                  >
-                    <Label>{t('clientSecret')}</Label>
-                    <InputGroup>
-                      <InputGroup.Input
-                        type={showClientSecret ? 'text' : 'password'}
-                        placeholder="••••••••••••••••"
-                        data-cy="sso-provider-form-oidc-client-secret-input"
+                    <TextField
+                      isRequired
+                      value={formValues.oidcConfiguration?.issuer ?? ''}
+                      onChange={(v) => setOidc('issuer', v)}
+                    >
+                      <Label>{t('issuer')}</Label>
+                      <Input
+                        placeholder="https://sso.example.com/auth/realms/example"
+                        data-cy="sso-provider-form-oidc-issuer-input"
                       />
-                      <InputGroup.Suffix>
+                    </TextField>
+
+                    <TextField
+                      isRequired
+                      value={formValues.oidcConfiguration?.authorizationURL ?? ''}
+                      onChange={(v) => setOidc('authorizationURL', v)}
+                    >
+                      <Label>{t('authorizationURL')}</Label>
+                      <Input
+                        placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/auth"
+                        data-cy="sso-provider-form-oidc-authorization-url-input"
+                      />
+                    </TextField>
+
+                    <TextField
+                      isRequired
+                      value={formValues.oidcConfiguration?.tokenURL ?? ''}
+                      onChange={(v) => setOidc('tokenURL', v)}
+                    >
+                      <Label>{t('tokenURL')}</Label>
+                      <Input
+                        placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/token"
+                        data-cy="sso-provider-form-oidc-token-url-input"
+                      />
+                    </TextField>
+
+                    <TextField
+                      isRequired
+                      value={formValues.oidcConfiguration?.userInfoURL ?? ''}
+                      onChange={(v) => setOidc('userInfoURL', v)}
+                    >
+                      <Label>{t('userInfoURL')}</Label>
+                      <Input
+                        placeholder="https://sso.example.com/auth/realms/example/protocol/openid-connect/userinfo"
+                        data-cy="sso-provider-form-oidc-user-info-url-input"
+                      />
+                    </TextField>
+                  </section>
+
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                      {t('sections.oidcCredentials')}
+                    </h3>
+                    <TextField
+                      isRequired
+                      value={formValues.oidcConfiguration?.clientId ?? ''}
+                      onChange={(v) => setOidc('clientId', v)}
+                    >
+                      <Label>{t('clientId')}</Label>
+                      <Input placeholder="your-client-id" data-cy="sso-provider-form-oidc-client-id-input" />
+                    </TextField>
+
+                    <TextField
+                      isRequired
+                      value={formValues.oidcConfiguration?.clientSecret ?? ''}
+                      onChange={(v) => setOidc('clientSecret', v)}
+                    >
+                      <Label>{t('clientSecret')}</Label>
+                      <InputGroup>
+                        <InputGroup.Input
+                          type={showClientSecret ? 'text' : 'password'}
+                          placeholder="••••••••••••••••"
+                          data-cy="sso-provider-form-oidc-client-secret-input"
+                        />
+                        <InputGroup.Suffix>
+                          <Tooltip>
+                            <Button
+                              variant="ghost"
+                              isIconOnly
+                              onPress={() => setShowClientSecret(!showClientSecret)}
+                              data-cy="sso-provider-form-oidc-toggle-client-secret-button"
+                            >
+                              {showClientSecret ? <EyeOff size={16} /> : <Eye size={16} />}
+                            </Button>
+                            <TooltipContent>
+                              {showClientSecret ? t('hideClientSecret') : t('showClientSecret')}
+                            </TooltipContent>
+                          </Tooltip>
+                        </InputGroup.Suffix>
+                      </InputGroup>
+                    </TextField>
+                  </section>
+
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                      {t('sections.oidcClaims')}
+                    </h3>
+                    <TextField value={scopesInput} onChange={setScopesInput}>
+                      <Label>{t('scopes')}</Label>
+                      <Input placeholder="openid, email, profile" data-cy="sso-provider-form-oidc-scopes-input" />
+                    </TextField>
+                    <TextField value={usernameClaimPathsInput} onChange={setUsernameClaimPathsInput}>
+                      <Label>{t('usernameClaimPaths')}</Label>
+                      <Input
+                        placeholder="preferred_username, email, sub"
+                        data-cy="sso-provider-form-oidc-username-claims-input"
+                      />
+                    </TextField>
+                    <TextField value={emailClaimPathsInput} onChange={setEmailClaimPathsInput}>
+                      <Label>{t('emailClaimPaths')}</Label>
+                      <Input
+                        placeholder="email, emails[0].value, upn"
+                        data-cy="sso-provider-form-oidc-email-claims-input"
+                      />
+                    </TextField>
+                  </section>
+
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                      {t('permissionMappings')}
+                    </h3>
+                    <p className="text-xs text-default-500">{t('permissionMappingsHint')}</p>
+                    {permissionKeys.map((permissionKey) => (
+                      <TextField
+                        key={`oidc-permission-${permissionKey}`}
+                        value={oidcPermissionMappingsInput[permissionKey]}
+                        onChange={(v) => setOidcPermissionMappingsInput((prev) => ({ ...prev, [permissionKey]: v }))}
+                      >
+                        <Label>{t(`permissionMappingLabels.${permissionKey}`)}</Label>
+                        <Input
+                          placeholder={t('permissionMappingsPlaceholder')}
+                          data-cy={`sso-provider-form-oidc-permission-mapping-${permissionKey}`}
+                        />
+                      </TextField>
+                    ))}
+                  </section>
+                </>
+              )}
+
+              {formValues.type === SSOProviderType.SAML && (
+                <>
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                      {t('sections.samlIdentityProvider')}
+                    </h3>
+                    <TextField
+                      isRequired
+                      value={formValues.samlConfiguration?.entryPoint ?? ''}
+                      onChange={(v) => setSaml('entryPoint', v)}
+                    >
+                      <Label>{t('entryPoint')}</Label>
+                      <Input
+                        placeholder="https://idp.example.com/realms/master/protocol/saml"
+                        data-cy="sso-provider-form-saml-entry-point-input"
+                      />
+                    </TextField>
+
+                    <TextField
+                      isRequired
+                      value={formValues.samlConfiguration?.issuer ?? ''}
+                      onChange={(v) => setSaml('issuer', v)}
+                    >
+                      <Label>{t('issuer')}</Label>
+                      <Input placeholder={window.location.origin ?? ''} data-cy="sso-provider-form-saml-issuer-input" />
+                    </TextField>
+
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-medium">{t('certificate')}</label>
+                      <TextArea
+                        name="samlConfiguration.certificate"
+                        value={formValues.samlConfiguration?.certificate ?? ''}
+                        onChange={(e) => setSaml('certificate', e.target.value)}
+                        placeholder="MIICmzCCAYMCBg..."
+                        required
+                        data-cy="sso-provider-form-saml-certificate-input"
+                      />
+                      <p className="text-xs text-default-500">{t('certificateHint')}</p>
+                    </div>
+
+                    <TextField
+                      value={formValues.samlConfiguration?.audience ?? ''}
+                      onChange={(v) => setSaml('audience', v)}
+                    >
+                      <Label>{t('audience')}</Label>
+                      <Input
+                        placeholder={window.location.origin ?? ''}
+                        data-cy="sso-provider-form-saml-audience-input"
+                      />
+                    </TextField>
+                  </section>
+
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                      {t('sections.samlAttributes')}
+                    </h3>
+                    <TextField value={emailAttributeKeysInput} onChange={setEmailAttributeKeysInput}>
+                      <Label>{t('emailAttributeKeys')}</Label>
+                      <Input
+                        placeholder="email, mail, urn:oid:1.2.840.113549.1.9.1"
+                        data-cy="sso-provider-form-saml-email-attribute-keys-input"
+                      />
+                      <Description>{t('emailAttributeKeysHint')}</Description>
+                    </TextField>
+                  </section>
+
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                      {t('sections.samlProvisioning')}
+                    </h3>
+                    <TextField
+                      value={formValues.samlConfiguration?.provisioningSecret ?? ''}
+                      onChange={(v) => setSaml('provisioningSecret', v)}
+                    >
+                      <Label>{t('samlProvisioningSecret')}</Label>
+                      <InputGroup>
+                        <Input
+                          type={showSamlProvisioningSecret ? 'text' : 'password'}
+                          placeholder="••••••••••••••••"
+                          data-cy="sso-provider-form-saml-provisioning-secret-input"
+                        />
                         <Tooltip>
                           <Button
                             variant="ghost"
                             isIconOnly
-                            onPress={() => setShowClientSecret(!showClientSecret)}
-                            data-cy="sso-provider-form-oidc-toggle-client-secret-button"
+                            onPress={() => setShowSamlProvisioningSecret(!showSamlProvisioningSecret)}
+                            data-cy="sso-provider-form-saml-provisioning-secret-toggle-button"
                           >
-                            {showClientSecret ? <EyeOff size={16} /> : <Eye size={16} />}
+                            {showSamlProvisioningSecret ? <EyeOff size={16} /> : <Eye size={16} />}
                           </Button>
                           <TooltipContent>
-                            {showClientSecret ? t('hideClientSecret') : t('showClientSecret')}
+                            {showSamlProvisioningSecret
+                              ? t('hideSamlProvisioningSecret')
+                              : t('showSamlProvisioningSecret')}
                           </TooltipContent>
                         </Tooltip>
-                      </InputGroup.Suffix>
-                    </InputGroup>
-                  </TextField>
-                </section>
-
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                    {t('sections.oidcClaims')}
-                  </h3>
-                  <TextField value={scopesInput} onChange={setScopesInput}>
-                    <Label>{t('scopes')}</Label>
-                    <Input placeholder="openid, email, profile" data-cy="sso-provider-form-oidc-scopes-input" />
-                  </TextField>
-                  <TextField value={usernameClaimPathsInput} onChange={setUsernameClaimPathsInput}>
-                    <Label>{t('usernameClaimPaths')}</Label>
-                    <Input
-                      placeholder="preferred_username, email, sub"
-                      data-cy="sso-provider-form-oidc-username-claims-input"
-                    />
-                  </TextField>
-                  <TextField value={emailClaimPathsInput} onChange={setEmailClaimPathsInput}>
-                    <Label>{t('emailClaimPaths')}</Label>
-                    <Input
-                      placeholder="email, emails[0].value, upn"
-                      data-cy="sso-provider-form-oidc-email-claims-input"
-                    />
-                  </TextField>
-                </section>
-
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                    {t('permissionMappings')}
-                  </h3>
-                  <p className="text-xs text-default-500">{t('permissionMappingsHint')}</p>
-                  {permissionKeys.map((permissionKey) => (
-                    <TextField
-                      key={`oidc-permission-${permissionKey}`}
-                      value={oidcPermissionMappingsInput[permissionKey]}
-                      onChange={(v) =>
-                        setOidcPermissionMappingsInput((prev) => ({ ...prev, [permissionKey]: v }))
-                      }
-                    >
-                      <Label>{t(`permissionMappingLabels.${permissionKey}`)}</Label>
-                      <Input
-                        placeholder={t('permissionMappingsPlaceholder')}
-                        data-cy={`sso-provider-form-oidc-permission-mapping-${permissionKey}`}
-                      />
+                      </InputGroup>
+                      <Description>{t('samlProvisioningSecretHint')}</Description>
                     </TextField>
-                  ))}
-                </section>
-              </>
-            )}
+                  </section>
 
-            {formValues.type === SSOProviderType.SAML && (
-              <>
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                    {t('sections.samlIdentityProvider')}
-                  </h3>
-                  <TextField
-                    isRequired
-                    value={formValues.samlConfiguration?.entryPoint ?? ''}
-                    onChange={(v) => setSaml('entryPoint', v)}
-                  >
-                    <Label>{t('entryPoint')}</Label>
-                    <Input
-                      placeholder="https://idp.example.com/realms/master/protocol/saml"
-                      data-cy="sso-provider-form-saml-entry-point-input"
-                    />
-                  </TextField>
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                      {t('permissionMappings')}
+                    </h3>
+                    <p className="text-xs text-default-500">{t('permissionMappingsHint')}</p>
+                    {permissionKeys.map((permissionKey) => (
+                      <TextField
+                        key={`saml-permission-${permissionKey}`}
+                        value={samlPermissionMappingsInput[permissionKey]}
+                        onChange={(v) => setSamlPermissionMappingsInput((prev) => ({ ...prev, [permissionKey]: v }))}
+                      >
+                        <Label>{t(`permissionMappingLabels.${permissionKey}`)}</Label>
+                        <Input
+                          placeholder={t('permissionMappingsPlaceholder')}
+                          data-cy={`sso-provider-form-saml-permission-mapping-${permissionKey}`}
+                        />
+                      </TextField>
+                    ))}
+                  </section>
 
-                  <TextField
-                    isRequired
-                    value={formValues.samlConfiguration?.issuer ?? ''}
-                    onChange={(v) => setSaml('issuer', v)}
-                  >
-                    <Label>{t('issuer')}</Label>
-                    <Input
-                      placeholder={window.location.origin ?? ''}
-                      data-cy="sso-provider-form-saml-issuer-input"
-                    />
-                  </TextField>
-
-                  <div className="flex flex-col gap-1">
-                    <label className="text-sm font-medium">{t('certificate')}</label>
-                    <TextArea
-                      name="samlConfiguration.certificate"
-                      value={formValues.samlConfiguration?.certificate ?? ''}
-                      onChange={(e) => setSaml('certificate', e.target.value)}
-                      placeholder="MIICmzCCAYMCBg..."
-                      required
-                      data-cy="sso-provider-form-saml-certificate-input"
-                    />
-                    <p className="text-xs text-default-500">{t('certificateHint')}</p>
-                  </div>
-
-                  <TextField
-                    value={formValues.samlConfiguration?.audience ?? ''}
-                    onChange={(v) => setSaml('audience', v)}
-                  >
-                    <Label>{t('audience')}</Label>
-                    <Input
-                      placeholder={window.location.origin ?? ''}
-                      data-cy="sso-provider-form-saml-audience-input"
-                    />
-                  </TextField>
-                </section>
-
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                    {t('sections.samlAttributes')}
-                  </h3>
-                  <TextField value={emailAttributeKeysInput} onChange={setEmailAttributeKeysInput}>
-                    <Label>{t('emailAttributeKeys')}</Label>
-                    <Input
-                      placeholder="email, mail, urn:oid:1.2.840.113549.1.9.1"
-                      data-cy="sso-provider-form-saml-email-attribute-keys-input"
-                    />
-                    <Description>{t('emailAttributeKeysHint')}</Description>
-                  </TextField>
-                </section>
-
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                    {t('sections.samlProvisioning')}
-                  </h3>
-                  <TextField
-                    value={formValues.samlConfiguration?.provisioningSecret ?? ''}
-                    onChange={(v) => setSaml('provisioningSecret', v)}
-                  >
-                    <Label>{t('samlProvisioningSecret')}</Label>
-                    <InputGroup>
-                      <Input
-                        type={showSamlProvisioningSecret ? 'text' : 'password'}
-                        placeholder="••••••••••••••••"
-                        data-cy="sso-provider-form-saml-provisioning-secret-input"
+                  <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
+                    <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                      {t('sections.samlSigning')}
+                    </h3>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-medium">{t('spSigningCertificate')}</label>
+                      <TextArea
+                        name="samlConfiguration.spSigningCertificate"
+                        value={formValues.samlConfiguration?.spSigningCertificate ?? ''}
+                        onChange={(e) => setSaml('spSigningCertificate', e.target.value)}
+                        placeholder="MIICmzCCAYMCBg..."
+                        data-cy="sso-provider-form-saml-sp-certificate-input"
                       />
-                      <Tooltip>
-                        <Button
-                          variant="ghost"
-                          isIconOnly
-                          onPress={() => setShowSamlProvisioningSecret(!showSamlProvisioningSecret)}
-                          data-cy="sso-provider-form-saml-provisioning-secret-toggle-button"
+                      <p className="text-xs text-default-500">{t('spSigningCertificateHint')}</p>
+                    </div>
+
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-medium">{t('spSigningPrivateKey')}</label>
+                      <TextArea
+                        name="samlConfiguration.spSigningPrivateKey"
+                        value={formValues.samlConfiguration?.spSigningPrivateKey ?? ''}
+                        onChange={(e) => setSaml('spSigningPrivateKey', e.target.value)}
+                        placeholder="-----BEGIN PRIVATE KEY-----"
+                        data-cy="sso-provider-form-saml-sp-private-key-input"
+                      />
+                      <p className="text-xs text-default-500">
+                        {providerDetails?.samlConfiguration?.spSigningKeyEncrypted
+                          ? t('spSigningPrivateKeyHintExisting')
+                          : t('spSigningPrivateKeyHint')}
+                      </p>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <LabeledSwitch
+                        isSelected={formValues.samlConfiguration?.signRequest ?? false}
+                        onChange={(value) => handleSamlToggleChange('signRequest', value)}
+                        data-cy="sso-provider-form-saml-sign-request-switch"
+                      >
+                        {t('signRequest')}
+                      </LabeledSwitch>
+                      <LabeledSwitch
+                        isSelected={formValues.samlConfiguration?.wantAssertionsSigned ?? false}
+                        onChange={(value) => handleSamlToggleChange('wantAssertionsSigned', value)}
+                        data-cy="sso-provider-form-saml-assertions-signed-switch"
+                      >
+                        {t('wantAssertionsSigned')}
+                      </LabeledSwitch>
+                      <LabeledSwitch
+                        isSelected={formValues.samlConfiguration?.wantAuthnResponseSigned ?? true}
+                        onChange={(value) => handleSamlToggleChange('wantAuthnResponseSigned', value)}
+                        data-cy="sso-provider-form-saml-response-signed-switch"
+                      >
+                        {t('wantAuthnResponseSigned')}
+                      </LabeledSwitch>
+                      <LabeledSwitch
+                        isSelected={formValues.samlConfiguration?.forceAuthn ?? false}
+                        onChange={(value) => handleSamlToggleChange('forceAuthn', value)}
+                        data-cy="sso-provider-form-saml-force-authn-switch"
+                      >
+                        {t('forceAuthn')}
+                      </LabeledSwitch>
+                    </div>
+                  </section>
+                </>
+              )}
+
+              <section
+                className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0"
+                data-cy="sso-provider-form-setup-section"
+              >
+                <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+                  {t('setupInstructions')}
+                </h3>
+                <p className="text-xs text-default-500">{t('setupInstructionsHint')}</p>
+                <dl className="flex flex-col gap-4">
+                  {!isSamlProvider && (
+                    <div className="flex flex-col gap-1">
+                      <dt className="text-sm font-medium">{t('authentikRedirectRegex')}</dt>
+                      <dd className="flex items-center gap-2 rounded-md border border-default-200 bg-default-50 px-3 py-2">
+                        <code
+                          className="flex-1 text-xs break-all font-mono text-default-700"
+                          data-cy="sso-provider-form-authentik-regex"
                         >
-                          {showSamlProvisioningSecret ? <EyeOff size={16} /> : <Eye size={16} />}
-                        </Button>
-                        <TooltipContent>
-                          {showSamlProvisioningSecret
-                            ? t('hideSamlProvisioningSecret')
-                            : t('showSamlProvisioningSecret')}
-                        </TooltipContent>
-                      </Tooltip>
-                    </InputGroup>
-                    <Description>{t('samlProvisioningSecretHint')}</Description>
-                  </TextField>
-                </section>
-
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                    {t('permissionMappings')}
-                  </h3>
-                  <p className="text-xs text-default-500">{t('permissionMappingsHint')}</p>
-                  {permissionKeys.map((permissionKey) => (
-                    <TextField
-                      key={`saml-permission-${permissionKey}`}
-                      value={samlPermissionMappingsInput[permissionKey]}
-                      onChange={(v) =>
-                        setSamlPermissionMappingsInput((prev) => ({ ...prev, [permissionKey]: v }))
-                      }
-                    >
-                      <Label>{t(`permissionMappingLabels.${permissionKey}`)}</Label>
-                      <Input
-                        placeholder={t('permissionMappingsPlaceholder')}
-                        data-cy={`sso-provider-form-saml-permission-mapping-${permissionKey}`}
-                      />
-                    </TextField>
-                  ))}
-                </section>
-
-                <section className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0">
-                  <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                    {t('sections.samlSigning')}
-                  </h3>
+                          {hasSetupUrls ? authentikRedirectRegexPattern : t('setupUrlPending')}
+                        </code>
+                        {hasSetupUrls && (
+                          <Tooltip>
+                            <Button
+                              variant="ghost"
+                              isIconOnly
+                              size="sm"
+                              onPress={() => handleCopyLoginUrl(authentikRedirectRegexPattern)}
+                              data-cy="sso-provider-form-authentik-regex-copy-button"
+                            >
+                              <Copy size={16} />
+                            </Button>
+                            <TooltipContent>{t('copy')}</TooltipContent>
+                          </Tooltip>
+                        )}
+                      </dd>
+                      <p className="text-xs text-default-500">
+                        {hasSetupUrls ? t('authentikRedirectRegexDescription') : t('setupUrlPending')}
+                      </p>
+                    </div>
+                  )}
                   <div className="flex flex-col gap-1">
-                    <label className="text-sm font-medium">{t('spSigningCertificate')}</label>
-                    <TextArea
-                      name="samlConfiguration.spSigningCertificate"
-                      value={formValues.samlConfiguration?.spSigningCertificate ?? ''}
-                      onChange={(e) => setSaml('spSigningCertificate', e.target.value)}
-                      placeholder="MIICmzCCAYMCBg..."
-                      data-cy="sso-provider-form-saml-sp-certificate-input"
-                    />
-                    <p className="text-xs text-default-500">{t('spSigningCertificateHint')}</p>
-                  </div>
-
-                  <div className="flex flex-col gap-1">
-                    <label className="text-sm font-medium">{t('spSigningPrivateKey')}</label>
-                    <TextArea
-                      name="samlConfiguration.spSigningPrivateKey"
-                      value={formValues.samlConfiguration?.spSigningPrivateKey ?? ''}
-                      onChange={(e) => setSaml('spSigningPrivateKey', e.target.value)}
-                      placeholder="-----BEGIN PRIVATE KEY-----"
-                      data-cy="sso-provider-form-saml-sp-private-key-input"
-                    />
-                    <p className="text-xs text-default-500">
-                      {providerDetails?.samlConfiguration?.spSigningKeyEncrypted
-                        ? t('spSigningPrivateKeyHintExisting')
-                        : t('spSigningPrivateKeyHint')}
-                    </p>
-                  </div>
-
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <LabeledSwitch
-                      isSelected={formValues.samlConfiguration?.signRequest ?? false}
-                      onChange={(value) => handleSamlToggleChange('signRequest', value)}
-                      data-cy="sso-provider-form-saml-sign-request-switch"
-                    >
-                      {t('signRequest')}
-                    </LabeledSwitch>
-                    <LabeledSwitch
-                      isSelected={formValues.samlConfiguration?.wantAssertionsSigned ?? false}
-                      onChange={(value) => handleSamlToggleChange('wantAssertionsSigned', value)}
-                      data-cy="sso-provider-form-saml-assertions-signed-switch"
-                    >
-                      {t('wantAssertionsSigned')}
-                    </LabeledSwitch>
-                    <LabeledSwitch
-                      isSelected={formValues.samlConfiguration?.wantAuthnResponseSigned ?? true}
-                      onChange={(value) => handleSamlToggleChange('wantAuthnResponseSigned', value)}
-                      data-cy="sso-provider-form-saml-response-signed-switch"
-                    >
-                      {t('wantAuthnResponseSigned')}
-                    </LabeledSwitch>
-                    <LabeledSwitch
-                      isSelected={formValues.samlConfiguration?.forceAuthn ?? false}
-                      onChange={(value) => handleSamlToggleChange('forceAuthn', value)}
-                      data-cy="sso-provider-form-saml-force-authn-switch"
-                    >
-                      {t('forceAuthn')}
-                    </LabeledSwitch>
-                  </div>
-                </section>
-              </>
-            )}
-
-            <section
-              className="w-full flex flex-col gap-4 pt-6 border-t border-default-200 first:pt-0 first:border-t-0"
-              data-cy="sso-provider-form-setup-section"
-            >
-              <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
-                {t('setupInstructions')}
-              </h3>
-              <p className="text-xs text-default-500">{t('setupInstructionsHint')}</p>
-              <dl className="flex flex-col gap-4">
-                {!isSamlProvider && (
-                  <div className="flex flex-col gap-1">
-                    <dt className="text-sm font-medium">{t('authentikRedirectRegex')}</dt>
+                    <dt className="text-sm font-medium">{isSamlProvider ? t('samlAcsUrl') : t('oidcRedirectUri')}</dt>
                     <dd className="flex items-center gap-2 rounded-md border border-default-200 bg-default-50 px-3 py-2">
                       <code
                         className="flex-1 text-xs break-all font-mono text-default-700"
-                        data-cy="sso-provider-form-authentik-regex"
+                        data-cy="sso-provider-form-callback-url"
                       >
-                        {hasSetupUrls ? authentikRedirectRegexPattern : t('setupUrlPending')}
+                        {hasSetupUrls ? (isSamlProvider ? samlCallbackUrl : oidcCallbackUrl) : t('setupUrlPending')}
                       </code>
                       {hasSetupUrls && (
                         <Tooltip>
@@ -1107,8 +1158,8 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
                             variant="ghost"
                             isIconOnly
                             size="sm"
-                            onPress={() => handleCopyLoginUrl(authentikRedirectRegexPattern)}
-                            data-cy="sso-provider-form-authentik-regex-copy-button"
+                            onPress={isSamlProvider ? handleCopySamlCallbackUrl : handleCopyOidcCallbackUrl}
+                            data-cy="sso-provider-form-callback-url-copy-button"
                           >
                             <Copy size={16} />
                           </Button>
@@ -1117,73 +1168,38 @@ export const SSOProvidersList = forwardRef<SSOProvidersListRef, React.ComponentP
                       )}
                     </dd>
                     <p className="text-xs text-default-500">
-                      {hasSetupUrls ? t('authentikRedirectRegexDescription') : t('setupUrlPending')}
-                    </p>
-                  </div>
-                )}
-                <div className="flex flex-col gap-1">
-                  <dt className="text-sm font-medium">
-                    {isSamlProvider ? t('samlAcsUrl') : t('oidcRedirectUri')}
-                  </dt>
-                  <dd className="flex items-center gap-2 rounded-md border border-default-200 bg-default-50 px-3 py-2">
-                    <code
-                      className="flex-1 text-xs break-all font-mono text-default-700"
-                      data-cy="sso-provider-form-callback-url"
-                    >
                       {hasSetupUrls
                         ? isSamlProvider
-                          ? samlCallbackUrl
-                          : oidcCallbackUrl
+                          ? t('samlAcsUrlDescription')
+                          : t('oidcRedirectUriDescription')
                         : t('setupUrlPending')}
-                    </code>
-                    {hasSetupUrls && (
-                      <Tooltip>
-                        <Button
-                          variant="ghost"
-                          isIconOnly
-                          size="sm"
-                          onPress={isSamlProvider ? handleCopySamlCallbackUrl : handleCopyOidcCallbackUrl}
-                          data-cy="sso-provider-form-callback-url-copy-button"
-                        >
-                          <Copy size={16} />
-                        </Button>
-                        <TooltipContent>{t('copy')}</TooltipContent>
-                      </Tooltip>
-                    )}
-                  </dd>
-                  <p className="text-xs text-default-500">
-                    {hasSetupUrls
-                      ? isSamlProvider
-                        ? t('samlAcsUrlDescription')
-                        : t('oidcRedirectUriDescription')
-                      : t('setupUrlPending')}
-                  </p>
-                </div>
-              </dl>
+                    </p>
+                  </div>
+                </dl>
 
-              <div className="flex flex-wrap gap-3 text-xs">
-                {docsSsoProvidersUrl && <Link href={docsSsoProvidersUrl}>{t('docsSsoProviders')}</Link>}
-                {docsAuthentikPermissionsUrl && (
-                  <Link href={docsAuthentikPermissionsUrl}>{t('docsAuthentikPermissions')}</Link>
-                )}
-              </div>
-            </section>
-          </div>
-        </DrawerBody>
-        <DrawerFooter>
-          <Button variant="secondary" onPress={() => setOpen(false)} data-cy="sso-provider-form-cancel-button">
-            {t('cancel')}
-          </Button>
-          <Button
-            variant="primary"
-            onPress={handleSubmit}
-            isDisabled={isSaveDisabled}
-            isPending={isMutationPending}
-            data-cy="sso-provider-form-save-button"
-          >
-            {t('save')}
-          </Button>
-        </DrawerFooter>
+                <div className="flex flex-wrap gap-3 text-xs">
+                  {docsSsoProvidersUrl && <Link href={docsSsoProvidersUrl}>{t('docsSsoProviders')}</Link>}
+                  {docsAuthentikPermissionsUrl && (
+                    <Link href={docsAuthentikPermissionsUrl}>{t('docsAuthentikPermissions')}</Link>
+                  )}
+                </div>
+              </section>
+            </div>
+          </DrawerBody>
+          <DrawerFooter>
+            <Button variant="secondary" onPress={() => setOpen(false)} data-cy="sso-provider-form-cancel-button">
+              {t('cancel')}
+            </Button>
+            <Button
+              variant="primary"
+              onPress={handleSubmit}
+              isDisabled={isSaveDisabled}
+              isPending={isMutationPending}
+              data-cy="sso-provider-form-save-button"
+            >
+              {t('save')}
+            </Button>
+          </DrawerFooter>
         </div>
       </StandardDrawer>
     </>

--- a/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
+++ b/apps/frontend/src/app/user-management/allowed-signup-domains-editor-modal/index.tsx
@@ -20,6 +20,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
   TextField,
   useOverlayState,
 } from '@heroui/react';
@@ -154,28 +155,30 @@ export function AllowedSignupDomainsEditorModal(props: Props) {
           </TextField>
 
           <Table>
-            <TableContent aria-label={t('table.ariaLabel')}>
-              <TableHeader>
-                <TableColumn isRowHeader>{t('table.columns.domain')}</TableColumn>
-                <TableColumn>{t('table.columns.actions')}</TableColumn>
-              </TableHeader>
-              <TableBody
-                items={(editedDomains ?? []).map((domain) => ({ value: domain }))}
-                renderEmptyState={() => <EmptyState />}
-              >
-                {(domain) => (
-                  <TableRow key={domain.value} id={domain.value}>
-                    <TableCell className="w-full">{domain.value}</TableCell>
-                    <TableCell className="flex-row flex">
-                      <Button variant="danger-soft" onPress={() => onRemoveDomain(domain.value)}>
-                        <Trash2Icon className="w-4 h-4" />
-                        {t('table.actions.removeDomain')}
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </TableContent>
+            <TableScrollContainer>
+              <TableContent aria-label={t('table.ariaLabel')}>
+                <TableHeader>
+                  <TableColumn isRowHeader>{t('table.columns.domain')}</TableColumn>
+                  <TableColumn>{t('table.columns.actions')}</TableColumn>
+                </TableHeader>
+                <TableBody
+                  items={(editedDomains ?? []).map((domain) => ({ value: domain }))}
+                  renderEmptyState={() => <EmptyState />}
+                >
+                  {(domain) => (
+                    <TableRow key={domain.value} id={domain.value}>
+                      <TableCell className="w-full">{domain.value}</TableCell>
+                      <TableCell className="flex-row flex">
+                        <Button variant="danger-soft" onPress={() => onRemoveDomain(domain.value)}>
+                          <Trash2Icon className="w-4 h-4" />
+                          {t('table.actions.removeDomain')}
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </TableContent>
+            </TableScrollContainer>
           </Table>
         </DrawerBody>
 

--- a/apps/frontend/src/app/user-management/index.tsx
+++ b/apps/frontend/src/app/user-management/index.tsx
@@ -12,12 +12,23 @@ import {
   TableColumn,
   TableContent,
   TableHeader,
+  TableScrollContainer,
   TableRow,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@heroui/react';
-import { CreditCardIcon, KeyIcon, SearchIcon, Settings2Icon, ShieldCheckIcon, ShieldOffIcon, UserPlusIcon, Users, WrenchIcon } from 'lucide-react';
+import {
+  CreditCardIcon,
+  KeyIcon,
+  SearchIcon,
+  Settings2Icon,
+  ShieldCheckIcon,
+  ShieldOffIcon,
+  UserPlusIcon,
+  Users,
+  WrenchIcon,
+} from 'lucide-react';
 import { TableToolbar } from '../../components/TableToolbar';
 import {
   SSOProvider,
@@ -48,10 +59,11 @@ export const UserManagementPage: React.FC = () => {
 
   const navigate = useNavigate();
 
-  const {
-    data: searchResult,
-    isFetched: isFetchedSearchResult,
-  } = useUsersServiceFindMany({ limit, page, search: debouncedSearch });
+  const { data: searchResult, isFetched: isFetchedSearchResult } = useUsersServiceFindMany({
+    limit,
+    page,
+    search: debouncedSearch,
+  });
 
   const totalPages = useMemo(() => {
     if (!searchResult?.total) {
@@ -89,46 +101,46 @@ export const UserManagementPage: React.FC = () => {
         backTo="/"
         icon={<Users className="w-6 h-6" />}
         data-cy="user-management-page-header"
-        actions={[
-          {
-            key: 'invite-user',
-            label: t('actions.inviteUser'),
-            icon: <UserPlusIcon className="w-4 h-4" />,
-            variant: 'primary',
-            renderTrigger: (triggerProps) => (
-              <InviteUserModal>
-                {(onOpen) => <Button {...triggerProps} onPress={onOpen} />}
-              </InviteUserModal>
-            ),
-          },
-          {
-            key: 'two-factor-policy',
-            label: t('actions.twoFactorPolicy'),
-            icon: <ShieldCheckIcon className="w-4 h-4" />,
-            renderTrigger: (triggerProps) => (
-              <TwoFactorPolicyModal>
-                {(onOpenTwoFactorPolicy) => <Button {...triggerProps} onPress={onOpenTwoFactorPolicy} />}
-              </TwoFactorPolicyModal>
-            ),
-          },
-          {
-            key: 'allowed-signup-domains',
-            label: t('actions.editAllowedSignupDomains'),
-            icon: <Settings2Icon className="w-4 h-4" />,
-            renderTrigger: (triggerProps) => (
-              <AllowedSignupDomainsEditorModal>
-                {(onOpen) => <Button {...triggerProps} onPress={onOpen} />}
-              </AllowedSignupDomainsEditorModal>
-            ),
-          },
-          {
-            key: 'sso',
-            label: t('actions.sso'),
-            icon: <KeyIcon className="w-4 h-4" />,
-            isHidden: !license?.modules.includes('sso'),
-            onPress: () => navigate('/sso/providers'),
-          },
-        ] satisfies PageAction[]}
+        actions={
+          [
+            {
+              key: 'invite-user',
+              label: t('actions.inviteUser'),
+              icon: <UserPlusIcon className="w-4 h-4" />,
+              variant: 'primary',
+              renderTrigger: (triggerProps) => (
+                <InviteUserModal>{(onOpen) => <Button {...triggerProps} onPress={onOpen} />}</InviteUserModal>
+              ),
+            },
+            {
+              key: 'two-factor-policy',
+              label: t('actions.twoFactorPolicy'),
+              icon: <ShieldCheckIcon className="w-4 h-4" />,
+              renderTrigger: (triggerProps) => (
+                <TwoFactorPolicyModal>
+                  {(onOpenTwoFactorPolicy) => <Button {...triggerProps} onPress={onOpenTwoFactorPolicy} />}
+                </TwoFactorPolicyModal>
+              ),
+            },
+            {
+              key: 'allowed-signup-domains',
+              label: t('actions.editAllowedSignupDomains'),
+              icon: <Settings2Icon className="w-4 h-4" />,
+              renderTrigger: (triggerProps) => (
+                <AllowedSignupDomainsEditorModal>
+                  {(onOpen) => <Button {...triggerProps} onPress={onOpen} />}
+                </AllowedSignupDomainsEditorModal>
+              ),
+            },
+            {
+              key: 'sso',
+              label: t('actions.sso'),
+              icon: <KeyIcon className="w-4 h-4" />,
+              isHidden: !license?.modules.includes('sso'),
+              onPress: () => navigate('/sso/providers'),
+            },
+          ] satisfies PageAction[]
+        }
       />
 
       <div className="mt-6">
@@ -146,127 +158,135 @@ export const UserManagementPage: React.FC = () => {
         />
 
         <Table>
-          <TableContent aria-label={t('table.ariaLabel')}>
-          <TableHeader>
-            <TableColumn width="0" className="hidden md:table-cell">
-              {t('table.columns.isEmailVerified')}
-            </TableColumn>
-            <TableColumn width="0">{t('table.columns.id')}</TableColumn>
-            <TableColumn isRowHeader>{t('table.columns.username')}</TableColumn>
-            <TableColumn className="hidden md:table-cell">{t('table.columns.externalIdentifier')}</TableColumn>
-            <TableColumn width="0" className="text-center">
-              {t('table.columns.ssoLinked')}
-            </TableColumn>
-            <TableColumn className="text-center">{t('table.columns.permissions')}</TableColumn>
-          </TableHeader>
+          <TableScrollContainer>
+            <TableContent aria-label={t('table.ariaLabel')}>
+              <TableHeader>
+                <TableColumn width="0" className="hidden md:table-cell">
+                  {t('table.columns.isEmailVerified')}
+                </TableColumn>
+                <TableColumn width="0">{t('table.columns.id')}</TableColumn>
+                <TableColumn isRowHeader>{t('table.columns.username')}</TableColumn>
+                <TableColumn className="hidden md:table-cell">{t('table.columns.externalIdentifier')}</TableColumn>
+                <TableColumn width="0" className="text-center">
+                  {t('table.columns.ssoLinked')}
+                </TableColumn>
+                <TableColumn className="text-center">{t('table.columns.permissions')}</TableColumn>
+              </TableHeader>
 
-            <TableBody
-              items={searchResult?.data ?? []}
-              renderEmptyState={() => <EmptyState />}
-            >
-              {(user) => {
-                const ssoDetails =
-                  (user as UserWithAuthDetails).authenticationDetails?.filter(
-                    (detail) => detail.ssoSubject || detail.providerId || detail.providerType,
-                  ) ?? [];
-                const ssoProviderNames = ssoDetails
-                  .map((detail) => {
-                    if (detail.providerId) {
-                      const provider = providersById.get(detail.providerId);
-                      if (provider?.name) {
-                        return provider.name;
+              <TableBody items={searchResult?.data ?? []} renderEmptyState={() => <EmptyState />}>
+                {(user) => {
+                  const ssoDetails =
+                    (user as UserWithAuthDetails).authenticationDetails?.filter(
+                      (detail) => detail.ssoSubject || detail.providerId || detail.providerType,
+                    ) ?? [];
+                  const ssoProviderNames = ssoDetails
+                    .map((detail) => {
+                      if (detail.providerId) {
+                        const provider = providersById.get(detail.providerId);
+                        if (provider?.name) {
+                          return provider.name;
+                        }
                       }
-                    }
-                    if (detail.providerType && detail.providerId) {
-                      return `${detail.providerType} #${detail.providerId}`;
-                    }
-                    return detail.providerType ?? '';
-                  })
-                  .filter((value) => value.length > 0)
-                  .join(', ');
-                const isSsoLinked = ssoDetails.length > 0;
+                      if (detail.providerType && detail.providerId) {
+                        return `${detail.providerType} #${detail.providerId}`;
+                      }
+                      return detail.providerType ?? '';
+                    })
+                    .filter((value) => value.length > 0)
+                    .join(', ');
+                  const isSsoLinked = ssoDetails.length > 0;
 
-                return (
-                  <TableRow key={user.id} id={user.id} className="cursor-pointer hover:bg-primary-50 transition-bg duration-300" onAction={() => navigate(`/users/${user.id}`)}>
-                    <TableCell className="hidden md:table-cell">
-                      {user.isEmailVerified ? <ShieldCheckIcon /> : <ShieldOffIcon />}
-                    </TableCell>
-                    <TableCell>{user.id}</TableCell>
-                    <TableCell>
-                      <AttraccessUser user={user} />
-                    </TableCell>
-                    <TableCell className="hidden md:table-cell">{user.externalIdentifier}</TableCell>
-                    <TableCell className="text-center">
-                      {isSsoLinked ? (
-                        <Tooltip>
-                          <TooltipTrigger tabIndex={0}>
-                            <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-primary-100 text-primary-700">
-                              <KeyIcon className="w-3.5 h-3.5" />
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent showArrow>{t('table.ssoLinked', { providers: ssoProviderNames || '-' })}</TooltipContent>
-                        </Tooltip>
-                      ) : (
-                        <span className="text-default-300">-</span>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex flex-wrap gap-1 justify-center">
-                        {[
-                          {
-                            key: 'canManageResources',
-                            enabled: user.systemPermissions?.canManageResources,
-                            label: t('table.columns.canManageResources'),
-                            icon: <WrenchIcon className="w-3.5 h-3.5" />,
-                          },
-                          {
-                            key: 'canManageSystemConfiguration',
-                            enabled: user.systemPermissions?.canManageSystemConfiguration,
-                            label: t('table.columns.canManageSystemConfiguration'),
-                            icon: <Settings2Icon className="w-3.5 h-3.5" />,
-                          },
-                          {
-                            key: 'canManageUsers',
-                            enabled: user.systemPermissions?.canManageUsers,
-                            label: t('table.columns.canManageUsers'),
-                            icon: <Users className="w-3.5 h-3.5" />,
-                          },
-                          {
-                            key: 'canManageBilling',
-                            enabled: user.systemPermissions?.canManageBilling,
-                            label: t('table.columns.canManageBilling'),
-                            icon: <CreditCardIcon className="w-3.5 h-3.5" />,
-                          },
-                        ]
-                          .filter((permission) => permission.enabled)
-                          .map((permission) => (
-                            <Tooltip key={permission.key}>
-                              <TooltipTrigger tabIndex={0}>
-                                <Chip
-                                  variant="soft"
-                                  color="accent"
-                                  className="min-w-0 px-2"
-                                  data-cy={`user-permission-chip-${permission.key}`}
-                                >
-                                  {permission.icon}
-                                </Chip>
-                              </TooltipTrigger>
-                              <TooltipContent showArrow>{permission.label}</TooltipContent>
-                            </Tooltip>
-                          ))}
-                        {![
-                          user.systemPermissions?.canManageResources,
-                          user.systemPermissions?.canManageSystemConfiguration,
-                          user.systemPermissions?.canManageUsers,
-                          user.systemPermissions?.canManageBilling,
-                        ].some(Boolean) && <span className="text-default-400 text-sm">{t('table.noPermissions')}</span>}
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                );
-              }}
-            </TableBody>
-          </TableContent>
+                  return (
+                    <TableRow
+                      key={user.id}
+                      id={user.id}
+                      className="cursor-pointer hover:bg-primary-50 transition-bg duration-300"
+                      onAction={() => navigate(`/users/${user.id}`)}
+                    >
+                      <TableCell className="hidden md:table-cell">
+                        {user.isEmailVerified ? <ShieldCheckIcon /> : <ShieldOffIcon />}
+                      </TableCell>
+                      <TableCell>{user.id}</TableCell>
+                      <TableCell>
+                        <AttraccessUser user={user} />
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell">{user.externalIdentifier}</TableCell>
+                      <TableCell className="text-center">
+                        {isSsoLinked ? (
+                          <Tooltip>
+                            <TooltipTrigger tabIndex={0}>
+                              <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-primary-100 text-primary-700">
+                                <KeyIcon className="w-3.5 h-3.5" />
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent showArrow>
+                              {t('table.ssoLinked', { providers: ssoProviderNames || '-' })}
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <span className="text-default-300">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1 justify-center">
+                          {[
+                            {
+                              key: 'canManageResources',
+                              enabled: user.systemPermissions?.canManageResources,
+                              label: t('table.columns.canManageResources'),
+                              icon: <WrenchIcon className="w-3.5 h-3.5" />,
+                            },
+                            {
+                              key: 'canManageSystemConfiguration',
+                              enabled: user.systemPermissions?.canManageSystemConfiguration,
+                              label: t('table.columns.canManageSystemConfiguration'),
+                              icon: <Settings2Icon className="w-3.5 h-3.5" />,
+                            },
+                            {
+                              key: 'canManageUsers',
+                              enabled: user.systemPermissions?.canManageUsers,
+                              label: t('table.columns.canManageUsers'),
+                              icon: <Users className="w-3.5 h-3.5" />,
+                            },
+                            {
+                              key: 'canManageBilling',
+                              enabled: user.systemPermissions?.canManageBilling,
+                              label: t('table.columns.canManageBilling'),
+                              icon: <CreditCardIcon className="w-3.5 h-3.5" />,
+                            },
+                          ]
+                            .filter((permission) => permission.enabled)
+                            .map((permission) => (
+                              <Tooltip key={permission.key}>
+                                <TooltipTrigger tabIndex={0}>
+                                  <Chip
+                                    variant="soft"
+                                    color="accent"
+                                    className="min-w-0 px-2"
+                                    data-cy={`user-permission-chip-${permission.key}`}
+                                  >
+                                    {permission.icon}
+                                  </Chip>
+                                </TooltipTrigger>
+                                <TooltipContent showArrow>{permission.label}</TooltipContent>
+                              </Tooltip>
+                            ))}
+                          {![
+                            user.systemPermissions?.canManageResources,
+                            user.systemPermissions?.canManageSystemConfiguration,
+                            user.systemPermissions?.canManageUsers,
+                            user.systemPermissions?.canManageBilling,
+                          ].some(Boolean) && (
+                            <span className="text-default-400 text-sm">{t('table.noPermissions')}</span>
+                          )}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                }}
+              </TableBody>
+            </TableContent>
+          </TableScrollContainer>
         </Table>
 
         <div className="flex w-full justify-end mt-4">

--- a/apps/frontend/src/app/user-management/invite-user-modal/csv-invite/index.tsx
+++ b/apps/frontend/src/app/user-management/invite-user-modal/csv-invite/index.tsx
@@ -11,6 +11,7 @@ import {
   TableContent,
   TableHeader,
   TableRow,
+  TableScrollContainer,
 } from '@heroui/react';
 import { Button } from '../../../../components/button';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -302,28 +303,30 @@ export function CsvInvite({ onSuccess, onError }: Props) {
       ))}
 
       <Table data-cy="csv-invite-table">
-        <TableContent aria-label="csv-invite-table">
-        <TableHeader>
-          <TableColumn isRowHeader>{t('preview.columns.index')}</TableColumn>
-          <TableColumn>{t('preview.columns.username')}</TableColumn>
-          <TableColumn>{t('preview.columns.email')}</TableColumn>
-          <TableColumn>{t('preview.columns.permissions.label')}</TableColumn>
-        </TableHeader>
-        <TableBody items={previewUsers} renderEmptyState={() => <EmptyState />}>
-          {(user) => (
-            <TableRow key={user.index} id={user.index}>
-              <TableCell>#{user.index}</TableCell>
-              <TableCell className="w-full">{user.username}</TableCell>
-              <TableCell>{user.email}</TableCell>
-              <TableCell className="flex-row flex gap-2 flex-wrap">
-                {user.permissions.map((permission) => (
-                  <Chip key={permission}>{t('preview.columns.permissions.values.' + permission)}</Chip>
-                ))}
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-        </TableContent>
+        <TableScrollContainer>
+          <TableContent aria-label="csv-invite-table">
+            <TableHeader>
+              <TableColumn isRowHeader>{t('preview.columns.index')}</TableColumn>
+              <TableColumn>{t('preview.columns.username')}</TableColumn>
+              <TableColumn>{t('preview.columns.email')}</TableColumn>
+              <TableColumn>{t('preview.columns.permissions.label')}</TableColumn>
+            </TableHeader>
+            <TableBody items={previewUsers} renderEmptyState={() => <EmptyState />}>
+              {(user) => (
+                <TableRow key={user.index} id={user.index}>
+                  <TableCell>#{user.index}</TableCell>
+                  <TableCell className="w-full">{user.username}</TableCell>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell className="flex-row flex gap-2 flex-wrap">
+                    {user.permissions.map((permission) => (
+                      <Chip key={permission}>{t('preview.columns.permissions.values.' + permission)}</Chip>
+                    ))}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </TableContent>
+        </TableScrollContainer>
       </Table>
 
       {rowErrors.length > 0 && (
@@ -338,24 +341,26 @@ export function CsvInvite({ onSuccess, onError }: Props) {
           </div>
 
           <Table>
-            <TableContent aria-label="csv-invite-errors">
-            <TableHeader>
-              <TableColumn isRowHeader>{t('errors.columns.row')}</TableColumn>
-              <TableColumn>{t('errors.columns.field')}</TableColumn>
-              <TableColumn>{t('errors.columns.message')}</TableColumn>
-              <TableColumn>{t('errors.columns.value')}</TableColumn>
-            </TableHeader>
-            <TableBody items={rowErrors}>
-              {(error) => (
-                <TableRow key={`${error.row}-${error.field ?? 'general'}`}>
-                  <TableCell>#{error.row}</TableCell>
-                  <TableCell>{error.field ?? '-'}</TableCell>
-                  <TableCell>{error.message}</TableCell>
-                  <TableCell>{error.value ?? '-'}</TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-            </TableContent>
+            <TableScrollContainer>
+              <TableContent aria-label="csv-invite-errors">
+                <TableHeader>
+                  <TableColumn isRowHeader>{t('errors.columns.row')}</TableColumn>
+                  <TableColumn>{t('errors.columns.field')}</TableColumn>
+                  <TableColumn>{t('errors.columns.message')}</TableColumn>
+                  <TableColumn>{t('errors.columns.value')}</TableColumn>
+                </TableHeader>
+                <TableBody items={rowErrors}>
+                  {(error) => (
+                    <TableRow key={`${error.row}-${error.field ?? 'general'}`}>
+                      <TableCell>#{error.row}</TableCell>
+                      <TableCell>{error.field ?? '-'}</TableCell>
+                      <TableCell>{error.message}</TableCell>
+                      <TableCell>{error.value ?? '-'}</TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </TableContent>
+            </TableScrollContainer>
           </Table>
         </div>
       )}

--- a/apps/frontend/src/components/IntroductionsManagement/history/index.tsx
+++ b/apps/frontend/src/components/IntroductionsManagement/history/index.tsx
@@ -14,6 +14,7 @@ import {
   TableColumn,
   TableContent,
   TableHeader,
+  TableScrollContainer,
   TableRow,
 } from '@heroui/react';
 import { useMemo, useState } from 'react';
@@ -68,28 +69,30 @@ export function IntroductionHistoryModal(props: Readonly<Props>) {
                 <ModalHeader>{t('modal.title')}</ModalHeader>
                 <ModalBody>
                   <Table>
-                    <TableContent aria-label={t('table.ariaLabel')}>
-                    <TableHeader>
-                      <TableColumn isRowHeader>{t('table.columns.date')}</TableColumn>
-                      <TableColumn>{t('table.columns.action')}</TableColumn>
-                      <TableColumn>{t('table.columns.comment')}</TableColumn>
-                    </TableHeader>
-                    <TableBody items={currentPage} renderEmptyState={() => <EmptyState />}>
-                      {(item) => (
-                        <TableRow key={item.id} id={item.id}>
-                          <TableCell>
-                            <DateTimeDisplay date={item.createdAt} />
-                          </TableCell>
-                          <TableCell>
-                            <IntroductionStatusChip isValid={item.action === 'grant'} />
-                          </TableCell>
-                          <TableCell>
-                            <blockquote className="text-sm whitespace-pre-wrap">{item.comment}</blockquote>
-                          </TableCell>
-                        </TableRow>
-                      )}
-                    </TableBody>
-                    </TableContent>
+                    <TableScrollContainer>
+                      <TableContent aria-label={t('table.ariaLabel')}>
+                        <TableHeader>
+                          <TableColumn isRowHeader>{t('table.columns.date')}</TableColumn>
+                          <TableColumn>{t('table.columns.action')}</TableColumn>
+                          <TableColumn>{t('table.columns.comment')}</TableColumn>
+                        </TableHeader>
+                        <TableBody items={currentPage} renderEmptyState={() => <EmptyState />}>
+                          {(item) => (
+                            <TableRow key={item.id} id={item.id}>
+                              <TableCell>
+                                <DateTimeDisplay date={item.createdAt} />
+                              </TableCell>
+                              <TableCell>
+                                <IntroductionStatusChip isValid={item.action === 'grant'} />
+                              </TableCell>
+                              <TableCell>
+                                <blockquote className="text-sm whitespace-pre-wrap">{item.comment}</blockquote>
+                              </TableCell>
+                            </TableRow>
+                          )}
+                        </TableBody>
+                      </TableContent>
+                    </TableScrollContainer>
                   </Table>
                 </ModalBody>
                 <ModalFooter>

--- a/apps/frontend/src/components/userSelectionList/index.tsx
+++ b/apps/frontend/src/components/userSelectionList/index.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableProps,
   TableRow,
+  TableScrollContainer,
 } from '@heroui/react';
 import { Button } from '../button';
 import { ReactNode, useCallback, useMemo, useState } from 'react';
@@ -107,66 +108,68 @@ export function UserSelectionList<TUser extends User = User>(props: Readonly<Pro
         autocompleteProps={{ size: 'sm' }}
         afterSelection={
           userSearchSelection && (
-            <Button variant="primary"
-              onPress={onAddUser}
-              isPending={addToSelectionIsLoading}
-              isIconOnly
-            ><PlusIcon className="w-4 h-4" /></Button>
+            <Button variant="primary" onPress={onAddUser} isPending={addToSelectionIsLoading} isIconOnly>
+              <PlusIcon className="w-4 h-4" />
+            </Button>
           )
         }
       />
 
       <Table {...tableProps}>
-        <TableContent aria-label={t('table.ariaLabel')}>
-        <TableHeader>
-          <TableColumn isRowHeader>{t('selectedUsers.columns.user')}</TableColumn>
-          {
-            (additionalColumns ?? []).map((col) => (
-              <TableColumn className={col.headerClassName} key={col.key} id={col.key}>
-                {col.label}
-              </TableColumn>
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            )) as any
-          }
-          <TableColumn>{t('selectedUsers.columns.actions')}</TableColumn>
-        </TableHeader>
-        <TableBody
-          items={currentPage}
-          renderEmptyState={() => <EmptyState />}
-        >
-          {(user) => (
-            <TableRow key={user.id} id={user.id} className={typeof rowClassName === 'function' ? rowClassName(user) : rowClassName}>
-              <TableCell className="w-full">
-                <AttraccessUser user={user} />
-              </TableCell>
-
+        <TableScrollContainer>
+          <TableContent aria-label={t('table.ariaLabel')}>
+            <TableHeader>
+              <TableColumn isRowHeader>{t('selectedUsers.columns.user')}</TableColumn>
               {
                 (additionalColumns ?? []).map((col) => (
-                  <TableCell className={col.cellClassName} key={col.key}>
-                    {typeof col.value === 'function' ? col.value(user) : col.value}
-                  </TableCell>
+                  <TableColumn className={col.headerClassName} key={col.key} id={col.key}>
+                    {col.label}
+                  </TableColumn>
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 )) as any
               }
+              <TableColumn>{t('selectedUsers.columns.actions')}</TableColumn>
+            </TableHeader>
+            <TableBody items={currentPage} renderEmptyState={() => <EmptyState />}>
+              {(user) => (
+                <TableRow
+                  key={user.id}
+                  id={user.id}
+                  className={typeof rowClassName === 'function' ? rowClassName(user) : rowClassName}
+                >
+                  <TableCell className="w-full">
+                    <AttraccessUser user={user} />
+                  </TableCell>
 
-              <TableCell>
-                <div className="flex gap-4 flex-row flex-wrap md:flex-nowrap">
-                  {parseActions(user).map((action) => (
-                    <Button
-                      {...{ ...action, label: undefined, onClick: undefined, startContent: undefined }}
-                      key={action.key}
-                      onPress={() => action.onClick(user)}
-                      className="flex"
-                    >
-                      {action.startContent}{action.label}
-                    </Button>
-                  ))}
-                </div>
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-        </TableContent>
+                  {
+                    (additionalColumns ?? []).map((col) => (
+                      <TableCell className={col.cellClassName} key={col.key}>
+                        {typeof col.value === 'function' ? col.value(user) : col.value}
+                      </TableCell>
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    )) as any
+                  }
+
+                  <TableCell>
+                    <div className="flex gap-4 flex-row flex-wrap md:flex-nowrap">
+                      {parseActions(user).map((action) => (
+                        <Button
+                          {...{ ...action, label: undefined, onClick: undefined, startContent: undefined }}
+                          key={action.key}
+                          onPress={() => action.onClick(user)}
+                          className="flex"
+                        >
+                          {action.startContent}
+                          {action.label}
+                        </Button>
+                      ))}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </TableContent>
+        </TableScrollContainer>
       </Table>
       {selectedUsers && totalPages > 1 && (
         <SimplePagination

--- a/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
+++ b/libs/plugins-frontend-ui/src/lib/components/ResourceSelector/ResourceSelector.tsx
@@ -2,7 +2,21 @@
 // FEATURE: Resource selection for plugins using HeroUI v3 Table compound
 import { useTranslations } from '../../i18n';
 import { useResourcesServiceGetAllResources } from '@attraccess/react-query-client';
-import { Checkbox, TextField, Label, InputGroup, Spinner, TableRoot, TableContent, TableBody, TableCell, TableColumn, TableHeader, TableRow } from '@heroui/react';
+import {
+  Checkbox,
+  TextField,
+  Label,
+  InputGroup,
+  Spinner,
+  TableRoot,
+  TableScrollContainer,
+  TableContent,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from '@heroui/react';
 import { SearchIcon } from 'lucide-react';
 import { useState, PropsWithChildren } from 'react';
 import de from './ResourceSelector.de.json';
@@ -56,46 +70,48 @@ export function ResourceSelector(props: Readonly<Props>) {
         className={listClassName}
         style={{ maxHeight: LIST_HEADER_HEIGHT_PX + MAX_VISIBLE_ROWS * LIST_ROW_HEIGHT_PX, overflowY: 'auto' }}
       >
-        <TableContent
-          selectionMode={multiple ? 'multiple' : 'single'}
-          selectedKeys={new Set(selection.map(String))}
-          onSelectionChange={(keys) => {
-            if (keys === 'all') {
-              onSelectionChange((resourceSearchResults?.data ?? []).map((r) => r.id));
-              return;
-            }
-            onSelectionChange(Array.from(keys).map((k) => Number(k)));
-          }}
-        >
-          <TableHeader>
-            <TableColumn className="pr-0 w-0">
-              {multiple ? (
-                <Checkbox aria-label={t('table.ariaLabel')} slot="selection">
-                  <Checkbox.Control>
-                    <Checkbox.Indicator />
-                  </Checkbox.Control>
-                </Checkbox>
-              ) : null}
-            </TableColumn>
-            <TableColumn className="w-full" isRowHeader>
-              {t('table.columns.name.header')}
-            </TableColumn>
-          </TableHeader>
-          <TableBody items={resourceSearchResults?.data ?? []}>
-            {(resource) => (
-              <TableRow key={resource.id} id={String(resource.id)}>
-                <TableCell className="pr-0">
-                  <Checkbox aria-label={resource.name} slot="selection" variant="secondary">
+        <TableScrollContainer>
+          <TableContent
+            selectionMode={multiple ? 'multiple' : 'single'}
+            selectedKeys={new Set(selection.map(String))}
+            onSelectionChange={(keys) => {
+              if (keys === 'all') {
+                onSelectionChange((resourceSearchResults?.data ?? []).map((r) => r.id));
+                return;
+              }
+              onSelectionChange(Array.from(keys).map((k) => Number(k)));
+            }}
+          >
+            <TableHeader>
+              <TableColumn className="pr-0 w-0">
+                {multiple ? (
+                  <Checkbox aria-label={t('table.ariaLabel')} slot="selection">
                     <Checkbox.Control>
                       <Checkbox.Indicator />
                     </Checkbox.Control>
                   </Checkbox>
-                </TableCell>
-                <TableCell>{resource.name}</TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </TableContent>
+                ) : null}
+              </TableColumn>
+              <TableColumn className="w-full" isRowHeader>
+                {t('table.columns.name.header')}
+              </TableColumn>
+            </TableHeader>
+            <TableBody items={resourceSearchResults?.data ?? []}>
+              {(resource) => (
+                <TableRow key={resource.id} id={String(resource.id)}>
+                  <TableCell className="pr-0">
+                    <Checkbox aria-label={resource.name} slot="selection" variant="secondary">
+                      <Checkbox.Control>
+                        <Checkbox.Indicator />
+                      </Checkbox.Control>
+                    </Checkbox>
+                  </TableCell>
+                  <TableCell>{resource.name}</TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </TableContent>
+        </TableScrollContainer>
       </TableRoot>
     </div>
   );


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Multiple tables overflowed the page on mobile instead of scrolling, so columns past the right edge were unreachable.

This wraps every HeroUI `Table`'s `TableContent` in HeroUI's `TableScrollContainer` — the same pattern already used by the Attractap, resource-groups, and MQTT-server lists. Wide tables now scroll horizontally **within their own container**; the page itself no longer overflows.

## Changes

- Wrapped `TableContent` in `TableScrollContainer` across **23** table-rendering components (and added the import).
- Replaced two ad-hoc `overflow-x-auto` div wrappers (`flows/variablesModal`, `csv-export/preview-table`) with `TableScrollContainer` for consistency.
- No logic changes — purely the scroll wrapper.

## Testing

- `nx affected` lint + typecheck + build + test passed via the precommit hook.
- Verified in a real browser at iPhone-14 width (390px):
  - **User management** table scrolls horizontally inside its card (`scrollWidth` 369 > `clientWidth` 350), and the page body does **not** overflow (`documentElement.scrollWidth` == `innerWidth` == 390).
  - **Plugins** table renders correctly inside the scroll container.
- Screenshots posted to the Linear issue.

Closes [ATT-518](https://linear.app/attraccess/issue/ATT-518/multiple-tables-not-scrollable-on-mobile)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
