### PR TITLE
feat(ATT-490): display Supervised by in active session, history & CSV export

### DIFF
--- a/apps/api/src/analytics/analytics.service.spec.ts
+++ b/apps/api/src/analytics/analytics.service.spec.ts
@@ -77,7 +77,7 @@ describe('AnalyticsService', () => {
           userId: 'DESC',
           startTime: 'DESC',
         },
-        relations: ['user', 'resource'],
+        relations: ['user', 'resource', 'supervisorUser'],
       });
 
       expect(result).toEqual(expectedResourceUsage);
@@ -102,7 +102,7 @@ describe('AnalyticsService', () => {
           userId: 'DESC',
           startTime: 'DESC',
         },
-        relations: ['user', 'resource'],
+        relations: ['user', 'resource', 'supervisorUser'],
       });
 
       expect(result).toEqual([]);

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -23,7 +23,7 @@ export class AnalyticsService {
         id: 'DESC',
         userId: 'DESC',
       },
-      relations: ['user', 'resource'],
+      relations: ['user', 'resource', 'supervisorUser'],
     };
 
     return await this.resourceUsageRepository.find(findOptions);

--- a/apps/api/src/resources/usage/resourceUsage.service.spec.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.spec.ts
@@ -903,7 +903,7 @@ describe('ResourceUsageService', () => {
           endTime: IsNull(),
           isFinalized: true,
         },
-        relations: ['user', 'resource', 'billingTransaction', 'project'],
+        relations: ['user', 'resource', 'billingTransaction', 'project', 'supervisorUser'],
       });
     });
 

--- a/apps/api/src/resources/usage/resourceUsage.service.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.ts
@@ -751,7 +751,7 @@ export class ResourceUsageService {
         endTime: IsNull(),
         isFinalized: onlyFinalized ? true : undefined,
       },
-      relations: ['user', 'resource', 'billingTransaction', 'project'],
+      relations: ['user', 'resource', 'billingTransaction', 'project', 'supervisorUser'],
     });
   }
 
@@ -774,7 +774,7 @@ export class ResourceUsageService {
       skip: (page - 1) * limit,
       take: limit,
       order: { startTime: 'DESC' },
-      relations: ['user', 'project', 'formSubmissions', 'formSubmissions.form', 'formSubmissions.user'],
+      relations: ['user', 'project', 'supervisorUser', 'formSubmissions', 'formSubmissions.form', 'formSubmissions.user'],
     });
 
     this.logger.debug(`Found ${data.length} usage records out of ${total} total for resource ${resourceId}`);

--- a/apps/frontend/src/app/csv-export/resource-usage/de.json
+++ b/apps/frontend/src/app/csv-export/resource-usage/de.json
@@ -14,6 +14,8 @@
     "usageInMinutes": "Nutzung in Minuten",
     "usageInHours": "Nutzung in Stunden",
     "startNotes": "Start-Notizen",
-    "endNotes": "End-Notizen"
+    "endNotes": "End-Notizen",
+    "supervisorId": "Aufsicht-ID",
+    "supervisorUsername": "Aufsicht-Name"
   }
 }

--- a/apps/frontend/src/app/csv-export/resource-usage/en.json
+++ b/apps/frontend/src/app/csv-export/resource-usage/en.json
@@ -14,6 +14,8 @@
     "usageInMinutes": "Usage in Minutes",
     "usageInHours": "Usage in Hours",
     "startNotes": "Start Notes",
-    "endNotes": "End Notes"
+    "endNotes": "End Notes",
+    "supervisorId": "Supervisor ID",
+    "supervisorUsername": "Supervisor Name"
   }
 }

--- a/apps/frontend/src/app/csv-export/resource-usage/index.tsx
+++ b/apps/frontend/src/app/csv-export/resource-usage/index.tsx
@@ -112,6 +112,16 @@ export function ResourceUsageExport(props: ExportProps) {
         key: 'endNotes',
         getter: (item) => item.endNotes ?? '',
       },
+      {
+        label: t('columns.supervisorId'),
+        key: 'supervisorId',
+        getter: (item) => item.supervisorUserId ?? '',
+      },
+      {
+        label: t('columns.supervisorUsername'),
+        key: 'supervisorUsername',
+        getter: (item) => item.supervisorUser?.username ?? '',
+      },
     ] as ColumnDefinition<ResourceUsage>[];
   }, [formatUsageDuration, formatDateTimeFull, t]);
 

--- a/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/index.tsx
@@ -10,7 +10,7 @@ import {
 import { Button } from '../../../../../components/button';
 import { buttonVariants } from '@heroui/styles';
 import { StopCircle, ChevronDownIcon } from 'lucide-react';
-import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { useTranslations, AttraccessUser } from '@attraccess/plugins-frontend-ui';
 import { useToastMessage } from '../../../../../components/toastProvider';
 import { SessionTimer } from '../SessionTimer';
 import { SessionNotesModal, SessionModalMode } from '../SessionNotesModal';
@@ -130,6 +130,12 @@ export function ActiveSessionDisplay({ resourceId, startTime }: ActiveSessionDis
             <p className="font-medium text-gray-900 dark:text-white whitespace-nowrap">
               {activeSession.usage.project.name}
             </p>
+          </div>
+        )}
+        {activeSession?.usage?.supervisorUser && (
+          <div>
+            <p className="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">{t('supervisedBy')}:</p>
+            <AttraccessUser user={activeSession.usage.supervisorUser} />
           </div>
         )}
         <SessionTimer startTime={startTime} />

--- a/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/translations/de.json
+++ b/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/translations/de.json
@@ -13,5 +13,6 @@
       "description": "Beenden Sie die Sitzung und geben Sie Notizen an."
     }
   },
