### PR TITLE
feat(plugins): hook plugin DB migrations into host migration management (ATT-547)

### DIFF
--- a/apps/api/src/main.bootstrap.ts
+++ b/apps/api/src/main.bootstrap.ts
@@ -9,6 +9,7 @@ import appConfiguration, { AppConfigType } from './config/app.config';
 import { DataSource } from 'typeorm';
 import { PluginService } from './plugin-system/plugin.service';
 import { PluginModule } from './plugin-system/plugin.module';
+import { PluginMigrationService } from './plugin-system/plugin-migration.service';
 import { HttpsOptions } from '@nestjs/common/interfaces/external/https-options.interface';
 import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -82,6 +83,16 @@ export async function bootstrap() {
     DISABLE_PLUGINS: earlyConfig.DISABLE_PLUGINS,
   });
   bootstrapLogger.log('PluginSystem configured.');
+
+  // Run plugin-shipped up-migrations BEFORE AppModule is imported, so every
+  // plugin's tables exist before any plugin code (its onModuleInit) runs. This
+  // uses a standalone DataSource per plugin against the same DB, so it does not
+  // interfere with the host DataSource (which opens later, inside AppModule).
+  // Per-plugin failures are isolated inside the service and never abort boot.
+  if (!earlyConfig.DISABLE_PLUGINS) {
+    bootstrapLogger.log('Running plugin database migrations...');
+    await PluginMigrationService.runPendingUpMigrationsForAllPlugins();
+  }
 
   // Import AppModule only now, so PluginModule.forRoot() sees the configured PLUGIN_DIR.
   const { AppModule } = await import('./app/app.module');

--- a/apps/api/src/plugin-system/plugin-loader.ts
+++ b/apps/api/src/plugin-system/plugin-loader.ts
@@ -1,0 +1,59 @@
+import { createRequire, Module as NodeModuleClass } from 'module';
+import { readFileSync } from 'fs';
+import { runInThisContext } from 'vm';
+import { dirname, isAbsolute } from 'path';
+
+// Loads a plugin's CommonJS entry so that its *externalized* host-shared packages
+// (@nestjs/common, typeorm, reflect-metadata, …) resolve to the host's single
+// copy. Plugins deliberately do not bundle those packages — a bundled copy is a
+// different class/symbol object and breaks DI token identity, constructor-metadata
+// reflection AND TypeORM type identity (a migration's `QueryRunner`/`MigrationInterface`
+// must be the host's, see docs/en/plugins/developing-plugins.md "Packaging the backend").
+// The shipped entry therefore does bare `require('typeorm')` etc. at runtime.
+//
+// Two failure modes have to be avoided at once:
+//   1. Resolution — in a production image the plugin lives under
+//      STORAGE_ROOT/plugins/… while the host's node_modules sits under
+//      dist/apps/api/, so a bare require resolved relative to the plugin's own
+//      directory finds nothing ("Cannot find module '@nestjs/common'").
+//   2. Identity — the loaded module must be the very same object the host uses,
+//      AND the plugin's decorators must run against the same global `Reflect`
+//      the host reads. Handing the entry to Node's own loader (`new Module().
+//      load()`) compiles it in a separate realm: its `__decorate`/`Reflect.
+//      metadata` writes land on a different `Reflect`/metadata registry, so DI
+//      sees no constructor dependencies and injections come back undefined.
+//
+// We satisfy both by compiling the entry in *this* realm with `vm.
+// runInThisContext` (so decorator metadata is written to the same `Reflect`
+// the host reads) and handing it a `require` that routes every *bare*
+// specifier — i.e. the externalized host-shared packages — to the host's own
+// require, returning the host's already-loaded instances regardless of where
+// the plugin lives on disk. Relative/absolute requests stay plugin-local.
+export function loadPluginEntryExports(entryFile: string): Record<string, unknown> & { default?: unknown } {
+  const NodeModule = NodeModuleClass as unknown as {
+    wrap(script: string): string;
+    _nodeModulePaths(from: string): string[];
+    new (id: string, parent?: unknown): {
+      filename: string;
+      paths: string[];
+      exports: Record<string, unknown> & { default?: unknown };
+      require(request: string): unknown;
+    };
+  };
+
+  const hostRequire = createRequire(__filename);
+  const isBareSpecifier = (request: string): boolean => !request.startsWith('.') && !isAbsolute(request);
+
+  const pluginModule = new NodeModule(entryFile, module);
+  pluginModule.filename = entryFile;
+  pluginModule.paths = NodeModule._nodeModulePaths(dirname(entryFile));
+
+  const pluginRequire = ((request: string): unknown =>
+    isBareSpecifier(request) ? hostRequire(request) : pluginModule.require(request)) as NodeJS.Require;
+  pluginRequire.resolve = hostRequire.resolve;
+
+  const compiled = runInThisContext(NodeModule.wrap(readFileSync(entryFile, 'utf8')), { filename: entryFile });
+  compiled.call(pluginModule.exports, pluginModule.exports, pluginRequire, pluginModule, entryFile, dirname(entryFile));
+
+  return pluginModule.exports;
+}

