### PR TITLE
feat(resources): supervision mode + auto-promotion settings (ATT-491)

### DIFF
--- a/apps/api/src/resources/dtos/createResource.dto.ts
+++ b/apps/api/src/resources/dtos/createResource.dto.ts
@@ -1,7 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsOptional, MinLength, IsEnum, IsUrl, ValidateIf, IsBoolean, IsObject, IsInt, Min } from 'class-validator';
 import { FileUpload } from '../../common/types/file-upload.types';
-import { DocumentationType, ResourceType } from '@attraccess/database-entities';
+import {
+  AutoIntroductionTarget,
+  DocumentationType,
+  ResourceType,
+  SupervisionMode,
+} from '@attraccess/database-entities';
 import { ToBoolean, ToJson, ToNumber } from '../../common/request-transformers';
 
 export class CreateResourceDto {
@@ -148,4 +153,57 @@ export class CreateResourceDto {
   @IsOptional()
   @ToBoolean()
   retrainingBlocksAccess?: boolean;
+
+  @ApiProperty({
+    description: 'Controls who may start a usage session on this resource',
+    required: false,
+    enum: SupervisionMode,
+    enumName: 'SupervisionMode',
+    default: SupervisionMode.INTRODUCTION_REQUIRED,
+    example: SupervisionMode.INTRODUCTION_REQUIRED,
+  })
+  @IsEnum(SupervisionMode)
+  @IsOptional()
+  supervisionMode?: SupervisionMode;
+
+  @ApiProperty({
+    description:
+      'Automatically create an introduction after this many supervised sessions. Null disables auto-promotion.',
+    required: false,
+    nullable: true,
+    example: 3,
+    type: Number,
+  })
+  @ToNumber()
+  @ValidateIf((o) => o.supervisedUsagesUntilIntroduction !== null && o.supervisedUsagesUntilIntroduction !== undefined)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  supervisedUsagesUntilIntroduction?: number | null;
+
+  @ApiProperty({
+    description: 'Target of the auto-created introduction once the supervised-usage threshold is reached',
+    required: false,
+    nullable: true,
+    enum: AutoIntroductionTarget,
+    enumName: 'AutoIntroductionTarget',
+    example: AutoIntroductionTarget.RESOURCE,
+  })
+  @IsEnum(AutoIntroductionTarget)
+  @IsOptional()
+  autoIntroductionTarget?: AutoIntroductionTarget | null;
+
+  @ApiProperty({
+    description: 'The group the auto-introduction targets when autoIntroductionTarget is GROUP',
+    required: false,
+    nullable: true,
+    example: 1,
+    type: Number,
+  })
+  @ToNumber()
+  @ValidateIf((o) => o.autoIntroductionGroupId !== null && o.autoIntroductionGroupId !== undefined)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  autoIntroductionGroupId?: number | null;
 }

--- a/apps/api/src/resources/dtos/updateResource.dto.ts
+++ b/apps/api/src/resources/dtos/updateResource.dto.ts
@@ -1,7 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsOptional, IsEnum, IsUrl, ValidateIf, IsBoolean, IsObject, IsInt, Min } from 'class-validator';
 import { FileUpload } from '../../common/types/file-upload.types';
