### PR TITLE
fix(attractap): freeze logout timeout while forms/actions in progress (ATT-542)

### DIFF
--- a/apps/attractap/firmware/src/application/application_state.cpp
+++ b/apps/attractap/firmware/src/application/application_state.cpp
@@ -298,10 +298,20 @@ void Application::processState() {
   }
 
   if (this->state == APPLICATION_STATE_UNLOCKED) {
-    // Subtract any accumulated pause time while actions were in-progress
+    // Subtract any accumulated pause time while actions were in-progress.
+    // accumulatedPauseMs only gets the elapsed delta added once an action
+    // finishes (endActionPause). While an action is still running -- most
+    // notably while the user fills out a resource usage form -- include the
+    // in-progress pause here too, so the logout timeout stays frozen for the
+    // whole duration instead of expiring mid-form.
+    uint32_t effectivePause = this->accumulatedPauseMs;
+    if (this->actionInProgressCount > 0) {
+      effectivePause +=
+          (now >= this->pauseStartMs) ? (now - this->pauseStartMs) : 0;
+    }
     uint32_t effectiveElapsed = now - this->timeOfUnlockedMs;
-    if (effectiveElapsed > this->accumulatedPauseMs) {
-      effectiveElapsed -= this->accumulatedPauseMs;
+    if (effectiveElapsed > effectivePause) {
+      effectiveElapsed -= effectivePause;
     } else {
       effectiveElapsed = 0;
     }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

The Attractap unlocked-session logout timeout (30s) could fire **while a user was filling out a resource usage form**, kicking them out mid-form.

**Root cause:** `accumulatedPauseMs` only folds the elapsed pause delta in once an action *completes* (`endActionPause`). While an action is still in progress — most notably while a form is displayed — the live timeout check at `application_state.cpp` ignored the in-progress pause, so the session timed out mid-form.

**Fix:** Include the in-progress pause (`now - pauseStartMs`) in the effective-pause calculation while `actionInProgressCount > 0`. The logout timeout now stays frozen for the whole form/action duration — matching the UI session-timeout indicator, which already freezes on `beginActionPause`.

## Flow covered

`beginActionPause` (button click) → server returns form → form displayed while action in-progress → `endActionPause` on submit/cancel. The fix freezes the timeout across that entire window.

## Testing

- `attractap-touch` firmware compiles clean: `[SUCCESS] Took 97.33 seconds`.

Firmware-only change — no frontend, no screenshots apply.

Closes [ATT-542](https://linear.app/attraccess/issue/ATT-542/attractap-forms-should-disable-logout-timeout)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Prevent the unlocked-session logout timer from expiring while a resource usage form or other in-progress action is active by accounting for the ongoing pause in timeout calculations.