### PR TITLE
feat(resources): supervised start UI — supervisor popup + approval popup (ATT-489)

### DIFF
--- a/apps/frontend/src/app/app.tsx
+++ b/apps/frontend/src/app/app.tsx
@@ -24,6 +24,7 @@ import { getBaseUrl } from '../api';
 import { AcceptInvitation } from './accept-invitation';
 import { TwoFactorGate } from './two-factor-gate';
 import { AttraccessUserActionsBridge } from '../components/attraccessUserActionsBridge';
+import { SupervisorApprovalListener } from '../components/supervisorApproval/SupervisorApprovalListener';
 
 function useRoutesWithAuthElements(routes: RouteConfig[]) {
   const { user } = useAuth();
@@ -122,6 +123,7 @@ function AppLayout(props: PropsWithChildren) {
                 <Layout noLayout={!isAuthenticated}>
                   {props.children}
                 </Layout>
+                {isAuthenticated && <SupervisorApprovalListener />}
               </AttraccessUserActionsBridge>
             </ReactFlowProvider>
           </ToastProvider>

--- a/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/ResourceUsageSession/index.tsx
@@ -14,6 +14,7 @@ import {
   Resource,
   useResourcesServiceResourceUsageCanControl,
   useResourceMaintenancesServiceFindMaintenances,
+  SupervisionMode,
 } from '@attraccess/react-query-client';
 import en from './translations/en.json';
 import de from './translations/de.json';
@@ -68,6 +69,11 @@ export function ResourceUsageSession({
 
   const canStartSession = canManageResources || access?.canControl || isIntroducer;
 
+  // A not-introduced user may still start via a supervisor when the resource allows it.
+  const supervisionEnabled =
+    resource.supervisionMode === SupervisionMode.SUPERVISION_ALLOWED ||
+    resource.supervisionMode === SupervisionMode.SUPERVISION_REQUIRED;
+
   const { data: activeMaintenances } = useResourceMaintenancesServiceFindMaintenances({
     resourceId,
     includeActive: true,
@@ -90,7 +96,7 @@ export function ResourceUsageSession({
       }
     }
 
-    if (!canStartSession) {
+    if (!canStartSession && !supervisionEnabled) {
       return <IntroductionRequiredDisplay resourceId={resourceId} />;
     }
 
@@ -102,6 +108,7 @@ export function ResourceUsageSession({
       <StartSessionControls
         resourceId={resourceId}
         insufficientBalanceDesiredAmount={insufficientBalanceDesiredAmount}
+        requiresSupervision={!canStartSession}
       />
     );
   };

--- a/apps/frontend/src/app/resources/usage/components/StartSessionControls/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/StartSessionControls/index.tsx
@@ -26,16 +26,22 @@ import { useResourceFormsSubmission } from '../../../forms/hooks/useResourceForm
 import { ResourceFormAction } from '../../../details/forms/types';
 import { DoorControls } from './DoorControls';
 import { MachineStartControls } from './MachineStartControls';
+import { SupervisedStartModal } from '../SupervisedStartModal';
 
 interface StartSessionControlsProps {
   resourceId: number;
   insufficientBalanceDesiredAmount?: number;
+  /**
+   * When true the user is not introduced but the resource allows supervision:
+   * starting opens the supervisor-selection popup instead of starting directly.
+   */
+  requiresSupervision?: boolean;
 }
 
 export function StartSessionControls(
   props: Readonly<StartSessionControlsProps> & React.HTMLAttributes<HTMLDivElement>,
 ) {
-  const { resourceId, insufficientBalanceDesiredAmount, ...divProps } = props;
+  const { resourceId, insufficientBalanceDesiredAmount, requiresSupervision, ...divProps } = props;
 
   const { data: resource } = useResourcesServiceGetOneResourceById({ id: resourceId });
 
@@ -54,6 +60,7 @@ export function StartSessionControls(
 
   const [isNotesModalOpen, setIsNotesModalOpen] = useState(false);
   const [isInsufficientBalance, setIsInsufficientBalance] = useState(false);
+  const [supervisedRequestBody, setSupervisedRequestBody] = useState<StartUsageSessionDto | null>(null);
 
   const onStartSuccess = useCallback(() => {
     setIsNotesModalOpen(false);
@@ -230,13 +237,23 @@ export function StartSessionControls(
         return;
       }
 
-      submitStartSessionWithRetry(action, {
+      const requestBody: StartUsageSessionDto = {
         ...(opts ?? {}),
         projectId: selectedProjectId,
         formSubmissions,
-      });
+      };
+
+      // Not introduced but supervision is allowed: defer to supervisor approval
+      // instead of starting directly. The user-facing start flow is unchanged.
+      if (requiresSupervision) {
+        setIsNotesModalOpen(false);
+        setSupervisedRequestBody(requestBody);
+        return;
+      }
+
+      submitStartSessionWithRetry(action, requestBody);
     },
-    [gatherFormSubmissions, selectedProjectId, submitStartSessionWithRetry],
+    [gatherFormSubmissions, requiresSupervision, selectedProjectId, submitStartSessionWithRetry],
   );
 
   const handleOpenStartSessionModal = () => {
@@ -287,6 +304,19 @@ export function StartSessionControls(
         onClose={() => setIsInsufficientBalance(false)}
         desiredAmount={insufficientBalanceDesiredAmount}
       />
+
+      {supervisedRequestBody && (
+        <SupervisedStartModal
+          isOpen={true}
+          onClose={() => setSupervisedRequestBody(null)}
+          resourceId={resourceId}
+          requestBody={supervisedRequestBody}
+          onApproved={() => {
+            setSupervisedRequestBody(null);
+            onStartSuccess();
+          }}
+        />
+      )}
       {formsModal}
     </div>
   );

--- a/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/index.test.tsx
+++ b/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/index.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SupervisedStartModal } from './index';
+
+const { requestMutate, ApiErrorMock } = vi.hoisted(() => {
+  class ApiErrorMock extends Error {
+    status: number;
+    constructor(status: number) {
+      super('api error');
+      this.status = status;
+    }
+  }
+  return { requestMutate: vi.fn(), ApiErrorMock };
+});
+
+vi.mock('../../../../../hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 1, username: 'me' } }),
+}));
+
+vi.mock('@attraccess/plugins-frontend-ui', () => ({
+  useTranslations: () => ({ t: (key: string) => key, tExists: () => true }),
+  AttraccessUser: ({ user }: { user: { username: string } }) => <div>{user.username}</div>,
+}));
+
+vi.mock('@attraccess/react-query-client', () => ({
+  ApiError: ApiErrorMock,
+  ResourceIntroducerType: { INTRODUCER: 'introducer', MAINTAINER: 'maintainer' },
+  useAccessControlServiceResourceIntroducersGetMany: () => ({
+    isLoading: false,
+    data: [
+      { id: 10, userId: 2, type: 'introducer', user: { id: 2, username: 'alice' } },
+      { id: 11, userId: 1, type: 'introducer', user: { id: 1, username: 'me' } },
+    ],
+  }),
+  useResourcesServiceResourceUsageRequestSupervisedSession: () => ({ mutate: requestMutate }),
+}));
+
+const getLastCallbacks = () => requestMutate.mock.calls[requestMutate.mock.calls.length - 1][1];
+
+describe('SupervisedStartModal', () => {
+  beforeEach(() => {
+    requestMutate.mockClear();
+  });
+
+  function renderModal(onApproved = vi.fn()) {
+    return render(
+      <SupervisedStartModal
+        isOpen={true}
+        onClose={vi.fn()}
+        resourceId={42}
+        requestBody={{ notes: 'hi' }}
+        onApproved={onApproved}
+      />,
+    );
+  }
+
+  it('lists authorized supervisors and excludes the requester', () => {
+    renderModal();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    // The requester (id 1) must not be offered as a supervisor.
+    expect(screen.queryByText('me')).not.toBeInTheDocument();
+  });
+
+  it('requests supervision for the selected supervisor and waits', async () => {
+    renderModal();
+    await userEvent.click(screen.getByText('alice'));
+
+    expect(requestMutate).toHaveBeenCalledWith(
+      { resourceId: 42, requestBody: { notes: 'hi', supervisorUserId: 2 } },
+      expect.any(Object),
+    );
+    expect(screen.getByText('waiting.description')).toBeInTheDocument();
+  });
+
+  it('shows the timeout state on a 408 and allows retry', async () => {
+    renderModal();
+    await userEvent.click(screen.getByText('alice'));
+
+    act(() => getLastCallbacks().onError(new ApiErrorMock(408)));
+    expect(screen.getByText('timeout.description')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('retry'));
+    expect(screen.getByText('select.description')).toBeInTheDocument();
+  });
+
+  it('shows the rejected state on a 403', async () => {
+    renderModal();
+    await userEvent.click(screen.getByText('alice'));
+
+    act(() => getLastCallbacks().onError(new ApiErrorMock(403)));
+    expect(screen.getByText('rejected.description')).toBeInTheDocument();
+  });
+
+  it('calls onApproved when the supervisor approves', async () => {
+    const onApproved = vi.fn();
+    renderModal(onApproved);
+    await userEvent.click(screen.getByText('alice'));
+
+    const session = { id: 99 };
+    act(() => getLastCallbacks().onSuccess(session));
+    expect(onApproved).toHaveBeenCalledWith(session);
+  });
+});

--- a/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/index.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  AlertContent,
+  AlertDescription,
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalContainer,
+  ModalDialog,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  Spinner,
+} from '@heroui/react';
+import { AttraccessUser, useTranslations } from '@attraccess/plugins-frontend-ui';
+import {
+  ApiError,
+  RequestSupervisedSessionDto,
+  ResourceIntroducerType,
+  ResourceUsage,
+  useAccessControlServiceResourceIntroducersGetMany,
+  useResourcesServiceResourceUsageRequestSupervisedSession,
+} from '@attraccess/react-query-client';
+import { Button } from '../../../../../components/button';
+import { AlertStatusIcon } from '../../../../../components/AlertStatusIcon';
+import { useAuth } from '../../../../../hooks/useAuth';
+import en from './translations/en.json';
+import de from './translations/de.json';
+
+/** The 30s supervisor-approval window, mirrored from the backend. */
+const APPROVAL_TIMEOUT_SECONDS = 30;
+
+type Phase = 'select' | 'waiting' | 'timeout' | 'rejected';
+
+export interface SupervisedStartModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  resourceId: number;
+  /** The start payload gathered from the normal start flow, minus the supervisor. */
+  requestBody: Omit<RequestSupervisedSessionDto, 'supervisorUserId'>;
+  onApproved: (session: ResourceUsage) => void;
+}
+
+export function SupervisedStartModal({
+  isOpen,
+  onClose,
+  resourceId,
+  requestBody,
+  onApproved,
+}: Readonly<SupervisedStartModalProps>) {
+  const { t } = useTranslations({ en, de });
+  const { user } = useAuth();
+
+  const [phase, setPhase] = useState<Phase>('select');
+  const [secondsLeft, setSecondsLeft] = useState(APPROVAL_TIMEOUT_SECONDS);
+
+  // Authorized supervisors are the resource's introducers and maintainers,
+  // excluding the requester themselves (self-supervision is rejected by the backend).
+  const { data: candidates, isLoading: isLoadingCandidates } = useAccessControlServiceResourceIntroducersGetMany({
+    resourceId,
+  });
+
+  const supervisors = useMemo(
+    () => (candidates ?? []).filter((candidate) => candidate.userId !== user?.id),
+    [candidates, user?.id],
+  );
+
+  const { mutate: requestSupervisedSession } = useResourcesServiceResourceUsageRequestSupervisedSession();
+
+  // Reset to the selection phase whenever the modal is (re)opened.
+  useEffect(() => {
+    if (isOpen) {
+      setPhase('select');
+      setSecondsLeft(APPROVAL_TIMEOUT_SECONDS);
+    }
+  }, [isOpen]);
+
+  // Countdown while waiting for the supervisor to respond.
+  useEffect(() => {
+    if (phase !== 'waiting') {
+      return;
+    }
+
+    setSecondsLeft(APPROVAL_TIMEOUT_SECONDS);
+    const interval = setInterval(() => {
+      setSecondsLeft((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [phase]);
+
+  const handleSelectSupervisor = useCallback(
+    (supervisorUserId: number) => {
+      setPhase('waiting');
+      requestSupervisedSession(
+        { resourceId, requestBody: { ...requestBody, supervisorUserId } },
+        {
+          onSuccess: (session) => {
+            onApproved(session as ResourceUsage);
+          },
+          onError: (error) => {
+            if (error instanceof ApiError && error.status === 408) {
+              setPhase('timeout');
+              return;
+            }
+            // 403 covers both an explicit rejection and an unauthorized supervisor.
+            setPhase('rejected');
+          },
+        },
+      );
+    },
+    [onApproved, requestBody, requestSupervisedSession, resourceId],
+  );
+
+  const renderBody = () => {
+    if (phase === 'waiting') {
+      return (
+        <div className="flex flex-col items-center gap-4 py-4 text-center">
+          <Spinner color="accent" />
+          <p className="text-gray-700 dark:text-gray-300">{t('waiting.description')}</p>
+          <p className="text-3xl font-semibold tabular-nums text-gray-900 dark:text-white">
+            {t('waiting.countdown', { seconds: secondsLeft })}
+          </p>
+        </div>
+      );
+    }
+
+    if (phase === 'timeout' || phase === 'rejected') {
+      return (
+        <div className="space-y-4">
+          <Alert status="warning">
+            <AlertStatusIcon status="warning" />
+            <AlertContent>
+              <AlertDescription>
+                {phase === 'timeout' ? t('timeout.description') : t('rejected.description')}
+              </AlertDescription>
+            </AlertContent>
+          </Alert>
+        </div>
+      );
+    }
+
+    if (isLoadingCandidates) {
+      return (
+        <div className="flex justify-center py-4">
+          <Spinner color="accent" />
+        </div>
+      );
+    }
+
+    if (supervisors.length === 0) {
+      return <p className="text-gray-500 dark:text-gray-400 italic">{t('select.empty')}</p>;
+    }
+
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-gray-700 dark:text-gray-300">{t('select.description')}</p>
+        <div className="space-y-2">
+          {supervisors.map((supervisor) => (
+            <button
+              key={supervisor.id}
+              type="button"
+              onClick={() => handleSelectSupervisor(supervisor.userId)}
+              className="w-full rounded-md border border-gray-200 dark:border-gray-700 p-2 text-left transition-colors hover:border-accent-500 hover:bg-gray-50 dark:hover:bg-gray-800"
+            >
+              <AttraccessUser
+                user={supervisor.user}
+                description={
+                  supervisor.type === ResourceIntroducerType.INTRODUCER
+                    ? t('select.role.introducer')
+                    : t('select.role.maintainer')
+                }
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <ModalBackdrop>
+        <ModalContainer size="md">
+          <ModalDialog>
+            {({ close }) => (
+              <>
+                <ModalHeader>
+                  <ModalHeading>{t('title')}</ModalHeading>
+                </ModalHeader>
+
+                <ModalBody>{renderBody()}</ModalBody>
+
+                <ModalFooter>
+                  {(phase === 'timeout' || phase === 'rejected') && (
+                    <Button variant="primary" onPress={() => setPhase('select')}>
+                      {t('retry')}
+                    </Button>
+                  )}
+                  <Button variant="ghost" onPress={close} isDisabled={phase === 'waiting'}>
+                    {t('cancel')}
+                  </Button>
+                </ModalFooter>
+              </>
+            )}
+          </ModalDialog>
+        </ModalContainer>
+      </ModalBackdrop>
+    </Modal>
+  );
+}

--- a/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/index.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   AlertContent,
   AlertDescription,
+  Description,
   Modal,
   ModalBackdrop,
   ModalBody,
@@ -118,10 +119,8 @@ export function SupervisedStartModal({
       return (
         <div className="flex flex-col items-center gap-4 py-4 text-center">
           <Spinner color="accent" />
-          <p className="text-gray-700 dark:text-gray-300">{t('waiting.description')}</p>
-          <p className="text-3xl font-semibold tabular-nums text-gray-900 dark:text-white">
-            {t('waiting.countdown', { seconds: secondsLeft })}
-          </p>
+          <Description>{t('waiting.description')}</Description>
+          <p className="text-3xl font-semibold tabular-nums">{t('waiting.countdown', { seconds: secondsLeft })}</p>
         </div>
       );
     }
@@ -150,19 +149,19 @@ export function SupervisedStartModal({
     }
 
     if (supervisors.length === 0) {
-      return <p className="text-gray-500 dark:text-gray-400 italic">{t('select.empty')}</p>;
+      return <Description>{t('select.empty')}</Description>;
     }
 
     return (
       <div className="space-y-3">
-        <p className="text-sm text-gray-700 dark:text-gray-300">{t('select.description')}</p>
+        <Description>{t('select.description')}</Description>
         <div className="space-y-2">
           {supervisors.map((supervisor) => (
-            <button
+            <Button
               key={supervisor.id}
-              type="button"
-              onClick={() => handleSelectSupervisor(supervisor.userId)}
-              className="w-full rounded-md border border-gray-200 dark:border-gray-700 p-2 text-left transition-colors hover:border-accent-500 hover:bg-gray-50 dark:hover:bg-gray-800"
+              variant="outline"
+              className="h-auto w-full justify-start py-2"
+              onPress={() => handleSelectSupervisor(supervisor.userId)}
             >
               <AttraccessUser
                 user={supervisor.user}
@@ -172,7 +171,7 @@ export function SupervisedStartModal({
                     : t('select.role.maintainer')
                 }
               />
-            </button>
+            </Button>
           ))}
         </div>
       </div>

--- a/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/translations/de.json
+++ b/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/translations/de.json
@@ -1,0 +1,23 @@
+{
+  "title": "Aufsicht erforderlich",
+  "select": {
+    "description": "Du bist noch nicht in diese Ressource eingewiesen. Wähle eine Aufsichtsperson, um die Freigabe für diese Sitzung anzufordern.",
+    "empty": "Derzeit sind keine berechtigten Aufsichtspersonen verfügbar.",
+    "role": {
+      "introducer": "Einweiser",
+      "maintainer": "Betreuer"
+    }
+  },
+  "waiting": {
+    "description": "Warte auf die Freigabe durch die Aufsichtsperson…",
+    "countdown": "{{seconds}}s"
+  },
+  "timeout": {
+    "description": "Die Aufsichtsperson hat nicht rechtzeitig reagiert. Bitte versuche es erneut oder wähle eine andere Aufsichtsperson."
+  },
+  "rejected": {
+    "description": "Deine Anfrage wurde abgelehnt. Bitte versuche es erneut oder wähle eine andere Aufsichtsperson."
+  },
+  "retry": "Erneut versuchen",
+  "cancel": "Abbrechen"
+}

--- a/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/translations/en.json
+++ b/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/translations/en.json
@@ -1,0 +1,23 @@
+{
+  "title": "Supervisor required",
+  "select": {
+    "description": "You are not yet introduced to this resource. Choose a supervisor to request approval for this session.",
+    "empty": "No authorized supervisors are currently available.",
+    "role": {
+      "introducer": "Introducer",
+      "maintainer": "Maintainer"
+    }
+  },
+  "waiting": {
+    "description": "Waiting for the supervisor to approve your request…",
+    "countdown": "{{seconds}}s"
+  },
+  "timeout": {
+    "description": "The supervisor did not respond in time. Please try again or pick another supervisor."
+  },
+  "rejected": {
+    "description": "Your request was declined. Please try again or pick another supervisor."
+  },
+  "retry": "Try again",
+  "cancel": "Cancel"
+}

--- a/apps/frontend/src/components/supervisorApproval/SupervisorApprovalListener.tsx
+++ b/apps/frontend/src/components/supervisorApproval/SupervisorApprovalListener.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  SupervisionRequestDto,
+  UseResourcesServiceResourceUsageGetActiveSessionKeyFn,
+  useResourcesServiceSupervisionApproveRequest,
+  useResourcesServiceSupervisionListPendingRequests,
+  useResourcesServiceSupervisionRejectRequest,
+} from '@attraccess/react-query-client';
+import { useAuth } from '../../hooks/useAuth';
+import { useSSE } from '../../utils/sse';
+import { useToastMessage } from '../toastProvider';
+import { useTranslations } from '@attraccess/plugins-frontend-ui';
+import { SupervisorApprovalModal } from './SupervisorApprovalModal';
+import en from './translations/en.json';
+import de from './translations/de.json';
+
+/** Mirrors the backend SupervisionLiveEventType enum (delivered over SSE). */
+enum SupervisionLiveEventType {
+  REQUESTED = 'requested',
+  EXPIRED = 'expired',
+  RESOLVED = 'resolved',
+  REJECTED = 'rejected',
+}
+
+interface SupervisionLiveEvent {
+  type: SupervisionLiveEventType;
+  requestId: string;
+  request: SupervisionRequestDto | null;
+}
+
+/**
+ * Global listener (mounted once for authenticated users) that surfaces incoming
+ * supervised-start requests as a realtime popup. Approving starts the session;
+ * the request auto-dismisses after the backend's 30s timeout.
+ */
+export function SupervisorApprovalListener() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const toast = useToastMessage();
+  const { t } = useTranslations({ en, de });
+
+  const [requests, setRequests] = useState<SupervisionRequestDto[]>([]);
+
+  // Seed from any requests already awaiting this supervisor (e.g. after reconnect).
+  const { data: pending } = useResourcesServiceSupervisionListPendingRequests(undefined, {
+    enabled: !!user,
+    refetchOnWindowFocus: true,
+  });
+
+  useEffect(() => {
+    if (!pending) {
+      return;
+    }
+    setRequests((prev) => {
+      const byId = new Map(prev.map((request) => [request.id, request]));
+      for (const request of pending as SupervisionRequestDto[]) {
+        byId.set(request.id, request);
+      }
+      return Array.from(byId.values());
+    });
+  }, [pending]);
+
+  const removeRequest = useCallback((requestId: string) => {
+    setRequests((prev) => prev.filter((request) => request.id !== requestId));
+  }, []);
+
+  const handleEvent = useCallback(
+    (event: SupervisionLiveEvent) => {
+      if (event.type === SupervisionLiveEventType.REQUESTED && event.request) {
+        const incoming = event.request;
+        setRequests((prev) => {
+          if (prev.some((request) => request.id === incoming.id)) {
+            return prev;
+          }
+          return [...prev, incoming];
+        });
+        return;
+      }
+
+      // EXPIRED / RESOLVED / REJECTED: the request is no longer actionable.
+      removeRequest(event.requestId);
+    },
+    [removeRequest],
+  );
+
+  useSSE<SupervisionLiveEvent>({
+    path: '/api/resources/supervision/requests/live',
+    onUpdate: handleEvent,
+    enabled: !!user,
+  });
+
+  const invalidateActiveSession = useCallback(
+    (resourceId: number) => {
+      queryClient.invalidateQueries({
+        queryKey: UseResourcesServiceResourceUsageGetActiveSessionKeyFn({ resourceId }),
+      });
+    },
+    [queryClient],
+  );
+
+  const { mutate: approveRequest, isPending: isApproving } = useResourcesServiceSupervisionApproveRequest();
+  const { mutate: rejectRequest, isPending: isRejecting } = useResourcesServiceSupervisionRejectRequest();
+
+  const activeRequest = requests[0];
+
+  const handleApprove = useCallback(() => {
+    if (!activeRequest) {
+      return;
+    }
+    const { id, resourceId } = activeRequest;
+    approveRequest(
+      { requestId: id },
+      {
+        onSuccess: () => {
+          invalidateActiveSession(resourceId);
+          toast.success({ title: t('toast.approved.title'), description: t('toast.approved.description') });
+          removeRequest(id);
+        },
+        onError: () => {
+          toast.error({ title: t('toast.error.title'), description: t('toast.error.description') });
+          removeRequest(id);
+        },
+      },
+    );
+  }, [activeRequest, approveRequest, invalidateActiveSession, removeRequest, t, toast]);
+
+  const handleReject = useCallback(() => {
+    if (!activeRequest) {
+      return;
+    }
+    const { id } = activeRequest;
+    rejectRequest(
+      { requestId: id },
+      {
+        onSettled: () => removeRequest(id),
+      },
+    );
+  }, [activeRequest, rejectRequest, removeRequest]);
+
+  const handleExpire = useCallback(() => {
+    if (activeRequest) {
+      removeRequest(activeRequest.id);
+    }
+  }, [activeRequest, removeRequest]);
+
+  if (!user || !activeRequest) {
+    return null;
+  }
+
+  return (
+    <SupervisorApprovalModal
+      key={activeRequest.id}
+      request={activeRequest}
+      onApprove={handleApprove}
+      onReject={handleReject}
+      onExpire={handleExpire}
+      isApproving={isApproving}
+      isRejecting={isRejecting}
+    />
+  );
+}

--- a/apps/frontend/src/components/supervisorApproval/SupervisorApprovalModal.test.tsx
+++ b/apps/frontend/src/components/supervisorApproval/SupervisorApprovalModal.test.tsx
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SupervisorApprovalModal } from './SupervisorApprovalModal';
+
+vi.mock('@attraccess/plugins-frontend-ui', () => ({
+  useTranslations: () => ({ t: (key: string) => key, tExists: () => true }),
+  AttraccessUser: ({ user }: { user: { username: string } }) => <div>requester:{user.username}</div>,
+}));
+
+vi.mock('@attraccess/react-query-client', () => ({
+  useResourcesServiceGetOneResourceById: () => ({ data: { id: 7, name: 'Laser Cutter' } }),
+}));
+
+const baseRequest = {
+  id: 'req-1',
+  resourceId: 7,
+  requesterUserId: 5,
+  requesterUsername: 'bob',
+  supervisorUserId: 1,
+  notes: 'please',
+  createdAt: new Date().toISOString(),
+  expiresAt: new Date(Date.now() + 30_000).toISOString(),
+};
+
+function renderModal(overrides = {}) {
+  const props = {
+    request: baseRequest,
+    onApprove: vi.fn(),
+    onReject: vi.fn(),
+    onExpire: vi.fn(),
+    isApproving: false,
+    isRejecting: false,
+    ...overrides,
+  };
+  render(<SupervisorApprovalModal {...props} />);
+  return props;
+}
+
+describe('SupervisorApprovalModal', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the requester and resource', () => {
+    renderModal();
+    expect(screen.getByText('requester:bob')).toBeInTheDocument();
+    expect(screen.getByText('please')).toBeInTheDocument();
+  });
+
+  it('calls onApprove and onReject', async () => {
+    const props = renderModal();
+    await userEvent.click(screen.getByText('approve'));
+    expect(props.onApprove).toHaveBeenCalled();
+    await userEvent.click(screen.getByText('reject'));
+    expect(props.onReject).toHaveBeenCalled();
+  });
+
+  it('calls onExpire once the deadline passes', () => {
+    vi.useFakeTimers();
+    const onExpire = vi.fn();
+    renderModal({ request: { ...baseRequest, expiresAt: new Date(Date.now() + 1000).toISOString() }, onExpire });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(onExpire).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/supervisorApproval/SupervisorApprovalModal.tsx
+++ b/apps/frontend/src/components/supervisorApproval/SupervisorApprovalModal.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import {
+  Card,
+  Description,
   Modal,
   ModalBackdrop,
   ModalBody,
@@ -73,9 +75,7 @@ export function SupervisorApprovalModal({
 
                 <ModalBody>
                   <div className="space-y-4">
-                    <p className="text-sm text-gray-700 dark:text-gray-300">
-                      {t('description', { resource: resource?.name ?? '' })}
-                    </p>
+                    <Description>{t('description', { resource: resource?.name ?? '' })}</Description>
 
                     <AttraccessUser
                       user={
@@ -88,15 +88,17 @@ export function SupervisorApprovalModal({
                     />
 
                     {request.notes ? (
-                      <div className="rounded-md bg-gray-50 dark:bg-gray-800 p-2">
-                        <p className="text-xs font-medium text-gray-500 dark:text-gray-400">{t('notesLabel')}</p>
-                        <p className="text-sm text-gray-800 dark:text-gray-200">{request.notes}</p>
-                      </div>
+                      <Card>
+                        <Card.Content className="gap-1">
+                          <Description>{t('notesLabel')}</Description>
+                          <p className="text-sm">{request.notes}</p>
+                        </Card.Content>
+                      </Card>
                     ) : null}
 
-                    <div className="flex items-center justify-center gap-2 text-gray-500 dark:text-gray-400">
+                    <div className="flex items-center justify-center gap-2">
                       <Spinner color="accent" size="sm" />
-                      <span className="tabular-nums">{t('countdown', { seconds: secondsLeft })}</span>
+                      <Description className="tabular-nums">{t('countdown', { seconds: secondsLeft })}</Description>
                     </div>
                   </div>
                 </ModalBody>

--- a/apps/frontend/src/components/supervisorApproval/SupervisorApprovalModal.tsx
+++ b/apps/frontend/src/components/supervisorApproval/SupervisorApprovalModal.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import {
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalContainer,
+  ModalDialog,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  Spinner,
+} from '@heroui/react';
+import { AttraccessUser, useTranslations } from '@attraccess/plugins-frontend-ui';
+import { SupervisionRequestDto, User, useResourcesServiceGetOneResourceById } from '@attraccess/react-query-client';
+import { Button } from '../button';
+import en from './translations/en.json';
+import de from './translations/de.json';
+
+export interface SupervisorApprovalModalProps {
+  request: SupervisionRequestDto;
+  onApprove: () => void;
+  onReject: () => void;
+  /** Called when the local countdown reaches zero (in sync with the backend timeout). */
+  onExpire: () => void;
+  isApproving: boolean;
+  isRejecting: boolean;
+}
+
+function secondsUntil(expiresAt: string): number {
+  return Math.max(0, Math.ceil((new Date(expiresAt).getTime() - new Date().getTime()) / 1000));
+}
+
+export function SupervisorApprovalModal({
+  request,
+  onApprove,
+  onReject,
+  onExpire,
+  isApproving,
+  isRejecting,
+}: Readonly<SupervisorApprovalModalProps>) {
+  const { t } = useTranslations({ en, de });
+  const [secondsLeft, setSecondsLeft] = useState(() => secondsUntil(request.expiresAt));
+
+  const { data: resource } = useResourcesServiceGetOneResourceById({ id: request.resourceId });
+
+  useEffect(() => {
+    setSecondsLeft(secondsUntil(request.expiresAt));
+
+    const interval = setInterval(() => {
+      const remaining = secondsUntil(request.expiresAt);
+      setSecondsLeft(remaining);
+      if (remaining <= 0) {
+        clearInterval(interval);
+        onExpire();
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [request.expiresAt, request.id, onExpire]);
+
+  const isBusy = isApproving || isRejecting;
+
+  return (
+    <Modal isOpen={true}>
+      <ModalBackdrop>
+        <ModalContainer size="md">
+          <ModalDialog>
+            {() => (
+              <>
+                <ModalHeader>
+                  <ModalHeading>{t('title')}</ModalHeading>
+                </ModalHeader>
+
+                <ModalBody>
+                  <div className="space-y-4">
+                    <p className="text-sm text-gray-700 dark:text-gray-300">
+                      {t('description', { resource: resource?.name ?? '' })}
+                    </p>
+
+                    <AttraccessUser
+                      user={
+                        {
+                          id: request.requesterUserId,
+                          username: request.requesterUsername,
+                        } as unknown as User
+                      }
+                      description={t('requesterRole')}
+                    />
+
+                    {request.notes ? (
+                      <div className="rounded-md bg-gray-50 dark:bg-gray-800 p-2">
+                        <p className="text-xs font-medium text-gray-500 dark:text-gray-400">{t('notesLabel')}</p>
+                        <p className="text-sm text-gray-800 dark:text-gray-200">{request.notes}</p>
+                      </div>
+                    ) : null}
+
+                    <div className="flex items-center justify-center gap-2 text-gray-500 dark:text-gray-400">
+                      <Spinner color="accent" size="sm" />
+                      <span className="tabular-nums">{t('countdown', { seconds: secondsLeft })}</span>
+                    </div>
+                  </div>
+                </ModalBody>
+
+                <ModalFooter>
+                  <Button variant="danger" onPress={onReject} isPending={isRejecting} isDisabled={isBusy}>
+                    {t('reject')}
+                  </Button>
+                  <Button variant="primary" onPress={onApprove} isPending={isApproving} isDisabled={isBusy}>
+                    {t('approve')}
+                  </Button>
+                </ModalFooter>
+              </>
+            )}
+          </ModalDialog>
+        </ModalContainer>
+      </ModalBackdrop>
+    </Modal>
+  );
+}

--- a/apps/frontend/src/components/supervisorApproval/translations/de.json
+++ b/apps/frontend/src/components/supervisorApproval/translations/de.json
@@ -1,0 +1,19 @@
+{
+  "title": "Aufsichtsanfrage",
+  "description": "Ein Nutzer möchte eine beaufsichtigte Sitzung an {{resource}} starten.",
+  "requesterRole": "Anfragender Nutzer",
+  "notesLabel": "Notizen",
+  "countdown": "Läuft ab in {{seconds}}s",
+  "approve": "Genehmigen",
+  "reject": "Ablehnen",
+  "toast": {
+    "approved": {
+      "title": "Sitzung genehmigt",
+      "description": "Die beaufsichtigte Sitzung wurde gestartet."
+    },
+    "error": {
+      "title": "Genehmigung fehlgeschlagen",
+      "description": "Die Anfrage ist möglicherweise abgelaufen. Bitte versuche es erneut."
+    }
+  }
+}

--- a/apps/frontend/src/components/supervisorApproval/translations/en.json
+++ b/apps/frontend/src/components/supervisorApproval/translations/en.json
@@ -1,0 +1,19 @@
+{
+  "title": "Supervision request",
+  "description": "A user wants to start a supervised session on {{resource}}.",
+  "requesterRole": "Requesting user",
+  "notesLabel": "Notes",
+  "countdown": "Expires in {{seconds}}s",
+  "approve": "Approve",
+  "reject": "Reject",
+  "toast": {
+    "approved": {
+      "title": "Session approved",
+      "description": "The supervised session has been started."
+    },
+    "error": {
+      "title": "Could not approve",
+      "description": "The request may have expired. Please try again."
+    }
+  }
+}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Frontend for **supervised start** ([ATT-489](https://linear.app/attraccess/issue/ATT-489)). Backend (ATT-487/490/491) already shipped; this wires the web UX. Core principle honored: **the start flow for the user stays identical to the normal start** — no relearning.

### User side (the user being introduced)
- Clicks **Start** as usual (`MachineStartControls`). When not introduced but the resource allows supervision, the previous *introduction-required* block is replaced: starting opens a **"Supervisor required"** popup listing the authorized supervisors (introducers + maintainers).
- After selecting a supervisor → waits for approval with a **30s countdown**. On timeout/rejection → clear message with **retry**. On approval → normal active-session view.

### Supervisor side
- A global SSE listener (`SupervisorApprovalListener`, mounted once for authenticated users) surfaces incoming requests as a **realtime popup** showing user + resource with **Approve/Reject**.
- **Auto-dismisses after 30s**, in sync with the backend timeout.

Supervisor-initiated flow is intentionally **out of scope** (discarded in the ticket).

## Implementation
- `SupervisedStartModal` — supervisor selection → waiting/countdown → timeout/rejected states with retry. Reuses the existing form/notes/project gathering, then calls `resourceUsageRequestSupervisedSession`.
- `ResourceUsageSession` — branches on `supervisionMode`: not-introduced + supervision allowed/required renders the normal `StartSessionControls` with `requiresSupervision`, otherwise the unchanged introduction-required block.
- `SupervisorApprovalListener` + `SupervisorApprovalModal` — SSE stream `/api/resources/supervision/requests/live`, seeded by `supervisionListPendingRequests` for reconnect; approve/reject mutations; countdown to `expiresAt`.
- de/en translations for both popups.

## Testing
- `pnpm nx run frontend:{lint,typecheck,build,test}` — all green (210 frontend tests, 8 new across the two popups).
- Browser-verified end-to-end with two real sessions (`agent-browser`): user popup, waiting/countdown, supervisor approval popup, approval → active session, and 30s timeout. Screenshots posted to Linear.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
