### PR TITLE
feat(attractap): redesign resource-usage form UI + prefetch field cache (ATT-541)

### DIFF
--- a/apps/attractap/firmware/lib/SensorLib/src/TouchDrvGT911.hpp
+++ b/apps/attractap/firmware/lib/SensorLib/src/TouchDrvGT911.hpp
@@ -203,12 +203,23 @@ public:
         uint8_t val = readGT911(GT911_POINT_INFO);
 
         bool haveKey = GT911_GET_HAVE_KEY(val);
-        // bool bufferStatus = GT911_GET_BUFFER_STATUS(val);
         // log_i("REG:0x%X S:0X%d K:%d\n", val,bufferStatus,haveKey);
 
         if (__homeButtonCb && haveKey) {
             __homeButtonCb(__userData);
         }
+
+        // The GT911 refreshes its coordinate buffer on its own 5-15 ms scan
+        // cadence and flags a fresh sample via the buffer-status bit. When the
+        // host polls faster than the controller scans, the bit is still clear:
+        // there is no new sample, NOT a release. Report "stale" so the caller
+        // can hold its previous state, and leave the buffer alone (the
+        // datasheet only asks for a 0-write after reading a ready sample).
+        if (!GT911_GET_BUFFER_STATUS(val)) {
+            __lastSampleStale = true;
+            return 0;
+        }
+        __lastSampleStale = false;
 
         clearBuffer();
 
@@ -221,6 +232,9 @@ public:
         uint8_t write_buffer[2] = {0x81, 0x4F};
         if (writeThenRead(write_buffer, SENSORLIB_COUNT(write_buffer),
                           buffer, 39) == DEV_WIRE_ERR) {
+            // Bus error mid-read: the sample never arrived, treat as stale
+            // rather than synthesizing an empty (released) sample.
+            __lastSampleStale = true;
             return 0;
         }
 
@@ -255,6 +269,14 @@ public:
         return touchPoint;
     }
 
+
+    // True when the last getPoint(x, y, size) call found no fresh sample
+    // (buffer-status bit clear or bus error). A return value of 0 then means
+    // "no new data since the last poll", not "finger lifted".
+    bool isLastSampleStale() const
+    {
+        return __lastSampleStale;
+    }
 
     bool isPressed()
     {
@@ -721,6 +743,7 @@ protected:
     int __irq_mode;
     uint8_t *__config = NULL;
     uint16_t __config_size = 0;
+    bool __lastSampleStale = false;
 };
 
 

--- a/apps/attractap/firmware/src/application/application.hpp
+++ b/apps/attractap/firmware/src/application/application.hpp
@@ -270,6 +270,30 @@ private:
     uint8_t formCursorFormIdx = 0;
     uint32_t formCursorOffset = 0;
 
+    // Prefetch cache for paginated form fields. Each navigation otherwise costs a
+    // full server round-trip; we cache visited pages and preload the next one so
+    // forward/back navigation renders instantly. Keyed by (formId, offset).
+    struct FormPageCacheEntry {
+      bool valid = false;
+      uint32_t formId = 0;
+      uint32_t offset = 0;
+      uint32_t lru = 0;
+      API::ResourceUsageFormFieldsPage page;
+    };
+    static constexpr uint8_t FORM_PAGE_CACHE_SIZE = 4;
+    FormPageCacheEntry formPageCache[FORM_PAGE_CACHE_SIZE];
+    uint32_t formCacheTick = 0;
+    // True while a GET for the field the user is currently waiting on is in flight.
+    bool awaitingFieldRender = false;
+
+    FormPageCacheEntry *findFormPageCache(uint32_t formId, uint32_t offset);
+    FormPageCacheEntry *storeFormPageCache(const API::ResourceUsageFormFieldsPage &page);
+    void invalidateFormPageCache(uint32_t formId, uint32_t offset);
+    void clearFormPageCache();
+    void renderFormFieldPage(const API::ResourceUsageFormFieldsPage &page);
+    bool computeNextFormCursor(uint8_t &formIdx, uint32_t &offset) const;
+    void prefetchNextFormField();
+
     void selectResource(const API::ResourceBrief &resource);
 
     void requestProjectsPage(uint32_t page);

