### PR TITLE
fix(ATT-539): make Grafana Pushover alerting opt-in so it starts without secrets

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -160,6 +160,14 @@ jobs:
       - name: Run fail2ban smoke test
         run: ./scripts/fail2ban-smoke.sh
 
+  grafana-provisioning-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Test Grafana provisioning prepare (Pushover opt-in)
+        run: ./scripts/grafana-provisioning-prepare.spec.sh
+
   containerize:
     runs-on: ubuntu-latest
     steps:

--- a/coolify.docker-compose.yml
+++ b/coolify.docker-compose.yml
@@ -89,6 +89,10 @@ services:
     entrypoint: ['/bin/sh', '-c']
     environment:
       - PROMETHEUS_METRICS_API_KEY=${PROMETHEUS_METRICS_API_KEY:-}
+      # Pushover alerting is opt-in: prepare-provisioning.sh strips the
+      # secret-requiring contact point + policy when these are unset (ATT-539).
+      - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
+      - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
     command:
       - >
         set -e &&
@@ -97,7 +101,8 @@ services:
           sed -i "s|# bearer_token: '<your-metrics-api-key>'|bearer_token: '$$PROMETHEUS_METRICS_API_KEY'|" /prometheus-config/prometheus.yml;
         fi &&
         cp -rT /app/share/monitoring/grafana/provisioning /grafana-provisioning &&
-        cp -rT /app/share/monitoring/grafana/dashboards /grafana-dashboards
+        cp -rT /app/share/monitoring/grafana/dashboards /grafana-dashboards &&
+        sh /app/share/monitoring/grafana/prepare-provisioning.sh /grafana-provisioning
     volumes:
       - prometheus-config:/prometheus-config
       - grafana-provisioning:/grafana-provisioning
@@ -129,6 +134,9 @@ services:
       - GF_SERVER_ROOT_URL=$SERVICE_URL_GRAFANA
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      # Read by $__env{} interpolation in the provisioned Pushover contact point.
+      - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
+      - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
     volumes:
       - grafana-data:/var/lib/grafana
       - grafana-provisioning:/etc/grafana/provisioning:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,11 +39,17 @@ services:
       dockerfile: Dockerfile
     restart: 'no'
     entrypoint: ['/bin/sh', '-c']
+    environment:
+      # Pushover alerting is opt-in: prepare-provisioning.sh strips the
+      # secret-requiring contact point + policy when these are unset (ATT-539).
+      - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
+      - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
     command:
       - >
         set -e &&
         cp -rT /app/share/monitoring/grafana/provisioning /grafana-provisioning &&
-        cp -rT /app/share/monitoring/grafana/dashboards /grafana-dashboards
+        cp -rT /app/share/monitoring/grafana/dashboards /grafana-dashboards &&
+        sh /app/share/monitoring/grafana/prepare-provisioning.sh /grafana-provisioning
     volumes:
       - prometheus-config:/prometheus-config
       - grafana-provisioning:/grafana-provisioning
@@ -173,6 +179,9 @@ services:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-attraccess}
       - GF_SERVER_HTTP_PORT=3001
+      # Read by $__env{} interpolation in the provisioned Pushover contact point.
+      - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
+      - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
     volumes:
       - grafana-provisioning:/etc/grafana/provisioning:ro
       - grafana-dashboards:/var/lib/grafana/dashboards:ro