-import { DocumentationType, ResourceType } from '@attraccess/database-entities';
+import {
+  AutoIntroductionTarget,
+  DocumentationType,
+  ResourceType,
+  SupervisionMode,
+} from '@attraccess/database-entities';
 import { ToBoolean, ToJson, ToNumber } from '../../common/request-transformers';
 
 export class UpdateResourceDto {
@@ -160,4 +165,56 @@ export class UpdateResourceDto {
   @ToBoolean()
   @IsOptional()
   retrainingBlocksAccess?: boolean;
+
+  @ApiProperty({
+    description: 'Controls who may start a usage session on this resource',
+    required: false,
+    enum: SupervisionMode,
+    enumName: 'SupervisionMode',
+    example: SupervisionMode.INTRODUCTION_REQUIRED,
+  })
+  @IsEnum(SupervisionMode)
+  @IsOptional()
+  supervisionMode?: SupervisionMode;
+
+  @ApiProperty({
+    description:
+      'Automatically create an introduction after this many supervised sessions. Null disables auto-promotion.',
+    required: false,
+    nullable: true,
+    example: 3,
+    type: Number,
+  })
+  @ToNumber()
+  @ValidateIf((o) => o.supervisedUsagesUntilIntroduction !== null && o.supervisedUsagesUntilIntroduction !== undefined)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  supervisedUsagesUntilIntroduction?: number | null;
+
+  @ApiProperty({
+    description: 'Target of the auto-created introduction once the supervised-usage threshold is reached',
+    required: false,
+    nullable: true,
+    enum: AutoIntroductionTarget,
+    enumName: 'AutoIntroductionTarget',
+    example: AutoIntroductionTarget.RESOURCE,
+  })
+  @IsEnum(AutoIntroductionTarget)
+  @IsOptional()
+  autoIntroductionTarget?: AutoIntroductionTarget | null;
+
+  @ApiProperty({
+    description: 'The group the auto-introduction targets when autoIntroductionTarget is GROUP',
+    required: false,
+    nullable: true,
+    example: 1,
+    type: Number,
+  })
+  @ToNumber()
+  @ValidateIf((o) => o.autoIntroductionGroupId !== null && o.autoIntroductionGroupId !== undefined)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  autoIntroductionGroupId?: number | null;
 }

--- a/apps/api/src/resources/resources.service.spec.ts
+++ b/apps/api/src/resources/resources.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ResourcesService } from './resources.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Resource, DocumentationType, ResourceType } from '@attraccess/database-entities';
+import { Resource, DocumentationType, ResourceType, SupervisionMode } from '@attraccess/database-entities';
 import { Repository, SelectQueryBuilder, Brackets } from 'typeorm';
 import { CreateResourceDto } from './dtos/createResource.dto';
 import { UpdateResourceDto } from './dtos/updateResource.dto';
@@ -535,6 +535,10 @@ describe('ResourcesService', () => {
         retrainingMaxAgeDays: createDto.retrainingMaxAgeDays ?? null,
         retrainingMaxInactivityDays: createDto.retrainingMaxInactivityDays ?? null,
         retrainingBlocksAccess: createDto.retrainingBlocksAccess ?? false,
+        supervisionMode: SupervisionMode.INTRODUCTION_REQUIRED,
+        supervisedUsagesUntilIntroduction: null,
+        autoIntroductionTarget: null,
+        autoIntroductionGroupId: null,
       });
       expect(resourceRepository.save).toHaveBeenCalled();
     });

--- a/apps/api/src/resources/resources.service.ts
+++ b/apps/api/src/resources/resources.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable, Logger, ForbiddenException, Inject } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In, Brackets } from 'typeorm';
-import { Resource } from '@attraccess/database-entities';
+import { Resource, SupervisionMode } from '@attraccess/database-entities';
 import { CreateResourceDto } from './dtos/createResource.dto';
 import { UpdateResourceDto } from './dtos/updateResource.dto';
 import { PaginatedResponse } from '../types/response';
@@ -57,6 +57,10 @@ export class ResourcesService {
       retrainingMaxAgeDays: dto.retrainingMaxAgeDays ?? null,
       retrainingMaxInactivityDays: dto.retrainingMaxInactivityDays ?? null,
       retrainingBlocksAccess: dto.retrainingBlocksAccess ?? false,
+      supervisionMode: dto.supervisionMode ?? SupervisionMode.INTRODUCTION_REQUIRED,
+      supervisedUsagesUntilIntroduction: dto.supervisedUsagesUntilIntroduction ?? null,
+      autoIntroductionTarget: dto.autoIntroductionTarget ?? null,
+      autoIntroductionGroupId: dto.autoIntroductionGroupId ?? null,
     });
 
     // Save the resource first to get an ID
