### PR TITLE
feat(ATT-520): secure backend hook for plugins to access MQTT server config

### DIFF
--- a/apps/api/src/mqtt/mqtt-server-host.provider.spec.ts
+++ b/apps/api/src/mqtt/mqtt-server-host.provider.spec.ts
@@ -1,0 +1,53 @@
+import { NotFoundException } from '@nestjs/common';
+import { MqttServer } from '@attraccess/database-entities';
+import { MqttServerService } from './servers/mqtt-server.service';
+import { MqttServerHostProviderService } from './mqtt-server-host.provider';
+
+describe('MqttServerHostProviderService', () => {
+  function buildProvider(findOne: jest.Mock): MqttServerHostProviderService {
+    return new MqttServerHostProviderService({ findOne } as unknown as MqttServerService);
+  }
+
+  it('maps the server (with its already-decrypted password) to a connection config', async () => {
+    const server: Partial<MqttServer> = {
+      id: 42,
+      name: 'Workshop',
+      host: 'mqtt.example.com',
+      port: 8883,
+      useTls: true,
+      username: 'mqttuser',
+      password: 'decrypted-secret',
+      clientId: 'attraccess-client-1',
+    };
+    const findOne = jest.fn().mockResolvedValue(server);
+    const provider = buildProvider(findOne);
+
+    const config = await provider.getServerConfig(42);
+
+    expect(findOne).toHaveBeenCalledWith(42);
+    expect(config).toEqual({
+      id: 42,
+      name: 'Workshop',
+      host: 'mqtt.example.com',
+      port: 8883,
+      useTls: true,
+      username: 'mqttuser',
+      password: 'decrypted-secret',
+      clientId: 'attraccess-client-1',
+    });
+  });
+
+  it('returns null when the server does not exist', async () => {
+    const findOne = jest.fn().mockRejectedValue(new NotFoundException('nope'));
+    const provider = buildProvider(findOne);
+
+    await expect(provider.getServerConfig(999)).resolves.toBeNull();
+  });
+
+  it('rethrows unexpected errors', async () => {
+    const findOne = jest.fn().mockRejectedValue(new Error('db down'));
+    const provider = buildProvider(findOne);
+
+    await expect(provider.getServerConfig(1)).rejects.toThrow('db down');
+  });
+});

--- a/apps/api/src/mqtt/mqtt-server-host.provider.ts
+++ b/apps/api/src/mqtt/mqtt-server-host.provider.ts
@@ -1,0 +1,39 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { MqttServerConnectionConfig, MqttServerHostProvider } from '@attraccess/plugins-backend-sdk';
+import { MqttServerService } from './servers/mqtt-server.service';
+
+/**
+ * Generic, broker-agnostic bridge that lets permitted plugins read an MQTT
+ * server's connection config and resolved credentials. All decryption happens
+ * here on the core side via MqttServerService.findOne; the plugin only ever
+ * receives the mapped MqttServerConnectionConfig. Registered under
+ * MQTT_SERVER_HOST_PROVIDER and reached only through
+ * PluginContext.getMqttServerConfig, which is gated by ACCESS_MQTT_SERVERS.
+ */
+@Injectable()
+export class MqttServerHostProviderService implements MqttServerHostProvider {
+  constructor(private readonly mqttServerService: MqttServerService) {}
+
+  async getServerConfig(serverId: number): Promise<MqttServerConnectionConfig | null> {
+    let server;
+    try {
+      server = await this.mqttServerService.findOne(serverId);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        return null;
+      }
+      throw error;
+    }
+
+    return {
+      id: server.id,
+      name: server.name,
+      host: server.host,
+      port: server.port,
+      useTls: server.useTls,
+      username: server.username,
+      password: server.password,
+      clientId: server.clientId,
+    };
+  }
+}

--- a/apps/api/src/mqtt/mqtt.module.ts
+++ b/apps/api/src/mqtt/mqtt.module.ts
@@ -1,15 +1,22 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MqttServer } from '@attraccess/database-entities';
+import { MQTT_SERVER_HOST_PROVIDER } from '@attraccess/plugins-backend-sdk';
 import { MqttServerController } from './servers/mqtt-server.controller';
 import { MqttServerService } from './servers/mqtt-server.service';
 import { MqttClientService } from './mqtt-client.service';
+import { MqttServerHostProviderService } from './mqtt-server-host.provider';
 import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [TypeOrmModule.forFeature([MqttServer]), ConfigModule],
   controllers: [MqttServerController],
-  providers: [MqttServerService, MqttClientService],
-  exports: [MqttClientService],
+  providers: [
+    MqttServerService,
+    MqttClientService,
+    MqttServerHostProviderService,
+    { provide: MQTT_SERVER_HOST_PROVIDER, useExisting: MqttServerHostProviderService },
+  ],
+  exports: [MqttClientService, MQTT_SERVER_HOST_PROVIDER],
 })
 export class MqttModule {}

