### PR TITLE
feat(resources): supervised start flow + supervisor approval (ATT-487)

### DIFF
--- a/apps/api/src/metrics/instrumentation/sse/sse.helper.ts
+++ b/apps/api/src/metrics/instrumentation/sse/sse.helper.ts
@@ -6,7 +6,7 @@ import { SSE_METRICS } from '../../definitions/tokens';
 import { SseMetrics } from '../../definitions/sse.metrics';
 import { MetricsToggleService } from '../../settings/metrics-toggle.service';
 
-export type SseStream = 'resource_usage' | 'billing' | 'resource_flows' | 'messaging';
+export type SseStream = 'resource_usage' | 'billing' | 'resource_flows' | 'messaging' | 'supervision';
 
 @Injectable()
 export class SseInstrumentation {

--- a/apps/api/src/resources/resources.module.ts
+++ b/apps/api/src/resources/resources.module.ts
@@ -18,6 +18,7 @@ import { SSEModule } from './sse/sse.module';
 import { ResourceGroupsModule } from './groups/resourceGroups.module';
 import { ResourcesService } from './resources.service';
 import { ResourceUsageModule } from './usage/resourceUsage.module';
+import { SupervisionModule } from './supervision/supervision.module';
 import { ResourceImageService } from './resourceImage.service';
 import { ResourceIntroductionsModule } from './introductions/resourceIntroductions.module';
 import { ResourceIntroducersModule } from './introducers/resourceIntroducers.module';
@@ -49,6 +50,7 @@ import { LicenseModule } from '../license/license.module';
     ResourceIntroductionsModule,
     ResourceIntroducersModule,
     ResourceUsageModule,
+    SupervisionModule,
     ResourceFlowsModule,
     ResourceMaintenanceModule,
     ResourceFormsModule,

--- a/apps/api/src/resources/supervision/dtos/requestSupervisedSession.dto.ts
+++ b/apps/api/src/resources/supervision/dtos/requestSupervisedSession.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsPositive } from 'class-validator';
+import { StartUsageSessionDto } from '../../usage/dtos/startUsageSession.dto';
+
+/**
+ * Payload for requesting a supervised usage session. Mirrors the regular start payload (notes,
+ * project, form submissions) and adds the selected supervisor.
+ */
+export class RequestSupervisedSessionDto extends StartUsageSessionDto {
+  @ApiProperty({
+    description: 'The ID of the user selected to supervise this session',
+    example: 42,
+  })
+  @IsInt()
+  @IsPositive()
+  supervisorUserId!: number;
+}

--- a/apps/api/src/resources/supervision/dtos/supervisionDecision.response.dto.ts
+++ b/apps/api/src/resources/supervision/dtos/supervisionDecision.response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Result of a supervisor decision that does not start a session (currently: rejection).
+ */
+export class SupervisionDecisionResponseDto {
+  @ApiProperty({ description: 'The outcome of the decision', example: 'rejected', enum: ['rejected'] })
+  status!: 'rejected';
+
+  @ApiProperty({ description: 'The supervision request the decision applies to' })
+  requestId!: string;
+}

--- a/apps/api/src/resources/supervision/dtos/supervisionLiveEvent.dto.ts
+++ b/apps/api/src/resources/supervision/dtos/supervisionLiveEvent.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SupervisionRequestDto } from './supervisionRequest.dto';
+
+export enum SupervisionLiveEventType {
+  /** A new supervision request is awaiting the supervisor. */
+  REQUESTED = 'requested',
+  /** A request lapsed after 30s without a response. */
+  EXPIRED = 'expired',
+  /** A request was approved and the session started. */
+  RESOLVED = 'resolved',
+  /** A request was rejected by the supervisor. */
+  REJECTED = 'rejected',
+}
+
+/**
+ * Realtime event delivered to a supervisor over SSE.
+ */
+export class SupervisionLiveEventDto {
+  @ApiProperty({ enum: SupervisionLiveEventType, enumName: 'SupervisionLiveEventType' })
+  type!: SupervisionLiveEventType;
+
+  @ApiProperty({ description: 'The supervision request this event refers to' })
+  requestId!: string;
+
+  @ApiProperty({
+    description: 'The full request payload (present for REQUESTED events, null otherwise)',
+    required: false,
+    nullable: true,
+    type: () => SupervisionRequestDto,
+  })
+  request!: SupervisionRequestDto | null;
+}

--- a/apps/api/src/resources/supervision/dtos/supervisionRequest.dto.ts
+++ b/apps/api/src/resources/supervision/dtos/supervisionRequest.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * Serialized, client-safe view of a pending in-memory supervision request.
+ */
+export class SupervisionRequestDto {
+  @ApiProperty({ description: 'The opaque identifier of the supervision request', example: 'b1d4...-uuid' })
+  id!: string;
+
+  @ApiProperty({ description: 'The resource the requester wants to use', example: 1 })
+  resourceId!: number;
+
+  @ApiProperty({ description: 'The ID of the user requesting the supervised session', example: 7 })
+  requesterUserId!: number;
+
+  @ApiProperty({ description: 'The username of the requester', example: 'alice' })
+  requesterUsername!: string;
+
+  @ApiProperty({ description: 'The ID of the supervisor whose approval is required', example: 42 })
+  supervisorUserId!: number;
+
+  @ApiProperty({ description: 'Optional notes supplied by the requester', required: false, nullable: true })
+  notes!: string | null;
+
+  @ApiProperty({ description: 'When the request was created' })
+  createdAt!: Date;
+
+  @ApiProperty({ description: 'When the request lapses if not answered (30s after creation)' })
+  expiresAt!: Date;
+}

--- a/apps/api/src/resources/supervision/supervision-live.service.ts
+++ b/apps/api/src/resources/supervision/supervision-live.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { Subject } from 'rxjs';
+import { SupervisionLiveEventDto } from './dtos/supervisionLiveEvent.dto';
+
+/**
+ * Per-supervisor realtime channel for supervision approval requests.
+ *
+ * Mirrors the billing/messaging live-notification pattern: each supervisor gets an on-demand
+ * RxJS Subject that the SSE endpoint subscribes to, and the supervision service pushes events into.
+ */
+@Injectable()
+export class SupervisionLiveService {
+  private readonly subjects = new Map<number, Subject<{ data: SupervisionLiveEventDto }>>();
+
+  public getSupervisorSubject(userId: number): Subject<{ data: SupervisionLiveEventDto }> {
+    if (!this.subjects.has(userId)) {
+      this.subjects.set(userId, new Subject<{ data: SupervisionLiveEventDto }>());
+    }
+    return this.subjects.get(userId);
+  }
+
+  public emitToSupervisor(userId: number, event: SupervisionLiveEventDto): void {
+    this.getSupervisorSubject(userId).next({ data: event });
+  }
+}