--- a/monitoring/grafana/prepare-provisioning.sh
+++ b/monitoring/grafana/prepare-provisioning.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Make the Pushover alerting integration opt-in (ATT-539).
+#
+# The contact point in alerting/contactpoints.yaml reads its secrets from the
+# grafana container environment ($__env{PUSHOVER_API_TOKEN/PUSHOVER_USER_KEY}).
+# Grafana validates contact points at provisioning time and exits the whole
+# process if a required secret (e.g. the Pushover user key) is empty — so an
+# unconfigured deployment crashes Grafana on startup.
+#
+# This script runs against a *writable* copy of the provisioning directory
+# before Grafana reads it. When either secret is missing it removes the
+# secret-requiring alerting files so Grafana starts cleanly with its built-in
+# default contact point and policy. The alert rules (rules.yaml) are kept
+# either way; with no custom policy they route to the default policy.
+#
+# Usage: prepare-provisioning.sh <provisioning-dir>
+set -eu
+
+PROVISIONING_DIR="${1:-/etc/grafana/provisioning}"
+ALERTING_DIR="$PROVISIONING_DIR/alerting"
+
+if [ -n "${PUSHOVER_API_TOKEN:-}" ] && [ -n "${PUSHOVER_USER_KEY:-}" ]; then
+  echo "[grafana-prepare] PUSHOVER_API_TOKEN and PUSHOVER_USER_KEY set — provisioning Pushover alerting"
+else
+  echo "[grafana-prepare] PUSHOVER_API_TOKEN/PUSHOVER_USER_KEY not fully set — skipping Pushover alerting provisioning"
+  rm -f "$ALERTING_DIR/contactpoints.yaml" "$ALERTING_DIR/policies.yaml"
+fi

--- a/monitoring/grafana/prepare-provisioning.sh
+++ b/monitoring/grafana/prepare-provisioning.sh
@@ -19,6 +19,16 @@ set -eu
 PROVISIONING_DIR="${1:-/etc/grafana/provisioning}"
 ALERTING_DIR="$PROVISIONING_DIR/alerting"
 
+# Fail fast on a misconfigured mount/path instead of silently no-op'ing the rm.
+if [ ! -d "$PROVISIONING_DIR" ]; then
+  echo "[grafana-prepare] ERROR: provisioning dir not found: $PROVISIONING_DIR" >&2
+  exit 1
+fi
+if [ ! -d "$ALERTING_DIR" ]; then
+  echo "[grafana-prepare] ERROR: alerting dir not found: $ALERTING_DIR" >&2
+  exit 1
+fi
+
 if [ -n "${PUSHOVER_API_TOKEN:-}" ] && [ -n "${PUSHOVER_USER_KEY:-}" ]; then
   echo "[grafana-prepare] PUSHOVER_API_TOKEN and PUSHOVER_USER_KEY set — provisioning Pushover alerting"
 else

--- a/scripts/grafana-provisioning-prepare.spec.sh
+++ b/scripts/grafana-provisioning-prepare.spec.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Test for monitoring/grafana/prepare-provisioning.sh.
+#
+# The prepare script makes the Pushover alerting contact point opt-in: it strips
+# the secret-requiring alerting files (contactpoints.yaml + policies.yaml) from a
+# provisioning directory when the PUSHOVER_* env vars are not fully set, so
+# Grafana does not refuse to start (ATT-539). When both secrets are present the
+# files are kept so Pushover alerting is provisioned.
+#
+# Designed to run on CI (GitHub Actions, ubuntu-latest) with no Docker needed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/monitoring/grafana/prepare-provisioning.sh"
+
+failures=0
+fail() {
+  echo "  ✗ $1"
+  failures=$((failures + 1))
+}
+pass() { echo "  ✓ $1"; }
+
+# Build a throwaway provisioning dir mirroring the real layout.
+make_provisioning() {
+  local dir="$1"
+  mkdir -p "$dir/alerting" "$dir/datasources" "$dir/dashboards"
+  echo 'contactPoints: []' >"$dir/alerting/contactpoints.yaml"
+  echo 'policies: []' >"$dir/alerting/policies.yaml"
+  echo 'groups: []' >"$dir/alerting/rules.yaml"
+  echo 'datasources: []' >"$dir/datasources/prometheus.yml"
+  echo 'providers: []' >"$dir/dashboards/dashboards.yml"
+}
+
+assert_absent() {
+  if [ -e "$1" ]; then fail "$2 (expected $1 to be removed)"; else pass "$2"; fi
+}
+assert_present() {
+  if [ -e "$1" ]; then pass "$2"; else fail "$2 (expected $1 to exist)"; fi
+}
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "✗ prepare script not found or not executable: $SCRIPT"
+  exit 1
+fi
+
+echo "case: both PUSHOVER secrets unset -> strip pushover files"
+TMP="$(mktemp -d)"
+make_provisioning "$TMP"
+( unset PUSHOVER_API_TOKEN PUSHOVER_USER_KEY; "$SCRIPT" "$TMP" )
+assert_absent  "$TMP/alerting/contactpoints.yaml" "contactpoints.yaml stripped"
+assert_absent  "$TMP/alerting/policies.yaml"      "policies.yaml stripped"
+assert_present "$TMP/alerting/rules.yaml"          "rules.yaml kept"
+assert_present "$TMP/datasources/prometheus.yml"   "datasources kept"
+rm -rf "$TMP"
+
+echo "case: only one secret set -> still strip (both required)"
+TMP="$(mktemp -d)"
+make_provisioning "$TMP"
+PUSHOVER_API_TOKEN="token-only" PUSHOVER_USER_KEY="" "$SCRIPT" "$TMP"
+assert_absent "$TMP/alerting/contactpoints.yaml" "contactpoints.yaml stripped (partial env)"
+assert_absent "$TMP/alerting/policies.yaml"      "policies.yaml stripped (partial env)"
+rm -rf "$TMP"
+
+echo "case: both PUSHOVER secrets set -> keep pushover files"
+TMP="$(mktemp -d)"
+make_provisioning "$TMP"
+PUSHOVER_API_TOKEN="real-token" PUSHOVER_USER_KEY="real-user-key" "$SCRIPT" "$TMP"
+assert_present "$TMP/alerting/contactpoints.yaml" "contactpoints.yaml kept"
+assert_present "$TMP/alerting/policies.yaml"      "policies.yaml kept"
+rm -rf "$TMP"
+
+echo "case: idempotent when files already absent"
+TMP="$(mktemp -d)"
+mkdir -p "$TMP/alerting"
+echo 'groups: []' >"$TMP/alerting/rules.yaml"
+( unset PUSHOVER_API_TOKEN PUSHOVER_USER_KEY; "$SCRIPT" "$TMP" )
+assert_present "$TMP/alerting/rules.yaml" "rules.yaml kept when pushover files absent"
+rm -rf "$TMP"
+
+if [ "$failures" -gt 0 ]; then
+  echo "✗ $failures assertion(s) failed"
+  exit 1
+fi
+echo "✓ all prepare-provisioning assertions passed"