@@ -124,6 +128,13 @@ export class ResourcesService {
     if (dto.retrainingMaxInactivityDays !== undefined)
       resource.retrainingMaxInactivityDays = dto.retrainingMaxInactivityDays;
     if (dto.retrainingBlocksAccess !== undefined) resource.retrainingBlocksAccess = dto.retrainingBlocksAccess;
+
+    // Supervision + auto-promotion settings
+    if (dto.supervisionMode !== undefined) resource.supervisionMode = dto.supervisionMode;
+    if (dto.supervisedUsagesUntilIntroduction !== undefined)
+      resource.supervisedUsagesUntilIntroduction = dto.supervisedUsagesUntilIntroduction;
+    if (dto.autoIntroductionTarget !== undefined) resource.autoIntroductionTarget = dto.autoIntroductionTarget;
+    if (dto.autoIntroductionGroupId !== undefined) resource.autoIntroductionGroupId = dto.autoIntroductionGroupId;
 
     if (image && dto.deleteImage) {
       throw new BadRequestException('Image and deleteImage cannot be used together');

--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.de.json
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.de.json
@@ -66,6 +66,47 @@
         "label": "Zugriff bis zur Nachschulung sperren",
         "description": "Wenn aktiviert, verlieren Benutzer den Zugriff, sobald die Nachschulung fällig ist, bis ein Einweiser sie nachschult."
       }
+    },
+    "supervision": {
+      "sectionTitle": "Beaufsichtigung",
+      "description": "Legen Sie fest, wer eine Nutzungssitzung an dieser Ressource starten darf.",
+      "mode": {
+        "label": "Beaufsichtigungsmodus",
+        "options": {
+          "introduction_required": {
+            "label": "Einweisung erforderlich",
+            "description": "Nur eingewiesene Benutzer dürfen eine Sitzung starten. Dies ist das Standardverhalten."
+          },
+          "supervision_allowed": {
+            "label": "Beaufsichtigung erlaubt",
+            "description": "Eingewiesene Benutzer dürfen selbst starten; nicht eingewiesene Benutzer nur, wenn eine Aufsicht anwesend ist."
+          },
+          "supervision_required": {
+            "label": "Beaufsichtigung erforderlich",
+            "description": "Jede Sitzung erfordert eine anwesende Aufsicht, auch für eingewiesene Benutzer."
+          }
+        }
+      },
+      "autoPromotion": {
+        "sectionTitle": "Automatische Einweisung",
+        "description": "Erteilt automatisch eine Einweisung, sobald ein Benutzer genügend beaufsichtigte Sitzungen absolviert hat.",
+        "disabledPlaceholder": "Deaktiviert",
+        "threshold": {
+          "label": "Beaufsichtigte Sitzungen bis zur Einweisung",
+          "description": "Nach so vielen beaufsichtigten Sitzungen wird der Benutzer automatisch eingewiesen. Leer lassen, um die automatische Einweisung zu deaktivieren."
+        },
+        "target": {
+          "label": "Einweisung erteilen für",
+          "options": {
+            "resource": "Diese Ressource",
+            "group": "Eine Ressourcengruppe"
+          }
+        },
+        "group": {
+          "label": "Ressourcengruppe",
+          "placeholder": "Gruppe auswählen"
+        }
+      }
     }
   },
   "create": {

--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.en.json
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.en.json
@@ -65,6 +65,47 @@
         "label": "Block access until retrained",
         "description": "If enabled, users lose access once retraining is due until an introducer retrains them."
       }
+    },
+    "supervision": {
+      "sectionTitle": "Supervision",
+      "description": "Control who may start a usage session on this resource.",
+      "mode": {
+        "label": "Supervision mode",
+        "options": {
+          "introduction_required": {
+            "label": "Introduction required",
+            "description": "Only introduced users may start a session. This is the default behavior."
+          },
+          "supervision_allowed": {
+            "label": "Supervision allowed",
+            "description": "Introduced users may start a session on their own; users without an introduction may start one while a supervisor is present."
+          },
+          "supervision_required": {
+            "label": "Supervision required",
+            "description": "Every session requires a present supervisor, even for introduced users."
+          }
+        }
+      },
+      "autoPromotion": {
+        "sectionTitle": "Auto-promotion to introduction",
+        "description": "Automatically grant an introduction after a user has completed enough supervised sessions.",
+        "disabledPlaceholder": "Disabled",
+        "threshold": {
+          "label": "Supervised sessions until introduction",
+          "description": "After this many supervised sessions the user is auto-introduced. Leave empty to disable auto-promotion."
+        },
+        "target": {
+          "label": "Grant introduction for",
+          "options": {
+            "resource": "This resource",
+            "group": "A resource group"
+          }
+        },
+        "group": {
+          "label": "Resource group",
+          "placeholder": "Select a group"
+        }
+      }
     }
   },
   "create": {

--- a/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
+++ b/apps/frontend/src/app/resources/editModal/resourceEditModal.tsx
@@ -23,6 +23,7 @@ import {
   useResourcesServiceCreateOneResource,
   ResourceType,
   useResourcesServiceGetAllResourcesKey,
+  SupervisionMode,
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToastMessage } from '../../../components/toastProvider';
@@ -31,6 +32,7 @@ import { SharedDataTab } from './tabs/shared';
 import { MachineTab } from './tabs/machine';
 import { DoorTab } from './tabs/door';
 import { RetrainingTab } from './tabs/retraining';
+import { SupervisionTab } from './tabs/supervision';
 import { ResourceMetadataEditor } from './resourceMetadataEditor';
 
 type ResourceFormData = Omit<UpdateResourceDto, 'metadata'> & {
@@ -66,6 +68,10 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
     retrainingMaxAgeDays: null,
     retrainingMaxInactivityDays: null,
     retrainingBlocksAccess: false,
+    supervisionMode: SupervisionMode.INTRODUCTION_REQUIRED,
+    supervisedUsagesUntilIntroduction: null,
+    autoIntroductionTarget: null,
+    autoIntroductionGroupId: null,
     metadata: {} as Record<string, unknown>,
   });
 
