### PR TITLE
ci(ATT-535): build plugin zips only when plugins affected in PR pipeline

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -79,13 +79,30 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-      - name: Lint plugin apps
-        run: pnpm nx run-many --target=lint --parallel=3 --projects=tag:type:plugin
-      - name: Build + zip plugin apps
-        run: pnpm nx run-many --target=package --parallel=3 --projects=tag:type:plugin
+
+      - name: Determine affected plugins
+        id: affected
+        run: |
+          set -euo pipefail
+          PROJECTS="$(pnpm nx show projects --affected --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:type:plugin --withTarget=package --json 2>/dev/null | jq -r 'join(",")')"
+          if [[ -z "$PROJECTS" ]]; then
+            echo "has_plugins=false" >> "$GITHUB_OUTPUT"
+            echo "No plugin projects affected by this PR."
+          else
+            echo "has_plugins=true" >> "$GITHUB_OUTPUT"
+            echo "projects=$PROJECTS" >> "$GITHUB_OUTPUT"
+            echo "Affected plugins: $PROJECTS"
+          fi
+
+      - name: Lint affected plugin apps
+        if: steps.affected.outputs.has_plugins == 'true'
+        run: pnpm nx run-many --target=lint --parallel=3 --projects=${{ steps.affected.outputs.projects }}
+      - name: Build + zip affected plugin apps
+        if: steps.affected.outputs.has_plugins == 'true'
+        run: pnpm nx run-many --target=package --parallel=3 --projects=${{ steps.affected.outputs.projects }}
 
       - name: Collect plugin ZIPs into a flat directory
-        if: always()
+        if: always() && steps.affected.outputs.has_plugins == 'true'
         run: |
           set -euo pipefail
           shopt -s nullglob globstar