--- a/apps/api/src/plugin-system/plugin-events.service.spec.ts
+++ b/apps/api/src/plugin-system/plugin-events.service.spec.ts
@@ -75,6 +75,7 @@ function baseContext(events: EventEmitter2, name: string): PluginContext {
     get: (() => ({})) as never,
     onEvent: () => ({ off: () => undefined }),
     emitEvent: () => undefined,
+    getMqttServerConfig: () => Promise.resolve(null),
   };
 }
 

--- a/apps/api/src/plugin-system/plugin-sandbox.service.spec.ts
+++ b/apps/api/src/plugin-system/plugin-sandbox.service.spec.ts
@@ -31,6 +31,17 @@ function buildBaseContext(events: EventEmitter2): PluginContext {
     get: (token) => ({ token } as never),
     onEvent: () => ({ off: () => undefined }),
     emitEvent: () => undefined,
+    getMqttServerConfig: (serverId) =>
+      Promise.resolve({
+        id: serverId,
+        name: 'srv',
+        host: 'mqtt.example.com',
+        port: 1883,
+        useTls: false,
+        username: 'u',
+        password: 'secret',
+        clientId: null,
+      }),
   };
 }
 
@@ -194,6 +205,31 @@ describe('PluginSandboxService', () => {
         PluginPermission.RESOLVE_HOST_PROVIDERS,
       ]);
       expect(() => granted.get('SOME_TOKEN')).not.toThrow();
+    });
+
+    it('gates getMqttServerConfig() behind ACCESS_MQTT_SERVERS', async () => {
+      const denied = PluginSandboxService.createGuardedContext(buildBaseContext(events), []);
+      expect(() => denied.getMqttServerConfig(1)).toThrow(PluginPermissionError);
+      expect(() => denied.getMqttServerConfig(1)).toThrow(/ACCESS_MQTT_SERVERS/);
+    });
+
+    it('returns the resolved MQTT config with ACCESS_MQTT_SERVERS', async () => {
+      const granted = PluginSandboxService.createGuardedContext(buildBaseContext(events), [
+        PluginPermission.ACCESS_MQTT_SERVERS,
+      ]);
+      await expect(granted.getMqttServerConfig(7)).resolves.toMatchObject({
+        id: 7,
+        host: 'mqtt.example.com',
+        port: 1883,
+        password: 'secret',
+      });
+    });
+
+    it('does not unlock getMqttServerConfig via RESOLVE_HOST_PROVIDERS', () => {
+      const ctx = PluginSandboxService.createGuardedContext(buildBaseContext(events), [
+        PluginPermission.RESOLVE_HOST_PROVIDERS,
+      ]);
+      expect(() => ctx.getMqttServerConfig(1)).toThrow(/ACCESS_MQTT_SERVERS/);
     });
   });
 });

--- a/apps/api/src/plugin-system/plugin-sandbox.service.ts
+++ b/apps/api/src/plugin-system/plugin-sandbox.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Type } from '@nestjs/common';
 import { Resource, Setting, User } from '@attraccess/database-entities';
 import {
   isPluginPermission,
+  MqttServerConnectionConfig,
   PluginContext,
   PluginPermission,
   PluginPermissionError,
@@ -141,6 +142,10 @@ export class PluginSandboxService {
       emitEvent<E extends SystemEvent>(event: E, payload: SystemEventPayload[E]): void {
         require(PluginPermission.EMIT_EVENTS, `emitEvent(${event})`);
         base.emitEvent(event, payload);
+      },
+      getMqttServerConfig(serverId: number): Promise<MqttServerConnectionConfig | null> {
+        require(PluginPermission.ACCESS_MQTT_SERVERS, `getMqttServerConfig(${serverId})`);
+        return base.getMqttServerConfig(serverId);
       },
     };
   }

--- a/apps/api/src/plugin-system/plugin.module.ts
+++ b/apps/api/src/plugin-system/plugin.module.ts
@@ -9,6 +9,9 @@ import {
   SystemEventHandler,
   SystemEventPayload,
   SystemEventSubscription,
+  MQTT_SERVER_HOST_PROVIDER,
+  MqttServerConnectionConfig,
+  MqttServerHostProvider,
 } from '@attraccess/plugins-backend-sdk';
 import { createRequire, Module as NodeModuleClass } from 'module';
 import { readFileSync } from 'fs';