@@ -158,6 +164,10 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
       retrainingMaxAgeDays: resource?.retrainingMaxAgeDays ?? null,
       retrainingMaxInactivityDays: resource?.retrainingMaxInactivityDays ?? null,
       retrainingBlocksAccess: resource?.retrainingBlocksAccess ?? false,
+      supervisionMode: resource?.supervisionMode ?? SupervisionMode.INTRODUCTION_REQUIRED,
+      supervisedUsagesUntilIntroduction: resource?.supervisedUsagesUntilIntroduction ?? null,
+      autoIntroductionTarget: resource?.autoIntroductionTarget ?? null,
+      autoIntroductionGroupId: resource?.autoIntroductionGroupId ?? null,
       metadata: (resource?.metadata ?? {}) as Record<string, unknown>,
     });
     setSelectedImage(null);
@@ -194,6 +204,10 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
           retrainingMaxAgeDays: formData.retrainingMaxAgeDays,
           retrainingMaxInactivityDays: formData.retrainingMaxInactivityDays,
           retrainingBlocksAccess: formData.retrainingBlocksAccess,
+          supervisionMode: formData.supervisionMode,
+          supervisedUsagesUntilIntroduction: formData.supervisedUsagesUntilIntroduction,
+          autoIntroductionTarget: formData.autoIntroductionTarget,
+          autoIntroductionGroupId: formData.autoIntroductionGroupId,
           metadata: formData.metadata as Record<string, unknown>,
         },
       });
@@ -211,6 +225,10 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
         retrainingMaxAgeDays: formData.retrainingMaxAgeDays,
         retrainingMaxInactivityDays: formData.retrainingMaxInactivityDays,
         retrainingBlocksAccess: formData.retrainingBlocksAccess,
+        supervisionMode: formData.supervisionMode,
+        supervisedUsagesUntilIntroduction: formData.supervisedUsagesUntilIntroduction,
+        autoIntroductionTarget: formData.autoIntroductionTarget,
+        autoIntroductionGroupId: formData.autoIntroductionGroupId,
         metadata: formData.metadata as Record<string, unknown>,
       },
     });
