### PR TITLE
fix(attractap): drop confusing boolean true/false label under form toggle (ATT-544)

### DIFF
--- a/apps/attractap/firmware/src/api/api.hpp
+++ b/apps/attractap/firmware/src/api/api.hpp
@@ -118,11 +118,6 @@ public:
         } number;
         struct
         {
-            String trueLabel;
-            String falseLabel;
-        } boolean;
-        struct
-        {
             uint8_t count = 0;
             String values[MAX_SELECT_OPTIONS];
         } select;

--- a/apps/attractap/firmware/src/api/api_forms.cpp
+++ b/apps/attractap/firmware/src/api/api_forms.cpp
@@ -381,14 +381,7 @@ void API::parseFormFieldOptions(ResourceUsageFormField &field, JsonVariantConst 
         }
         break;
     case ResourceUsageFormFieldType::BOOLEAN:
-        if (options["trueLabel"].is<const char *>())
-        {
-            field.options.boolean.trueLabel = options["trueLabel"].as<const char *>();
-        }
-        if (options["falseLabel"].is<const char *>())
-        {
-            field.options.boolean.falseLabel = options["falseLabel"].as<const char *>();
-        }
+        // Boolean fields use a plain yes/no switch and carry no options.
         break;
     default:
         break;

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsForms.cpp
@@ -400,18 +400,6 @@ void ResourceDetailsScreen::buildCurrentFormField()
             {
                lv_obj_add_state(sw, LV_STATE_CHECKED);
             }
-            if (field.options.boolean.trueLabel.length() > 0 || field.options.boolean.falseLabel.length() > 0)
-            {
-               String boolLabels = field.options.boolean.trueLabel.length() ? field.options.boolean.trueLabel : "An";
-               boolLabels += " / ";
-               boolLabels += field.options.boolean.falseLabel.length() ? field.options.boolean.falseLabel : "Aus";
-               lv_obj_t *info = lv_label_create(fieldContainer);
-               lv_label_set_text(info, boolLabels.c_str());
-               lv_obj_set_style_text_color(info, lv_color_hex(0x9CA3AF), LV_PART_MAIN | LV_STATE_DEFAULT);
-               lv_obj_set_style_text_font(info, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
-               lv_obj_set_style_width(info, lv_pct(100), LV_PART_MAIN | LV_STATE_DEFAULT);
-               lv_label_set_long_mode(info, LV_LABEL_LONG_WRAP);
-            }
          }
          else if (field.type == API::ResourceUsageFormFieldType::SELECT)
          {


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Some Attractap form toggles rendered a meaningless description line beneath the switch, e.g. **`erledigt / noch nicht`**.

**Root cause:** ATT-189 standardized boolean form fields on a plain yes/no switch and removed the `trueLabel`/`falseLabel` editor from the frontend. The Attractap firmware was never updated — it still read legacy `trueLabel`/`falseLabel` options (lingering on forms created before ATT-189) and rendered them as a `"<true> / <false>"` label under the toggle. Next to a bare on/off switch that text conveys nothing about which position means what, hence "this makes no sense."

## Changes (firmware only)

- `resourceDetailsForms.cpp` — remove the boolean label description rendered under the switch.
- `api_forms.cpp` — stop parsing the now-unused `trueLabel`/`falseLabel` JSON options.
- `api.hpp` — drop the dead `boolean { trueLabel, falseLabel }` struct fields.

No API or frontend changes: the backend still tolerates legacy stored options (harmless, never read), and the frontend already renders the clean yes/no switch since ATT-189. The fix kills the bad rendering even for legacy DB rows that still carry the labels.

## Testing

- `pio run -e attractap-touch` → **SUCCESS** (Flash 79.6%, RAM 47.3%).
- No frontend visual change to screenshot — the bug was on the Attractap device display only.

Closes [ATT-544](https://linear.app/attraccess/issue/ATT-544/attractap-forms-weird-toggle-button-description)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->