@@ -193,6 +196,13 @@ export class PluginModule {
       },
       emitEvent<E extends SystemEvent>(event: E, payload: SystemEventPayload[E]): void {
         PluginModule.pluginEvents().emit(event, payload);
+      },
+      getMqttServerConfig(serverId: number): Promise<MqttServerConnectionConfig | null> {
+        const provider = PluginModule.requireRef(PluginModule.moduleRef, 'ModuleRef').get<MqttServerHostProvider>(
+          MQTT_SERVER_HOST_PROVIDER,
+          { strict: false }
+        );
+        return provider.getServerConfig(serverId);
       },
     };
 

--- a/apps/api/src/plugin-system/poc/external-plugin.integration.spec.ts
+++ b/apps/api/src/plugin-system/poc/external-plugin.integration.spec.ts
@@ -94,6 +94,7 @@ async function bootAndPing(artifactPath: string): Promise<PocPongPayload> {
     emitEvent<E extends SystemEvent>(event: E, payload: SystemEventPayload[E]) {
       pluginEvents.emit(event, payload);
     },
+    getMqttServerConfig: () => Promise.resolve(null),
   };
 
   const plugin = loadDefaultExport(artifactPath);

--- a/docs/de/plugins/developing-plugins.md
+++ b/docs/de/plugins/developing-plugins.md
@@ -108,6 +108,7 @@ nennt.
 | `EMIT_EVENTS` | `context.emitEvent(...)` und `context.events.emit(...)` / `emitAsync(...)` -- auf dem geteilten Event-Bus senden. |
 | `LISTEN_EVENTS` | `context.onEvent(...)` und `context.events.on(...)` / `once(...)` / ... -- den geteilten Event-Bus abonnieren. |
 | `RESOLVE_HOST_PROVIDERS` | `context.get(token)` -- beliebige Host-Dienste per Injection-Token auflösen. |
+| `ACCESS_MQTT_SERVERS` | `context.getMqttServerConfig(serverId)` -- Verbindungskonfiguration und aufgelöste (entschlüsselte) Zugangsdaten eines MQTT-Servers lesen. |
 
 `context.manifest` und `context.logger` sind immer verfügbar und benötigen
 keine Berechtigung. Eine unbekannte Berechtigung führt dazu, dass das Plugin

--- a/docs/en/plugins/developing-plugins.md
+++ b/docs/en/plugins/developing-plugins.md
@@ -150,6 +150,7 @@ export default plugin;
 | `context.emitEvent(event, payload)` | Emit a typed `SystemEvent`. | `EMIT_EVENTS` |
 | `context.events` | The raw shared event bus (restricted surface). | per-method |
 | `context.get(token)` | Resolve an arbitrary host provider by token. | `RESOLVE_HOST_PROVIDERS` |
+| `context.getMqttServerConfig(serverId)` | Resolve an MQTT server's connection config + resolved (decrypted) credentials. | `ACCESS_MQTT_SERVERS` |
 
 > [!IMPORTANT]
 > Resolve services and repositories through `context`, never by re-initialising
@@ -173,6 +174,7 @@ naming the missing permission.
 | `EMIT_EVENTS` | `context.emitEvent(...)` and `context.events.emit(...)` / `emitAsync(...)`. |
 | `LISTEN_EVENTS` | `context.onEvent(...)` and `context.events.on(...)` / `once(...)` / ... |
 | `RESOLVE_HOST_PROVIDERS` | `context.get(token)` — resolve arbitrary host services by token. |
+| `ACCESS_MQTT_SERVERS` | `context.getMqttServerConfig(serverId)` — read an MQTT server's connection config and resolved credentials. |
 
 A few notes on the boundary:
 

--- a/libs/plugins-backend-sdk/src/lib/plugin-context.ts
+++ b/libs/plugins-backend-sdk/src/lib/plugin-context.ts
@@ -21,6 +21,40 @@ export interface PluginManifestInfo {
 }
 
 /**
+ * DI token under which the host registers its MqttServerHostProvider
+ * implementation. The plugin context resolves the provider through this token;
+ * plugins never reference it directly — they call getMqttServerConfig instead.
+ */
+export const MQTT_SERVER_HOST_PROVIDER = Symbol.for('attraccess.plugin.mqttServerHostProvider');
+
+/**
+ * Connection configuration for a single MQTT server, including its resolved
+ * (decrypted) credentials. A generic, broker-agnostic shape carrying only the
+ * fields a plugin needs to open a connection or call a server's management API.
+ */
+export interface MqttServerConnectionConfig {
+  readonly id: number;
+  readonly name: string;
+  readonly host: string;
+  readonly port: number;
+  readonly useTls: boolean;
+  readonly username: string | null;
+  /** Resolved (decrypted) password. Only ever provided to permitted plugins. */
+  readonly password: string | null;
+  readonly clientId: string | null;
+}
+
+/**
+ * Host-side provider that resolves an MQTT server's connection config. The core
+ * application implements this — all credential decryption stays core-side — and
+ * registers it under MQTT_SERVER_HOST_PROVIDER. Plugins reach it only through
+ * PluginContext.getMqttServerConfig, gated by the ACCESS_MQTT_SERVERS permission.
+ */
+export interface MqttServerHostProvider {
+  getServerConfig(serverId: number): Promise<MqttServerConnectionConfig | null>;
+}
+
+/**
  * Curated facade handed to a backend plugin at load time. It is the single,
  * versioned seam between plugin code and the host application. Adding a field is
  * a minor SDK bump; removing/changing one is a major bump.
@@ -59,6 +93,15 @@ export interface PluginContext {
    * EMIT_EVENTS permission. The payload is type-checked against the event.
    */
   emitEvent<E extends SystemEvent>(event: E, payload: SystemEventPayload[E]): void;
