### PR TITLE
feat(resources): hide groups from non-members (ATT-515)

### DIFF
--- a/apps/api/src/database/migrations/1781400000000-resource-group-is-hidden.ts
+++ b/apps/api/src/database/migrations/1781400000000-resource-group-is-hidden.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ResourceGroupIsHidden1781400000000 implements MigrationInterface {
+  name = 'ResourceGroupIsHidden1781400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "resource_group" ADD COLUMN "isHidden" boolean NOT NULL DEFAULT (0)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "resource_group" DROP COLUMN "isHidden"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -123,3 +123,4 @@ export * from './1781100000000-message-email-fallback';
 export * from './1780200000000-attractap-crash-report-symbolication';
 export * from './1781200000000-resource-usage-note-email-template';
 export * from './1781300000000-attractap-crash-report-reboot-reason';
+export * from './1781400000000-resource-group-is-hidden';

--- a/apps/api/src/resources/groups/dto/createGroup.dto.ts
+++ b/apps/api/src/resources/groups/dto/createGroup.dto.ts
@@ -55,4 +55,16 @@ export class CreateResourceGroupDto {
   @IsBoolean()
   @IsOptional()
   retrainingBlocksAccess?: boolean;
+
+  @ApiProperty({
+    description:
+      'Whether to hide this group from users who are not part of it (introducer, maintainer or introduced). Users with the canManageResources permission always see hidden groups.',
+    required: false,
+    default: false,
+    example: false,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isHidden?: boolean;
 }

--- a/apps/api/src/resources/groups/dto/updateGroup.dto.ts
+++ b/apps/api/src/resources/groups/dto/updateGroup.dto.ts
@@ -55,4 +55,15 @@ export class UpdateResourceGroupDto {
   @IsBoolean()
   @IsOptional()
   retrainingBlocksAccess?: boolean;
+
+  @ApiProperty({
+    description:
+      'Whether to hide this group from users who are not part of it (introducer, maintainer or introduced). Users with the canManageResources permission always see hidden groups.',
+    required: false,
+    example: false,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isHidden?: boolean;
 }

--- a/apps/api/src/resources/groups/resourceGroups.controller.ts
+++ b/apps/api/src/resources/groups/resourceGroups.controller.ts
@@ -1,15 +1,22 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put } from '@nestjs/common';
-import { ResourceGroupsService } from './resourceGroups.service';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, Req } from '@nestjs/common';
+import { ResourceGroupsService, GroupVisibilityContext } from './resourceGroups.service';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ResourceGroup } from '@attraccess/database-entities';
 import { CreateResourceGroupDto } from './dto/createGroup.dto';
 import { UpdateResourceGroupDto } from './dto/updateGroup.dto';
-import { Auth } from '@attraccess/plugins-backend-sdk';
+import { Auth, AuthenticatedRequest } from '@attraccess/plugins-backend-sdk';
 
 @ApiTags('Resources')
 @Controller('resource-groups')
 export class ResourceGroupsController {
   constructor(private readonly resourceGroupsService: ResourceGroupsService) {}
+
+  private getVisibilityContext(req: AuthenticatedRequest): GroupVisibilityContext {
+    return {
+      userId: req.user.id,
+      canManageResources: req.user.systemPermissions.canManageResources === true,
+    };
+  }
 
   @Post()
   @ApiOperation({ summary: 'Create a new resource group', operationId: 'resourceGroupsCreateOne' })
@@ -24,17 +31,19 @@ export class ResourceGroupsController {
   }
 
   @Get()
+  @Auth()
   @ApiOperation({ summary: 'Get many resource groups', operationId: 'resourceGroupsGetMany' })
   @ApiResponse({
     status: 200,
     description: 'The resource groups have been successfully retrieved.',
     type: [ResourceGroup],
   })
-  async getAll(): Promise<ResourceGroup[]> {
-    return await this.resourceGroupsService.getMany();
+  async getAll(@Req() req: AuthenticatedRequest): Promise<ResourceGroup[]> {
+    return await this.resourceGroupsService.getMany(this.getVisibilityContext(req));
   }
 
   @Get(':id')
+  @Auth()
   @ApiOperation({ summary: 'Get a resource group by ID', operationId: 'resourceGroupsGetOne' })
   @ApiParam({ name: 'id', description: 'The ID of the resource group', type: Number })
   @ApiResponse({
@@ -46,8 +55,8 @@ export class ResourceGroupsController {
     description: 'The resource group has been successfully retrieved.',
     type: ResourceGroup,
   })
-  async getOne(@Param('id', ParseIntPipe) id: number): Promise<ResourceGroup> {
-    return await this.resourceGroupsService.getOne({ id });
+  async getOne(@Param('id', ParseIntPipe) id: number, @Req() req: AuthenticatedRequest): Promise<ResourceGroup> {
+    return await this.resourceGroupsService.getOne({ id }, undefined, this.getVisibilityContext(req));
   }
 
   @Put(':id')

--- a/apps/api/src/resources/groups/resourceGroups.service.ts
+++ b/apps/api/src/resources/groups/resourceGroups.service.ts
@@ -36,7 +36,11 @@ export class ResourceGroupsService {
   ) {}
 
   /**
-   * Whether the user is "part of" the group: an introducer/maintainer of it, or has been introduced to it.
+   * Whether the user is "part of" the group: an introducer/maintainer of it, or has a currently
+   * valid introduction to it.
+   *
+   * An introduction counts only if its latest history item is a GRANT — revoked introductions keep
+   * their row (and a REVOKE history item) in the database but must not grant visibility.
    */
   public async userIsPartOfGroup(groupId: number, userId: number): Promise<boolean> {
     const introducerCount = await this.resourceIntroducerRepository.count({
@@ -46,11 +50,36 @@ export class ResourceGroupsService {
       return true;
     }
 
-    const introductionCount = await this.resourceIntroductionRepository.count({
-      where: { resourceGroupId: groupId, receiverUserId: userId },
-    });
-    return introductionCount > 0;
+    const activeIntroductions = await this.resourceIntroductionRepository.query(
+      `SELECT 1 FROM "resource_introduction" "rin"
+       WHERE "rin"."resourceGroupId" = ? AND "rin"."receiverUserId" = ?
+       AND (
+         SELECT "h"."action" FROM "resource_introduction_history_item" "h"
+         WHERE "h"."introductionId" = "rin"."id"
+         ORDER BY "h"."createdAt" DESC, "h"."id" DESC
+         LIMIT 1
+       ) = 'grant'
+       LIMIT 1`,
+      [groupId, userId],
+    );
+    return activeIntroductions.length > 0;
   }
+
+  /**
+   * SQL fragment (for use against the `group` query-builder alias) that is true when the user has a
+   * currently valid (latest history item = GRANT) introduction to the group. Uses the `:userId`
+   * named parameter.
+   */
+  private static readonly ACTIVE_INTRODUCTION_EXISTS_SQL = `EXISTS (
+    SELECT 1 FROM "resource_introduction" "rin"
+    WHERE "rin"."resourceGroupId" = group.id AND "rin"."receiverUserId" = :userId
+    AND (
+      SELECT "h"."action" FROM "resource_introduction_history_item" "h"
+      WHERE "h"."introductionId" = "rin"."id"
+      ORDER BY "h"."createdAt" DESC, "h"."id" DESC
+      LIMIT 1
+    ) = 'grant'
+  )`;
 
   public async createOne(dto: CreateResourceGroupDto): Promise<ResourceGroup> {
     const resourceGroup = this.resourceGroupRepository.create({
@@ -83,10 +112,7 @@ export class ResourceGroupsService {
         `EXISTS (SELECT 1 FROM "resource_introducer" "ri" WHERE "ri"."resourceGroupId" = group.id AND "ri"."userId" = :userId)`,
         { userId: visibility.userId },
       )
-      .orWhere(
-        `EXISTS (SELECT 1 FROM "resource_introduction" "rin" WHERE "rin"."resourceGroupId" = group.id AND "rin"."receiverUserId" = :userId)`,
-        { userId: visibility.userId },
-      )
+      .orWhere(ResourceGroupsService.ACTIVE_INTRODUCTION_EXISTS_SQL, { userId: visibility.userId })
       .getMany();
   }
 

--- a/apps/api/src/resources/groups/resourceGroups.service.ts
+++ b/apps/api/src/resources/groups/resourceGroups.service.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { Inject, Injectable } from '@nestjs/common';
-import { Resource, ResourceGroup } from '@attraccess/database-entities';
+import { Resource, ResourceGroup, ResourceIntroducer, ResourceIntroduction } from '@attraccess/database-entities';
 import { EntityManager, Repository } from 'typeorm';
 import { CreateResourceGroupDto } from './dto/createGroup.dto';
 import { UpdateResourceGroupDto } from './dto/updateGroup.dto';
@@ -14,6 +14,11 @@ interface GetOneSearchOptions {
   id: number;
 }
 
+export interface GroupVisibilityContext {
+  userId: number;
+  canManageResources: boolean;
+}
+
 @Injectable()
 export class ResourceGroupsService {
   constructor(
@@ -21,10 +26,31 @@ export class ResourceGroupsService {
     private readonly resourceGroupRepository: Repository<ResourceGroup>,
     @InjectRepository(Resource)
     private readonly resourceRepository: Repository<Resource>,
+    @InjectRepository(ResourceIntroducer)
+    private readonly resourceIntroducerRepository: Repository<ResourceIntroducer>,
+    @InjectRepository(ResourceIntroduction)
+    private readonly resourceIntroductionRepository: Repository<ResourceIntroduction>,
     @Inject(EventEmitter2)
     private readonly eventEmitter: EventEmitter2,
     private readonly metricsService: MetricsService,
   ) {}
+
+  /**
+   * Whether the user is "part of" the group: an introducer/maintainer of it, or has been introduced to it.
+   */
+  public async userIsPartOfGroup(groupId: number, userId: number): Promise<boolean> {
+    const introducerCount = await this.resourceIntroducerRepository.count({
+      where: { resourceGroupId: groupId, userId },
+    });
+    if (introducerCount > 0) {
+      return true;
+    }
+
+    const introductionCount = await this.resourceIntroductionRepository.count({
+      where: { resourceGroupId: groupId, receiverUserId: userId },
+    });
+    return introductionCount > 0;
+  }
 
   public async createOne(dto: CreateResourceGroupDto): Promise<ResourceGroup> {
     const resourceGroup = this.resourceGroupRepository.create({
@@ -33,6 +59,7 @@ export class ResourceGroupsService {
       retrainingMaxAgeDays: dto.retrainingMaxAgeDays ?? null,
       retrainingMaxInactivityDays: dto.retrainingMaxInactivityDays ?? null,
       retrainingBlocksAccess: dto.retrainingBlocksAccess ?? false,
+      isHidden: dto.isHidden ?? false,
     });
     const savedResourceGroup = await this.resourceGroupRepository.save(resourceGroup);
     this.eventEmitter.emit(
@@ -43,11 +70,31 @@ export class ResourceGroupsService {
     return savedResourceGroup;
   }
 
-  public async getMany(): Promise<ResourceGroup[]> {
-    return await this.resourceGroupRepository.find();
+  public async getMany(visibility?: GroupVisibilityContext): Promise<ResourceGroup[]> {
+    // Users that can manage resources (and any caller without a visibility context) see every group.
+    if (!visibility || visibility.canManageResources) {
+      return await this.resourceGroupRepository.find();
+    }
+
+    return await this.resourceGroupRepository
+      .createQueryBuilder('group')
+      .where('group.isHidden = :notHidden', { notHidden: false })
+      .orWhere(
+        `EXISTS (SELECT 1 FROM "resource_introducer" "ri" WHERE "ri"."resourceGroupId" = group.id AND "ri"."userId" = :userId)`,
+        { userId: visibility.userId },
+      )
+      .orWhere(
+        `EXISTS (SELECT 1 FROM "resource_introduction" "rin" WHERE "rin"."resourceGroupId" = group.id AND "rin"."receiverUserId" = :userId)`,
+        { userId: visibility.userId },
+      )
+      .getMany();
   }
 
-  public async getOne(searchOptions: GetOneSearchOptions, relations?: string[]): Promise<ResourceGroup> {
+  public async getOne(
+    searchOptions: GetOneSearchOptions,
+    relations?: string[],
+    visibility?: GroupVisibilityContext,
+  ): Promise<ResourceGroup> {
     const group = await this.resourceGroupRepository.findOne({
       where: {
         id: searchOptions.id,
@@ -58,6 +105,14 @@ export class ResourceGroupsService {
 
     if (!group) {
       throw new ResourceGroupNotFoundException({ id: searchOptions.id });
+    }
+
+    // Hidden groups are only visible to managers and users that are part of the group.
+    if (group.isHidden && visibility && !visibility.canManageResources) {
+      const isPartOfGroup = await this.userIsPartOfGroup(group.id, visibility.userId);
+      if (!isPartOfGroup) {
+        throw new ResourceGroupNotFoundException({ id: searchOptions.id });
+      }
     }
 
     return group;
@@ -80,6 +135,7 @@ export class ResourceGroupsService {
         updateDto.retrainingBlocksAccess !== undefined
           ? updateDto.retrainingBlocksAccess
           : resourceGroup.retrainingBlocksAccess,
+      isHidden: updateDto.isHidden !== undefined ? updateDto.isHidden : resourceGroup.isHidden,
     });
     this.eventEmitter.emit(
       ResourceGroupIntroductionChangedEvent.EVENT_NAME,

--- a/apps/frontend/src/app/resource-groups/GroupDetailsForm/index.tsx
+++ b/apps/frontend/src/app/resource-groups/GroupDetailsForm/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, HTMLAttributes } from 'react';
 import { Form, Input, Label, Spinner, TextArea, TextField } from '@heroui/react';
 import { Button } from '../../../components/button';
+import { LabeledSwitch } from '../../../components/labeledSwitch';
 import { Save, Edit3, Trash2Icon } from 'lucide-react';
 import {
   useResourcesServiceResourceGroupsGetOne,
@@ -29,6 +30,7 @@ export function GroupDetailsForm(props: Readonly<GroupDetailsFormProps & Omit<HT
   const queryClient = useQueryClient();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [isHidden, setIsHidden] = useState(false);
   const navigate = useNavigate();
 
   const { data: group, isLoading, error } = useResourcesServiceResourceGroupsGetOne({ id: groupId });
@@ -55,6 +57,7 @@ export function GroupDetailsForm(props: Readonly<GroupDetailsFormProps & Omit<HT
     if (group) {
       setName(group.name);
       setDescription(group.description || '');
+      setIsHidden(group.isHidden ?? false);
     }
   }, [group]);
 
@@ -64,7 +67,7 @@ export function GroupDetailsForm(props: Readonly<GroupDetailsFormProps & Omit<HT
 
     await updateGroup({
       id: groupId,
-      requestBody: { name: name.trim(), description: description.trim() || undefined },
+      requestBody: { name: name.trim(), description: description.trim() || undefined, isHidden },
     });
   };
 
@@ -140,6 +143,21 @@ export function GroupDetailsForm(props: Readonly<GroupDetailsFormProps & Omit<HT
             onChange={(e) => setDescription(e.target.value)}
             data-cy="group-details-form-description-input"
           />
+        </section>
+
+        <section className="w-full flex flex-col gap-2">
+          <h3 className="text-sm uppercase tracking-wide font-semibold text-default-700">
+            {t('sections.visibility')}
+          </h3>
+
+          <LabeledSwitch
+            isSelected={isHidden}
+            onChange={setIsHidden}
+            data-cy="group-details-form-is-hidden-switch"
+          >
+            <span className="text-small">{t('form.fields.isHidden.label')}</span>
+          </LabeledSwitch>
+          <span className="text-tiny text-default-400">{t('form.fields.isHidden.description')}</span>
         </section>
 
         <div className="flex flex-col gap-2 w-full">

--- a/apps/frontend/src/app/resource-groups/GroupDetailsForm/translations/de.json
+++ b/apps/frontend/src/app/resource-groups/GroupDetailsForm/translations/de.json
@@ -1,6 +1,7 @@
 {
   "sections": {
-    "details": "Details"
+    "details": "Details",
+    "visibility": "Sichtbarkeit"
   },
   "form": {
     "title": "Details",
@@ -13,6 +14,10 @@
       "description": {
         "label": "Beschreibung",
         "placeholder": "Gruppenbeschreibung eingeben (optional)"
+      },
+      "isHidden": {
+        "label": "Vor Benutzern verbergen, die nicht Teil dieser Gruppe sind",
+        "description": "Verwende dies für organisatorische Gruppen, die nicht für alle relevant sind."
       }
     },
     "buttons": {

--- a/apps/frontend/src/app/resource-groups/GroupDetailsForm/translations/en.json
+++ b/apps/frontend/src/app/resource-groups/GroupDetailsForm/translations/en.json
@@ -1,6 +1,7 @@
 {
   "sections": {
-    "details": "Details"
+    "details": "Details",
+    "visibility": "Visibility"
   },
   "form": {
     "title": "Details",
@@ -13,6 +14,10 @@
       "description": {
         "label": "Description",
         "placeholder": "Enter group description (optional)"
+      },
+      "isHidden": {
+        "label": "Hide from users who are not part of this group",
+        "description": "Use this for organizational groups that are not relevant to everyone."
       }
     },
     "buttons": {

--- a/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.de.json
+++ b/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.de.json
@@ -27,5 +27,12 @@
     "blocksAccess": {
       "label": "Zugriff bis zur Nachschulung sperren"
     }
+  },
+  "visibility": {
+    "sectionTitle": "Sichtbarkeit",
+    "description": "Verwende dies für organisatorische Gruppen, die nicht für alle relevant sind.",
+    "hidden": {
+      "label": "Vor Benutzern verbergen, die nicht Teil dieser Gruppe sind"
+    }
   }
 }

--- a/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.en.json
+++ b/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.en.json
@@ -27,5 +27,12 @@
     "blocksAccess": {
       "label": "Block access until retrained"
     }
+  },
+  "visibility": {
+    "sectionTitle": "Visibility",
+    "description": "Use this for organizational groups that are not relevant to everyone.",
+    "hidden": {
+      "label": "Hide from users who are not part of this group"
+    }
   }
 }

--- a/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.tsx
+++ b/apps/frontend/src/app/resource-groups/upsertModal/resourceGroupUpsertModal.tsx
@@ -60,6 +60,7 @@ export function ResourceGroupUpsertModal(props: Readonly<Props>) {
     retrainingMaxAgeDays: null,
     retrainingMaxInactivityDays: null,
     retrainingBlocksAccess: false,
+    isHidden: false,
   });
   const [apiErrors, setApiErrors] = useState<{ [key: string]: string[] | undefined }>({});
 
@@ -135,6 +136,7 @@ export function ResourceGroupUpsertModal(props: Readonly<Props>) {
           retrainingMaxAgeDays: props.resourceGroup.retrainingMaxAgeDays ?? null,
           retrainingMaxInactivityDays: props.resourceGroup.retrainingMaxInactivityDays ?? null,
           retrainingBlocksAccess: props.resourceGroup.retrainingBlocksAccess ?? false,
+          isHidden: props.resourceGroup.isHidden ?? false,
         });
       } else {
         // Reset form for create mode or when no resource group is provided
@@ -144,6 +146,7 @@ export function ResourceGroupUpsertModal(props: Readonly<Props>) {
           retrainingMaxAgeDays: null,
           retrainingMaxInactivityDays: null,
           retrainingBlocksAccess: false,
+          isHidden: false,
         });
       }
       setApiErrors({}); // Clear errors when modal opens
@@ -168,6 +171,7 @@ export function ResourceGroupUpsertModal(props: Readonly<Props>) {
         retrainingMaxAgeDays: formData.retrainingMaxAgeDays,
         retrainingMaxInactivityDays: formData.retrainingMaxInactivityDays,
         retrainingBlocksAccess: formData.retrainingBlocksAccess,
+        isHidden: formData.isHidden,
       };
 
       if (isEditMode && props.resourceGroup) {
@@ -267,6 +271,19 @@ export function ResourceGroupUpsertModal(props: Readonly<Props>) {
                 data-cy="resource-group-retraining-blocks-access-switch"
               >
                 <span className="text-small">{t('retraining.blocksAccess.label')}</span>
+              </LabeledSwitch>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <h3 className="text-small font-semibold">{t('visibility.sectionTitle')}</h3>
+              <span className="text-tiny text-default-400">{t('visibility.description')}</span>
+
+              <LabeledSwitch
+                isSelected={formData.isHidden ?? false}
+                onChange={(value) => setFormData({ ...formData, isHidden: value })}
+                data-cy="resource-group-is-hidden-switch"
+              >
+                <span className="text-small">{t('visibility.hidden.label')}</span>
               </LabeledSwitch>
             </div>
           </DrawerBody>

--- a/libs/database-entities/src/lib/entities/resourceGroup.entity.ts
+++ b/libs/database-entities/src/lib/entities/resourceGroup.entity.ts
@@ -64,6 +64,15 @@ export class ResourceGroup {
   })
   retrainingBlocksAccess!: boolean;
 
+  @Column({ type: 'boolean', default: false })
+  @ApiProperty({
+    description:
+      'Whether to hide this group from users who are not part of it (introducer, maintainer or introduced). Users with the canManageResources permission always see hidden groups.',
+    example: false,
+    default: false,
+  })
+  isHidden!: boolean;
+
   @CreateDateColumn()
   @ApiProperty({
     description: 'When the resource was created',


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
Adds a per-group **Visibility** toggle (`isHidden`) so organizational groups can be hidden from users who are not part of them. Contrary to groups that represent machine types/rooms, organizational groups have no benefit for every person.

"Part of the group" = introducer, maintainer, or introduced (has a `resource_introduction`). Users with the `canManageResources` permission always see hidden groups.

## Changes
**Backend**
- `ResourceGroup` entity: new `isHidden` boolean column (default `false`) + migration `1781400000000-resource-group-is-hidden`.
- Create/Update DTOs: optional `isHidden`.
- Service: `getMany` filters hidden groups by membership; `getOne` returns **404** for non-members of a hidden group; create/update persist `isHidden`.
- Controller: `GET /resource-groups` and `GET /resource-groups/:id` now require auth and pass the requesting user's visibility context.

**Frontend**
- Visibility toggle (`LabeledSwitch`) in the group settings form and the create/edit drawer, with EN/DE translations.

## Testing
- `nx test api` — 116 suites / 1304 tests pass. `nx test frontend react-query-client database-entities` pass. Lint + typecheck pass.
- Manual browser + API verification (screenshots and results posted on the Linear issue):
  - Admin sees all groups.
  - Non-member: hidden group excluded from list; direct `GET /:id` → 404.
  - Member (introducer): hidden group visible; `GET /:id` → 200.

Closes [ATT-515](https://linear.app/attraccess/issue/ATT-515/groups-hidden-for-non-group-level-introduced-people)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