--- a/apps/api/src/resources/supervision/supervision.controller.ts
+++ b/apps/api/src/resources/supervision/supervision.controller.ts
@@ -1,0 +1,103 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Req, Sse } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Observable } from 'rxjs';
+import { Auth, AuthenticatedRequest } from '@attraccess/plugins-backend-sdk';
+import { ResourceUsage } from '@attraccess/database-entities';
+import { SseInstrumentation } from '../../metrics/instrumentation/sse/sse.helper';
+import { SupervisionService } from './supervision.service';
+import { SupervisionLiveService } from './supervision-live.service';
+import { RequestSupervisedSessionDto } from './dtos/requestSupervisedSession.dto';
+import { SupervisionRequestDto } from './dtos/supervisionRequest.dto';
+import { SupervisionDecisionResponseDto } from './dtos/supervisionDecision.response.dto';
+import { SupervisionLiveEventDto } from './dtos/supervisionLiveEvent.dto';
+
+@ApiTags('Resources')
+@Controller('resources')
+export class SupervisionController {
+  constructor(
+    private readonly supervisionService: SupervisionService,
+    private readonly supervisionLive: SupervisionLiveService,
+    private readonly sse: SseInstrumentation,
+  ) {}
+
+  @Post(':resourceId/usage/supervision/request')
+  @Auth()
+  @ApiOperation({
+    summary: 'Request a supervised usage session and wait (up to 30s) for supervisor approval',
+    operationId: 'resourceUsageRequestSupervisedSession',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'The supervisor approved within 30 seconds and the supervised session started.',
+    type: ResourceUsage,
+  })
+  @ApiResponse({ status: 400, description: 'Bad Request - resource does not allow supervision or self-supervision' })
+  @ApiResponse({ status: 401, description: 'Unauthorized - User is not authenticated' })
+  @ApiResponse({ status: 403, description: 'The selected supervisor is not authorized, or the request was rejected.' })
+  @ApiResponse({ status: 404, description: 'Resource or supervisor not found.' })
+  @ApiResponse({ status: 408, description: 'The supervisor did not respond within 30 seconds.' })
+  async requestSupervisedSession(
+    @Param('resourceId', ParseIntPipe) resourceId: number,
+    @Body() dto: RequestSupervisedSessionDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<ResourceUsage> {
+    return this.supervisionService.requestSupervisedSession(resourceId, req.user, dto);
+  }
+
+  @Get('supervision/requests')
+  @Auth()
+  @ApiOperation({
+    summary: 'List supervision requests awaiting the authenticated supervisor',
+    operationId: 'supervisionListPendingRequests',
+  })
+  @ApiResponse({ status: 200, description: 'The pending supervision requests.', type: [SupervisionRequestDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized - User is not authenticated' })
+  listPendingRequests(@Req() req: AuthenticatedRequest): SupervisionRequestDto[] {
+    return this.supervisionService.listPendingForSupervisor(req.user.id);
+  }
+
+  @Sse('supervision/requests/live')
+  @Auth()
+  @ApiOperation({
+    summary: 'Subscribe to live supervision requests for the authenticated supervisor',
+    operationId: 'supervisionLive',
+  })
+  streamRequests(@Req() req: AuthenticatedRequest): Observable<{ data: SupervisionLiveEventDto }> {
+    const subject = this.supervisionLive.getSupervisorSubject(req.user.id);
+    return this.sse.wrap('supervision', subject.asObservable());
+  }
+
+  @Post('supervision/requests/:requestId/approve')
+  @Auth()
+  @ApiOperation({
+    summary: 'Approve a pending supervised session request',
+    operationId: 'supervisionApproveRequest',
+  })
+  @ApiResponse({ status: 201, description: 'The supervised session started.', type: ResourceUsage })
+  @ApiResponse({ status: 401, description: 'Unauthorized - User is not authenticated' })
+  @ApiResponse({ status: 403, description: 'You are not the requested supervisor for this session.' })
+  @ApiResponse({ status: 404, description: 'The request was not found or has already expired.' })
+  approveRequest(
+    @Param('requestId') requestId: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<ResourceUsage> {
+    return this.supervisionService.approve(requestId, req.user);
+  }
+
+  @Post('supervision/requests/:requestId/reject')
+  @Auth()
+  @ApiOperation({
+    summary: 'Reject a pending supervised session request',
+    operationId: 'supervisionRejectRequest',
+  })
+  @ApiResponse({ status: 201, description: 'The request was rejected.', type: SupervisionDecisionResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized - User is not authenticated' })
+  @ApiResponse({ status: 403, description: 'You are not the requested supervisor for this session.' })
+  @ApiResponse({ status: 404, description: 'The request was not found or has already expired.' })
+  rejectRequest(
+    @Param('requestId') requestId: string,
+    @Req() req: AuthenticatedRequest,
+  ): SupervisionDecisionResponseDto {
+    return this.supervisionService.reject(requestId, req.user);
+  }
+}

--- a/apps/api/src/resources/supervision/supervision.module.ts
+++ b/apps/api/src/resources/supervision/supervision.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { ResourceUsageModule } from '../usage/resourceUsage.module';
+import { SupervisionController } from './supervision.controller';
+import { SupervisionService } from './supervision.service';
+import { SupervisionLiveService } from './supervision-live.service';
+
+/**
+ * Supervised-session approval lifecycle: request -> realtime delivery to supervisor -> approve/reject
+ * (or 30s timeout) -> start the session via the existing usage start path with the supervisor attached.
+ */
+@Module({
+  imports: [ResourceUsageModule],
+  controllers: [SupervisionController],
+  providers: [SupervisionService, SupervisionLiveService],
+  exports: [SupervisionService, SupervisionLiveService],
+})
+export class SupervisionModule {}

--- a/apps/api/src/resources/supervision/supervision.service.spec.ts
+++ b/apps/api/src/resources/supervision/supervision.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException, RequestTimeoutException } from '@nestjs/common';
+import { ResourceUsage, User } from '@attraccess/database-entities';
+import { SupervisionService } from './supervision.service';
+import { SupervisionLiveService } from './supervision-live.service';
+import { ResourceUsageService } from '../usage/resourceUsage.service';
+import { RequestSupervisedSessionDto } from './dtos/requestSupervisedSession.dto';
+import { SupervisionLiveEventType } from './dtos/supervisionLiveEvent.dto';
+
+// Lets pending request promises settle/flush without depending on real timers.
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('SupervisionService', () => {
+  let service: SupervisionService;
+  let resourceUsageService: { validateSupervisedStart: jest.Mock; startSession: jest.Mock };
+  let live: { emitToSupervisor: jest.Mock; getSupervisorSubject: jest.Mock };
+
+  const requester: User = { id: 1, username: 'requester' } as User;
+  const supervisor: User = { id: 2, username: 'supervisor' } as User;
+  const dto: RequestSupervisedSessionDto = { supervisorUserId: 2, notes: 'please supervise' };
+  const startedSession = { id: 99, resourceId: 5, userId: 1, supervisorUserId: 2 } as ResourceUsage;
+
+  beforeEach(async () => {
+    resourceUsageService = {
+      validateSupervisedStart: jest.fn().mockResolvedValue(undefined),
+      startSession: jest.fn().mockResolvedValue(startedSession),
+    };
+    live = {
+      emitToSupervisor: jest.fn(),
+      getSupervisorSubject: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SupervisionService,
+        { provide: ResourceUsageService, useValue: resourceUsageService },
+        { provide: SupervisionLiveService, useValue: live },
+      ],
+    }).compile();
+
+    service = module.get(SupervisionService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  const createRequest = async () => {
+    const pending = service.requestSupervisedSession(5, requester, dto);
+    // attach a no-op catch so unsettled/late rejections never surface as unhandled
+    pending.catch(() => undefined);
+    await flush();
+    const requestedEvent = live.emitToSupervisor.mock.calls.find(
+      (c) => c[1].type === SupervisionLiveEventType.REQUESTED,
+    );
+    return { pending, requestId: requestedEvent?.[1].requestId as string };
+  };
+
+  it('validates eagerly and emits a REQUESTED event to the selected supervisor', async () => {
+    const { requestId } = await createRequest();
+
+    expect(resourceUsageService.validateSupervisedStart).toHaveBeenCalledWith(5, requester, 2);
+    expect(requestId).toBeDefined();
+
+    const [supervisorId, event] = live.emitToSupervisor.mock.calls[0];
+    expect(supervisorId).toBe(2);
+    expect(event).toMatchObject({
+      type: SupervisionLiveEventType.REQUESTED,
+      requestId,
+      request: expect.objectContaining({ resourceId: 5, requesterUserId: 1, supervisorUserId: 2, notes: 'please supervise' }),
+    });
+  });
+
+  it('propagates validation errors without creating a pending request', async () => {
+    resourceUsageService.validateSupervisedStart.mockRejectedValueOnce(new ForbiddenException('nope'));
+
+    await expect(service.requestSupervisedSession(5, requester, dto)).rejects.toBeInstanceOf(ForbiddenException);
+    expect(service.listPendingForSupervisor(2)).toHaveLength(0);
+    expect(live.emitToSupervisor).not.toHaveBeenCalled();
+  });
+
+  it('starts the session on approval and resolves the requester', async () => {
+    const { pending, requestId } = await createRequest();
+
+    const approved = await service.approve(requestId, supervisor);
+
+    expect(resourceUsageService.startSession).toHaveBeenCalledWith(5, requester, dto, { supervisorUserId: 2 });
+    expect(approved).toBe(startedSession);
+    await expect(pending).resolves.toBe(startedSession);
+    expect(service.listPendingForSupervisor(2)).toHaveLength(0);
+    expect(
+      live.emitToSupervisor.mock.calls.some((c) => c[1].type === SupervisionLiveEventType.RESOLVED),
+    ).toBe(true);
+  });
+
+  it('rejects the requester when the supervisor rejects the request', async () => {
+    const { pending, requestId } = await createRequest();
+
+    const result = service.reject(requestId, supervisor);
+
+    expect(result).toEqual({ status: 'rejected', requestId });
+    await expect(pending).rejects.toBeInstanceOf(ForbiddenException);
+    expect(resourceUsageService.startSession).not.toHaveBeenCalled();
+    expect(
+      live.emitToSupervisor.mock.calls.some((c) => c[1].type === SupervisionLiveEventType.REJECTED),
+    ).toBe(true);
+  });
+
+  it('expires the request after 30s and times out the requester', async () => {
+    jest.useFakeTimers();
+    const pending = service.requestSupervisedSession(5, requester, dto);
+    pending.catch(() => undefined);
+    await Promise.resolve();
+
+    jest.advanceTimersByTime(SupervisionService.APPROVAL_TTL_MS);
+
+    await expect(pending).rejects.toBeInstanceOf(RequestTimeoutException);
+    expect(service.listPendingForSupervisor(2)).toHaveLength(0);
+
+    const expiredEvent = live.emitToSupervisor.mock.calls.find(
+      (c) => c[1].type === SupervisionLiveEventType.EXPIRED,
+    );
+    expect(expiredEvent).toBeDefined();
+  });
+
+  it('rejects approval from someone other than the requested supervisor', async () => {
+    const { requestId } = await createRequest();
+    const stranger = { id: 3, username: 'stranger' } as User;
+
+    await expect(service.approve(requestId, stranger)).rejects.toBeInstanceOf(ForbiddenException);
+    expect(resourceUsageService.startSession).not.toHaveBeenCalled();
+    // the request remains pending for the real supervisor
+    expect(service.listPendingForSupervisor(2)).toHaveLength(1);
+  });
+
+  it('throws NotFound for an unknown or already-settled request', async () => {
+    await expect(service.approve('does-not-exist', supervisor)).rejects.toBeInstanceOf(NotFoundException);
+    expect(() => service.reject('does-not-exist', supervisor)).toThrow(NotFoundException);
+  });
+
+  it('propagates a failed session start to both supervisor and requester', async () => {
+    resourceUsageService.startSession.mockRejectedValueOnce(new Error('resource in use'));
+    const { pending, requestId } = await createRequest();
+
+    await expect(service.approve(requestId, supervisor)).rejects.toThrow('resource in use');
+    await expect(pending).rejects.toThrow('resource in use');
+  });
+
+  it('allows multiple parallel pending requests for the same supervisor (no limit)', async () => {
+    await createRequest();
+    await createRequest();
+
+    expect(service.listPendingForSupervisor(2)).toHaveLength(2);
+  });
+});

--- a/apps/api/src/resources/supervision/supervision.service.ts
+++ b/apps/api/src/resources/supervision/supervision.service.ts
@@ -1,0 +1,212 @@
+import { ForbiddenException, Injectable, Logger, NotFoundException, RequestTimeoutException } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { ResourceUsage, User } from '@attraccess/database-entities';
+import { ResourceUsageService } from '../usage/resourceUsage.service';
+import { RequestSupervisedSessionDto } from './dtos/requestSupervisedSession.dto';
+import { SupervisionRequestDto } from './dtos/supervisionRequest.dto';
+import { SupervisionDecisionResponseDto } from './dtos/supervisionDecision.response.dto';
+import { SupervisionLiveService } from './supervision-live.service';
+import { SupervisionLiveEventType } from './dtos/supervisionLiveEvent.dto';
+
+interface PendingSupervisionRequest {
+  id: string;
+  resourceId: number;
+  requester: User;
+  supervisorUserId: number;
+  dto: RequestSupervisedSessionDto;
+  createdAt: Date;
+  expiresAt: Date;
+  timeout: ReturnType<typeof setTimeout>;
+  resolve: (session: ResourceUsage) => void;
+  reject: (error: Error) => void;
+  settled: boolean;
+}
+
+/**
+ * Manages the short-lived, in-memory supervised-session approval lifecycle.
+ *
+ * A request is created when a user asks for a supervised session and selects a supervisor. It is
+ * delivered to the supervisor in realtime (SSE) and lapses automatically after 30 seconds. The
+ * requester's call resolves with the started session on approval, or rejects on timeout/rejection.
+ *
+ * No persistent entity is used — multiple parallel requests per supervisor are allowed without limit.
+ */
+@Injectable()
+export class SupervisionService {
+  /** A pending request lapses this many milliseconds after creation. */
+  public static readonly APPROVAL_TTL_MS = 30_000;
+
+  private readonly logger = new Logger(SupervisionService.name);
+  private readonly pending = new Map<string, PendingSupervisionRequest>();
+
+  constructor(
+    private readonly resourceUsageService: ResourceUsageService,
+    private readonly supervisionLive: SupervisionLiveService,
+  ) {}
+
+  /**
+   * Creates a supervision request and returns a promise that resolves with the started session once
+   * the supervisor approves, or rejects with a timeout/rejection error.
+   */
+  public async requestSupervisedSession(
+    resourceId: number,
+    requester: User,
+    dto: RequestSupervisedSessionDto,
+  ): Promise<ResourceUsage> {
+    // Validate eagerly so the requester gets immediate, meaningful feedback instead of waiting 30s
+    // for a request that could never have been approved (wrong supervisor, self-supervision, ...).
+    await this.resourceUsageService.validateSupervisedStart(resourceId, requester, dto.supervisorUserId);
+
+    const id = randomUUID();
+    const createdAt = new Date();
+    const expiresAt = new Date(createdAt.getTime() + SupervisionService.APPROVAL_TTL_MS);
+
+    const sessionPromise = new Promise<ResourceUsage>((resolve, reject) => {
+      const timeout = setTimeout(() => this.expire(id), SupervisionService.APPROVAL_TTL_MS);
+      // Don't keep the process alive solely for a pending approval.
+      if (typeof timeout.unref === 'function') {
+        timeout.unref();
+      }
+
+      this.pending.set(id, {
+        id,
+        resourceId,
+        requester,
+        supervisorUserId: dto.supervisorUserId,
+        dto,
+        createdAt,
+        expiresAt,
+        timeout,
+        resolve,
+        reject,
+        settled: false,
+      });
+    });
+
+    const stored = this.pending.get(id);
+    this.logger.debug(
+      `Supervision request ${id} created for resource ${resourceId} (requester ${requester.id}, supervisor ${dto.supervisorUserId})`,
+    );
+    this.supervisionLive.emitToSupervisor(dto.supervisorUserId, {
+      type: SupervisionLiveEventType.REQUESTED,
+      requestId: id,
+      request: this.toDto(stored),
+    });
+
+    return sessionPromise;
+  }
+
+  /**
+   * Approves a pending request: starts the supervised session via the normal start path with the
+   * supervisor attached, then resolves the waiting requester.
+   */
+  public async approve(requestId: string, supervisor: User): Promise<ResourceUsage> {
+    const request = this.getPendingForSupervisorOrThrow(requestId, supervisor);
+    this.clear(request);
+
+    try {
+      const session = await this.resourceUsageService.startSession(request.resourceId, request.requester, request.dto, {
+        supervisorUserId: supervisor.id,
+      });
+      this.fulfil(request, session);
+      this.supervisionLive.emitToSupervisor(supervisor.id, {
+        type: SupervisionLiveEventType.RESOLVED,
+        requestId,
+        request: null,
+      });
+      return session;
+    } catch (error) {
+      // Surface the failure to both the supervisor (HTTP error) and the waiting requester.
+      this.fail(request, error as Error);
+      throw error;
+    }
+  }
+
+  /**
+   * Rejects a pending request: the waiting requester is failed with a Forbidden error.
+   */
+  public reject(requestId: string, supervisor: User): SupervisionDecisionResponseDto {
+    const request = this.getPendingForSupervisorOrThrow(requestId, supervisor);
+    this.clear(request);
+    this.fail(request, new ForbiddenException('The supervision request was rejected by the supervisor'));
+    this.supervisionLive.emitToSupervisor(supervisor.id, {
+      type: SupervisionLiveEventType.REJECTED,
+      requestId,
+      request: null,
+    });
+    return { status: 'rejected', requestId };
+  }
+
+  /**
+   * Lists the requests currently awaiting a given supervisor (used for SSE reconnect/initial state).
+   */
+  public listPendingForSupervisor(supervisorUserId: number): SupervisionRequestDto[] {
+    const requests: SupervisionRequestDto[] = [];
+    for (const request of this.pending.values()) {
+      if (request.supervisorUserId === supervisorUserId) {
+        requests.push(this.toDto(request));
+      }
+    }
+    return requests;
+  }
+
+  private getPendingForSupervisorOrThrow(requestId: string, supervisor: User): PendingSupervisionRequest {
+    const request = this.pending.get(requestId);
+    if (!request) {
+      throw new NotFoundException('Supervision request not found or already expired');
+    }
+    if (request.supervisorUserId !== supervisor.id) {
+      throw new ForbiddenException('You are not the requested supervisor for this session');
+    }
+    return request;
+  }
+
+  private expire(requestId: string): void {
+    const request = this.pending.get(requestId);
+    if (!request) {
+      return;
+    }
+    this.clear(request);
+    this.logger.debug(`Supervision request ${requestId} expired`);
+    this.fail(request, new RequestTimeoutException('Supervision request expired before the supervisor responded'));
+    this.supervisionLive.emitToSupervisor(request.supervisorUserId, {
+      type: SupervisionLiveEventType.EXPIRED,
+      requestId,
+      request: null,
+    });
+  }
+
+  private clear(request: PendingSupervisionRequest): void {
+    clearTimeout(request.timeout);
+    this.pending.delete(request.id);
+  }
+
+  private fulfil(request: PendingSupervisionRequest, session: ResourceUsage): void {
+    if (request.settled) {
+      return;
+    }
+    request.settled = true;
+    request.resolve(session);
+  }
+
+  private fail(request: PendingSupervisionRequest, error: Error): void {
+    if (request.settled) {
+      return;
+    }
+    request.settled = true;
+    request.reject(error);
+  }
+
+  private toDto(request: PendingSupervisionRequest): SupervisionRequestDto {
+    return {
+      id: request.id,
+      resourceId: request.resourceId,
+      requesterUserId: request.requester.id,
+      requesterUsername: request.requester.username,
+      supervisorUserId: request.supervisorUserId,
+      notes: request.dto.notes ?? null,
+      createdAt: request.createdAt,
+      expiresAt: request.expiresAt,
+    };
+  }
+}

--- a/apps/api/src/resources/usage/events/resource-usage.events.ts
+++ b/apps/api/src/resources/usage/events/resource-usage.events.ts
@@ -35,3 +35,19 @@ export class ResourceUsageNoteAddedEvent {
     public readonly author: Pick<User, 'id' | 'username'>
   ) {}
 }
+
+/**
+ * Emitted whenever a supervised usage session starts. Acts as the counter signal consumed by the
+ * supervised-usage auto-promotion follow-up (ATT-486), which decides when to auto-create an
+ * introduction for the supervised user.
+ */
+export class SupervisedUsageStartedEvent {
+  public static readonly EVENT_NAME = 'resource.usage.supervised_started';
+
+  constructor(
+    public readonly resourceId: number,
+    public readonly userId: number,
+    public readonly supervisorUserId: number,
+    public readonly usageId: number
+  ) {}
+}

--- a/apps/api/src/resources/usage/resourceUsage.service.spec.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.spec.ts
@@ -9,10 +9,11 @@ import {
   User,
   ResourceBillingConfiguration,
   ResourceFlowNodeType,
+  SupervisionMode,
 } from '@attraccess/database-entities';
 import { Repository, IsNull, SelectQueryBuilder } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { StartUsageSessionDto } from './dtos/startUsageSession.dto';
 import { EndUsageSessionDto } from './dtos/endUsageSession.dto';
 import { ResourcesService } from '../resources.service';
@@ -29,6 +30,7 @@ import {
   ResourceUsageEvent,
   ResourceUsageTakenOverEvent,
   ResourceUsageNoteAddedEvent,
+  SupervisedUsageStartedEvent,
 } from './events/resource-usage.events';
 import { BillingService } from '../../billing/billing.service';
 import { InsufficientBalanceError } from '../../billing/errors/insufficient-balance.error';
@@ -55,6 +57,7 @@ describe('ResourceUsageService', () => {
   let service: ResourceUsageService;
   let resourceUsageRepository: jest.Mocked<Repository<ResourceUsage>>;
   let resourceRepository: jest.Mocked<Repository<Resource>>;
+  let userRepository: jest.Mocked<Repository<User>>;
   let resourceIntroductionService: jest.Mocked<ResourceIntroductionsService>;
   let resourceIntroducersService: jest.Mocked<ResourceIntroducersService>;
   let resourceGroupsIntroductionsService: jest.Mocked<ResourceGroupsIntroductionsService>;
@@ -192,6 +195,10 @@ describe('ResourceUsageService', () => {
           useFactory: mockRepository,
         },
         {
+          provide: getRepositoryToken(User),
+          useFactory: mockRepository,
+        },
+        {
           provide: ResourcesService,
           useValue: mockResourcesService,
         },
@@ -264,6 +271,7 @@ describe('ResourceUsageService', () => {
     service = module.get<ResourceUsageService>(ResourceUsageService);
     resourceRepository = module.get(getRepositoryToken(Resource));
     resourceUsageRepository = module.get(getRepositoryToken(ResourceUsage));
+    userRepository = module.get(getRepositoryToken(User));
     resourceIntroductionService = module.get(ResourceIntroductionsService);
     resourceIntroducersService = module.get(ResourceIntroducersService);
     resourceGroupsIntroductionsService = module.get(ResourceGroupsIntroductionsService);
@@ -297,6 +305,9 @@ describe('ResourceUsageService', () => {
         }
         if (entity === ResourceUsage) {
           return { findOne: resourceUsageRepository.findOne } as unknown as Repository<ResourceUsage>;
+        }
+        if (entity === User) {
+          return { findOne: userRepository.findOne } as unknown as Repository<User>;
         }
         return { findOne: jest.fn() } as unknown as Repository<unknown>;
       }),
@@ -889,6 +900,148 @@ describe('ResourceUsageService', () => {
     });
   });
 
+  describe('supervised start', () => {
+    const requester: User = { id: 1, username: 'requester' } as User;
+    const supervisor: User = { id: 2, username: 'supervisor' } as User;
+
+    const supervisedResource = (mode: SupervisionMode): Resource =>
+      ({
+        id: 1,
+        name: 'Supervised Resource',
+        allowTakeOver: false,
+        type: ResourceType.Machine,
+        supervisionMode: mode,
+      }) as Resource;
+
+    const mockSuccessfulSessionCreation = (supervisorUserId: number) => {
+      const createdSession = {
+        id: 1,
+        resourceId: 1,
+        userId: 1,
+        usageAction: ResourceUsageAction.Usage,
+        startTime: new Date(),
+        endTime: null,
+        isFinalized: false,
+        supervisorUserId,
+        user: { id: 1 } as User,
+        resource: { id: 1 } as Resource,
+      } as ResourceUsage;
+      const finalizedSession = { ...createdSession, isFinalized: true };
+
+      resourceUsageRepository.findOne
+        .mockResolvedValueOnce(null) // getActiveSession
+        .mockResolvedValueOnce(createdSession) // newly created session
+        .mockResolvedValueOnce(finalizedSession) // finalized session for return
+        .mockResolvedValueOnce(finalizedSession); // emitUsageEvent fetch
+
+      const mockQueryBuilder = createMockQueryBuilder(null);
+      (transactionalEntityManager.createQueryBuilder as jest.Mock).mockReturnValue(
+        mockQueryBuilder as unknown as SelectQueryBuilder<ResourceUsage>,
+      );
+      return { finalizedSession, mockQueryBuilder };
+    };
+
+    it('starts a supervised session, sets supervisorUserId, and emits the auto-promotion counter event', async () => {
+      const dto: StartUsageSessionDto = { notes: 'Supervised run' };
+      resourceRepository.findOne.mockResolvedValue(supervisedResource(SupervisionMode.SUPERVISION_ALLOWED));
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(false);
+      userRepository.findOne.mockResolvedValue(supervisor);
+      resourceIntroducersService.canMaintain.mockResolvedValue(true);
+
+      const { finalizedSession, mockQueryBuilder } = mockSuccessfulSessionCreation(2);
+
+      const result = await service.startSession(1, requester, dto, { supervisorUserId: 2 });
+
+      expect(result).toEqual(finalizedSession);
+      expect(mockQueryBuilder.values).toHaveBeenCalledWith(expect.objectContaining({ supervisorUserId: 2 }));
+
+      const counterEmit = eventEmitter.emit.mock.calls.find((c) => c[0] === SupervisedUsageStartedEvent.EVENT_NAME);
+      expect(counterEmit).toBeDefined();
+      const payload = counterEmit?.[1] as SupervisedUsageStartedEvent;
+      expect(payload).toBeInstanceOf(SupervisedUsageStartedEvent);
+      expect(payload).toMatchObject({ resourceId: 1, userId: 1, supervisorUserId: 2 });
+    });
+
+    it('accepts a supervisor authorized via canManageResources even without an introducer role', async () => {
+      const dto: StartUsageSessionDto = {};
+      const adminSupervisor = { id: 2, username: 'admin', systemPermissions: { canManageResources: true } } as User;
+      resourceRepository.findOne.mockResolvedValue(supervisedResource(SupervisionMode.SUPERVISION_ALLOWED));
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(false);
+      userRepository.findOne.mockResolvedValue(adminSupervisor);
+      resourceIntroducersService.canMaintain.mockResolvedValue(false);
+
+      mockSuccessfulSessionCreation(2);
+
+      await expect(service.startSession(1, requester, dto, { supervisorUserId: 2 })).resolves.toMatchObject({
+        supervisorUserId: 2,
+      });
+    });
+
+    it('allows a supervised start on SUPERVISION_REQUIRED even for an introduced user', async () => {
+      const dto: StartUsageSessionDto = {};
+      resourceRepository.findOne.mockResolvedValue(supervisedResource(SupervisionMode.SUPERVISION_REQUIRED));
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(false);
+      userRepository.findOne.mockResolvedValue(supervisor);
+      resourceIntroducersService.canMaintain.mockResolvedValue(true);
+
+      mockSuccessfulSessionCreation(2);
+
+      await expect(service.startSession(1, requester, dto, { supervisorUserId: 2 })).resolves.toMatchObject({
+        supervisorUserId: 2,
+      });
+    });
+
+    it('rejects self-supervision', async () => {
+      resourceRepository.findOne.mockResolvedValue(supervisedResource(SupervisionMode.SUPERVISION_ALLOWED));
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(false);
+
+      await expect(service.startSession(1, requester, {}, { supervisorUserId: requester.id })).rejects.toThrow(
+        new BadRequestException('You cannot supervise your own session'),
+      );
+    });
+
+    it('rejects a supervisor that is neither introducer/maintainer nor resource manager', async () => {
+      resourceRepository.findOne.mockResolvedValue(supervisedResource(SupervisionMode.SUPERVISION_ALLOWED));
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(false);
+      userRepository.findOne.mockResolvedValue(supervisor);
+      resourceIntroducersService.canMaintain.mockResolvedValue(false);
+
+      await expect(service.startSession(1, requester, {}, { supervisorUserId: 2 })).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
+
+    it('rejects a supervised start when the resource does not allow supervision', async () => {
+      resourceRepository.findOne.mockResolvedValue(supervisedResource(SupervisionMode.INTRODUCTION_REQUIRED));
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(false);
+      userRepository.findOne.mockResolvedValue(supervisor);
+
+      await expect(service.startSession(1, requester, {}, { supervisorUserId: 2 })).rejects.toThrow(
+        new BadRequestException('This resource does not support supervised sessions'),
+      );
+    });
+
+    it('rejects an unknown supervisor', async () => {
+      resourceRepository.findOne.mockResolvedValue(supervisedResource(SupervisionMode.SUPERVISION_ALLOWED));
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(false);
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.startSession(1, requester, {}, { supervisorUserId: 999 })).rejects.toThrow(
+        new NotFoundException('Supervisor with ID 999 not found'),
+      );
+    });
+
+    it('blocks a solo start on SUPERVISION_REQUIRED even for an introduced user', async () => {
+      resourceRepository.findOne.mockResolvedValue(supervisedResource(SupervisionMode.SUPERVISION_REQUIRED));
+      resourceMaintenanceService.hasActiveMaintenance.mockResolvedValue(false);
+      resourceIntroductionService.hasValidIntroduction.mockResolvedValue(true);
+
+      await expect(service.startSession(1, requester, {})).rejects.toThrow(
+        new BadRequestException('This resource requires a supervisor; request a supervised session instead'),
+      );
+    });
+  });
+
   describe('getActiveSession', () => {
     it('should return active session when it exists', async () => {
       const mockActiveSession = { id: 1, resourceId: 1, userId: 1, user: { id: 1 } as User } as ResourceUsage;
@@ -1139,6 +1292,44 @@ describe('ResourceUsageService', () => {
         true,
       );
       await expect(resourceIntroducersService.canMaintain.mock.results.at(-1)?.value).resolves.toBe(true);
+      expect(flowExecutorService.runFlow).toHaveBeenCalledWith(
+        mockActiveSession.resourceId,
+        ResourceFlowNodeType.INPUT_RESOURCE_USAGE_STOPPED,
+        expect.objectContaining({ endNotes: prefixedNotes }),
+        expect.anything(),
+      );
+    });
+
+    it('allows the supervisor of a supervised session to end it without an introducer role', async () => {
+      const dto: EndUsageSessionDto = { notes: 'Supervisor stop' };
+      const sessionOwner = { id: 60, username: 'student' } as User;
+      const supervisorUser = { id: 61, username: 'supervisor' } as User;
+      const mockActiveSession = {
+        id: 9,
+        resourceId: 40,
+        userId: sessionOwner.id,
+        supervisorUserId: supervisorUser.id,
+        startTime: new Date(),
+        user: sessionOwner,
+      } as ResourceUsage;
+      const prefixedNotes = `[By #${supervisorUser.id} - ${supervisorUser.username}] ${dto.notes}`;
+      const mockUpdatedSession = { ...mockActiveSession, endTime: new Date(), endNotes: prefixedNotes };
+
+      resourceUsageRepository.findOne
+        .mockResolvedValueOnce(mockActiveSession)
+        .mockResolvedValueOnce(mockUpdatedSession)
+        .mockResolvedValueOnce(mockUpdatedSession);
+
+      const mockUpdateQueryBuilder = createMockQueryBuilder(null);
+      (transactionalEntityManager.createQueryBuilder as jest.Mock).mockReturnValue(
+        mockUpdateQueryBuilder as unknown as SelectQueryBuilder<ResourceUsage>,
+      );
+
+      const result = await service.endSession(mockActiveSession.resourceId, supervisorUser, dto);
+
+      expect(result).toBe(mockUpdatedSession);
+      // The supervisor short-circuits the authorization check; no introducer lookup needed.
+      expect(resourceIntroducersService.canMaintain).not.toHaveBeenCalled();
       expect(flowExecutorService.runFlow).toHaveBeenCalledWith(
         mockActiveSession.resourceId,
         ResourceFlowNodeType.INPUT_RESOURCE_USAGE_STOPPED,

--- a/apps/api/src/resources/usage/resourceUsage.service.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.ts
@@ -8,6 +8,7 @@ import {
   ResourceType,
   ResourceUsage,
   ResourceUsageAction,
+  SupervisionMode,
   User,
 } from '@attraccess/database-entities';
 import { StartUsageSessionDto } from './dtos/startUsageSession.dto';
@@ -22,6 +23,7 @@ import {
   ResourceUsageEvent,
   ResourceUsageTakenOverEvent,
   ResourceUsageNoteAddedEvent,
+  SupervisedUsageStartedEvent,
 } from './events/resource-usage.events';
 import { ResourceIntroductionsService } from '../introductions/resouceIntroductions.service';
 import { ResourceIntroducersService } from '../introducers/resourceIntroducers.service';
@@ -44,6 +46,14 @@ export interface EndSessionOptions {
   skipFormSubmissions?: boolean;
   /** Skip emitting ResourceUsageNoteAddedEvent (used when the note is auto-generated, e.g. flow-ended). */
   skipNoteNotification?: boolean;
+}
+
+export interface StartSessionOptions {
+  /**
+   * When set, the session is started as a supervised session attributed to this supervisor.
+   * The supervisor is validated against the resource (introducer/maintainer or canManageResources).
+   */
+  supervisorUserId?: number;
 }
 
 @Injectable()
@@ -77,6 +87,8 @@ export class ResourceUsageService {
     private readonly resourceRepository: Repository<Resource>,
     @InjectRepository(ResourceUsage)
     private readonly resourceUsageRepository: Repository<ResourceUsage>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     private readonly resourceIntroductionService: ResourceIntroductionsService,
     private readonly resourceIntroducersService: ResourceIntroducersService,
     private readonly resourceGroupsIntroductionsService: ResourceGroupsIntroductionsService,
@@ -154,6 +166,67 @@ export class ResourceUsageService {
 
     this.logger.debug(`User ${user.id} cannot control resource ${resourceId}`);
     return false;
+  }
+
+  /**
+   * Validates that a supervised start is permissible for the given resource and supervisor.
+   *
+   * Throws when:
+   * - the resource does not allow supervision (supervisionMode is INTRODUCTION_REQUIRED),
+   * - the requester selected themselves as supervisor,
+   * - the supervisor does not exist,
+   * - the supervisor is neither an introducer/maintainer for the resource nor a global resource manager.
+   *
+   * Does NOT check the requester's own introduction status: a supervised start exists precisely to
+   * let a non-introduced user start under a qualified supervisor.
+   */
+  public async validateSupervisedStart(
+    resourceId: number,
+    requester: User,
+    supervisorUserId: number,
+    transactionalEntityManager?: EntityManager,
+    preloadedResource?: Resource,
+  ): Promise<void> {
+    const resourceRepository = transactionalEntityManager
+      ? transactionalEntityManager.getRepository(Resource)
+      : this.resourceRepository;
+
+    const resource = preloadedResource ?? (await resourceRepository.findOne({ where: { id: resourceId } }));
+    if (!resource) {
+      throw new ResourceNotFoundException(resourceId);
+    }
+
+    if (
+      resource.supervisionMode !== SupervisionMode.SUPERVISION_ALLOWED &&
+      resource.supervisionMode !== SupervisionMode.SUPERVISION_REQUIRED
+    ) {
+      throw new BadRequestException('This resource does not support supervised sessions');
+    }
+
+    if (supervisorUserId === requester.id) {
+      throw new BadRequestException('You cannot supervise your own session');
+    }
+
+    const userRepository = transactionalEntityManager
+      ? transactionalEntityManager.getRepository(User)
+      : this.userRepository;
+
+    const supervisor = await userRepository.findOne({ where: { id: supervisorUserId } });
+    if (!supervisor) {
+      throw new NotFoundException(`Supervisor with ID ${supervisorUserId} not found`);
+    }
+
+    const supervisorCanManage = supervisor.systemPermissions?.canManageResources === true;
+    const supervisorCanMaintain = await this.resourceIntroducersService.canMaintain(
+      resourceId,
+      supervisorUserId,
+      true,
+      transactionalEntityManager,
+    );
+
+    if (!supervisorCanManage && !supervisorCanMaintain) {
+      throw new ForbiddenException('The selected supervisor is not authorized to supervise this resource');
+    }
   }
 
   private async getResource(
@@ -285,8 +358,15 @@ export class ResourceUsageService {
     return flowPayload;
   }
 
-  async startSession(resourceId: number, user: User, dto: StartUsageSessionDto): Promise<ResourceUsage> {
-    this.logger.debug(`Starting session for resource ${resourceId} by user ${user.id}`, { dto });
+  async startSession(
+    resourceId: number,
+    user: User,
+    dto: StartUsageSessionDto,
+    options: StartSessionOptions = {},
+  ): Promise<ResourceUsage> {
+    this.logger.debug(`Starting session for resource ${resourceId} by user ${user.id}`, { dto, options });
+
+    const supervisorUserId = options.supervisorUserId ?? null;
 
     // Defer event emission until after the transaction commits to avoid stale reads in listeners
     let endedUsageIdToEmit: number | null = null;
@@ -294,15 +374,34 @@ export class ResourceUsageService {
     let takeoverEndedUser: User | null = null;
 
     const newSession = await this.resourceUsageRepository.manager.transaction(async (transactionalEntityManager) => {
+      // Maintenance/health are enforced here; the control gate is applied below so the supervised
+      // path can bypass the introduction requirement when a qualified supervisor is present.
       const resource = await this.getResource(
         resourceId,
         user,
         {
           checkMaintenance: true,
-          checkControlPermission: true,
+          checkControlPermission: false,
         },
         transactionalEntityManager,
       );
+
+      // Gate: the solo path stays identical to today's behavior. Only when the user cannot start
+      // solo (or the resource mandates supervision) does the supervised path apply.
+      if (supervisorUserId === null) {
+        const userCanControl = await this.canControllResource(resourceId, user, transactionalEntityManager);
+        if (!userCanControl) {
+          this.logger.warn(`User ${user.id} cannot control resource ${resourceId} - missing introduction`);
+          throw new BadRequestException('You must complete the resource introduction before using it');
+        }
+        if (resource.supervisionMode === SupervisionMode.SUPERVISION_REQUIRED) {
+          throw new BadRequestException(
+            'This resource requires a supervisor; request a supervised session instead',
+          );
+        }
+      } else {
+        await this.validateSupervisedStart(resourceId, user, supervisorUserId, transactionalEntityManager, resource);
+      }
 
       if (resource.type !== ResourceType.Machine) {
         throw new BadRequestException('Resource is not a machine');
@@ -363,6 +462,10 @@ export class ResourceUsageService {
         endNotes: null,
         isFinalized: false,
       };
+
+      if (supervisorUserId !== null) {
+        usageData.supervisorUserId = supervisorUserId;
+      }
 
       if (dto.projectId !== undefined) {
         const project = await this.projectsService.findOneById(user.id, dto.projectId);
@@ -469,6 +572,15 @@ export class ResourceUsageService {
     }
     this.emitSystemUsageEvent(SystemEvent.RESOURCE_USAGE_STARTED, newSession?.resource, newSession?.user);
 
+    // Counter signal for the supervised-usage auto-promotion follow-up (ATT-486): every supervised
+    // session start is counted there to decide when to auto-create an introduction for the user.
+    if (supervisorUserId !== null && newSession?.id) {
+      this.eventEmitter.emit(
+        SupervisedUsageStartedEvent.EVENT_NAME,
+        new SupervisedUsageStartedEvent(resourceId, user.id, supervisorUserId, newSession.id),
+      );
+    }
+
     this.metricsService.resourceUsageSessionsTotal.inc({ action: 'start' });
     this.metricsService.resourceUsageSessionsActive.inc();
 
@@ -505,8 +617,10 @@ export class ResourceUsageService {
     // Check if the user is authorized to end the session
     const canManageResources = user.systemPermissions?.canManageResources || false;
     const isSessionOwner = activeSession.user.id === user.id;
+    // The supervisor of a supervised session may end it as well.
+    const isSupervisor = activeSession.supervisorUserId != null && activeSession.supervisorUserId === user.id;
 
-    if (!isSessionOwner && !canManageResources) {
+    if (!isSessionOwner && !isSupervisor && !canManageResources) {
       const canMaintain = await this.resourceIntroducersService.canMaintain(activeSession.resourceId, user.id, true);
       if (!canMaintain) {
         this.logger.warn(


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Implements the backend for **supervised usage sessions** (ATT-487). The normal start flow stays identical for users who can already start solo — a supervisor step is only added when there is no valid introduction and the resource allows supervision.

## Gate logic (`resourceUsage.service.ts`)
- `startSession` now accepts `StartSessionOptions.supervisorUserId`.
- **Solo path** unchanged. `SUPERVISION_REQUIRED` blocks a solo start (even for introduced users) and directs the user to the supervised flow.
- **Supervised path** (new `validateSupervisedStart`): allowed only when `supervisionMode ∈ {SUPERVISION_ALLOWED, SUPERVISION_REQUIRED}`; supervisor must not be the requester, must exist, and must be an introducer/maintainer for the resource **or** have `canManageResources`. On success the session records `ResourceUsage.supervisorUserId`.

## Approval lifecycle (`supervision/`)
- `SupervisionService`: in-memory, short-lived approval requests (no persistent entity). A request is delivered to the supervisor in realtime over SSE and **auto-expires after 30s** (requester gets a `408`).
- On approval within 30s the session starts via the existing `startSession` path with the supervisor attached; rejection fails the requester with `403`.
- **Multiple parallel requests per supervisor are allowed** (no limit).
- `SupervisionLiveService`: per-supervisor SSE channel mirroring the messaging/billing live-notification pattern.
- Endpoints (Swagger-documented): `POST /resources/:resourceId/usage/supervision/request`, `POST /resources/supervision/requests/:requestId/approve`, `POST /resources/supervision/requests/:requestId/reject`, `GET /resources/supervision/requests`, `SSE /resources/supervision/requests/live`.

## Misc
- `endSession`: the session's supervisor may now end it.
- Emits `SupervisedUsageStartedEvent` as the auto-promotion counter signal for the ATT-486 follow-up.
- No DB migration needed — `supervisorUserId`/`supervisionMode` columns already shipped with ATT-486.

## Testing
- `tsc --noEmit` (api app) and eslint clean; full api `lint build test e2e` passed via the pre-commit hook.
- Unit tests: supervised gate (self-supervision, unauthorized supervisor, unknown supervisor, mode rules, `SUPERVISION_REQUIRED` solo block, supervisor-via-`canManageResources`), endSession-by-supervisor, and the full approval lifecycle (approve, reject, **30s timeout**, wrong supervisor, unknown request, failed start, parallel requests). 49 + 8 tests green.

## Linear
https://linear.app/attraccess/issue/ATT-487/p1-backend-supervised-start-flow-supervisor-approval-30s-expiry

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