--- a/apps/attractap/firmware/src/application/application_forms.cpp
+++ b/apps/attractap/firmware/src/application/application_forms.cpp
@@ -11,6 +11,8 @@ void Application::handleFormsRequest(
   this->hasPendingFormRequest = true;
   this->formCursorFormIdx = 0;
   this->formCursorOffset = 0;
+  this->clearFormPageCache();
+  this->awaitingFieldRender = false;
   Display::resourceDetailsScreen.hideActionProgress();
   Display::resourceDetailsScreen.showFormsModal(this->pendingFormRequest);
   this->requestCurrentFormField();
@@ -68,6 +70,18 @@ void Application::requestCurrentFormField() {
   }
   const API::ResourceUsageFormMeta &form =
       this->pendingFormRequest.forms[this->formCursorFormIdx];
+
+  // Serve from cache when available (instant); otherwise fetch and wait.
+  FormPageCacheEntry *cached =
+      this->findFormPageCache(form.id, this->formCursorOffset);
+  if (cached) {
+    this->awaitingFieldRender = false;
+    this->renderFormFieldPage(cached->page);
+    this->prefetchNextFormField();
+    return;
+  }
+
+  this->awaitingFieldRender = true;
   this->api.requestFormFields(this->pendingFormRequest.resourceId,
                               this->pendingFormRequest.action, form.id,
                               this->formCursorOffset, API::MAX_FORM_PAGE_FIELDS);
@@ -107,10 +121,26 @@ void Application::handleFormFields(const API::ResourceUsageFormFieldsPage &page)
   if (!this->hasPendingFormRequest) {
     return;
   }
-  bool canGoBack = this->globalFormFieldNumber() > 1;
-  Display::resourceDetailsScreen.renderFormField(
-      page, canGoBack, this->isLastFormField(), this->globalFormFieldNumber(),
-      this->totalFormFields());
+
+  // Always cache the page (covers both the awaited current field and prefetched
+  // neighbours). renderFormFieldPage reads from the stable cache slot, never the
+  // shared scratch buffer, so the displayed page survives later prefetch traffic.
+  FormPageCacheEntry *entry = this->storeFormPageCache(page);
+  if (!entry) {
+    return;
+  }
+
+  // Render only when this page is the one the user is actually waiting on.
+  if (this->awaitingFieldRender &&
+      this->formCursorFormIdx < this->pendingFormRequest.formCount) {
+    uint32_t currentFormId =
+        this->pendingFormRequest.forms[this->formCursorFormIdx].id;
+    if (page.formId == currentFormId && page.offset == this->formCursorOffset) {
+      this->awaitingFieldRender = false;
+      this->renderFormFieldPage(entry->page);
+      this->prefetchNextFormField();
+    }
+  }
 }
 
 void Application::handleFormPageNext(const API::FormPageSubmission &page) {
@@ -127,6 +157,9 @@ void Application::handleFormPageResult(
     return;
   }
   if (result.valid) {
+    // The submitted field's draft value changed server-side; drop its cached copy
+    // so navigating back re-fetches the persisted answer instead of a stale one.
+    this->invalidateFormPageCache(result.formId, result.offset);
     this->advanceFormCursor();
     this->requestCurrentFormField();
   } else {
@@ -164,6 +197,8 @@ void Application::handleFormsCancel() {
   this->pendingActionType = PENDING_ACTION_NONE;
   this->formCursorFormIdx = 0;
   this->formCursorOffset = 0;
+  this->clearFormPageCache();
+  this->awaitingFieldRender = false;
   Display::resourceDetailsScreen.hideFormsModal();
   Display::resourceDetailsScreen.hideActionProgress();
   this->endActionPause();
@@ -176,5 +211,106 @@ void Application::onActionResult(const String &eventType) {
     this->hasPendingFormRequest = false;
     Display::resourceDetailsScreen.hideFormsModal();
   }
+}
+
+Application::FormPageCacheEntry *Application::findFormPageCache(uint32_t formId,
+                                                               uint32_t offset) {
+  for (uint8_t i = 0; i < FORM_PAGE_CACHE_SIZE; ++i) {
+    FormPageCacheEntry &entry = this->formPageCache[i];
+    if (entry.valid && entry.formId == formId && entry.offset == offset) {
+      entry.lru = ++this->formCacheTick;
+      return &entry;
+    }
+  }
+  return nullptr;
+}
+
+Application::FormPageCacheEntry *
+Application::storeFormPageCache(const API::ResourceUsageFormFieldsPage &page) {
+  FormPageCacheEntry *slot = this->findFormPageCache(page.formId, page.offset);
+  if (!slot) {
+    // Reuse an empty slot, else evict the least-recently-used entry.
+    slot = &this->formPageCache[0];
+    for (uint8_t i = 0; i < FORM_PAGE_CACHE_SIZE; ++i) {
+      if (!this->formPageCache[i].valid) {
+        slot = &this->formPageCache[i];
+        break;
+      }
+      if (this->formPageCache[i].lru < slot->lru) {
+        slot = &this->formPageCache[i];
+      }
+    }
+  }
+  slot->valid = true;
+  slot->formId = page.formId;
+  slot->offset = page.offset;
+  slot->lru = ++this->formCacheTick;
+  slot->page = page;
+  return slot;
+}
+
+void Application::invalidateFormPageCache(uint32_t formId, uint32_t offset) {
+  for (uint8_t i = 0; i < FORM_PAGE_CACHE_SIZE; ++i) {
+    FormPageCacheEntry &entry = this->formPageCache[i];
+    if (entry.valid && entry.formId == formId && entry.offset == offset) {
+      entry.valid = false;
+    }
+  }
+}
+
+void Application::clearFormPageCache() {
+  for (uint8_t i = 0; i < FORM_PAGE_CACHE_SIZE; ++i) {
+    this->formPageCache[i].valid = false;
+  }
+  this->formCacheTick = 0;
+}
+
+void Application::renderFormFieldPage(
+    const API::ResourceUsageFormFieldsPage &page) {
+  bool canGoBack = this->globalFormFieldNumber() > 1;
+  Display::resourceDetailsScreen.renderFormField(
+      page, canGoBack, this->isLastFormField(), this->globalFormFieldNumber(),
+      this->totalFormFields());
+}
+
+bool Application::computeNextFormCursor(uint8_t &formIdx,
+                                        uint32_t &offset) const {
+  formIdx = this->formCursorFormIdx;
+  offset = this->formCursorOffset + API::MAX_FORM_PAGE_FIELDS;
+  if (formIdx < this->pendingFormRequest.formCount &&
+      offset >= this->pendingFormRequest.forms[formIdx].fieldCount) {
+    formIdx++;
+    offset = 0;
+  }
+  while (formIdx < this->pendingFormRequest.formCount &&
+         this->pendingFormRequest.forms[formIdx].fieldCount == 0) {
+    formIdx++;
+    offset = 0;
+  }
+  return formIdx < this->pendingFormRequest.formCount;
+}
+
+void Application::prefetchNextFormField() {
+  if (!this->hasPendingFormRequest) {
+    return;
+  }
+  // Never issue a prefetch while the current field's GET is still outstanding —
+  // a second in-flight request could overwrite the shared scratch buffer and the
+  // awaited render would be lost.
+  if (this->awaitingFieldRender) {
+    return;
+  }
+  uint8_t nextFormIdx = 0;
+  uint32_t nextOffset = 0;
+  if (!this->computeNextFormCursor(nextFormIdx, nextOffset)) {
+    return; // current field is the last one
+  }
+  uint32_t formId = this->pendingFormRequest.forms[nextFormIdx].id;
+  if (this->findFormPageCache(formId, nextOffset)) {
+    return; // already cached
+  }
+  this->api.requestFormFields(this->pendingFormRequest.resourceId,
+                              this->pendingFormRequest.action, formId, nextOffset,
+                              API::MAX_FORM_PAGE_FIELDS);
 }
 #endif

--- a/apps/attractap/firmware/src/display/driver/gt911/rgb_gt911_driver.cpp
+++ b/apps/attractap/firmware/src/display/driver/gt911/rgb_gt911_driver.cpp
@@ -253,6 +253,7 @@ bool RgbGt911Driver::readTouch(TouchPoint &point)
     }
 
     uint8_t touched = 0;
+    bool stale = false;
     {
         // One GT911 point read = one atomic conversation on the shared bus, so
         // it can never interleave with a PN532 exchange on the NFC task
@@ -261,12 +262,34 @@ bool RgbGt911Driver::readTouch(TouchPoint &point)
         // a leaf lock, NFC code never takes lv_lock while holding it.
         I2CBusGuard busGuard;
         touched = touch.getPoint(x, y, touch.getSupportTouchPoint());
+        stale = touch.isLastSampleStale();
     }
 
     if (touched <= 0)
     {
+        // The GT911 scans every 5-15 ms while LVGL polls every 15 ms
+        // (LV_DEF_REFR_PERIOD); a poll can land before the controller has a
+        // fresh sample. Treating that as "finger lifted" splits one press into
+        // several press/release pairs — each pair is a CLICKED event, so
+        // switches toggled right back and taps got swallowed (ATT-541). Hold
+        // the last known press through stale polls; a real release is a fresh
+        // empty sample and is still reported immediately. The hold window is
+        // capped so a wedged controller/bus cannot leave a press stuck.
+        if (stale && lastTouchPressed && (millis() - lastFreshSampleMs) <= TOUCH_STALE_HOLD_MS)
+        {
+            point = lastTouchPoint;
+            point.pressed = true;
+            return true;
+        }
+        if (!stale)
+        {
+            lastFreshSampleMs = millis();
+        }
+        lastTouchPressed = false;
         return false;
     }
+
+    lastFreshSampleMs = millis();
 
     logger.debugf("Touch detected: touched=%d, x=%d, y=%d", touched, x[0], y[0]);
 
@@ -276,5 +299,8 @@ bool RgbGt911Driver::readTouch(TouchPoint &point)
     point.x = (int16_t)(gfx->width() - 1) - x[0];
     point.y = (int16_t)(gfx->height() - 1) - y[0];
     point.pressed = true;
+
+    lastTouchPoint = point;
+    lastTouchPressed = true;
     return true;
 }

--- a/apps/attractap/firmware/src/display/driver/gt911/rgb_gt911_driver.hpp
+++ b/apps/attractap/firmware/src/display/driver/gt911/rgb_gt911_driver.hpp
@@ -42,4 +42,13 @@ private:
     uint32_t screenHeight = 0;
     bool initialized = false;
     bool touchInitialized = false;
