### PR TITLE
fix(attractap): refresh reader resource list on health change (ATT-540)

### DIFF
--- a/apps/api/src/attractap/websockets/websocket-event.service.spec.ts
+++ b/apps/api/src/attractap/websockets/websocket-event.service.spec.ts
@@ -4,6 +4,9 @@ import { AttractapGateway } from './websocket.gateway';
 import { ReaderDeletedEvent, ReaderUpdatedEvent } from '../events';
 import { ResourceUsageEvent, ResourceUsageTakenOverEvent } from '../../resources/usage/events/resource-usage.events';
 import { ResourceChangedEvent } from '../../resources/events/resource-changed.event';
+import { ResourceMaintenanceChangedEvent } from '../../resources/maintenances/events/resource-maintenance-changed.event';
+import { ResourceHealthChangedEvent } from '../../resources/health/events/resource-health-changed.event';
+import { ResourceHealthStatus } from '@attraccess/database-entities';
 
 describe('WebSocketEventService', () => {
   let service: WebSocketEventService;
@@ -70,6 +73,28 @@ describe('WebSocketEventService', () => {
       const event = new ResourceChangedEvent(30);
       await service.onResourceChanged(event);
       expect(gateway.sendResourceListToReadersWithResource).toHaveBeenCalledWith(30);
+    });
+  });
+
+  describe('onResourceMaintenanceChanged', () => {
+    it('calls sendResourceListToReadersWithResource with the resource id', async () => {
+      const event = { resourceId: 40 } as ResourceMaintenanceChangedEvent;
+      await service.onResourceMaintenanceChanged(event);
+      expect(gateway.sendResourceListToReadersWithResource).toHaveBeenCalledWith(40);
+    });
+  });
+
+  describe('onResourceHealthChanged', () => {
+    it('calls sendResourceListToReadersWithResource with the resource id', async () => {
+      const event = new ResourceHealthChangedEvent(
+        50,
+        '',
+        ResourceHealthStatus.HEALTHY,
+        null,
+        ResourceHealthStatus.UNHEALTHY,
+      );
+      await service.onResourceHealthChanged(event);
+      expect(gateway.sendResourceListToReadersWithResource).toHaveBeenCalledWith(50);
     });
   });
 });

--- a/apps/api/src/attractap/websockets/websocket-event.service.ts
+++ b/apps/api/src/attractap/websockets/websocket-event.service.ts
@@ -6,6 +6,7 @@ import { ResourceUsageEvent, ResourceUsageTakenOverEvent } from '../../resources
 import { ResourceChangedEvent } from '../../resources/events/resource-changed.event';
 import { ResourceMaintenanceChangedEvent } from '../../resources/maintenances/events/resource-maintenance-changed.event';
 import { ResourceFlowChangedEvent } from '../../resources/flows/events/resource-flow-changed.event';
+import { ResourceHealthChangedEvent } from '../../resources/health/events/resource-health-changed.event';
 
 @Injectable()
 export class WebSocketEventService {
@@ -47,6 +48,12 @@ export class WebSocketEventService {
   @OnEvent(ResourceMaintenanceChangedEvent.EVENT_NAME)
   public async onResourceMaintenanceChanged(event: ResourceMaintenanceChangedEvent) {
     this.logger.debug({ resourceId: event.resourceId }, 'Got resource maintenance changed event');
+    this.attractapGateway.sendResourceListToReadersWithResource(event.resourceId);
+  }
+
+  @OnEvent(ResourceHealthChangedEvent.EVENT_NAME)
+  public async onResourceHealthChanged(event: ResourceHealthChangedEvent) {
+    this.logger.debug({ resourceId: event.resourceId }, 'Got resource health changed event');
     this.attractapGateway.sendResourceListToReadersWithResource(event.resourceId);
   }
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Attractap readers showed a stale resource-health banner: once a resource was marked unhealthy, the reader kept showing the "unhealthy" warning even after the resource recovered.

**Root cause:** `WebSocketEventService` pushes a fresh `RESOURCE_LIST` to readers on usage, reader, resource, flow, and maintenance changes — but it never listened for `ResourceHealthChangedEvent`. So health transitions (including a recovery clearing the unhealthy entry) were emitted but never propagated to connected readers. The firmware already re-renders the health panel on every `RESOURCE_LIST` (`refreshAccessState`), so the only gap was the missing backend push.

## Changes

- Add an `@OnEvent(ResourceHealthChangedEvent.EVENT_NAME)` handler in `WebSocketEventService` that calls `sendResourceListToReadersWithResource(event.resourceId)`.
- Add spec coverage for the new health handler (plus the previously-untested maintenance handler).

## Testing

- `nx test api --testFile=websocket-event.service.spec.ts` → 8 passed
- `nx lint api` → clean
- Full `api` lint/build/test/e2e ran green via the pre-commit hook

No web-frontend surface changed (backend event wiring); the affected UI is the Attractap hardware reader, so no browser screenshots apply.

Closes [ATT-540](https://linear.app/attraccess/issue/ATT-540/attractap-does-not-refresh-resource-health-state)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