-  "project": "Projekt"
+  "project": "Projekt",
+  "supervisedBy": "Beaufsichtigt von"
 }

--- a/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/translations/en.json
+++ b/apps/frontend/src/app/resources/usage/components/ActiveSessionDisplay/translations/en.json
@@ -13,5 +13,6 @@
       "description": "End the session and provide notes."
     }
   },
-  "project": "Project"
+  "project": "Project",
+  "supervisedBy": "Supervised by"
 }

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableHeaders.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableHeaders.tsx
@@ -27,6 +27,9 @@ export function generateHeaderColumns(
       <TableColumn key="project" id="project" className="hidden 2xl:table-cell">
         {t('headers.machine.project')}
       </TableColumn>,
+      <TableColumn key="supervisor" id="supervisor" className="hidden xl:table-cell">
+        {t('headers.machine.supervisor')}
+      </TableColumn>,
     );
   } else if (resource.type === 'door') {
     headers.push(

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableRows.tsx
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/tableRows.tsx
@@ -56,6 +56,13 @@ export function generateRowCells(
       <TableCell key={`project-${session.id}`} className="hidden 2xl:table-cell">
         {projectCellRenderer ? projectCellRenderer(session) : session.project?.name}
       </TableCell>,
+      <TableCell key={`supervisor-${session.id}`} className="hidden xl:table-cell">
+        {session.supervisorUser ? (
+          <AttraccessUser user={session.supervisorUser} />
+        ) : (
+          <span className="text-gray-400 dark:text-gray-500">—</span>
+        )}
+      </TableCell>,
     );
   } else if (resource.type === 'door') {
     cells.push(

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/translations/de.json
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/translations/de.json
@@ -8,7 +8,8 @@
       "startTime": "Startzeit",
       "endTime": "Endzeit",
       "duration": "Dauer",
-      "project": "Projekt"
+      "project": "Projekt",
+      "supervisor": "Aufsicht"
     },
     "door": {
       "time": "Zeit",

--- a/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/translations/en.json
+++ b/apps/frontend/src/app/resources/usage/components/HistoryTable/utils/translations/en.json
@@ -8,7 +8,8 @@
       "startTime": "Start Time",
       "endTime": "End Time",
       "duration": "Duration",
-      "project": "Project"
+      "project": "Project",
+      "supervisor": "Supervisor"
     },
     "door": {
       "time": "Time",

--- a/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/index.tsx
@@ -216,6 +216,13 @@ export function OtherUserSessionDisplay({ resourceId }: OtherUserSessionDisplayP
           ({t('sessionStarted')} <DateTimeDisplay date={activeSession.startTime} />)
         </p>
 
+        {activeSession.supervisorUser && (
+          <div className="space-y-1">
+            <p className="text-sm text-gray-500 dark:text-gray-400">{t('supervisedBy')}:</p>
+            <AttraccessUser user={activeSession.supervisorUser} />
+          </div>
+        )}
+
         <div>
           <Button
             variant="ghost"

--- a/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/translations/de.json
+++ b/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/translations/de.json
@@ -2,6 +2,7 @@
   "resourceInUseBy": "Ressource wird derzeit verwendet von:",
   "unknownUser": "Unbekannter Benutzer",
   "sessionStarted": "Sitzung gestartet",
+  "supervisedBy": "Beaufsichtigt von",
   "contact": {
     "button": "Aktuellen Nutzer kontaktieren",
     "error": "Kontaktaufnahme fehlgeschlagen",

--- a/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/translations/en.json
+++ b/apps/frontend/src/app/resources/usage/components/OtherUserSessionDisplay/translations/en.json
@@ -2,6 +2,7 @@
   "resourceInUseBy": "Resource currently in use by:",
   "unknownUser": "Unknown User",
   "sessionStarted": "Session Started",
+  "supervisedBy": "Supervised by",
   "contact": {
     "button": "Contact current user",
     "error": "Could not contact user",


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Makes the session **supervisor** visible across the resource-usage UI ([ATT-490](https://linear.app/attraccess/issue/ATT-490/p1-frontend-display-supervised-by-in-active-session-historyaudit)).

### Changes
- **Active session** — `ActiveSessionDisplay` (own session) and `OtherUserSessionDisplay` (other user's session) now show **"Supervised by"** with the supervisor rendered via `AttraccessUser`, only when a supervisor is set.
- **Usage history** — `HistoryTable` gains a **Supervisor** column for machine sessions (`utils/tableHeaders.tsx`, `utils/tableRows.tsx`); empty sessions show an em-dash.
- **CSV export** — resource-usage export adds **Supervisor ID** + **Supervisor Name** columns.
- **i18n** — de/en translations for all of the above.
- **API (read path)** — `getActiveSession`, `getResourceUsageHistory`, and analytics `getResourceUsageHoursInDateRange` now load the `supervisorUser` relation so the field reaches the generated client. The `supervisorUser`/`supervisorUserId` fields themselves already exist on the entity (ATT-486).

### Notes
- No code path sets `supervisorUserId` yet — that arrives with the supervised start flow (ATT-487). This PR is the display layer; it renders the supervisor whenever the field is populated.
- Generated `react-query-client` is gitignored and regenerated in CI from swagger.

### Testing
- `nx typecheck` (frontend, react-query-client) ✓
- `nx lint` (api, frontend) ✓ (1 pre-existing unrelated warning)
- `nx test api frontend` ✓ (1298 api tests pass; updated 3 specs that assert the relations arrays)
- Browser verification with screenshots posted to the Linear issue.

Closes ATT-490.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
