### PR TITLE
feat(database-entities): supervisionMode + supervisorUserId + auto-promotion settings (ATT-486)

### DIFF
--- a/apps/api/src/database/migrations/1781500000000-supervised-usage.ts
+++ b/apps/api/src/database/migrations/1781500000000-supervised-usage.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SupervisedUsage1781500000000 implements MigrationInterface {
+  name = 'SupervisedUsage1781500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "resource" ADD COLUMN "supervisionMode" varchar CHECK( "supervisionMode" IN ('introduction_required','supervision_allowed','supervision_required') ) NOT NULL DEFAULT ('introduction_required')`
+    );
+    await queryRunner.query(`ALTER TABLE "resource" ADD COLUMN "supervisedUsagesUntilIntroduction" integer`);
+    await queryRunner.query(
+      `ALTER TABLE "resource" ADD COLUMN "autoIntroductionTarget" varchar CHECK( "autoIntroductionTarget" IN ('resource','group') )`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "resource" ADD COLUMN "autoIntroductionGroupId" integer REFERENCES "resource_group" ("id") ON DELETE SET NULL`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "resource_usage" ADD COLUMN "supervisorUserId" integer REFERENCES "user" ("id") ON DELETE SET NULL`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "resource_usage" DROP COLUMN "supervisorUserId"`);
+
+    await queryRunner.query(`ALTER TABLE "resource" DROP COLUMN "autoIntroductionGroupId"`);
+    await queryRunner.query(`ALTER TABLE "resource" DROP COLUMN "autoIntroductionTarget"`);
+    await queryRunner.query(`ALTER TABLE "resource" DROP COLUMN "supervisedUsagesUntilIntroduction"`);
+    await queryRunner.query(`ALTER TABLE "resource" DROP COLUMN "supervisionMode"`);
+  }
+}

--- a/apps/api/src/database/migrations/index.ts
+++ b/apps/api/src/database/migrations/index.ts
@@ -124,3 +124,4 @@ export * from './1780200000000-attractap-crash-report-symbolication';
 export * from './1781200000000-resource-usage-note-email-template';
 export * from './1781300000000-attractap-crash-report-reboot-reason';
 export * from './1781400000000-resource-group-is-hidden';
+export * from './1781500000000-supervised-usage';

--- a/apps/api/src/test-utils/resource.fixtures.ts
+++ b/apps/api/src/test-utils/resource.fixtures.ts
@@ -1,4 +1,4 @@
-import { DocumentationType, Resource, ResourceType } from '@attraccess/database-entities';
+import { DocumentationType, Resource, ResourceType, SupervisionMode } from '@attraccess/database-entities';
 
 export function createMockResource(overrides: Partial<Resource> = {}): Resource {
   const now = new Date();
@@ -16,6 +16,11 @@ export function createMockResource(overrides: Partial<Resource> = {}): Resource 
     retrainingMaxAgeDays: null,
     retrainingMaxInactivityDays: null,
     retrainingBlocksAccess: false,
+    supervisionMode: SupervisionMode.INTRODUCTION_REQUIRED,
+    supervisedUsagesUntilIntroduction: null,
+    autoIntroductionTarget: null,
+    autoIntroductionGroupId: null,
+    autoIntroductionGroup: null,
     metadata: null,
     createdAt: now,
     updatedAt: now,

--- a/apps/frontend/src/test-utils/fixtures.ts
+++ b/apps/frontend/src/test-utils/fixtures.ts
@@ -1,4 +1,4 @@
-import { Resource, ResourceType } from '@attraccess/react-query-client';
+import { Resource, ResourceType, SupervisionMode } from '@attraccess/react-query-client';
 
 /**
  * Creates a mock resource with the given overrides
@@ -15,6 +15,7 @@ export function createMockResource(overrides?: Partial<Resource>): Resource {
     retrainingMaxAgeDays: null,
     retrainingMaxInactivityDays: null,
     retrainingBlocksAccess: false,
+    supervisionMode: SupervisionMode.INTRODUCTION_REQUIRED,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     groups: [],

--- a/libs/database-entities/src/lib/entities-index.ts
+++ b/libs/database-entities/src/lib/entities-index.ts
@@ -13,6 +13,7 @@ import {
 } from './entities/resourceIntroductionHistoryItem.entity';
 import { ResourceIntroducer, ResourceIntroducerType } from './entities/resourceIntroducer.entity';
 import { ResourceUsage } from './entities/resourceUsage.entity';
+import { SupervisionMode, AutoIntroductionTarget } from './entities/resource.supervision';
 import { SSOProvider, SSOProviderType } from './entities/ssoProvider.entity';
 import { SSOProviderOIDCConfiguration } from './entities/ssoProvider.oidc';
 import { SSOProviderSAMLConfiguration } from './entities/ssoProvider.saml';
@@ -140,6 +141,8 @@ export {
   ResourceMaintenanceScheduleUsageCountConfig,
   ResourceMaintenanceScheduleTimeIntervalConfig,
   ResourceType,
+  SupervisionMode,
+  AutoIntroductionTarget,
   ResourceUsageAction,
   ButtonNodeDataSchema,
   IfNodeDataSchema,

--- a/libs/database-entities/src/lib/entities/resource.entity.ts
+++ b/libs/database-entities/src/lib/entities/resource.entity.ts
@@ -6,6 +6,8 @@ import {
   UpdateDateColumn,
   OneToMany,
   ManyToMany,
+  ManyToOne,
+  JoinColumn,
   JoinTable,
   DeleteDateColumn,
 } from 'typeorm';
@@ -23,6 +25,7 @@ import { Attractap } from './attractap.entity';
 import { ResourceMaintenance } from './resource.maintenance';
 import { ResourceMaintenanceSchedule } from './resource-maintenance-schedule.entity';
 import { ResourceType } from './resource.type';
+import { SupervisionMode, AutoIntroductionTarget } from './resource.supervision';
 import { ResourceBillingConfiguration } from './resource-billing-configuration.entity';
 import { Form } from './form';
 
@@ -136,6 +139,60 @@ export class Resource {
     default: false,
   })
   retrainingBlocksAccess!: boolean;
+
+  @Column({
+    type: 'simple-enum',
+    enum: SupervisionMode,
+    default: SupervisionMode.INTRODUCTION_REQUIRED,
+  })
+  @ApiProperty({
+    description: 'Controls who may start a usage session on this resource',
+    enum: SupervisionMode,
+    enumName: 'SupervisionMode',
+    example: SupervisionMode.INTRODUCTION_REQUIRED,
+    default: SupervisionMode.INTRODUCTION_REQUIRED,
+  })
+  supervisionMode!: SupervisionMode;
+
+  @Column({ type: 'integer', nullable: true })
+  @ApiProperty({
+    description:
+      'Automatically create an introduction after this many supervised sessions. Null disables auto-promotion.',
+    example: 3,
+    required: false,
+    nullable: true,
+  })
+  supervisedUsagesUntilIntroduction!: number | null;
+
+  @Column({ type: 'simple-enum', enum: AutoIntroductionTarget, nullable: true })
+  @ApiProperty({
+    description: 'Target of the auto-created introduction once the supervised-usage threshold is reached',
+    enum: AutoIntroductionTarget,
+    enumName: 'AutoIntroductionTarget',
+    example: AutoIntroductionTarget.RESOURCE,
+    required: false,
+    nullable: true,
+  })
+  autoIntroductionTarget!: AutoIntroductionTarget | null;
+
+  @Column({ type: 'integer', nullable: true })
+  @ApiProperty({
+    description: 'The group the auto-introduction targets when autoIntroductionTarget is GROUP',
+    example: 1,
+    required: false,
+    nullable: true,
+  })
+  autoIntroductionGroupId!: number | null;
+
+  @ManyToOne(() => ResourceGroup, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'autoIntroductionGroupId' })
+  @ApiProperty({
+    description: 'The group the auto-introduction targets when autoIntroductionTarget is GROUP',
+    type: () => ResourceGroup,
+    required: false,
+    nullable: true,
+  })
+  autoIntroductionGroup!: ResourceGroup | null;
 
   @Column({ type: 'json', nullable: true })
   @ApiProperty({

--- a/libs/database-entities/src/lib/entities/resource.supervision.ts
+++ b/libs/database-entities/src/lib/entities/resource.supervision.ts
@@ -1,0 +1,21 @@
+/**
+ * Controls who may start a usage session on a resource.
+ */
+export enum SupervisionMode {
+  /** Today's behavior: only introduced users may start a session. */
+  INTRODUCTION_REQUIRED = 'introduction_required',
+  /** Introduced users alone; non-introduced users only with a present supervisor. */
+  SUPERVISION_ALLOWED = 'supervision_allowed',
+  /** Even introduced users need a present supervisor. */
+  SUPERVISION_REQUIRED = 'supervision_required',
+}
+
+/**
+ * Target of an auto-created introduction once the supervised-usage threshold is reached.
+ */
+export enum AutoIntroductionTarget {
+  /** Create an introduction for this resource. */
+  RESOURCE = 'resource',
+  /** Create a group introduction instead of a resource introduction. */
+  GROUP = 'group',
+}

--- a/libs/database-entities/src/lib/entities/resourceUsage.entity.ts
+++ b/libs/database-entities/src/lib/entities/resourceUsage.entity.ts
@@ -148,4 +148,22 @@ export class ResourceUsage {
   @Column({ type: 'boolean', default: false })
   @ApiProperty({ description: 'Whether the resource usage is finalized' })
   isFinalized!: boolean;
+
+  @Column({ nullable: true, type: 'integer' })
+  @ApiProperty({
+    description: 'The ID of the supervisor who supervised this session (null if unsupervised or supervisor deleted)',
+    example: 1,
+    required: false,
+    nullable: true,
+  })
+  supervisorUserId!: number | null;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'supervisorUserId' })
+  @ApiProperty({
+    description: 'The supervisor who supervised this session',
+    required: false,
+    type: () => User,
+  })
+  supervisorUser!: User | null;
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Foundation for supervised resource usage (ATT-486). Pure schema/entity work — **no behavior changes**. Existing resources keep today's behavior via defaults.

### `Resource`
- `supervisionMode` (enum, default `INTRODUCTION_REQUIRED`)
  - `INTRODUCTION_REQUIRED` (today): only introduced users may start.
  - `SUPERVISION_ALLOWED`: introduced users alone; non-introduced users only with a present supervisor.
  - `SUPERVISION_REQUIRED`: even introduced users need a present supervisor.
- Auto-promotion settings:
  - `supervisedUsagesUntilIntroduction` (integer, nullable — null = off)
  - `autoIntroductionTarget` (enum `RESOURCE | GROUP`, nullable)
  - `autoIntroductionGroupId` (nullable) + `autoIntroductionGroup` relation (FK → `resource_group`, `ON DELETE SET NULL`)

### `ResourceUsage`
- `supervisorUserId` (integer, nullable) + `supervisorUser` relation (FK → `user`, `ON DELETE SET NULL`)

### Migration
- `apps/api/src/database/migrations/1781500000000-supervised-usage.ts`
- All existing resources default to `INTRODUCTION_REQUIRED`.

### Exports
- `@attraccess/database-entities` exports `SupervisionMode` and `AutoIntroductionTarget`.

## Testing
- Migration runs green on a full migration chain against a fresh SQLite DB.
- `nx run database-entities:build` + `lint` green.
- `nx run api:lint` green; api test suite green (1296 tests).
- Frontend/api-client regenerated; `frontend:typecheck` green (new required `supervisionMode` added to test fixtures).
- Full pre-commit affected suite (lint, typecheck, build, test, e2e) green.

## Linear
https://linear.app/attraccess/issue/ATT-486

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