@@ -96,7 +113,7 @@ jobs:
 
       - name: Upload plugin ZIPs
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && steps.affected.outputs.has_plugins == 'true'
         with:
           name: plugins-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
           path: dist/plugin-zips/*.zip
@@ -115,17 +132,21 @@ jobs:
             echo ""
             echo "Commit \`${{ github.event.pull_request.head.sha }}\` · workflow run [\`${{ github.run_id }}\`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
             echo ""
-            found=false
-            for zip in dist/plugin-zips/*.zip; do
-              found=true
-              size="$(du -h "$zip" | cut -f1)"
-              echo "- \`$(basename "$zip")\` (${size})"
-            done
-            if [ "$found" = false ]; then
-              echo "_No plugin ZIPs were produced for this PR._"
+            if [[ "${{ steps.affected.outputs.has_plugins }}" != "true" ]]; then
+              echo "_No plugin changes detected in this PR — skipped plugin build._"
             else
-              echo ""
-              echo "Download the ZIPs from the [workflow artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+              found=false
+              for zip in dist/plugin-zips/*.zip; do
+                found=true
+                size="$(du -h "$zip" | cut -f1)"
+                echo "- \`$(basename "$zip")\` (${size})"
+              done
+              if [ "$found" = false ]; then
+                echo "_No plugin ZIPs were produced for this PR._"
+              else
+                echo ""
+                echo "Download the ZIPs from the [workflow artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+              fi
             fi
           } > "$out"
           {

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -80,29 +80,17 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
 
-      - name: Determine affected plugins
-        id: affected
-        run: |
-          set -euo pipefail
-          PROJECTS="$(pnpm nx show projects --affected --base=origin/${{ github.event.pull_request.base.ref }} --projects=tag:type:plugin --withTarget=package --json 2>/dev/null | jq -r 'join(",")')"
-          if [[ -z "$PROJECTS" ]]; then
-            echo "has_plugins=false" >> "$GITHUB_OUTPUT"
-            echo "No plugin projects affected by this PR."
-          else
-            echo "has_plugins=true" >> "$GITHUB_OUTPUT"
-            echo "projects=$PROJECTS" >> "$GITHUB_OUTPUT"
-            echo "Affected plugins: $PROJECTS"
-          fi
-
+      # Only affected plugins are linted/packaged. The `*,!tag:type:plugin`
+      # exclude keeps the affected set restricted to plugin apps, so a PR that
+      # touches no plugin (or shared global) runs nothing here.
       - name: Lint affected plugin apps
-        if: steps.affected.outputs.has_plugins == 'true'
-        run: pnpm nx run-many --target=lint --parallel=3 --projects=${{ steps.affected.outputs.projects }}
+        run: pnpm nx affected --target=lint --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --exclude='*,!tag:type:plugin'
       - name: Build + zip affected plugin apps
-        if: steps.affected.outputs.has_plugins == 'true'
-        run: pnpm nx run-many --target=package --parallel=3 --projects=${{ steps.affected.outputs.projects }}
+        run: pnpm nx affected --target=package --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --exclude='*,!tag:type:plugin'
 
       - name: Collect plugin ZIPs into a flat directory
-        if: always() && steps.affected.outputs.has_plugins == 'true'
+        id: collect
+        if: always()
         run: |
           set -euo pipefail
           shopt -s nullglob globstar
@@ -110,10 +98,18 @@ jobs:
           for zip in apps/plugins/**/dist/*.zip; do
             cp "$zip" dist/plugin-zips/
           done
+          zips=(dist/plugin-zips/*.zip)
+          if [[ ${#zips[@]} -gt 0 ]]; then
+            echo "has_plugins=true" >> "$GITHUB_OUTPUT"
+            echo "Collected ${#zips[@]} plugin ZIP(s)."
+          else
+            echo "has_plugins=false" >> "$GITHUB_OUTPUT"
+            echo "No plugin ZIPs produced — no plugins affected by this PR."
+          fi
 
       - name: Upload plugin ZIPs
         uses: actions/upload-artifact@v4
-        if: always() && steps.affected.outputs.has_plugins == 'true'
+        if: always() && steps.collect.outputs.has_plugins == 'true'
         with:
           name: plugins-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
           path: dist/plugin-zips/*.zip
@@ -132,21 +128,15 @@ jobs:
             echo ""
             echo "Commit \`${{ github.event.pull_request.head.sha }}\` · workflow run [\`${{ github.run_id }}\`](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
             echo ""
-            if [[ "${{ steps.affected.outputs.has_plugins }}" != "true" ]]; then
+            if [[ "${{ steps.collect.outputs.has_plugins }}" != "true" ]]; then
               echo "_No plugin changes detected in this PR — skipped plugin build._"
             else
-              found=false
               for zip in dist/plugin-zips/*.zip; do
-                found=true
                 size="$(du -h "$zip" | cut -f1)"
                 echo "- \`$(basename "$zip")\` (${size})"
               done
-              if [ "$found" = false ]; then
-                echo "_No plugin ZIPs were produced for this PR._"
-              else
-                echo ""
-                echo "Download the ZIPs from the [workflow artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
-              fi
+              echo ""
+              echo "Download the ZIPs from the [workflow artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})."
             fi
           } > "$out"
           {


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

The PR pipeline's `plugins` job previously ran `nx run-many --projects=tag:type:plugin` on every PR, building and zipping all plugin apps regardless of what changed. This switches it to an **nx affected** approach so plugins are only built and attached when a plugin (or a shared global) is actually affected by the PR.

## Changes (`.github/workflows/pull-requests.yml`)

- New **Determine affected plugins** step computes affected plugin projects via `nx show projects --affected --base=origin/<base> --projects=tag:type:plugin --withTarget=package --json`, parsed with `jq`. Sets `has_plugins` + comma-separated `projects` outputs.
- **Lint** and **Build + zip** steps now run `nx run-many` against only the affected plugin list, gated on `has_plugins == 'true'`.
- **Collect ZIPs** and **Upload artifact** steps gated on `has_plugins == 'true'`.
- **Sticky PR comment** still always posts; shows `_No plugin changes detected in this PR — skipped plugin build._` when no plugins are affected, keeping the comment accurate across pushes.

The release pipeline (`release.yml`) is intentionally left building all plugins — releases should always ship every plugin.

## Notes

- `pull-requests.yml` is listed in `nx.json` `sharedGlobals`, so editing it marks all projects affected — this PR will exercise the new plugin path itself.
- Uses the same `--base=origin/${{ github.event.pull_request.base.ref }}` pattern as the existing affected lint/test jobs.

## Testing

- Validated YAML parses and all jobs present.
- Verified locally: `nx show projects --affected --projects=tag:type:plugin --withTarget=package --json | jq -r 'join(",")'` returns `plugin-rabbitmq` when affected and empty string when nothing matches.

Linear: [ATT-535](https://linear.app/attraccess/issue/ATT-535/pr-pipeline-should-only-build-and-attach-plugin-zip-files-when-plugins)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->