--- a/apps/api/src/plugin-system/plugin-migration.service.spec.ts
+++ b/apps/api/src/plugin-system/plugin-migration.service.spec.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { DataSource } from 'typeorm';
+import { PluginService } from './plugin.service';
+import { PluginMigrationService } from './plugin-migration.service';
+import { LoadedPluginManifest } from './plugin.manifest';
+
+// A plain-CommonJS migrations entry, exactly as a built plugin would ship one:
+// it creates and drops a single table. Authored without importing typeorm so the
+// test fixture stays dependency-free; the host runs up()/down() with its own
+// QueryRunner.
+const MIGRATION_ENTRY = `
+class CreateWidget1700000000000 {
+  constructor() { this.name = 'CreateWidget1700000000000'; }
+  async up(queryRunner) {
+    await queryRunner.query('CREATE TABLE "plugin_widget" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "label" varchar NOT NULL)');
+  }
+  async down(queryRunner) {
+    await queryRunner.query('DROP TABLE "plugin_widget"');
+  }
+}
+module.exports = { CreateWidget1700000000000 };
+`;
+
+function writeMigrationPlugin(root: string, folder: string, name: string): void {
+  const dir = join(root, folder);
+  mkdirSync(join(dir, 'mig'), { recursive: true });
+  writeFileSync(join(dir, 'mig', 'index.js'), MIGRATION_ENTRY, 'utf8');
+  writeFileSync(
+    join(dir, 'plugin.json'),
+    JSON.stringify({
+      name,
+      version: '1.0.0',
+      main: {
+        frontend: { directory: 'frontend', entryPoint: 'index.mjs' },
+        backend: { directory: 'dist', entryPoint: 'index.js' },
+        migrations: { directory: 'mig', entryPoint: 'index.js' },
+      },
+      attraccessVersion: { min: '1.0.0' },
+      permissions: [],
+    })
+  );
+}
+
+async function tableExists(dbFile: string, table: string): Promise<boolean> {
+  const probe = new DataSource({ type: 'sqlite', database: dbFile });
+  await probe.initialize();
+  try {
+    const rows: unknown[] = await probe.query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`, [table]);
+    return rows.length > 0;
+  } finally {
+    await probe.destroy();
+  }
+}
+
+describe('PluginMigrationService', () => {
+  let root: string;
+  let dbFile: string;
+  let manifest: LoadedPluginManifest;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'plugin-migration-'));
+    dbFile = join(root, 'test.sqlite');
+    PluginService.configure({ PLUGIN_DIR: root, RESTART_BY_EXIT: true });
+    PluginMigrationService.configureForTesting({ type: 'sqlite', database: dbFile });
+
+    writeMigrationPlugin(root, 'widgets', 'widgets');
+    // getPlugins() rewrites the migrations directory to be plugin-folder relative
+    // and assigns an id, mirroring real discovery.
+    manifest = PluginService.getPlugins().find((p) => p.name === 'widgets') as LoadedPluginManifest;
+  });
+
+  afterEach(() => {
+    PluginMigrationService.configureForTesting(null);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('discovers the migrations entry on the manifest', () => {
+    expect(manifest).toBeDefined();
+    expect(PluginMigrationService.hasMigrations(manifest)).toBe(true);
+    expect(PluginMigrationService.migrationsTableName(manifest)).toBe('plugin_migrations_widgets');
+  });
+
+  it('runs up-migrations through the host runner and tracks them in a plugin-scoped table', async () => {
+    const applied = await PluginMigrationService.runUpMigrations(manifest);
+
+    expect(applied).toBe(1);
+    expect(await tableExists(dbFile, 'plugin_widget')).toBe(true);
+    // Tracked separately from host migrations.
+    expect(await tableExists(dbFile, 'plugin_migrations_widgets')).toBe(true);
+    expect(await tableExists(dbFile, 'migrations')).toBe(false);
+  });
+
+  it('is idempotent — already-applied migrations are skipped on re-run', async () => {
+    await PluginMigrationService.runUpMigrations(manifest);
+    const secondRun = await PluginMigrationService.runUpMigrations(manifest);
+
+    expect(secondRun).toBe(0);
+    expect(await tableExists(dbFile, 'plugin_widget')).toBe(true);
+  });
+
+  it('reverts migrations and drops the tracking table on down', async () => {
+    await PluginMigrationService.runUpMigrations(manifest);
+
+    const reverted = await PluginMigrationService.runDownMigrations(manifest);
+
+    expect(reverted).toBe(1);
+    expect(await tableExists(dbFile, 'plugin_widget')).toBe(false);
+    expect(await tableExists(dbFile, 'plugin_migrations_widgets')).toBe(false);
+  });
+
+  it('is a no-op for a plugin without a migrations entry', async () => {
+    writeFileSync(
+      join(root, 'widgets', 'plugin.json'),
+      JSON.stringify({
+        name: 'widgets',
+        version: '1.0.0',
+        main: {
+          frontend: { directory: 'frontend', entryPoint: 'index.mjs' },
+          backend: { directory: 'dist', entryPoint: 'index.js' },
+        },
+        attraccessVersion: { min: '1.0.0' },
+        permissions: [],
+      })
+    );
+    // Re-discover so the cached manifest is dropped.
+    PluginService.configure({ PLUGIN_DIR: root, RESTART_BY_EXIT: true });
+    const noMig = PluginService.getPlugins().find((p) => p.name === 'widgets') as LoadedPluginManifest;
+
+    expect(PluginMigrationService.hasMigrations(noMig)).toBe(false);
+    expect(await PluginMigrationService.runUpMigrations(noMig)).toBe(0);
+  });
+});

--- a/apps/api/src/plugin-system/plugin-migration.service.ts
+++ b/apps/api/src/plugin-system/plugin-migration.service.ts
@@ -1,0 +1,209 @@
+import { Logger } from '@nestjs/common';
+import { DataSource, DataSourceOptions, MigrationExecutor } from 'typeorm';
+import { mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import type { PluginMigrationClass } from '@attraccess/plugins-backend-sdk';
+import { dataSourceConfig } from '../database/datasource';
+import { loadPluginEntryExports } from './plugin-loader';
+import { LoadedPluginManifest } from './plugin.manifest';
+import { PluginService } from './plugin.service';
+
+/**
+ * Runs plugin-shipped TypeORM migrations through the host's migration management.
+ *
+ * Design (see docs/en/plugins/database-migrations.md):
+ *  - A plugin declares a `main.migrations` entry whose module exports migration
+ *    classes (named exports, mirroring the host's `migrations/index.ts`, or a
+ *    default-exported array).
+ *  - Each plugin's migrations are tracked in their OWN table
+ *    (`plugin_migrations_<name>`), so plugin versions never collide with host
+ *    migrations or with each other, and "revert everything for this plugin" is a
+ *    well-defined operation at uninstall.
+ *  - We run them on a short-lived, standalone DataSource pointed at the *same*
+ *    SQLite database as the host. That lets a plugin own its `migrations` array
+ *    and `migrationsTableName` without mutating the host DataSource (which has a
+ *    fixed entity/migration set and `migrationsRun: true`).
+ *  - Up-migrations run on boot, BEFORE the Nest app (and therefore any plugin
+ *    code) starts — so a plugin's tables exist before its services initialise,
+ *    and already-applied migrations are skipped (safe across restarts/re-install).
+ *  - Down-migrations run on uninstall, in reverse order, before the plugin's
+ *    files are removed — so its tables/data are cleaned up.
+ *
+ * Caveat: because plugin migrations may run before the host's own migrations on a
+ * fresh database, a plugin migration must not depend on (e.g. FK to) host tables.
+ * Plugin schema is isolated by design — this matches the plugin sandbox boundary.
+ */
+export class PluginMigrationService {
+  private static logger = new Logger('PluginMigrationService');
+
+  // Test seam: override the base DataSource options (e.g. point at a temp SQLite
+  // file) instead of the host's resolved config. Null = use the host config.
+  private static baseConfigOverride: Partial<DataSourceOptions> | null = null;
+
+  public static configureForTesting(config: Partial<DataSourceOptions> | null): void {
+    PluginMigrationService.baseConfigOverride = config;
+  }
+
+  /**
+   * Plugin-scoped migrations tracking table. Sanitised so the plugin name can be
+   * dropped into an identifier safely.
+   */
+  public static migrationsTableName(manifest: Pick<LoadedPluginManifest, 'name'>): string {
+    const safeName = manifest.name.replace(/[^a-zA-Z0-9_]/g, '_');
+    return `plugin_migrations_${safeName}`;
+  }
+
+  public static hasMigrations(manifest: LoadedPluginManifest): boolean {
+    return Boolean(manifest.main?.migrations?.directory && manifest.main?.migrations?.entryPoint);
+  }
+
+  private static migrationsEntryPath(manifest: LoadedPluginManifest): string {
+    return join(
+      PluginService.PLUGIN_PATH,
+      manifest.main.migrations.directory,
+      manifest.main.migrations.entryPoint
+    );
+  }
+
+  /**
+   * Loads the plugin's migration classes from its bundled migrations entry, in
+   * the host's module realm so `instanceof`/TypeORM type identity hold.
+   */
+  public static loadMigrationClasses(manifest: LoadedPluginManifest): PluginMigrationClass[] {
+    const entry = PluginMigrationService.migrationsEntryPath(manifest);
+    const exports = loadPluginEntryExports(entry);
+
+    const candidates = Array.isArray(exports.default) ? exports.default : Object.values(exports);
+    const classes = candidates.filter((value): value is PluginMigrationClass => typeof value === 'function');
+
+    if (classes.length === 0) {
+      throw new Error(`Plugin "${manifest.name}" migrations entry "${entry}" exported no migration classes.`);
+    }
+
+    return classes;
+  }
+
+  private static buildDataSource(
+    manifest: LoadedPluginManifest,
+    migrations: PluginMigrationClass[]
+  ): DataSource {
+    const base = (PluginMigrationService.baseConfigOverride ?? dataSourceConfig) as DataSourceOptions;
+
+    const databaseFile = (base as { database?: unknown }).database;
+    if (typeof databaseFile === 'string') {
+      // The host normally creates the storage dir, but plugin up-migrations may
+      // run before the host DataSource opens on a fresh install.
+      mkdirSync(dirname(databaseFile), { recursive: true });
+    }
+
+    return new DataSource({
+      ...base,
+      entities: [],
+      synchronize: false,
+      migrationsRun: false,
+      migrations,
+      migrationsTableName: PluginMigrationService.migrationsTableName(manifest),
+    } as DataSourceOptions);
+  }
+
+  /**
+   * SQLite serialises writers per file. While plugin migrations run, the host
+   * connection is either not open yet (boot) or idle (uninstall), but give the
+   * driver a little patience rather than failing fast on a transient lock.
+   */
+  private static async relaxBusyTimeout(dataSource: DataSource): Promise<void> {
+    if (dataSource.options.type === 'sqlite') {
+      await dataSource.query('PRAGMA busy_timeout = 5000');
+    }
+  }
+
+  /** Runs all pending up-migrations for a single plugin. Returns the count applied. */
+  public static async runUpMigrations(manifest: LoadedPluginManifest): Promise<number> {
+    if (!PluginMigrationService.hasMigrations(manifest)) {
+      return 0;
+    }
+
+    const classes = PluginMigrationService.loadMigrationClasses(manifest);
+    const dataSource = PluginMigrationService.buildDataSource(manifest, classes);
+    await dataSource.initialize();
+
+    try {
+      await PluginMigrationService.relaxBusyTimeout(dataSource);
+      const applied = await dataSource.runMigrations({ transaction: 'all' });
+      if (applied.length > 0) {
+        PluginMigrationService.logger.log(
+          `Applied ${applied.length} migration(s) for plugin "${manifest.name}": ${applied
+            .map((migration) => migration.name)
+            .join(', ')}`
+        );
+      }
+      return applied.length;
+    } finally {
+      await dataSource.destroy();
+    }
+  }
+
+  /**
+   * Reverts every applied migration for a single plugin, in reverse order, then
+   * drops the plugin's tracking table. Returns the count reverted.
+   */
+  public static async runDownMigrations(manifest: LoadedPluginManifest): Promise<number> {
+    if (!PluginMigrationService.hasMigrations(manifest)) {
+      return 0;
+    }
+
+    const classes = PluginMigrationService.loadMigrationClasses(manifest);
+    const dataSource = PluginMigrationService.buildDataSource(manifest, classes);
+    await dataSource.initialize();
+
+    try {
+      await PluginMigrationService.relaxBusyTimeout(dataSource);
+      const executor = new MigrationExecutor(dataSource);
+      const executed = await executor.getExecutedMigrations();
+
+      for (let i = 0; i < executed.length; i++) {
+        await dataSource.undoLastMigration({ transaction: 'all' });
+      }
+
+      // Nothing left to track — remove the plugin's bookkeeping table too.
+      const tableName = PluginMigrationService.migrationsTableName(manifest);
+      await dataSource.query(`DROP TABLE IF EXISTS "${tableName}"`);
+
+      if (executed.length > 0) {
+        PluginMigrationService.logger.log(
+          `Reverted ${executed.length} migration(s) for plugin "${manifest.name}".`
+        );
+      }
+      return executed.length;
+    } finally {
+      await dataSource.destroy();
+    }
+  }
+
+  /**
+   * Runs pending up-migrations for every discovered plugin that ships them.
+   * Per-plugin failures are isolated and recorded as a load error so one broken
+   * plugin can never block host boot.
+   */
+  public static async runPendingUpMigrationsForAllPlugins(): Promise<void> {
+    const plugins = PluginService.getPlugins().filter((manifest) => PluginMigrationService.hasMigrations(manifest));
+
+    if (plugins.length === 0) {
+      return;
+    }
+
+    PluginMigrationService.logger.log(`Running plugin migrations for ${plugins.length} plugin(s)...`);
+
+    for (const manifest of plugins) {
+      try {
+        await PluginMigrationService.runUpMigrations(manifest);
+      } catch (error) {
+        PluginMigrationService.logger.error(
+          `Failed to run migrations for plugin "${manifest.name}"; the plugin will be flagged as failed.`,
+          error as Error
+        );
+        PluginService.setPluginLoadError(`${manifest.name}@${manifest.version}`, error as Error);
+      }
+    }
+  }
+}

--- a/apps/api/src/plugin-system/plugin.manifest.spec.ts
+++ b/apps/api/src/plugin-system/plugin.manifest.spec.ts
@@ -1,0 +1,36 @@
+import { PluginManifestSchema } from './plugin.manifest';
+
+const BASE = {
+  name: 'demo',
+  version: '1.0.0',
+  main: {
+    frontend: { directory: 'frontend', entryPoint: 'index.mjs' },
+    backend: { directory: 'dist', entryPoint: 'index.js' },
+  },
+  attraccessVersion: { min: '1.0.0' },
+  permissions: [],
+};
+
+describe('PluginManifestSchema migrations entry', () => {
+  it('accepts a manifest without a migrations entry', () => {
+    const parsed = PluginManifestSchema.parse(BASE);
+    expect(parsed.main.migrations).toBeUndefined();
+  });
+
+  it('accepts and parses a migrations entry', () => {
+    const parsed = PluginManifestSchema.parse({
+      ...BASE,
+      main: { ...BASE.main, migrations: { directory: 'dist', entryPoint: 'migrations.js' } },
+    });
+    expect(parsed.main.migrations).toEqual({ directory: 'dist', entryPoint: 'migrations.js' });
+  });
+
+  it('rejects a malformed migrations entry', () => {
+    expect(() =>
+      PluginManifestSchema.parse({
+        ...BASE,
+        main: { ...BASE.main, migrations: { directory: 'dist' } },
+      })
+    ).toThrow();
+  });
+});

--- a/apps/api/src/plugin-system/plugin.manifest.ts
+++ b/apps/api/src/plugin-system/plugin.manifest.ts
@@ -30,6 +30,21 @@ export class PluginMainBackend {
   entryPoint: string;
 }
 
+export class PluginMainMigrations {
+  @ApiProperty({
+    description: "The directory holding the plugin's bundled database migrations",
+    example: 'dist',
+  })
+  directory: string;
+
+  @ApiProperty({
+    description:
+      'The entry point exporting the migration classes, relative to the migrations directory. The module exports TypeORM migration classes (named exports or a default-exported array).',
+    example: 'migrations.js',
+  })
+  entryPoint: string;
+}
+
 export class PluginMain {
   @ApiProperty({
     description: 'The frontend files of the plugin',
@@ -48,6 +63,14 @@ export class PluginMain {
     },
   })
   backend?: PluginMainBackend;
+
+  @ApiProperty({
+    description:
+      "The plugin's database migrations entry. When present, the host runs the exported up-migrations on load (boot) and the down-migrations on uninstall, tracked in a plugin-scoped migrations table.",
+    type: PluginMainMigrations,
+    required: false,
+  })
+  migrations?: PluginMainMigrations;
 }
 
 export class PluginAttraccessVersion {
@@ -142,6 +165,7 @@ export const PluginManifestSchema = z.object({
   main: z.object({
     frontend: mainSchema,
     backend: mainSchema,
+    migrations: mainSchema.optional(),
   }),
   version: z.string(),
   attraccessVersion: z

--- a/apps/api/src/plugin-system/plugin.module.ts
+++ b/apps/api/src/plugin-system/plugin.module.ts
@@ -13,15 +13,13 @@ import {
   MqttServerConnectionConfig,
   MqttServerHostProvider,
 } from '@attraccess/plugins-backend-sdk';
-import { createRequire, Module as NodeModuleClass } from 'module';
-import { readFileSync } from 'fs';
-import { runInThisContext } from 'vm';
 import { LoadedPluginManifest } from './plugin.manifest';
 import { PluginService } from './plugin.service';
 import { PluginSandboxService } from './plugin-sandbox.service';
 import { PluginEventsService } from './plugin-events.service';
 import { PluginController } from './plugin.controller';
-import { dirname, isAbsolute, join } from 'path';
+import { loadPluginEntryExports } from './plugin-loader';
+import { join } from 'path';
 
 @Global()
 @Module({})
@@ -94,7 +92,7 @@ export class PluginModule {
       return null;
     }
 
-    const importedModule = PluginModule.loadPluginExports(
+    const importedModule = loadPluginEntryExports(
       join(PluginService.PLUGIN_PATH, manifest.main.backend.directory, manifest.main.backend.entryPoint)
     );
 
@@ -111,68 +109,6 @@ export class PluginModule {
 
     const context = PluginModule.createPluginContext(manifest);
     return (exported as PluginBackendModule).register(context);
-  }
-
-  // Loads a plugin's CommonJS backend entry so that its *externalized*
-  // host-shared packages (@nestjs/common, typeorm, reflect-metadata, …) resolve
-  // to the host's single copy. Plugins deliberately do not bundle those packages
-  // — a bundled copy is a different class/symbol object and breaks DI token
-  // identity and constructor-metadata reflection (see
-  // docs/en/plugins/developing-plugins.md "Packaging the backend"). The shipped
-  // index.js therefore does a bare `require('@nestjs/common')` at runtime.
-  //
-  // Two failure modes have to be avoided at once:
-  //   1. Resolution — in a production image the plugin lives under
-  //      STORAGE_ROOT/plugins/… while the host's node_modules sits under
-  //      dist/apps/api/, so a bare require resolved relative to the plugin's own
-  //      directory finds nothing ("Cannot find module '@nestjs/common'").
-  //   2. Identity — the loaded module must be the very same object the host uses,
-  //      AND the plugin's decorators must run against the same global `Reflect`
-  //      the host reads. Handing the entry to Node's own loader (`new Module().
-  //      load()`) compiles it in a separate realm: its `__decorate`/`Reflect.
-  //      metadata` writes land on a different `Reflect`/metadata registry, so DI
-  //      sees no constructor dependencies and injections come back undefined.
-  //
-  // We satisfy both by compiling the entry in *this* realm with `vm.
-  // runInThisContext` (so decorator metadata is written to the same `Reflect`
-  // the host reads) and handing it a `require` that routes every *bare*
-  // specifier — i.e. the externalized host-shared packages — to the host's own
-  // require, returning the host's already-loaded instances regardless of where
-  // the plugin lives on disk. Relative/absolute requests stay plugin-local.
-  private static loadPluginExports(entryFile: string): { default?: unknown } {
-    const NodeModule = NodeModuleClass as unknown as {
-      wrap(script: string): string;
-      _nodeModulePaths(from: string): string[];
-      new (id: string, parent?: unknown): {
-        filename: string;
-        paths: string[];
-        exports: { default?: unknown };
-        require(request: string): unknown;
-      };
-    };
-
-    const hostRequire = createRequire(__filename);
-    const isBareSpecifier = (request: string): boolean => !request.startsWith('.') && !isAbsolute(request);
-
-    const pluginModule = new NodeModule(entryFile, module);
-    pluginModule.filename = entryFile;
-    pluginModule.paths = NodeModule._nodeModulePaths(dirname(entryFile));
-
-    const pluginRequire = ((request: string): unknown =>
-      isBareSpecifier(request) ? hostRequire(request) : pluginModule.require(request)) as NodeJS.Require;
-    pluginRequire.resolve = hostRequire.resolve;
-
-    const compiled = runInThisContext(NodeModule.wrap(readFileSync(entryFile, 'utf8')), { filename: entryFile });
-    compiled.call(
-      pluginModule.exports,
-      pluginModule.exports,
-      pluginRequire,
-      pluginModule,
-      entryFile,
-      dirname(entryFile)
-    );
-
-    return pluginModule.exports;
   }
 
   private static createPluginContext(manifest: LoadedPluginManifest): PluginContext {

--- a/apps/api/src/plugin-system/plugin.service.ts
+++ b/apps/api/src/plugin-system/plugin.service.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import type { PluginManifestInfo } from '@attraccess/plugins-backend-sdk';
 import { PluginManifest, PluginManifestSchema, LoadedPluginManifest } from './plugin.manifest';
 import { PluginSandboxService } from './plugin-sandbox.service';
+import { PluginMigrationService } from './plugin-migration.service';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { FileUpload } from '../common/types/file-upload.types';
 import { rename, rm } from 'fs/promises';
@@ -136,6 +137,10 @@ export class PluginService {
       manifest.main.frontend.directory = join(pluginFolder, manifest.main.frontend.directory);
     }
 
+    if (manifest.main.migrations?.directory) {
+      manifest.main.migrations.directory = join(pluginFolder, manifest.main.migrations.directory);
+    }
+
     return manifest;
   }
 
@@ -214,6 +219,21 @@ export class PluginService {
     if (!existsSync(pluginFolder)) {
       PluginService.logger.error(`Plugin folder ${pluginFolder} of plugin ${plugin.name} not found`);
       throw new NotFoundException('Plugin not found');
+    }
+
+    // Revert the plugin's database migrations (drops its tables/data) BEFORE the
+    // files are removed — the migration classes live in the plugin bundle and
+    // must still be on disk to run. A failure here is logged but never blocks the
+    // uninstall: the admin asked for the plugin to be gone.
+    if (PluginMigrationService.hasMigrations(plugin)) {
+      try {
+        await PluginMigrationService.runDownMigrations(plugin);
+      } catch (error) {
+        PluginService.logger.error(
+          `Failed to revert migrations for plugin ${plugin.name}; removing files anyway. Its tables may be orphaned.`,
+          error as Error
+        );
+      }
     }
 
     // delete folder

--- a/docs/en/_sidebar.md
+++ b/docs/en/_sidebar.md
@@ -75,6 +75,7 @@
   - [Overview](plugins/overview.md)
   - [Installing Plugins](plugins/installing-plugins.md)
   - [Developing Plugins](plugins/developing-plugins.md)
+  - [Database Migrations](plugins/database-migrations.md)
 
 - **Monitoring & Metrics**
   - [Overview](monitoring/overview.md)

--- a/docs/en/plugins/database-migrations.md
+++ b/docs/en/plugins/database-migrations.md
@@ -1,0 +1,127 @@
+# Plugin Database Migrations
+
+A plugin that needs its own persistent tables ships **TypeORM migrations** and
+lets the host run them. The host manages the full lifecycle:
+
+- **On load (boot):** pending up-migrations run before any plugin code starts.
+- **On uninstall:** the plugin's down-migrations run in reverse order, so its
+  tables and data are removed cleanly — no orphaned schema.
+
+This replaces the old workaround of issuing raw `CREATE TABLE IF NOT EXISTS` from
+a service's `onModuleInit`, which had no versioning and left tables behind on
+uninstall.
+
+> [!TIP]
+> Migrations are optional. A plugin that stores nothing — or reads only host
+> tables it has permission for — needs no migrations entry.
+
+## How it works
+
+Each plugin's migrations are tracked in their **own** table,
+`plugin_migrations_<name>`, separate from the host's `migrations` table and from
+every other plugin's. Because the bookkeeping is isolated:
+
+- Plugin migration versions never collide with the host's or another plugin's.
+- "Revert everything this plugin created" is well-defined at uninstall — the host
+  reverts every row in that plugin's tracking table, then drops the table.
+
+The host runs your migrations on a short-lived, standalone connection pointed at
+the **same** database, so your plugin owns its migration set without touching the
+host's fixed entity/migration pipeline. Up-migrations are idempotent across
+restarts and re-installs: already-applied migrations are skipped.
+
+> [!WARNING]
+> Plugin up-migrations may run **before** the host's own migrations on a fresh
+> database. A plugin migration must therefore **not** depend on (e.g. add a
+> foreign key to) host tables — they may not exist yet. Keep plugin schema
+> self-contained. This matches the plugin sandbox boundary.
+
+## 1. Declare the migrations entry
+
+Add `main.migrations` to `plugin.json`, pointing at the bundled module that
+exports your migration classes:
+
+```json
+{
+  "name": "plugin-widgets",
+  "version": "1.0.0",
+  "main": {
+    "backend": { "directory": "dist", "entryPoint": "index.js" },
+    "migrations": { "directory": "dist", "entryPoint": "migrations.js" }
+  },
+  "attraccessVersion": { "min": "1.0.0" }
+}
+```
+
+`directory` + `entryPoint` are resolved relative to the ZIP root, exactly like
+`main.backend`. The entry is loaded independently of the backend module, so the
+host can revert your migrations on uninstall even if the backend itself failed to
+load.
+
+## 2. Write the migrations
+
+Author them exactly like host migrations. Prefix the class name with a
+millisecond timestamp so ordering is deterministic, and implement both `up` and
+`down`:
+
+```ts
+import { MigrationInterface, QueryRunner } from '@attraccess/plugins-backend-sdk';
+
+export class CreateWidgets1700000000000 implements MigrationInterface {
+  name = 'CreateWidgets1700000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "plugin_widgets" (
+        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        "label" varchar NOT NULL
+      )`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "plugin_widgets"`);
+  }
+}
+```
+
+> [!TIP]
+> Import `MigrationInterface`, `QueryRunner`, and the schema-builder helpers
+> (`Table`, `TableColumn`, …) from `@attraccess/plugins-backend-sdk`. The SDK
+> re-exports them from the host's single TypeORM copy, so your migration runs
+> against the same types the host uses — never add your own `typeorm` dependency.
+>
+> Prefix every table with your plugin name (e.g. `plugin_widgets_*`) to avoid
+> clashing with host or other-plugin tables in the shared database.
+
+## 3. Bundle the migrations entry
+
+The migrations entry is a normal CommonJS module exporting the migration classes
+— as **named exports** (mirroring the host's `migrations/index.ts`) or as a
+**default-exported array**:
+
+```ts
+// migrations.ts → bundled to dist/migrations.js
+export * from './migrations/1700000000000-create-widgets';
+```
+
+Build it alongside your backend (e.g. a second esbuild entry) so `dist/migrations.js`
+ships in the package. Like the backend entry, externalize `typeorm` so it resolves
+to the host's copy at runtime rather than being bundled.
+
+## Lifecycle summary
+
+| Event | What the host does |
+|-------|--------------------|
+| Plugin installed → restart → boot | Runs pending up-migrations before plugin code starts. |
+| Subsequent boots | Skips already-applied migrations (idempotent). |
+| Plugin uninstalled | Runs down-migrations in reverse, then drops `plugin_migrations_<name>`. |
+
+A failing up-migration flags that plugin as failed but never blocks host boot or
+other plugins. A failing down-migration on uninstall is logged; the plugin files
+are still removed (its tables may then be orphaned).
+
+## See Also
+
+- [Developing Plugins](plugins/developing-plugins.md)
+- [Installing Plugins](plugins/installing-plugins.md)

--- a/docs/en/plugins/developing-plugins.md
+++ b/docs/en/plugins/developing-plugins.md
@@ -60,6 +60,7 @@ versions it supports, and the permissions it needs:
 | `name` | yes | Unique identifier; also the on-disk folder name. |
 | `version` | yes | Your plugin's semantic version. |
 | `main.backend` / `main.frontend` | at least one | `directory` + `entryPoint`, relative to the ZIP root. |
+| `main.migrations` | no | `directory` + `entryPoint` of a module exporting TypeORM migration classes. See [Database Migrations](plugins/database-migrations.md). |
 | `attraccessVersion` | yes | Compatibility range — at least one of `min`, `max`, `exact`. |
 | `permissions` | no | Backend capabilities you need (see [Permissions](#backend-plugin-permissions)). Defaults to `[]`. |
 

--- a/libs/plugins-backend-sdk/src/index.ts
+++ b/libs/plugins-backend-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/plugin.interface';
 export * from './lib/plugin-context';
+export * from './lib/plugin-migrations';
 export * from './lib/semver';
 
 export * from './lib/auth-decorator';

--- a/libs/plugins-backend-sdk/src/lib/plugin-migrations.ts
+++ b/libs/plugins-backend-sdk/src/lib/plugin-migrations.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface } from 'typeorm';
+
+/**
+ * Constructor of a TypeORM migration a plugin ships. A plugin's migrations entry
+ * module exports one or more of these (either as named exports, mirroring the
+ * host's own `migrations/index.ts`, or as a default-exported array). The host
+ * collects them and runs them through its migration runner against a
+ * plugin-scoped migrations table — see {@link PluginContext} docs and
+ * `docs/en/plugins/database-migrations.md`.
+ *
+ * Author them exactly like host migrations: implement `up`/`down`, prefix the
+ * class name with a millisecond timestamp so ordering is deterministic
+ * (`class CreateWidgets1700000000000 implements MigrationInterface`).
+ */
+export type PluginMigrationClass = new () => MigrationInterface;
+
+// Re-exported from the host's single TypeORM copy so a plugin can author
+// migrations against the SDK without taking its own `typeorm` dependency (a
+// bundled copy would be a different module object — see plugin.module loader).
+export type { MigrationInterface, QueryRunner } from 'typeorm';
+export { Table, TableColumn, TableForeignKey, TableIndex } from 'typeorm';


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Gives plugins a first-class way to ship database migrations that hook into the host's TypeORM migration management — run on load, reverted on uninstall — replacing the raw `CREATE TABLE` / no-cleanup workaround.

Resolves [ATT-547](https://linear.app/attraccess/issue/ATT-547).

## What changed

- **Manifest** (`plugin.json`): optional `main.migrations` entry `{ directory, entryPoint }` pointing at a bundled module that exports TypeORM migration classes (named exports or a default array).
- **SDK** (`@attraccess/plugins-backend-sdk`): adds `PluginMigrationClass` and re-exports `MigrationInterface`, `QueryRunner`, and schema builders (`Table`, `TableColumn`, …) from the host's single TypeORM copy, so plugins author migrations without taking their own `typeorm` dependency.
- **`PluginMigrationService`**: runs each plugin's migrations on a short-lived **standalone DataSource** against the shared DB, tracked in a **per-plugin `plugin_migrations_<name>` table** — versions never collide with host or other plugins, and "revert everything for this plugin" is well-defined.
  - **On boot** (in `main.bootstrap`, *before* AppModule loads): pending up-migrations run before any plugin code starts; already-applied ones are skipped (idempotent). Per-plugin failures are isolated and flagged as a load error — they never abort host boot.
  - **On uninstall** (`PluginService.deletePlugin`): down-migrations run in reverse, then the tracking table is dropped — before plugin files are removed.
- Extracts the realm-aware plugin entry loader into `plugin-loader.ts` (shared by the module loader and the migration loader; ensures plugin migrations run against the host's TypeORM types).
- Docs: new `docs/en/plugins/database-migrations.md` + manifest table/sidebar updates.

## Design decisions / open questions from the issue

- **Tracking: separate table per plugin** (`plugin_migrations_<name>`) rather than prefixed names in the shared `migrations` table — cleaner isolation and a clean revert-all on uninstall.
- **Ordering caveat:** plugin up-migrations may run before the host's own migrations on a fresh DB, so a plugin migration must not FK to host tables. Plugin schema is self-contained by design (matches the sandbox boundary). Documented.

## Testing

- `nx test api` — full suite green (1470 tests). New specs:
  - `plugin-migration.service.spec.ts` — up creates + tracks in the plugin-scoped table (not the host `migrations` table), idempotent re-run, down drops table + tracking table, no-op without a migrations entry.
  - `plugin.manifest.spec.ts` — schema accepts/validates the migrations entry.
- `nx lint api,plugins-backend-sdk`, `nx build api`, `nx build plugins-backend-sdk` — all pass.

## Note on the Shelly follow-up

The issue's second "Done when" (convert Shelly's manual `CREATE TABLE` to migrations) depends on [ATT-496](https://linear.app/attraccess/issue/ATT-496); the Shelly plugin is not present on `main` yet. This PR delivers the mechanism + tests + docs; the Shelly conversion is a fast follow-up once ATT-496 lands.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Add first-class support for plugin-managed database migrations that integrate with the host’s TypeORM migration lifecycle, including execution on boot and cleanup on uninstall.

New Features:
- Allow plugins to declare bundled TypeORM migrations via an optional main.migrations entry in plugin manifests.
- Expose migration-related types and helpers through the plugins backend SDK so plugins can author migrations without depending directly on TypeORM.
- Introduce a plugin migration service that runs each plugin’s migrations against the shared database using per-plugin migration tables.

Enhancements:
- Run plugin migrations during application bootstrap before loading AppModule, and automatically revert them when a plugin is uninstalled.
- Extract the realm-aware plugin entry loader into a shared utility reused for both backend and migration entry loading.

Documentation:
- Document how plugins define, bundle, and lifecycle-manage database migrations, and update plugin docs navigation and manifest reference accordingly.

Tests:
- Add unit tests covering plugin manifest validation for migrations and the full up/down migration lifecycle, including idempotency and per-plugin tracking tables.