### PR TITLE
feat(attractap): loading spinner + input blocking on form navigation (ATT-543)

### DIFF
--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
@@ -28,6 +28,10 @@ void ResourceDetailsScreen::resetFormsModalState()
    this->formsBackButton = nullptr;
    this->formsNextButton = nullptr;
    this->formsNextLabel = nullptr;
+   this->formsCancelButton = nullptr;
+   this->formsBusyOverlay = nullptr;
+   this->formsBusyLabel = nullptr;
+   this->formsBusy = false;
    this->formsModalMeta = nullptr;
    this->formsModalPage = nullptr;
    this->formsCanGoBack = false;
@@ -79,6 +83,8 @@ void ResourceDetailsScreen::showFormsModal(const API::ResourceUsageFormRequest &
       lv_obj_clear_flag(this->formsModalOverlay, LV_OBJ_FLAG_HIDDEN);
    }
    this->updateFormsModalLayoutForKeyboard(false);
+   // Block input while the first field is being fetched from the server.
+   this->setFormsBusy(true, "Laden...");
 }
 void ResourceDetailsScreen::renderFormField(const API::ResourceUsageFormFieldsPage &page, bool canGoBack, bool isLast, uint32_t fieldNumber, uint32_t totalFields)
 {
@@ -86,6 +92,9 @@ void ResourceDetailsScreen::renderFormField(const API::ResourceUsageFormFieldsPa
    this->formsCanGoBack = canGoBack;
    this->formsIsLastField = isLast;
    this->ensureFormsModal();
+
+   // Field arrived from the server: release the input block.
+   this->setFormsBusy(false);
 
    if (this->formsModalProgressLabel)
    {
@@ -120,6 +129,8 @@ void ResourceDetailsScreen::renderFormField(const API::ResourceUsageFormFieldsPa
 }
 void ResourceDetailsScreen::showFormPageErrors(const API::ResourceUsageFormPageResult &result)
 {
+   // Server rejected the page: release the block so the user can correct input.
+   this->setFormsBusy(false);
    this->clearFormFieldErrors();
    bool shown = false;
    for (uint8_t i = 0; i < result.errorCount; ++i)
@@ -234,6 +245,7 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_add_event_cb(backBtn, &ResourceDetailsScreen::onFormsBack, LV_EVENT_CLICKED, this);
 
    lv_obj_t *cancelBtn = lv_button_create(footer);
+   this->formsCancelButton = cancelBtn;
    lv_obj_set_width(cancelBtn, LV_SIZE_CONTENT);
    lv_obj_set_height(cancelBtn, LV_SIZE_CONTENT);
    lv_obj_set_style_pad_all(cancelBtn, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
@@ -258,6 +270,77 @@ void ResourceDetailsScreen::ensureFormsModal()
    lv_obj_set_width(this->formsKeyboard, lv_pct(100));
    lv_obj_add_flag(this->formsKeyboard, LV_OBJ_FLAG_HIDDEN);
    lv_obj_add_event_cb(this->formsKeyboard, &ResourceDetailsScreen::onFormsKeyboardEvent, LV_EVENT_ALL, this);
+
+   // Busy overlay: created last so it floats above the panel + keyboard. While
+   // visible it blocks all input behind it (CLICKABLE) until the server responds.
+   lv_obj_t *busy = lv_obj_create(overlay);
+   this->formsBusyOverlay = busy;
+   lv_obj_remove_style_all(busy);
+   lv_obj_add_flag(busy, LV_OBJ_FLAG_IGNORE_LAYOUT);
+   lv_obj_add_flag(busy, LV_OBJ_FLAG_CLICKABLE);
+   lv_obj_add_flag(busy, LV_OBJ_FLAG_HIDDEN);
+   lv_obj_remove_flag(busy, LV_OBJ_FLAG_SCROLLABLE);
+   lv_obj_set_size(busy, lv_pct(100), lv_pct(100));
+   lv_obj_set_align(busy, LV_ALIGN_CENTER);
+   lv_obj_set_style_bg_color(busy, lv_color_black(), LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_style_bg_opa(busy, 160, LV_PART_MAIN | LV_STATE_DEFAULT);
+   lv_obj_set_flex_flow(busy, LV_FLEX_FLOW_COLUMN);
+   lv_obj_set_flex_align(busy, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+   lv_obj_set_style_pad_row(busy, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+   lv_obj_t *busySpinner = lv_spinner_create(busy);
+   lv_obj_set_size(busySpinner, 48, 48);
+   lv_obj_remove_flag(busySpinner, LV_OBJ_FLAG_CLICKABLE);
+
+   this->formsBusyLabel = lv_label_create(busy);
+   lv_label_set_text(this->formsBusyLabel, "Bitte warten");
+   lv_obj_set_style_text_color(this->formsBusyLabel, lv_color_white(), LV_PART_MAIN | LV_STATE_DEFAULT);
+}
+void ResourceDetailsScreen::setFormsBusy(bool busy, const char *text)
+{
+   this->formsBusy = busy;
+   if (busy)
+   {
+      this->hideFormsKeyboard();
+   }
+   if (this->formsBusyLabel && text)
+   {
+      lv_label_set_text(this->formsBusyLabel, text);
+   }
+   // Disable footer buttons as well so they read as inactive behind the overlay.
+   lv_obj_t *const buttons[] = {this->formsNextButton, this->formsBackButton, this->formsCancelButton};
+   for (lv_obj_t *button : buttons)
+   {
+      if (!button)
+      {
+         continue;
+      }
+      if (busy)
+      {
+         lv_obj_add_state(button, LV_STATE_DISABLED);
+      }
+      else
+      {
+         lv_obj_clear_state(button, LV_STATE_DISABLED);
+      }
+   }
+   // Back button stays disabled on the first field even when not busy.
+   if (!busy && this->formsBackButton && !this->formsCanGoBack)
+   {
+      lv_obj_add_state(this->formsBackButton, LV_STATE_DISABLED);
+   }
+   if (this->formsBusyOverlay)
+   {
+      if (busy)
+      {
+         lv_obj_clear_flag(this->formsBusyOverlay, LV_OBJ_FLAG_HIDDEN);
+         lv_obj_move_foreground(this->formsBusyOverlay);
+      }
+      else
+      {
+         lv_obj_add_flag(this->formsBusyOverlay, LV_OBJ_FLAG_HIDDEN);
+      }
+   }
 }
 void ResourceDetailsScreen::buildCurrentFormField()
 {
@@ -720,11 +803,17 @@ void ResourceDetailsScreen::onFormsNext(lv_event_t *e)
    {
       return;
    }
+   if (self->formsBusy)
+   {
+      return;
+   }
    API::FormPageSubmission &page = self->formPageScratch;
    if (!self->collectCurrentField(page))
    {
       return;
    }
+   // Block further input until the server confirms or rejects this page.
+   self->setFormsBusy(true, "Bitte warten");
    if (self->formPageNextCallback)
    {
       self->formPageNextCallback(page);
@@ -741,10 +830,16 @@ void ResourceDetailsScreen::onFormsBack(lv_event_t *e)
    {
       return;
    }
+   if (self->formsBusy)
+   {
+      return;
+   }
    if (!self->formsCanGoBack)
    {
       return;
    }
+   // Block further input until the previous field arrives from the server.
+   self->setFormsBusy(true, "Bitte warten");
    if (self->formPageBackCallback)
    {
       self->formPageBackCallback();

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsScreen.hpp
@@ -132,6 +132,10 @@ private:
     lv_obj_t *formsBackButton = nullptr;
     lv_obj_t *formsNextButton = nullptr;
     lv_obj_t *formsNextLabel = nullptr;
+    lv_obj_t *formsCancelButton = nullptr;
+    lv_obj_t *formsBusyOverlay = nullptr;
+    lv_obj_t *formsBusyLabel = nullptr;
+    bool formsBusy = false;
     const API::ResourceUsageFormRequest *formsModalMeta = nullptr;
     const API::ResourceUsageFormFieldsPage *formsModalPage = nullptr;
     bool formsCanGoBack = false;
@@ -234,6 +238,7 @@ private:
     FormFieldWidget *findFieldWidget(uint32_t formId, uint32_t fieldId);
     FormFieldWidget *findFieldWidgetByObject(lv_obj_t *object);
     void clearFormFieldErrors();
+    void setFormsBusy(bool busy, const char *text = nullptr);
     void hideFormsKeyboard();
     void updateFormsModalLayoutForKeyboard(bool keyboardVisible);
     void showKeyboardForWidget(FormFieldWidget &widget, lv_obj_t *target);


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds a loading animation and input blocking to the **Attractap reader** resource-usage form flow. Previously, clicking **Weiter** (next) / **Zurück** (back) fired an async WebSocket request to the server, but the buttons stayed live and there was no feedback — so a user could double-tap and submit a page twice, or tap before the next field had loaded.

Now a spinner overlay ("Bitte warten") covers the form modal from the moment a page action is sent until the server responds, blocking all input behind it. It is released when the next field renders or when the server returns a validation error (so the user can correct and resubmit).

## Changes

- **`resourceDetailsForms.cpp`**
  - New busy overlay (LVGL spinner + label) built in `ensureFormsModal`, created last so it floats above the panel and keyboard and blocks input (`CLICKABLE`).
  - New `setFormsBusy(bool, text)` helper — shows/hides the overlay, disables/enables next/back/cancel buttons, hides the keyboard, and keeps Back disabled on the first field.
  - Busy set on: initial form load (`showFormsModal`), **Next** (`onFormsNext`), **Back** (`onFormsBack`).
  - Busy cleared on: field render (`renderFormField`) and server validation error (`showFormPageErrors`).
  - Re-entrancy guards in `onFormsNext` / `onFormsBack` ignore taps while busy.
- **`resourceDetailsScreen.hpp`** — new members (`formsCancelButton`, `formsBusyOverlay`, `formsBusyLabel`, `formsBusy`) and `setFormsBusy` declaration; reset in `resetFormsModalState`.

## Testing

- `pio run -e attractap-touch` → **SUCCESS** (firmware compiles and links; RAM 47.3%, Flash 79.6%).
- No web frontend was changed — this is the on-device LVGL UI, so no browser screenshots apply. No host simulator exists in the firmware project to capture the device display.

Closes [ATT-543](https://linear.app/attraccess/issue/ATT-543/attractap-forms-loading-animation)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
