### PR TITLE
fix(attractap): prevent loopTask watchdog crash from destroying active screen (ATT-510)

### DIFF
--- a/apps/attractap/firmware/src/display/display.cpp
+++ b/apps/attractap/firmware/src/display/display.cpp
@@ -267,7 +267,13 @@ void Display::loop()
             {
                 for (IScreen *scr : Display::pendingDestroyScreens)
                 {
-                    if (scr)
+                    // Never tear down the screen that is currently active: a
+                    // re-transition during the destroy window can make a queued
+                    // screen active again, and freeing its LVGL tree would null
+                    // its widget pointers (-> lv_obj_get_screen(NULL) assert ->
+                    // loopTask hang -> task watchdog). transitionToScreen already
+                    // dequeues reused screens; this is a final safety net.
+                    if (scr && scr != Display::activeScreen)
                     {
                         Display::logger.debugf("Destroying screen: %s", scr->getName().c_str());
                         scr->destroy();

--- a/apps/attractap/firmware/src/display/display_router.cpp
+++ b/apps/attractap/firmware/src/display/display_router.cpp
@@ -1,5 +1,7 @@
 #include "display.hpp"
 
+#include <algorithm>
+
 // Screen routing: transition between IScreen instances with a fade animation.
 // Unloading of the previous screen is deferred until the transition completes
 // (handled in Display::loop via pendingDestroyScreens).
@@ -31,6 +33,17 @@ void Display::transitionToScreen(IScreen *screen, std::function<void()> onTransi
         return;
     }
 
+    // The incoming screen is being (re)activated, so it must never be torn down
+    // by the deferred-destroy queue. A previous transition may have queued it for
+    // unload (e.g. InitScreen <-> Lockscreen churn during websocket reconnect);
+    // if it stayed queued the later destroy would free the LVGL tree of the now
+    // active screen, leaving widget pointers NULL -> lv_obj_get_screen(NULL)
+    // assert -> loopTask hang -> task watchdog reboot. Dequeue it here.
+    Display::pendingDestroyScreens.erase(
+        std::remove(Display::pendingDestroyScreens.begin(),
+                    Display::pendingDestroyScreens.end(), screen),
+        Display::pendingDestroyScreens.end());
+
     IScreen *previousScreen = Display::activeScreen;
     if (Display::activeScreen)
     {
@@ -54,7 +67,14 @@ void Display::transitionToScreen(IScreen *screen, std::function<void()> onTransi
 
     if (previousScreen && previousScreen != screen && previousScreen->shouldAutoUnload())
     {
-        Display::logger.debugf("Queued screen %s for unload", previousScreen->getName().c_str());
-        Display::pendingDestroyScreens.push_back(previousScreen);
+        bool alreadyQueued =
+            std::find(Display::pendingDestroyScreens.begin(),
+                      Display::pendingDestroyScreens.end(),
+                      previousScreen) != Display::pendingDestroyScreens.end();
+        if (!alreadyQueued)
+        {
+            Display::logger.debugf("Queued screen %s for unload", previousScreen->getName().c_str());
+            Display::pendingDestroyScreens.push_back(previousScreen);
+        }
     }
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Fixes a high-severity reader crash-reboot under websocket reconnect churn (ATT-510). Under disconnect→reconnect churn the reader rebuilds screens rapidly (InitScreen ↔ Lockscreen). A screen queued for deferred unload could be re-activated before its destroy fired, and `transitionToScreen` never removed the reused screen from `pendingDestroyScreens`. The later deferred destroy then freed the LVGL tree of the **now-active** screen. The next `onScreenLeave()`/`loop()` dereferenced NULL widget pointers → `lv_obj_get_screen: obj != NULL` assert → `loopTask` stopped feeding the task watchdog → `abort()` → reboot (marked `crash-loop`).

This matches the serial evidence: the assert fires immediately after `Transitioning to screen: Lockscreen`, which calls `activeScreen->onScreenLeave()` on the just-destroyed `InitScreen` (`resetState(nullptr, …)`).

## Root cause

Deferred-destroy lifecycle race in screen routing:
1. `→ Lockscreen`: `InitScreen` queued for destroy.
2. `→ InitScreen` (fast churn): becomes `activeScreen` but stays in the destroy queue (never dequeued on reuse).
3. Destroy window elapses → `InitScreen::destroy()` frees its LVGL tree while it is active, nulling all widget pointers.
4. Next access on the active screen dereferences NULL → LVGL assert → loopTask hang → task watchdog.

Heap was healthy (free ~115k), confirming this is a lifecycle race, not exhaustion (distinct from ATT-508).

## Changes

- `display_router.cpp` — `transitionToScreen` now removes the incoming screen from `pendingDestroyScreens` (a reused screen must never be torn down); dedup the enqueue of the previous screen.
- `display.cpp` — deferred-destroy loop never destroys `activeScreen` (final safety net).

## Testing

- `pio run -e attractap-touch-v2` → **SUCCESS** (matches the affected firmware `Attractap Touch V2 WiFi`).
- On-device repro is intermittent (timing race); no host LVGL test harness exists for screen lifecycle, so verification is by build + root-cause reasoning against the serial trace.

Closes [ATT-510](https://linear.app/attraccess/issue/ATT-510/attractap-looptask-watchdog-crash-via-lv-obj-get-screen-null-deref)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Prevent active screens from being destroyed during deferred unload to avoid crash-reboot under rapid screen transitions.

Bug Fixes:
- Ensure a screen being reactivated is removed from the deferred-destroy queue so it cannot be torn down while active.
- Avoid queuing the same previous screen multiple times for deferred destruction.
- Skip destroying the currently active screen during the deferred-destroy loop as a final safeguard against lifecycle races.