--- a/scripts/grafana-provisioning-prepare.spec.sh
+++ b/scripts/grafana-provisioning-prepare.spec.sh
@@ -78,6 +78,15 @@ echo 'groups: []' >"$TMP/alerting/rules.yaml"
 assert_present "$TMP/alerting/rules.yaml" "rules.yaml kept when pushover files absent"
 rm -rf "$TMP"
 
+echo "case: missing provisioning dir -> fail fast"
+TMP="$(mktemp -d)"; rmdir "$TMP"
+if "$SCRIPT" "$TMP" 2>/dev/null; then fail "expected non-zero exit for missing provisioning dir"; else pass "exits non-zero for missing provisioning dir"; fi
+
+echo "case: missing alerting dir -> fail fast"
+TMP="$(mktemp -d)"
+if "$SCRIPT" "$TMP" 2>/dev/null; then fail "expected non-zero exit for missing alerting dir"; else pass "exits non-zero for missing alerting dir"; fi
+rm -rf "$TMP"
+
 if [ "$failures" -gt 0 ]; then
   echo "✗ $failures assertion(s) failed"
   exit 1

--- a/services.docker-compose.yml
+++ b/services.docker-compose.yml
@@ -170,6 +170,27 @@ services:
       - '--storage.tsdb.retention.time=30d'
       - '--web.enable-lifecycle'
 
+  # Copies provisioning into a writable volume and strips the opt-in Pushover
+  # alerting files when the PUSHOVER_* secrets are unset, so Grafana starts even
+  # without Pushover configured (ATT-539). Dashboards stay bind-mounted for live
+  # editing; only provisioning is snapshotted here.
+  grafana-provisioning-init:
+    image: grafana/grafana:13.0.1
+    restart: 'no'
+    user: root
+    entrypoint: ['/bin/sh', '-c']
+    environment:
+      - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
+      - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
+    command:
+      - >
+        set -e &&
+        cp -r /src/provisioning/. /grafana-provisioning/ &&
+        sh /src/prepare-provisioning.sh /grafana-provisioning
+    volumes:
+      - ./monitoring/grafana:/src:ro
+      - grafana-provisioning:/grafana-provisioning
+
   grafana:
     image: grafana/grafana:13.0.1
     ports:
@@ -178,8 +199,14 @@ services:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-attraccess}
       - GF_SERVER_HTTP_PORT=3001
+      # Read by $__env{} interpolation in the provisioned Pushover contact point.
+      - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
+      - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
+    depends_on:
+      grafana-provisioning-init:
+        condition: service_completed_successfully
     volumes:
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana-provisioning:/etc/grafana/provisioning:ro
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
 
@@ -209,4 +236,6 @@ volumes:
   prometheus-data:
     driver: local
   grafana-data:
+    driver: local
+  grafana-provisioning:
     driver: local

--- a/services.docker-compose.yml
+++ b/services.docker-compose.yml
@@ -185,7 +185,8 @@ services:
     command:
       - >
         set -e &&
-        cp -r /src/provisioning/. /grafana-provisioning/ &&
+        rm -rf /grafana-provisioning/* /grafana-provisioning/.[!.]* 2>/dev/null || true &&
+        cp -rT /src/provisioning /grafana-provisioning &&
         sh /src/prepare-provisioning.sh /grafana-provisioning
     volumes:
       - ./monitoring/grafana:/src:ro


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Problem

Grafana validates provisioned alerting contact points at startup and **exits the whole process** when a required secret is empty. With `PUSHOVER_API_TOKEN` / `PUSHOVER_USER_KEY` unset, the provisioned Pushover contact point failed validation and crashed Grafana on boot:

```
Failed to provision alerting error="failure parsing contact points: Pushover: failed to validate integration \"Pushover\" (UID pushover-attraccess) of type \"pushover\": user key not found"
✗ invalid service state: Failed ... starting module provisioning ...
```

## Fix

Pushover alerting is now **opt-in**. A new `monitoring/grafana/prepare-provisioning.sh` runs against a *writable copy* of the provisioning directory before Grafana reads it. When either Pushover secret is missing it strips the secret-requiring alerting files (`contactpoints.yaml` + `policies.yaml`), so Grafana starts cleanly with its built-in default contact point and policy. When both secrets are present the files are kept and Pushover alerting is provisioned as before.

Alert rules (`rules.yaml`) are kept either way — they route via the notification policy, so with no custom policy they fall back to Grafana's default policy.

## Changes

- **`monitoring/grafana/prepare-provisioning.sh`** — strips the opt-in Pushover files when `PUSHOVER_API_TOKEN`/`PUSHOVER_USER_KEY` are not both set.
- **`docker-compose.yml` / `coolify.docker-compose.yml`** — run the prepare script in the existing grafana-init step; pass `PUSHOVER_*` to both init and grafana services.
- **`services.docker-compose.yml`** — new `grafana-provisioning-init` container copies provisioning into a writable named volume and runs the prepare script; grafana depends on it.
- **`scripts/grafana-provisioning-prepare.spec.sh`** + CI job — no-Docker spec covering: both unset → strip, partial env → strip, both set → keep, idempotent when files already absent.

## Testing

`./scripts/grafana-provisioning-prepare.spec.sh` — all assertions pass. Added as `grafana-provisioning-smoke` job in the PR pipeline.

Linear: [ATT-539](https://linear.app/attraccess/issue/ATT-539/grafana-pushover-contactpoint-kills-grafana-when-env-not-set)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Make Grafana’s Pushover alerting configuration optional so instances can start without Pushover secrets, and add coverage to ensure the provisioning behaviour is correct.

New Features:
- Introduce a provisioning preparation script that conditionally enables Grafana’s Pushover alerting based on the presence of PUSHOVER secrets.

Enhancements:
- Route Grafana provisioning through a writable volume and init container so alerting configuration can be sanitized before Grafana starts.

Build:
- Update Docker Compose configurations to run the provisioning preparation script and propagate Pushover-related environment variables to the relevant init and Grafana services.

Tests:
- Add a shell-based smoke/spec script to verify the provisioning preparation logic across different secret configurations and idempotency.
- Wire the provisioning smoke test into the pull-request GitHub Actions workflow.