@@ -264,6 +282,11 @@ export function ResourceEditModal(props: ResourceEditModalProps) {
               <div className="flex flex-col gap-2 w-full">
                 <h3 className="text-small font-semibold">{t('inputs.retraining.sectionTitle')}</h3>
                 <RetrainingTab t={t} formData={formData} setField={setField} resource={resource} />
+              </div>
+
+              <div className="flex flex-col gap-2 w-full">
+                <h3 className="text-small font-semibold">{t('inputs.supervision.sectionTitle')}</h3>
+                <SupervisionTab t={t} formData={formData} setField={setField} resource={resource} />
               </div>
 
               <ResourceMetadataEditor

--- a/apps/frontend/src/app/resources/editModal/tabs/supervision.tsx
+++ b/apps/frontend/src/app/resources/editModal/tabs/supervision.tsx
@@ -1,0 +1,168 @@
+import { Label, Radio, RadioGroup, TextField, Input } from '@heroui/react';
+import { AutoIntroductionTarget, SupervisionMode, useResourcesServiceResourceGroupsGetMany } from '@attraccess/react-query-client';
+import { Select } from '../../../../components/select';
+import { EditorTabProps } from './props';
+
+const SUPERVISION_MODES: SupervisionMode[] = [
+  SupervisionMode.INTRODUCTION_REQUIRED,
+  SupervisionMode.SUPERVISION_ALLOWED,
+  SupervisionMode.SUPERVISION_REQUIRED,
+];
+
+export function SupervisionTab(props: EditorTabProps) {
+  const { t, formData, setField } = props;
+
+  const supervisionMode = formData.supervisionMode ?? SupervisionMode.INTRODUCTION_REQUIRED;
+  const supervisionAllowed =
+    supervisionMode === SupervisionMode.SUPERVISION_ALLOWED ||
+    supervisionMode === SupervisionMode.SUPERVISION_REQUIRED;
+
+  const autoPromotionEnabled =
+    formData.supervisedUsagesUntilIntroduction !== null &&
+    formData.supervisedUsagesUntilIntroduction !== undefined;
+
+  const target = formData.autoIntroductionTarget ?? AutoIntroductionTarget.RESOURCE;
+
+  const { data: groups, isLoading: groupsLoading } = useResourcesServiceResourceGroupsGetMany(undefined, {
+    enabled: supervisionAllowed && autoPromotionEnabled && target === AutoIntroductionTarget.GROUP,
+  });
+
+  const onModeChange = (value: string) => {
+    const mode = value as SupervisionMode;
+    setField('supervisionMode', mode);
+
+    // Auto-promotion is only relevant when supervision is allowed.
+    if (mode === SupervisionMode.INTRODUCTION_REQUIRED) {
+      setField('supervisedUsagesUntilIntroduction', null);
+      setField('autoIntroductionTarget', null);
+      setField('autoIntroductionGroupId', null);
+    }
+  };
+
+  const onThresholdChange = (raw: string) => {
+    const trimmed = raw.trim();
+    if (trimmed === '') {
+      setField('supervisedUsagesUntilIntroduction', null);
+      setField('autoIntroductionTarget', null);
+      setField('autoIntroductionGroupId', null);
+      return;
+    }
+
+    setField('supervisedUsagesUntilIntroduction', Math.max(1, Math.floor(Number(trimmed))));
+    // Default the target as soon as auto-promotion is turned on.
+    if (formData.autoIntroductionTarget === null || formData.autoIntroductionTarget === undefined) {
+      setField('autoIntroductionTarget', AutoIntroductionTarget.RESOURCE);
+    }
+  };
+
+  const onTargetChange = (value: string) => {
+    const newTarget = value as AutoIntroductionTarget;
+    setField('autoIntroductionTarget', newTarget);
+    if (newTarget !== AutoIntroductionTarget.GROUP) {
+      setField('autoIntroductionGroupId', null);
+    }
+  };
+
+  const thresholdValue =
+    formData.supervisedUsagesUntilIntroduction === null || formData.supervisedUsagesUntilIntroduction === undefined
+      ? ''
+      : String(formData.supervisedUsagesUntilIntroduction);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-tiny text-default-400">{t('inputs.supervision.description')}</span>
+
+      <RadioGroup
+        value={supervisionMode}
+        onChange={onModeChange}
+        data-cy="resource-edit-modal-supervision-mode-radiogroup"
+      >
+        <Label className="sr-only">{t('inputs.supervision.mode.label')}</Label>
+        {SUPERVISION_MODES.map((mode) => (
+          <Radio key={mode} value={mode} data-cy={`resource-edit-modal-supervision-mode-${mode}`}>
+            <Radio.Control>
+              <Radio.Indicator />
+            </Radio.Control>
+            <Radio.Content>
+              <span className="text-small">{t(`inputs.supervision.mode.options.${mode}.label`)}</span>
+              <span className="text-tiny text-default-400">{t(`inputs.supervision.mode.options.${mode}.description`)}</span>
+            </Radio.Content>
+          </Radio>
+        ))}
+      </RadioGroup>
+
+      {supervisionAllowed && (
+        <div className="flex flex-col gap-3 pt-3 border-t border-default-200">
+          <h4 className="text-small font-semibold">{t('inputs.supervision.autoPromotion.sectionTitle')}</h4>
+          <span className="text-tiny text-default-400">{t('inputs.supervision.autoPromotion.description')}</span>
+
+          <TextField
+            value={thresholdValue}
+            onChange={onThresholdChange}
+            data-cy="resource-edit-modal-supervision-threshold-input"
+            className="w-full"
+          >
+            <Label>{t('inputs.supervision.autoPromotion.threshold.label')}</Label>
+            <Input
+              type="number"
+              min={1}
+              className="w-full"
+              placeholder={t('inputs.supervision.autoPromotion.disabledPlaceholder')}
+            />
+            <span className="text-tiny text-default-400">
+              {t('inputs.supervision.autoPromotion.threshold.description')}
+            </span>
+          </TextField>
+
+          {autoPromotionEnabled && (
+            <>
+              <RadioGroup
+                value={target}
+                onChange={onTargetChange}
+                orientation="horizontal"
+                data-cy="resource-edit-modal-auto-introduction-target-radiogroup"
+              >
+                <Label>{t('inputs.supervision.autoPromotion.target.label')}</Label>
+                <Radio
+                  value={AutoIntroductionTarget.RESOURCE}
+                  data-cy="resource-edit-modal-auto-introduction-target-resource"
+                >
+                  <Radio.Control>
+                    <Radio.Indicator />
+                  </Radio.Control>
+                  <Radio.Content>{t('inputs.supervision.autoPromotion.target.options.resource')}</Radio.Content>
+                </Radio>
+                <Radio
+                  value={AutoIntroductionTarget.GROUP}
+                  data-cy="resource-edit-modal-auto-introduction-target-group"
+                >
+                  <Radio.Control>
+                    <Radio.Indicator />
+                  </Radio.Control>
+                  <Radio.Content>{t('inputs.supervision.autoPromotion.target.options.group')}</Radio.Content>
+                </Radio>
+              </RadioGroup>
+
+              {target === AutoIntroductionTarget.GROUP && (
+                <Select
+                  label={t('inputs.supervision.autoPromotion.group.label')}
+                  placeholder={t('inputs.supervision.autoPromotion.group.placeholder')}
+                  value={
+                    formData.autoIntroductionGroupId === null || formData.autoIntroductionGroupId === undefined
+                      ? undefined
+                      : String(formData.autoIntroductionGroupId)
+                  }
+                  onChange={(key) => setField('autoIntroductionGroupId', key ? Number(key) : null)}
+                  isLoading={groupsLoading}
+                  items={(groups ?? []).map((group) => ({ key: String(group.id), label: group.name }))}
+                  className="w-full"
+                  data-cy="resource-edit-modal-auto-introduction-group-select"
+                />
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
Adds per-resource **Supervision** configuration to the resource edit/create modal (ATT-279 point 1).

### Fields (Supervision section in `apps/frontend/src/app/resources/editModal/`)
- **`supervisionMode`** — radio with explanatory texts: `INTRODUCTION_REQUIRED` / `SUPERVISION_ALLOWED` / `SUPERVISION_REQUIRED`.
- **Auto-promotion**
  - `supervisedUsagesUntilIntroduction` (number, empty = off).
  - `autoIntroductionTarget`: this resource vs. a resource group; for group, `autoIntroductionGroupId` selection.
- **Visibility / dependencies**: auto-promotion is only shown when supervision is allowed; the threshold gates the target choice; the group select only appears when target = group.
- **de/en** translations added.

### Backend wiring
- New optional fields on `CreateResourceDto` / `UpdateResourceDto` (validated, Swagger-documented).
- `ResourcesService` persists them on create and applies them on update.
- Updated `resources.service.spec.ts` expectation for the new create defaults.

### Extra fix
- HeroUI v3 `Radio` is the Root only — the bare `<Radio>` rendered without a selection circle. Added the `Radio.Control` / `Radio.Indicator` / `Radio.Content` slots so the selected option is visibly indicated.

## Testing
- `nx typecheck`/`lint` (api + frontend) green; `nx test api` 1298 passing; precommit `lint,typecheck,build,test,e2e` green.
- **Browser-verified** end-to-end with `agent-browser`: created a resource with supervision + group auto-promotion, confirmed persistence in DB, and confirmed the edit modal re-hydrates saved values. Screenshots of every state posted to the Linear issue.

## Linear
[ATT-491](https://linear.app/attraccess/issue/ATT-491/p1-frontend-resource-settings-for-supervision-mode-auto-promotion)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->