+
+    // Ghost-release suppression (ATT-541): the GT911 scans on its own 5-15 ms
+    // cadence, so a 15 ms LVGL poll can land before a fresh sample exists.
+    // Such "stale" polls hold the last pressed state instead of reporting a
+    // release; the cap keeps a wedged controller from leaving a press stuck.
+    static constexpr uint32_t TOUCH_STALE_HOLD_MS = 100;
+    TouchPoint lastTouchPoint{};
+    bool lastTouchPressed = false;
+    uint32_t lastFreshSampleMs = 0;
 };

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
@@ -410,6 +410,13 @@ void ResourceDetailsScreen::buildCurrentFormField()
    lv_obj_set_style_width(resourceNameLabel, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_label_set_long_mode(resourceNameLabel, LV_LABEL_LONG_WRAP);
 
+   lv_obj_t *formTitle = lv_label_create(this->formsModalList);
+   lv_label_set_text(formTitle, formName.c_str());
+   lv_obj_set_style_text_font(formTitle, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_color(formTitle, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_label_set_long_mode(formTitle, LV_LABEL_LONG_WRAP);
+   lv_obj_set_style_width(formTitle, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
+
    {
       lv_obj_t *formCard = lv_obj_create(this->formsModalList);
       lv_obj_remove_style_all(formCard);
@@ -423,13 +430,6 @@ void ResourceDetailsScreen::buildCurrentFormField()
       lv_obj_set_style_pad_row(formCard, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
       lv_obj_set_flex_flow(formCard, LV_FLEX_FLOW_COLUMN);
       lv_obj_set_flex_align(formCard, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
-
-      lv_obj_t *formTitle = lv_label_create(formCard);
-      lv_label_set_text(formTitle, formName.c_str());
-      lv_obj_set_style_text_font(formTitle, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
-      lv_obj_set_style_text_color(formTitle, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
-      lv_label_set_long_mode(formTitle, LV_LABEL_LONG_WRAP);
-      lv_obj_set_style_width(formTitle, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
 
       {
          const API::ResourceUsageFormField &field = this->formsModalPage->fields[0];

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
@@ -27,12 +27,17 @@ void ResourceDetailsScreen::resetFormsModalState()
    this->formsProgressBar = nullptr;
    this->formsBreadcrumbLabel = nullptr;
    this->formsCancelButton = nullptr;
-   this->formsKeyboard = nullptr;
    this->formsBackButton = nullptr;
    this->formsNextButton = nullptr;
    this->formsNextLabel = nullptr;
    this->formsBusyOverlay = nullptr;
    this->formsBusyLabel = nullptr;
+   this->formsEditorOverlay = nullptr;
+   this->formsEditorTitleLabel = nullptr;
+   this->formsEditorTextarea = nullptr;
+   this->formsEditorSpacer = nullptr;
+   this->formsEditorKeyboard = nullptr;
+   this->formsEditorWidgetIndex = 0;
    this->formsBusy = false;
    this->formsModalMeta = nullptr;
    this->formsModalPage = nullptr;
@@ -79,12 +84,11 @@ void ResourceDetailsScreen::showFormsModal(const API::ResourceUsageFormRequest &
       lv_obj_add_state(this->formsBackButton, LV_STATE_DISABLED);
    }
 
-   this->hideFormsKeyboard();
+   this->closeFormsEditor(false);
    if (this->formsModalOverlay)
    {
       lv_obj_clear_flag(this->formsModalOverlay, LV_OBJ_FLAG_HIDDEN);
    }
-   this->updateFormsModalLayoutForKeyboard(false);
    // Block input while the first field is being fetched from the server.
    this->setFormsBusy(true, "Laden...");
 }
@@ -128,12 +132,7 @@ void ResourceDetailsScreen::renderFormField(const API::ResourceUsageFormFieldsPa
       lv_label_set_text(this->formsNextLabel, isLast ? "Absenden" : "Weiter");
    }
 
-   if (this->formsModalContent)
-   {
-      lv_obj_scroll_to_y(this->formsModalContent, 0, LV_ANIM_OFF);
-   }
-   this->hideFormsKeyboard();
-   this->updateFormsModalLayoutForKeyboard(false);
+   this->closeFormsEditor(false);
 }
 void ResourceDetailsScreen::showFormPageErrors(const API::ResourceUsageFormPageResult &result)
 {
@@ -161,7 +160,7 @@ void ResourceDetailsScreen::hideFormsModal()
    {
       lv_obj_add_flag(this->formsModalOverlay, LV_OBJ_FLAG_HIDDEN);
    }
-   this->hideFormsKeyboard();
+   this->closeFormsEditor(false);
 }
 void ResourceDetailsScreen::ensureFormsModal()
 {
@@ -239,7 +238,9 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_bar_set_range(this->formsProgressBar, 0, 100);
    lv_bar_set_value(this->formsProgressBar, 0, LV_ANIM_OFF);
 
-   // Scrollable body: breadcrumb + the single focused field, filling the panel.
+   // Body: breadcrumb + the single focused field, filling the panel. Never
+   // scrolls — text fields are tap-to-edit previews, editing happens in the
+   // fullscreen editor overlay, so everything always fits the screen.
    lv_obj_t *content = lv_obj_create(panel);
    this->formsModalContent = content;
    lv_obj_remove_style_all(content);
@@ -248,8 +249,7 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
    lv_obj_set_style_pad_row(content, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_pad_column(content, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_add_flag(content, LV_OBJ_FLAG_SCROLLABLE);
-   lv_obj_set_scroll_dir(content, LV_DIR_VER);
+   lv_obj_remove_flag(content, LV_OBJ_FLAG_SCROLLABLE);
    lv_obj_set_flex_grow(content, 1);
 
    this->formsBreadcrumbLabel = lv_label_create(content);
@@ -311,10 +311,80 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_set_align(this->formsNextLabel, LV_ALIGN_CENTER);
    lv_obj_add_event_cb(nextBtn, &ResourceDetailsScreen::onFormsNext, LV_EVENT_CLICKED, this);
 
-   this->formsKeyboard = lv_keyboard_create(overlay);
-   lv_obj_set_width(this->formsKeyboard, lv_pct(100));
-   lv_obj_add_flag(this->formsKeyboard, LV_OBJ_FLAG_HIDDEN);
-   lv_obj_add_event_cb(this->formsKeyboard, &ResourceDetailsScreen::onFormsKeyboardEvent, LV_EVENT_ALL, this);
+   // Fullscreen text editor overlay: opened when a text/number preview box is
+   // tapped. Solid background, textarea filling everything above the pinned
+   // keyboard — the page itself never scrolls; only the text inside the
+   // textarea scrolls when it grows beyond the visible area.
+   lv_obj_t *editor = lv_obj_create(overlay);
+   this->formsEditorOverlay = editor;
+   lv_obj_remove_style_all(editor);
+   lv_obj_add_flag(editor, LV_OBJ_FLAG_IGNORE_LAYOUT);
+   lv_obj_add_flag(editor, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_add_flag(editor, LV_OBJ_FLAG_HIDDEN);
+   lv_obj_remove_flag(editor, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_size(editor, lv_pct(100), lv_pct(100));
+   lv_obj_set_align(editor, LV_ALIGN_CENTER);
+   lv_obj_set_style_bg_color(editor, lv_color_hex(0x111827), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(editor, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_top(editor, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_left(editor, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_right(editor, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_bottom(editor, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_row(editor, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_flex_flow(editor, LV_FLEX_FLOW_COLUMN);
+   lv_obj_set_flex_align(editor, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+   // Editor header: field name (left) + cancel button (right).
+   lv_obj_t *editorHeader = lv_obj_create(editor);
+   lv_obj_remove_style_all(editorHeader);
+   lv_obj_remove_flag(editorHeader, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_width(editorHeader, lv_pct(100));
+   lv_obj_set_height(editorHeader, LV_SIZE_CONTENT);
+   lv_obj_set_flex_flow(editorHeader, LV_FLEX_FLOW_ROW);
+   lv_obj_set_flex_align(editorHeader, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+   lv_obj_set_style_pad_column(editorHeader, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   this->formsEditorTitleLabel = lv_label_create(editorHeader);
+   lv_label_set_text(this->formsEditorTitleLabel, "");
+   lv_obj_set_flex_grow(this->formsEditorTitleLabel, 1);
+   lv_label_set_long_mode(this->formsEditorTitleLabel, LV_LABEL_LONG_DOT);
+   lv_obj_set_style_text_color(this->formsEditorTitleLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_font(this->formsEditorTitleLabel, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   lv_obj_t *editorCancelBtn = lv_button_create(editorHeader);
+   lv_obj_remove_style_all(editorCancelBtn);
+   lv_obj_set_size(editorCancelBtn, 34, 34);
+   lv_obj_set_style_radius(editorCancelBtn, LV_RADIUS_CIRCLE, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_color(editorCancelBtn, lv_color_hex(0x1F2937), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(editorCancelBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_t *editorCancelLabel = lv_label_create(editorCancelBtn);
+   lv_label_set_text(editorCancelLabel, LV_SYMBOL_CLOSE);
+   lv_obj_set_style_text_color(editorCancelLabel, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_center(editorCancelLabel);
+   lv_obj_add_event_cb(editorCancelBtn, &ResourceDetailsScreen::onFormsEditorCancel, LV_EVENT_CLICKED, this);
+
+   // Textarea fills all space between header and keyboard.
+   lv_obj_t *editorTa = lv_textarea_create(editor);
+   this->formsEditorTextarea = editorTa;
+   lv_obj_set_width(editorTa, lv_pct(100));
+   lv_obj_set_flex_grow(editorTa, 1);
+   lv_obj_set_style_bg_color(editorTa, lv_color_hex(0x374151), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_color(editorTa, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   // Spacer keeps the keyboard pinned to the bottom when the textarea is
+   // one-line (multiline textareas grow instead, see openFormsEditor).
+   lv_obj_t *editorSpacer = lv_obj_create(editor);
+   this->formsEditorSpacer = editorSpacer;
+   lv_obj_remove_style_all(editorSpacer);
+   lv_obj_remove_flag(editorSpacer, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_remove_flag(editorSpacer, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_set_width(editorSpacer, lv_pct(100));
+   lv_obj_set_flex_grow(editorSpacer, 1);
+
+   this->formsEditorKeyboard = lv_keyboard_create(editor);
+   lv_obj_set_width(this->formsEditorKeyboard, lv_pct(100));
+   lv_obj_set_height(this->formsEditorKeyboard, lv_pct(45));
+   lv_obj_add_event_cb(this->formsEditorKeyboard, &ResourceDetailsScreen::onFormsEditorKeyboardEvent, LV_EVENT_ALL, this);
 
    // Busy overlay: created last so it floats above the panel + keyboard. While
    // visible it blocks all input behind it (CLICKABLE) until the server responds.
@@ -346,7 +416,7 @@ void ResourceDetailsScreen::setFormsBusy(bool busy, const char *text)
    this->formsBusy = busy;
    if (busy)
    {
-      this->hideFormsKeyboard();
+      this->closeFormsEditor(false);
    }
    if (this->formsBusyLabel && text)
    {
@@ -506,6 +576,8 @@ void ResourceDetailsScreen::buildCurrentFormField()
          widget.type = field.type;
          widget.isRequired = field.isRequired;
          widget.input = nullptr;
+         widget.previewLabel = nullptr;
+         widget.textValue = "";
          widget.errorLabel = nullptr;
          widget.definition = &field;
          widget.owner = this;
@@ -597,30 +669,40 @@ void ResourceDetailsScreen::buildCurrentFormField()
          }
          else
          {
-            lv_obj_t *ta = lv_textarea_create(fieldContainer);
-            widget.input = ta;
-            if (field.hasValue && field.value.length() > 0)
-            {
-               lv_textarea_set_text(ta, field.value.c_str());
-            }
-            lv_obj_set_width(ta, lv_pct(100));
-            lv_obj_set_style_bg_color(ta, lv_color_hex(0x374151), LV_PART_MAIN | LV_STATE_DEFAULT);
-            lv_obj_set_style_text_color(ta, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
-            lv_obj_set_style_pad_left(ta, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
-            lv_obj_set_style_pad_right(ta, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+            // Text/number fields are not edited inline: a tap-to-edit preview
+            // box opens the fullscreen editor overlay (textarea + keyboard),
+            // so the form page itself never has to scroll.
             bool multiline = field.type == API::ResourceUsageFormFieldType::TEXT && field.options.text.multiline;
-            lv_textarea_set_one_line(ta, !multiline);
-            if (field.type == API::ResourceUsageFormFieldType::TEXT && field.options.text.hasPlaceholder)
-            {
-               lv_textarea_set_placeholder_text(ta, field.options.text.placeholder.c_str());
-            }
-            if (field.type == API::ResourceUsageFormFieldType::NUMBER)
-            {
-               lv_textarea_set_accepted_chars(ta, "0123456789-.");
-               lv_textarea_set_one_line(ta, true);
-            }
-            lv_obj_add_event_cb(ta, &ResourceDetailsScreen::onFormFieldFocus, LV_EVENT_CLICKED, this);
-            lv_obj_add_event_cb(ta, &ResourceDetailsScreen::onFormFieldFocus, LV_EVENT_FOCUSED, this);
+
+            lv_obj_t *preview = lv_obj_create(fieldContainer);
+            widget.input = preview;
+            widget.textValue = field.hasValue ? field.value : String("");
+            lv_obj_remove_style_all(preview);
+            lv_obj_add_flag(preview, LV_OBJ_FLAG_CLICKABLE);
+            lv_obj_remove_flag(preview, LV_OBJ_FLAG_SCROLLABLE);
+            lv_obj_set_width(preview, lv_pct(100));
+            lv_obj_set_height(preview, multiline ? 96 : 52);
+            lv_obj_set_style_bg_color(preview, lv_color_hex(0x374151), LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_bg_opa(preview, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_radius(preview, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_pad_all(preview, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_pad_column(preview, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_flex_flow(preview, LV_FLEX_FLOW_ROW);
+            lv_obj_set_flex_align(preview, LV_FLEX_ALIGN_SPACE_BETWEEN,
+                                  multiline ? LV_FLEX_ALIGN_START : LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_START);
+
+            lv_obj_t *valueLabel = lv_label_create(preview);
+            widget.previewLabel = valueLabel;
+            lv_obj_set_flex_grow(valueLabel, 1);
+            // Multiline: wrap and clip at the fixed preview height. Single line: ellipsis.
+            lv_label_set_long_mode(valueLabel, multiline ? LV_LABEL_LONG_WRAP : LV_LABEL_LONG_DOT);
+
+            lv_obj_t *editIcon = lv_label_create(preview);
+            lv_label_set_text(editIcon, LV_SYMBOL_EDIT);
+            lv_obj_set_style_text_color(editIcon, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
+
+            lv_obj_add_event_cb(preview, &ResourceDetailsScreen::onFieldPreviewClick, LV_EVENT_CLICKED, this);
+            this->updateFieldPreview(widget);
          }
 
          widget.errorLabel = lv_label_create(fieldContainer);
@@ -699,8 +781,8 @@ bool ResourceDetailsScreen::collectCurrentField(API::FormPageSubmission &outPage
          continue;
       }
 
-      const char *rawText = widget.input ? lv_textarea_get_text(widget.input) : "";
-      String value = rawText ? String(rawText) : "";
+      // Text/number values live in widget.textValue (committed by the fullscreen editor).
+      String value = widget.textValue;
       value.trim();
 
       if (value.length() == 0)
@@ -779,44 +861,113 @@ void ResourceDetailsScreen::clearFormFieldErrors()
       lv_label_set_text(this->formsModalErrorLabel, "");
    }
 }
-void ResourceDetailsScreen::hideFormsKeyboard()
+void ResourceDetailsScreen::updateFieldPreview(FormFieldWidget &widget)
 {
-   if (!this->formsKeyboard)
+   if (!widget.previewLabel)
    {
       return;
    }
-   lv_obj_add_flag(this->formsKeyboard, LV_OBJ_FLAG_HIDDEN);
-   lv_keyboard_set_textarea(this->formsKeyboard, nullptr);
-   this->updateFormsModalLayoutForKeyboard(false);
+   String trimmed = widget.textValue;
+   trimmed.trim();
+   if (trimmed.length() == 0)
+   {
+      // Empty: show the field placeholder (or a generic hint) in muted gray.
+      const char *hint = "Antippen zum Eingeben";
+      if (widget.definition && widget.type == API::ResourceUsageFormFieldType::TEXT &&
+          widget.definition->options.text.hasPlaceholder && widget.definition->options.text.placeholder.length() > 0)
+      {
+         hint = widget.definition->options.text.placeholder.c_str();
+      }
+      lv_label_set_text(widget.previewLabel, hint);
+      lv_obj_set_style_text_color(widget.previewLabel, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   }
+   else
+   {
+      lv_label_set_text(widget.previewLabel, widget.textValue.c_str());
+      lv_obj_set_style_text_color(widget.previewLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   }
 }
-void ResourceDetailsScreen::updateFormsModalLayoutForKeyboard(bool keyboardVisible)
+void ResourceDetailsScreen::openFormsEditor(uint16_t widgetIndex)
 {
-   (void)keyboardVisible;
-   if (!this->formsModalOverlay)
+   if (!this->formsEditorOverlay || !this->formsEditorTextarea || !this->formsEditorKeyboard)
    {
       return;
    }
-   lv_obj_mark_layout_as_dirty(this->formsModalOverlay);
-   lv_obj_update_layout(this->formsModalOverlay);
+   if (widgetIndex >= this->formFieldWidgetCount)
+   {
+      return;
+   }
+   FormFieldWidget &widget = this->formFieldWidgets[widgetIndex];
+   this->formsEditorWidgetIndex = widgetIndex;
+
+   if (this->formsEditorTitleLabel)
+   {
+      String title = widget.definition ? widget.definition->name : String("");
+      if (widget.isRequired)
+      {
+         title += " *";
+      }
+      lv_label_set_text(this->formsEditorTitleLabel, title.c_str());
+   }
+
+   bool multiline = widget.definition && widget.type == API::ResourceUsageFormFieldType::TEXT &&
+                    widget.definition->options.text.multiline;
+   lv_textarea_set_one_line(this->formsEditorTextarea, !multiline);
+   // Multiline: textarea fills the space above the keyboard. One-line: textarea
+   // stays compact under the header, spacer pushes the keyboard to the bottom.
+   lv_obj_set_flex_grow(this->formsEditorTextarea, multiline ? 1 : 0);
+   if (this->formsEditorSpacer)
+   {
+      lv_obj_set_flex_grow(this->formsEditorSpacer, multiline ? 0 : 1);
+      lv_obj_set_height(this->formsEditorSpacer, multiline ? 0 : LV_SIZE_CONTENT);
+   }
+   lv_textarea_set_accepted_chars(this->formsEditorTextarea,
+                                  widget.type == API::ResourceUsageFormFieldType::NUMBER ? "0123456789-." : nullptr);
+   const char *placeholder = "";
+   if (widget.definition && widget.type == API::ResourceUsageFormFieldType::TEXT &&
+       widget.definition->options.text.hasPlaceholder)
+   {
+      placeholder = widget.definition->options.text.placeholder.c_str();
+   }
+   lv_textarea_set_placeholder_text(this->formsEditorTextarea, placeholder);
+   lv_textarea_set_text(this->formsEditorTextarea, widget.textValue.c_str());
+   lv_textarea_set_cursor_pos(this->formsEditorTextarea, LV_TEXTAREA_CURSOR_LAST);
+
+   lv_keyboard_set_mode(this->formsEditorKeyboard,
+                        widget.type == API::ResourceUsageFormFieldType::NUMBER ? LV_KEYBOARD_MODE_NUMBER
+                                                                               : LV_KEYBOARD_MODE_TEXT_LOWER);
+   lv_keyboard_set_textarea(this->formsEditorKeyboard, this->formsEditorTextarea);
+
+   lv_obj_clear_flag(this->formsEditorOverlay, LV_OBJ_FLAG_HIDDEN);
+   lv_obj_move_foreground(this->formsEditorOverlay);
+   // Busy overlay must stay above everything when it shows up later.
+   if (this->formsBusyOverlay)
+   {
+      lv_obj_move_foreground(this->formsBusyOverlay);
+   }
 }
-void ResourceDetailsScreen::showKeyboardForWidget(FormFieldWidget &widget, lv_obj_t *target)
+void ResourceDetailsScreen::closeFormsEditor(bool commit)
 {
-   if (!this->formsKeyboard)
+   if (!this->formsEditorOverlay)
    {
       return;
    }
-   lv_keyboard_set_textarea(this->formsKeyboard, target);
-   lv_keyboard_mode_t mode = LV_KEYBOARD_MODE_TEXT_LOWER;
-   if (widget.type == API::ResourceUsageFormFieldType::NUMBER)
+   if (commit && this->formsEditorTextarea && this->formsEditorWidgetIndex < this->formFieldWidgetCount)
    {
-      mode = LV_KEYBOARD_MODE_NUMBER;
+      FormFieldWidget &widget = this->formFieldWidgets[this->formsEditorWidgetIndex];
+      if (widget.type != API::ResourceUsageFormFieldType::BOOLEAN &&
+          widget.type != API::ResourceUsageFormFieldType::SELECT)
+      {
+         const char *text = lv_textarea_get_text(this->formsEditorTextarea);
+         widget.textValue = text ? String(text) : String("");
+         this->updateFieldPreview(widget);
+      }
    }
-   lv_keyboard_set_mode(this->formsKeyboard, mode);
-   lv_obj_clear_flag(this->formsKeyboard, LV_OBJ_FLAG_HIDDEN);
-   // Use recursive scroll to ensure nested containers (form cards inside the modal list)
-   // adjust even when the keyboard shrinks the available viewport.
-   lv_obj_scroll_to_view_recursive(target, LV_ANIM_OFF);
-   this->updateFormsModalLayoutForKeyboard(true);
+   if (this->formsEditorKeyboard)
+   {
+      lv_keyboard_set_textarea(this->formsEditorKeyboard, nullptr);
+   }
+   lv_obj_add_flag(this->formsEditorOverlay, LV_OBJ_FLAG_HIDDEN);
 }
 void ResourceDetailsScreen::onFormsNext(lv_event_t *e)
 {
@@ -888,10 +1039,9 @@ void ResourceDetailsScreen::onFormsCancel(lv_event_t *e)
       self->formsCancelCallback();
    }
 }
-void ResourceDetailsScreen::onFormFieldFocus(lv_event_t *e)
+void ResourceDetailsScreen::onFieldPreviewClick(lv_event_t *e)
 {
-   auto code = lv_event_get_code(e);
-   if (code != LV_EVENT_CLICKED && code != LV_EVENT_FOCUSED)
+   if (lv_event_get_code(e) != LV_EVENT_CLICKED)
    {
       return;
    }
@@ -900,21 +1050,23 @@ void ResourceDetailsScreen::onFormFieldFocus(lv_event_t *e)
    {
       return;
    }
-   lv_obj_t *target = static_cast<lv_obj_t *>(lv_event_get_target(e));
+   if (self->formsBusy)
+   {
+      return;
+   }
+   lv_obj_t *target = static_cast<lv_obj_t *>(lv_event_get_current_target(e));
    FormFieldWidget *widget = self->findFieldWidgetByObject(target);
    if (!widget)
    {
-      self->hideFormsKeyboard();
       return;
    }
    if (widget->type == API::ResourceUsageFormFieldType::BOOLEAN || widget->type == API::ResourceUsageFormFieldType::SELECT)
    {
-      self->hideFormsKeyboard();
       return;
    }
-   self->showKeyboardForWidget(*widget, target);
+   self->openFormsEditor(widget->widgetIndex);
 }
-void ResourceDetailsScreen::onFormsKeyboardEvent(lv_event_t *e)
+void ResourceDetailsScreen::onFormsEditorKeyboardEvent(lv_event_t *e)
 {
    auto code = lv_event_get_code(e);
    if (code != LV_EVENT_READY && code != LV_EVENT_CANCEL)
@@ -926,7 +1078,21 @@ void ResourceDetailsScreen::onFormsKeyboardEvent(lv_event_t *e)
    {
       return;
    }
-   self->hideFormsKeyboard();
+   // Checkmark commits the text, keyboard-hide discards it.
+   self->closeFormsEditor(code == LV_EVENT_READY);
+}
+void ResourceDetailsScreen::onFormsEditorCancel(lv_event_t *e)
+{
+   if (lv_event_get_code(e) != LV_EVENT_CLICKED)
+   {
+      return;
+   }
+   auto *self = static_cast<ResourceDetailsScreen *>(lv_event_get_user_data(e));
+   if (!self)
+   {
+      return;
+   }
+   self->closeFormsEditor(false);
 }
 void ResourceDetailsScreen::onSelectOptionClick(lv_event_t *e)
 {

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
@@ -24,11 +24,13 @@ void ResourceDetailsScreen::resetFormsModalState()
    this->formsModalList = nullptr;
    this->formsModalErrorLabel = nullptr;
    this->formsModalProgressLabel = nullptr;
+   this->formsProgressBar = nullptr;
+   this->formsBreadcrumbLabel = nullptr;
+   this->formsCancelButton = nullptr;
    this->formsKeyboard = nullptr;
    this->formsBackButton = nullptr;
    this->formsNextButton = nullptr;
    this->formsNextLabel = nullptr;
-   this->formsCancelButton = nullptr;
    this->formsBusyOverlay = nullptr;
    this->formsBusyLabel = nullptr;
    this->formsBusy = false;
@@ -98,8 +100,14 @@ void ResourceDetailsScreen::renderFormField(const API::ResourceUsageFormFieldsPa
 
    if (this->formsModalProgressLabel)
    {
-      String progress = "Feld " + String(fieldNumber) + " / " + String(totalFields);
+      String progress = String(fieldNumber) + " / " + String(totalFields);
       lv_label_set_text(this->formsModalProgressLabel, progress.c_str());
+   }
+
+   if (this->formsProgressBar && totalFields > 0)
+   {
+      int32_t pct = static_cast<int32_t>((static_cast<uint64_t>(fieldNumber) * 100) / totalFields);
+      lv_bar_set_value(this->formsProgressBar, pct, LV_ANIM_ON);
    }
 
    this->buildCurrentFormField();
@@ -189,23 +197,67 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_remove_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
    lv_obj_set_flex_grow(panel, 1);
 
+   // Header: step counter (left) + dismiss button (right).
+   lv_obj_t *header = lv_obj_create(panel);
+   lv_obj_remove_style_all(header);
+   lv_obj_remove_flag(header, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_width(header, lv_pct(100));
+   lv_obj_set_height(header, LV_SIZE_CONTENT);
+   lv_obj_set_flex_flow(header, LV_FLEX_FLOW_ROW);
+   lv_obj_set_flex_align(header, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+   this->formsModalProgressLabel = lv_label_create(header);
+   lv_label_set_text(this->formsModalProgressLabel, "");
+   lv_obj_set_style_text_color(this->formsModalProgressLabel, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_font(this->formsModalProgressLabel, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   lv_obj_t *cancelBtn = lv_button_create(header);
+   this->formsCancelButton = cancelBtn;
+   lv_obj_remove_style_all(cancelBtn);
+   lv_obj_set_size(cancelBtn, 34, 34);
+   lv_obj_set_style_radius(cancelBtn, LV_RADIUS_CIRCLE, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_color(cancelBtn, lv_color_hex(0x1F2937), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(cancelBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_t *cancelLabel = lv_label_create(cancelBtn);
+   lv_label_set_text(cancelLabel, LV_SYMBOL_CLOSE);
+   lv_obj_set_style_text_color(cancelLabel, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_center(cancelLabel);
+   lv_obj_add_event_cb(cancelBtn, &ResourceDetailsScreen::onFormsCancel, LV_EVENT_CLICKED, this);
+
+   // Slim progress bar tracking field N of total.
+   this->formsProgressBar = lv_bar_create(panel);
+   lv_obj_set_width(this->formsProgressBar, lv_pct(100));
+   lv_obj_set_height(this->formsProgressBar, 6);
+   lv_obj_set_style_margin_top(this->formsProgressBar, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_margin_bottom(this->formsProgressBar, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_radius(this->formsProgressBar, 3, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_color(this->formsProgressBar, lv_color_hex(0x374151), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(this->formsProgressBar, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_radius(this->formsProgressBar, 3, LV_PART_INDICATOR | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_color(this->formsProgressBar, lv_color_hex(0x10B981), LV_PART_INDICATOR | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(this->formsProgressBar, 255, LV_PART_INDICATOR | LV_STATE_DEFAULT);
+   lv_bar_set_range(this->formsProgressBar, 0, 100);
+   lv_bar_set_value(this->formsProgressBar, 0, LV_ANIM_OFF);
+
+   // Scrollable body: breadcrumb + the single focused field, filling the panel.
    lv_obj_t *content = lv_obj_create(panel);
    this->formsModalContent = content;
    lv_obj_remove_style_all(content);
-   // the content container is the dedicated scroll root
    lv_obj_set_width(content, lv_pct(100));
    lv_obj_set_flex_flow(content, LV_FLEX_FLOW_COLUMN);
    lv_obj_set_flex_align(content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
-   lv_obj_set_style_pad_row(content, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_row(content, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_pad_column(content, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_add_flag(content, LV_OBJ_FLAG_SCROLLABLE);
    lv_obj_set_scroll_dir(content, LV_DIR_VER);
    lv_obj_set_flex_grow(content, 1);
 
-   this->formsModalProgressLabel = lv_label_create(content);
-   lv_label_set_text(this->formsModalProgressLabel, "");
-   lv_obj_set_style_text_color(this->formsModalProgressLabel, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_set_style_text_font(this->formsModalProgressLabel, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+   this->formsBreadcrumbLabel = lv_label_create(content);
+   lv_label_set_text(this->formsBreadcrumbLabel, "");
+   lv_obj_set_style_text_color(this->formsBreadcrumbLabel, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_text_font(this->formsBreadcrumbLabel, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_width(this->formsBreadcrumbLabel, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_label_set_long_mode(this->formsBreadcrumbLabel, LV_LABEL_LONG_WRAP);
 
    this->formsModalErrorLabel = lv_label_create(content);
    lv_label_set_text(this->formsModalErrorLabel, "");
@@ -220,45 +272,38 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_set_height(list, LV_SIZE_CONTENT);
    lv_obj_set_flex_flow(list, LV_FLEX_FLOW_COLUMN);
    lv_obj_set_flex_align(list, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
-   lv_obj_set_style_pad_row(list, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_set_style_pad_column(list, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_row(list, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_column(list, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_top(list, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-   lv_obj_t *footer = lv_obj_create(content);
+   // Footer pinned below the body: secondary back + primary next/submit.
+   lv_obj_t *footer = lv_obj_create(panel);
    lv_obj_remove_style_all(footer);
    lv_obj_remove_flag(footer, LV_OBJ_FLAG_SCROLLABLE);
    lv_obj_set_width(footer, lv_pct(100));
    lv_obj_set_height(footer, LV_SIZE_CONTENT);
-   lv_obj_set_flex_flow(footer, LV_FLEX_FLOW_ROW_WRAP);
+   lv_obj_set_flex_flow(footer, LV_FLEX_FLOW_ROW);
    lv_obj_set_flex_align(footer, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-   lv_obj_set_style_pad_top(footer, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_top(footer, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_pad_column(footer, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_set_style_pad_row(footer, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
 
    lv_obj_t *backBtn = lv_button_create(footer);
    this->formsBackButton = backBtn;
-   lv_obj_set_width(backBtn, LV_SIZE_CONTENT);
+   lv_obj_set_flex_grow(backBtn, 1);
    lv_obj_set_height(backBtn, LV_SIZE_CONTENT);
-   lv_obj_set_style_pad_all(backBtn, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_all(backBtn, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_color(backBtn, lv_color_hex(0x1F2937), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(backBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_t *backLabel = lv_label_create(backBtn);
    lv_label_set_text(backLabel, "Zurueck");
    lv_obj_set_align(backLabel, LV_ALIGN_CENTER);
    lv_obj_add_event_cb(backBtn, &ResourceDetailsScreen::onFormsBack, LV_EVENT_CLICKED, this);
 
-   lv_obj_t *cancelBtn = lv_button_create(footer);
-   this->formsCancelButton = cancelBtn;
-   lv_obj_set_width(cancelBtn, LV_SIZE_CONTENT);
-   lv_obj_set_height(cancelBtn, LV_SIZE_CONTENT);
-   lv_obj_set_style_pad_all(cancelBtn, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_t *cancelLabel = lv_label_create(cancelBtn);
-   lv_label_set_text(cancelLabel, "Abbrechen");
-   lv_obj_set_align(cancelLabel, LV_ALIGN_CENTER);
-   lv_obj_add_event_cb(cancelBtn, &ResourceDetailsScreen::onFormsCancel, LV_EVENT_CLICKED, this);
-
    lv_obj_t *nextBtn = lv_button_create(footer);
    this->formsNextButton = nextBtn;
-   lv_obj_set_width(nextBtn, LV_SIZE_CONTENT);
+   lv_obj_set_flex_grow(nextBtn, 2);
    lv_obj_set_height(nextBtn, LV_SIZE_CONTENT);
-   lv_obj_set_style_pad_all(nextBtn, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_pad_all(nextBtn, 12, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_bg_color(nextBtn, lv_color_hex(0x10B981), LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_bg_opa(nextBtn, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
    this->formsNextLabel = lv_label_create(nextBtn);
@@ -399,48 +444,38 @@ void ResourceDetailsScreen::buildCurrentFormField()
       }
    }
 
-   lv_obj_t *pageTitleLabel = lv_label_create(this->formsModalList);
-   lv_label_set_text(pageTitleLabel, pageTitle.c_str());
-   lv_obj_set_style_text_color(pageTitleLabel, lv_color_hex(0xE5E7EB), LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_set_style_width(pageTitleLabel, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
-
-   lv_obj_t *resourceNameLabel = lv_label_create(this->formsModalList);
-   lv_label_set_text(resourceNameLabel, resourceName.c_str());
-   lv_obj_set_style_text_color(resourceNameLabel, lv_color_hex(0xE5E7EB), LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_set_style_width(resourceNameLabel, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_label_set_long_mode(resourceNameLabel, LV_LABEL_LONG_WRAP);
-
-   lv_obj_t *formTitle = lv_label_create(this->formsModalList);
-   lv_label_set_text(formTitle, formName.c_str());
-   lv_obj_set_style_text_font(formTitle, &lv_font_montserrat_18, LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_obj_set_style_text_color(formTitle, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
-   lv_label_set_long_mode(formTitle, LV_LABEL_LONG_WRAP);
-   lv_obj_set_style_width(formTitle, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
+   // Compact breadcrumb instead of three stacked headers: action context on the
+   // first line, resource + form scope on the second.
+   if (this->formsBreadcrumbLabel)
+   {
+      String breadcrumb = pageTitle;
+      String scope = resourceName;
+      if (formName.length() > 0)
+      {
+         if (scope.length() > 0)
+         {
+            scope += " - ";
+         }
+         scope += formName;
+      }
+      if (scope.length() > 0)
+      {
+         breadcrumb += "\n" + scope;
+      }
+      lv_label_set_text(this->formsBreadcrumbLabel, breadcrumb.c_str());
+   }
 
    {
-      lv_obj_t *formCard = lv_obj_create(this->formsModalList);
-      lv_obj_remove_style_all(formCard);
-      lv_obj_remove_flag(formCard, LV_OBJ_FLAG_SCROLLABLE);
-      lv_obj_set_width(formCard, lv_pct(100));
-      lv_obj_set_height(formCard, LV_SIZE_CONTENT);
-      lv_obj_set_style_bg_color(formCard, lv_color_hex(0x1F2937), LV_PART_MAIN | LV_STATE_DEFAULT);
-      lv_obj_set_style_bg_opa(formCard, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
-      lv_obj_set_style_radius(formCard, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
-      lv_obj_set_style_pad_all(formCard, 8, LV_PART_MAIN | LV_STATE_DEFAULT);
-      lv_obj_set_style_pad_row(formCard, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
-      lv_obj_set_flex_flow(formCard, LV_FLEX_FLOW_COLUMN);
-      lv_obj_set_flex_align(formCard, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
-
       {
          const API::ResourceUsageFormField &field = this->formsModalPage->fields[0];
-         lv_obj_t *fieldContainer = lv_obj_create(formCard);
+         lv_obj_t *fieldContainer = lv_obj_create(this->formsModalList);
          lv_obj_remove_style_all(fieldContainer);
          lv_obj_remove_flag(fieldContainer, LV_OBJ_FLAG_SCROLLABLE);
          lv_obj_set_width(fieldContainer, lv_pct(100));
          lv_obj_set_height(fieldContainer, LV_SIZE_CONTENT);
          lv_obj_set_flex_flow(fieldContainer, LV_FLEX_FLOW_COLUMN);
          lv_obj_set_flex_align(fieldContainer, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
-         lv_obj_set_style_pad_row(fieldContainer, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+         lv_obj_set_style_pad_row(fieldContainer, 6, LV_PART_MAIN | LV_STATE_DEFAULT);
 
          String fieldTitle = field.name;
          if (field.isRequired)
@@ -449,7 +484,8 @@ void ResourceDetailsScreen::buildCurrentFormField()
          }
          lv_obj_t *fieldLabel = lv_label_create(fieldContainer);
          lv_label_set_text(fieldLabel, fieldTitle.c_str());
-         lv_obj_set_style_text_color(fieldLabel, lv_color_hex(0xE5E5E5), LV_PART_MAIN | LV_STATE_DEFAULT);
+         lv_obj_set_style_text_font(fieldLabel, &lv_font_montserrat_24, LV_PART_MAIN | LV_STATE_DEFAULT);
+         lv_obj_set_style_text_color(fieldLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
          lv_obj_set_style_width(fieldLabel, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
          lv_label_set_long_mode(fieldLabel, LV_LABEL_LONG_WRAP);
 
@@ -479,6 +515,8 @@ void ResourceDetailsScreen::buildCurrentFormField()
          {
             lv_obj_t *sw = lv_switch_create(fieldContainer);
             widget.input = sw;
+            lv_obj_set_size(sw, 64, 32);
+            lv_obj_set_style_bg_color(sw, lv_color_hex(0x10B981), LV_PART_INDICATOR | LV_STATE_CHECKED);
             if (field.hasValue && field.value == "true")
             {
                lv_obj_add_state(sw, LV_STATE_CHECKED);

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.cpp
@@ -654,7 +654,11 @@ void ResourceDetailsScreen::destroy()
    this->formsModalList = nullptr;
    this->formsModalErrorLabel = nullptr;
    this->formsModalProgressLabel = nullptr;
-   this->formsKeyboard = nullptr;
+   this->formsEditorOverlay = nullptr;
+   this->formsEditorTitleLabel = nullptr;
+   this->formsEditorTextarea = nullptr;
+   this->formsEditorSpacer = nullptr;
+   this->formsEditorKeyboard = nullptr;
    this->formsBackButton = nullptr;
    this->formsNextButton = nullptr;
    this->formsNextLabel = nullptr;

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
@@ -131,12 +131,18 @@ private:
     lv_obj_t *formsProgressBar = nullptr;
     lv_obj_t *formsBreadcrumbLabel = nullptr;
     lv_obj_t *formsCancelButton = nullptr;
-    lv_obj_t *formsKeyboard = nullptr;
     lv_obj_t *formsBackButton = nullptr;
     lv_obj_t *formsNextButton = nullptr;
     lv_obj_t *formsNextLabel = nullptr;
     lv_obj_t *formsBusyOverlay = nullptr;
     lv_obj_t *formsBusyLabel = nullptr;
+    // Fullscreen text editor overlay: textarea on top, keyboard pinned below.
+    lv_obj_t *formsEditorOverlay = nullptr;
+    lv_obj_t *formsEditorTitleLabel = nullptr;
+    lv_obj_t *formsEditorTextarea = nullptr;
+    lv_obj_t *formsEditorSpacer = nullptr; // pushes keyboard to the bottom for one-line fields
+    lv_obj_t *formsEditorKeyboard = nullptr;
+    uint16_t formsEditorWidgetIndex = 0;
     bool formsBusy = false;
     const API::ResourceUsageFormRequest *formsModalMeta = nullptr;
     const API::ResourceUsageFormFieldsPage *formsModalPage = nullptr;
@@ -156,6 +162,8 @@ private:
         API::ResourceUsageFormFieldType type;
         bool isRequired;
         lv_obj_t *input = nullptr;
+        lv_obj_t *previewLabel = nullptr; // value preview inside the tap-to-edit box (text/number fields)
+        String textValue;                 // committed value for text/number fields (edited via the fullscreen editor)
         lv_obj_t *errorLabel = nullptr;
         const API::ResourceUsageFormField *definition = nullptr;
         uint8_t selectedOptionIndex = 0; // For SELECT: 0 = no selection, 1+ = option index
@@ -197,8 +205,9 @@ private:
     static void onFormsNext(lv_event_t *e);
     static void onFormsBack(lv_event_t *e);
     static void onFormsCancel(lv_event_t *e);
-    static void onFormFieldFocus(lv_event_t *e);
-    static void onFormsKeyboardEvent(lv_event_t *e);
+    static void onFieldPreviewClick(lv_event_t *e);
+    static void onFormsEditorKeyboardEvent(lv_event_t *e);
+    static void onFormsEditorCancel(lv_event_t *e);
     static void onSelectOptionClick(lv_event_t *e);
     static void onSelectContainerSizeChanged(lv_event_t *e);
     void updateSelectButtonStyles(FormFieldWidget &widget);
@@ -241,9 +250,9 @@ private:
     FormFieldWidget *findFieldWidgetByObject(lv_obj_t *object);
     void clearFormFieldErrors();
     void setFormsBusy(bool busy, const char *text = nullptr);
-    void hideFormsKeyboard();
-    void updateFormsModalLayoutForKeyboard(bool keyboardVisible);
-    void showKeyboardForWidget(FormFieldWidget &widget, lv_obj_t *target);
+    void openFormsEditor(uint16_t widgetIndex);
+    void closeFormsEditor(bool commit);
+    void updateFieldPreview(FormFieldWidget &widget);
     void applyCachedState();
     void disposeProjectsModal();
     void disposeFormsModal();

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
@@ -128,11 +128,13 @@ private:
     lv_obj_t *formsModalList = nullptr;
     lv_obj_t *formsModalErrorLabel = nullptr;
     lv_obj_t *formsModalProgressLabel = nullptr;
+    lv_obj_t *formsProgressBar = nullptr;
+    lv_obj_t *formsBreadcrumbLabel = nullptr;
+    lv_obj_t *formsCancelButton = nullptr;
     lv_obj_t *formsKeyboard = nullptr;
     lv_obj_t *formsBackButton = nullptr;
     lv_obj_t *formsNextButton = nullptr;
     lv_obj_t *formsNextLabel = nullptr;
-    lv_obj_t *formsCancelButton = nullptr;
     lv_obj_t *formsBusyOverlay = nullptr;
     lv_obj_t *formsBusyLabel = nullptr;
     bool formsBusy = false;


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

Attractap device-screen (LVGL firmware) resource-usage form: title fix → full redesign + latency optimization. [ATT-541](https://linear.app/attraccess/issue/ATT-541/attractap-move-form-title-out-of-form-input-box)

## 1. Form title fix (original scope)
`formTitle` moved out of the dark input card to sit above it, as a sibling of the page/resource headers.

## 2. Typeform-style redesign
One focused question per screen, using the whole panel, flatter and more minimal:
- Compact **step counter** (`2 / 14`) + slim **progress bar** at top (replaces `Feld X / Y`).
- **Breadcrumb** — `action` line + `resource - form` line — replaces three stacked headers (page title / resource name / form title).
- **Flat field** directly on the panel (no nested card), with a **large field-name heading** (montserrat 24), description, and bigger inputs (e.g. enlarged switch).
- **Pinned footer**: secondary `Zurueck` + wide primary `Weiter`/`Absenden`. `Abbrechen` demoted to a header **✕** button. Footer sits above the keyboard when it opens (hidden objects are excluded from LVGL flex layout).

## 3. Prefetch + cache (faster loads)
Every field navigation used to cost a full server round-trip (`RESOURCE_USAGE_FORM_GET_FIELDS`), flashing `Laden...` each time.
- **LRU cache** of fetched pages keyed `(formId, offset)` (4 entries).
- **Back is instant** — visited pages stay cached.
- **Next is instant** — the next field is preloaded in the background, so it renders the moment the server validates the current submission (submit is still required for server-side validation/draft persistence).
- **Correctness**: a submitted field's cache entry is invalidated (its draft changed server-side), so navigating back re-fetches the persisted answer; the background prefetch then re-warms it.
- **Race-safe**: prefetch never fires while the current field's GET is outstanding, so the single shared scratch buffer can't be clobbered and drop the awaited render.

## 4. GT911 ghost-release fix (reported during testing)
Symptom: a boolean switch in the form toggled and immediately flipped back; taps on other inputs were sporadically swallowed.

Root cause is in touch input, not the form logic. The GT911 controller refreshes its coordinate buffer on its own 5–15 ms scan cadence and flags a fresh sample via the buffer-status bit (reg `0x814E`, bit 7). The vendored SensorLib `getPoint()` ignored that bit and cleared the buffer on every poll. Since ATT-554 dropped the LVGL indev poll period to 15 ms, a poll could land before a new sample existed and report "no touch" while the finger was still down. LVGL turned each gap into a release+press pair — an extra `CLICKED` event that toggled the switch right back.

- `TouchDrvGT911::getPoint()` now honors the buffer-status bit: no fresh sample (or a bus error mid-read) reports "stale" via new `isLastSampleStale()` and leaves the buffer untouched instead of synthesizing an empty (released) sample.
- `RgbGt911Driver::readTouch()` holds the last pressed state through stale polls, capped at 100 ms so a wedged controller/bus can't stick a press. A genuine release is a *fresh* empty sample and is still reported immediately.

## Files
- `display/screens/resourceDetails/resourceDetailsForms.cpp`, `resourceDetailsScreen.hpp` — UI rewrite (`ensureFormsModal`, `buildCurrentFormField`, `renderFormField`).
- `application/application_forms.cpp`, `application.hpp` — prefetch/cache flow.
- `lib/SensorLib/src/TouchDrvGT911.hpp`, `display/driver/gt911/rgb_gt911_driver.{cpp,hpp}` — ghost-release suppression.

## Testing
Firmware compiled: `pio run -e attractap-touch` and `pio run -e attractap-touch-v2` → SUCCESS. Ghost-release fix needs on-device confirmation (touch hardware timing); no on-device screenshot path available in this environment (embedded LVGL UI, not a web frontend).

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