+
+  /**
+   * Resolve an MQTT server's connection configuration, including its resolved
+   * (decrypted) credentials. Requires the ACCESS_MQTT_SERVERS permission.
+   * Returns null when no server with the given id exists. The host performs all
+   * credential decryption; the plugin only ever receives the mapped config — it
+   * stays broker-agnostic (no RabbitMQ awareness).
+   */
+  getMqttServerConfig(serverId: number): Promise<MqttServerConnectionConfig | null>;
 }
 
 /**

--- a/libs/plugins-backend-sdk/src/lib/plugin.interface.ts
+++ b/libs/plugins-backend-sdk/src/lib/plugin.interface.ts
@@ -52,6 +52,8 @@ export enum PluginPermission {
   LISTEN_EVENTS = 'LISTEN_EVENTS',
   /** Resolve arbitrary host providers by token via context.get(). */
   RESOLVE_HOST_PROVIDERS = 'RESOLVE_HOST_PROVIDERS',
+  /** Read an MQTT server's connection config + resolved credentials via getMqttServerConfig(). */
+  ACCESS_MQTT_SERVERS = 'ACCESS_MQTT_SERVERS',
 }
 
 /**
@@ -66,6 +68,7 @@ export const PLUGIN_PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = 
   [PluginPermission.EMIT_EVENTS]: 'Publish events on the shared application event bus.',
   [PluginPermission.LISTEN_EVENTS]: 'Subscribe to events on the shared application event bus.',
   [PluginPermission.RESOLVE_HOST_PROVIDERS]: 'Resolve arbitrary host services by injection token.',
+  [PluginPermission.ACCESS_MQTT_SERVERS]: "Read an MQTT server's connection configuration and resolved credentials.",
 };
 
 /**


### PR DESCRIPTION
Assignee: [Jan Jaap](https://linear.app/attraccess/profiles/38d3ae9f-6a62-44f6-9347-df8bd3024dd2)

## Summary

Exposes a secure, permission-gated backend hook so plugins can read an MQTT server's connection config (host, port, TLS, resolved credentials) to talk to the server's management API — without broadening secret exposure or duplicating the MQTT module.

Core-change ticket #2 of 2 for the RabbitMQ plugin work (parent ATT-255). Stays RabbitMQ-agnostic.

## Changes

- **New plugin permission `ACCESS_MQTT_SERVERS`** gates the hook; the plugin sandbox enforces it (does not unlock via `RESOLVE_HOST_PROVIDERS`).
- **`PluginContext.getMqttServerConfig(serverId)`** — new context method returning `MqttServerConnectionConfig | null`.
- **`MqttServerHostProviderService`** bridges to `MqttServerService.findOne`, keeping all credential decryption (`EncryptionService`) core-side. The plugin only ever receives the mapped, broker-agnostic config. Registered under the `MQTT_SERVER_HOST_PROVIDER` DI token, exported from `MqttModule`.
- **SDK** (`plugins-backend-sdk`): `MQTT_SERVER_HOST_PROVIDER` token, `MqttServerConnectionConfig`, `MqttServerHostProvider` interface, context method + permission table docs (EN/DE).

## Acceptance criteria

- ✅ A plugin with `ACCESS_MQTT_SERVERS` obtains an MQTT server's connection details incl. resolved credentials via the plugin context.
- ✅ Plugins without the permission cannot (throws `PluginPermissionError` naming `ACCESS_MQTT_SERVERS`).
- ✅ No RabbitMQ-specific code in core; encryption stays core-side.

## Testing

- `plugins-backend-sdk`: 44 tests pass.
- `api`: 1442 tests pass (incl. new `MqttServerHostProviderService` spec + sandbox permission-gating specs).
- Lint clean (`--max-warnings=0`), `tsc --noEmit` clean, builds succeed. Precommit hook green.

No frontend changes — no UI screenshots applicable.

Closes [ATT-520](https://linear.app/attraccess/issue/ATT-520/expose-a-secure-backend-hook-for-plugins-to-access-mqtt-server-config)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
