### PR TITLE
feat(ATT-537): surface maintenance state in resource lists and lock screen

### DIFF
--- a/apps/attractap/firmware/src/application/application_state.cpp
+++ b/apps/attractap/firmware/src/application/application_state.cpp
@@ -258,7 +258,8 @@ void Application::processState() {
 
         Display::lockscreen.setResourceName(resource.name);
         Display::lockscreen.setUsageInfo(resource.hasActiveUsage,
-                                         resource.activeUser);
+                                         resource.activeUser,
+                                         resource.isUnderMaintenance);
 
         // Directly pass the native struct to the screen so it can avoid String
         // conversions

--- a/apps/attractap/firmware/src/display/screens/lockscreen/lockscreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/lockscreen/lockscreen.cpp
@@ -95,7 +95,7 @@ void Lockscreen::setResourceName(const char *resourceName)
     this->updateUsageInfo();
 }
 
-void Lockscreen::setUsageInfo(bool hasActiveUsage, const char *username)
+void Lockscreen::setUsageInfo(bool hasActiveUsage, const char *username, bool isUnderMaintenance)
 {
     if (hasActiveUsage)
     {
@@ -103,6 +103,7 @@ void Lockscreen::setUsageInfo(bool hasActiveUsage, const char *username)
         this->username[API::MAX_USERNAME_LEN - 1] = '\0';
     }
     this->hasActiveUsage = hasActiveUsage;
+    this->isUnderMaintenance = isUnderMaintenance;
 
     this->updateUsageInfo();
 }
@@ -116,11 +117,17 @@ void Lockscreen::updateUsageInfo()
 
     lv_label_set_text(this->resourceNameLabel, this->resourceName);
 
+    // Status priority mirrors the web resource list: in use > maintenance > available.
     if (this->hasActiveUsage)
     {
         String usageText = "In Verwendung: " + String(this->username);
         lv_label_set_text(this->usageInfoLabel, usageText.c_str());
         lv_obj_set_style_text_color(this->usageInfoLabel, lv_color_hex(0xF31260), LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+    else if (this->isUnderMaintenance)
+    {
+        lv_label_set_text(this->usageInfoLabel, "In Wartung");
+        lv_obj_set_style_text_color(this->usageInfoLabel, lv_color_hex(0xF5A524), LV_PART_MAIN | LV_STATE_DEFAULT);
     }
     else
     {

--- a/apps/attractap/firmware/src/display/screens/lockscreen/lockscreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/lockscreen/lockscreen.hpp
@@ -18,7 +18,7 @@ public:
     void destroy() override;
 
     void setResourceName(const char *resourceName);
-    void setUsageInfo(bool hasActiveUsage, const char *username);
+    void setUsageInfo(bool hasActiveUsage, const char *username, bool isUnderMaintenance);
 
 private:
     lv_obj_t *screen = nullptr;
@@ -29,6 +29,7 @@ private:
     char resourceName[API::MAX_RESOURCE_NAME_LEN];
     char username[API::MAX_USERNAME_LEN];
     bool hasActiveUsage;
+    bool isUnderMaintenance;
 
     void updateUsageInfo();
 };

--- a/apps/attractap/firmware/src/display/screens/resourceList/resourceListScreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceList/resourceListScreen.cpp
@@ -80,9 +80,14 @@ void ResourceListScreen::addResourceListItem(const API::ResourceBrief &resource)
    lv_obj_set_style_border_opa(resourceButton, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_border_width(resourceButton, 20, LV_PART_MAIN | LV_STATE_DEFAULT);
    lv_obj_set_style_border_side(resourceButton, LV_BORDER_SIDE_RIGHT, LV_PART_MAIN | LV_STATE_DEFAULT);
+   // Status priority mirrors the web resource list: in use > maintenance > available.
    if (resource.hasActiveUsage)
    {
       lv_obj_set_style_border_color(resourceButton, lv_color_hex(0xF31260), LV_PART_MAIN | LV_STATE_DEFAULT);
+   }
+   else if (resource.isUnderMaintenance)
+   {
+      lv_obj_set_style_border_color(resourceButton, lv_color_hex(0xF5A524), LV_PART_MAIN | LV_STATE_DEFAULT);
    }
    else
    {

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/statusChip/de.json
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/statusChip/de.json
@@ -1,6 +1,7 @@
 {
   "status": {
     "inUse": "In Benutzung",
-    "available": "Verfügbar"
+    "available": "Verfügbar",
+    "maintenance": "In Wartung"
   }
 }

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/statusChip/en.json
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/statusChip/en.json
@@ -1,6 +1,7 @@
 {
   "status": {
     "inUse": "In Use",
-    "available": "Available"
+    "available": "Available",
+    "maintenance": "In Maintenance"
   }
 }

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/statusChip/index.test.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/statusChip/index.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusChip } from './index';
+
+let sessionData: unknown;
+let maintenanceData: unknown;
+
+vi.mock('@attraccess/plugins-frontend-ui', () => ({
+  useTranslations: () => ({
+    t: (key: string) => {
+      const dict: Record<string, string> = {
+        'status.inUse': 'In Use',
+        'status.available': 'Available',
+        'status.maintenance': 'In Maintenance',
+      };
+      return dict[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@attraccess/react-query-client', () => ({
+  useResourcesServiceResourceUsageGetActiveSession: () => ({ data: sessionData }),
+  useResourceMaintenancesServiceFindMaintenances: () => ({ data: maintenanceData }),
+}));
+
+describe('StatusChip', () => {
+  beforeEach(() => {
+    sessionData = undefined;
+    maintenanceData = undefined;
+  });
+
+  it('shows Available when idle and not under maintenance', () => {
+    render(<StatusChip resourceId={1} />);
+    expect(screen.getByText('Available')).toBeInTheDocument();
+  });
+
+  it('shows In Use when there is an active session', () => {
+    sessionData = { usage: { id: 1 } };
+    render(<StatusChip resourceId={1} />);
+    expect(screen.getByText('In Use')).toBeInTheDocument();
+  });
+
+  it('shows In Maintenance when active maintenance exists and no session', () => {
+    maintenanceData = { data: [{ id: 1 }] };
+    render(<StatusChip resourceId={1} />);
+    expect(screen.getByText('In Maintenance')).toBeInTheDocument();
+    expect(screen.queryByText('Available')).not.toBeInTheDocument();
+  });
+
+  it('prioritizes an active session over maintenance', () => {
+    sessionData = { usage: { id: 1 } };
+    maintenanceData = { data: [{ id: 1 }] };
+    render(<StatusChip resourceId={1} />);
+    expect(screen.getByText('In Use')).toBeInTheDocument();
+    expect(screen.queryByText('In Maintenance')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/resourceOverview/resourceGroupCard/statusChip/index.tsx
+++ b/apps/frontend/src/app/resourceOverview/resourceGroupCard/statusChip/index.tsx
@@ -1,5 +1,8 @@
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
-import { useResourcesServiceResourceUsageGetActiveSession } from '@attraccess/react-query-client';
+import {
+  useResourceMaintenancesServiceFindMaintenances,
+  useResourcesServiceResourceUsageGetActiveSession,
+} from '@attraccess/react-query-client';
 import { Chip } from '@heroui/react';
 import { useMemo } from 'react';
 
@@ -16,10 +19,27 @@ export function StatusChip(props: Readonly<Props>) {
   const { t } = useTranslations({ de, en });
 
   const { data: session } = useResourcesServiceResourceUsageGetActiveSession({ resourceId });
+  const { data: activeMaintenances } = useResourceMaintenancesServiceFindMaintenances({
+    resourceId,
+    includeActive: true,
+  });
 
   const isInUse = useMemo(() => {
     return !!session?.usage;
   }, [session]);
 
-  return <Chip color={isInUse ? 'danger' : 'success'}>{isInUse ? t('status.inUse') : t('status.available')}</Chip>;
+  const isUnderMaintenance = useMemo(() => {
+    return (activeMaintenances?.data?.length ?? 0) > 0;
+  }, [activeMaintenances]);
+
+  // In-use takes priority over maintenance to mirror the resource details view.
+  if (isInUse) {
+    return <Chip color="danger">{t('status.inUse')}</Chip>;
+  }
+
+  if (isUnderMaintenance) {
+    return <Chip color="warning">{t('status.maintenance')}</Chip>;
+  }
+
+  return <Chip color="success">{t('status.available')}</Chip>;
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Maintenance status was only visible in the resource details view. This surfaces it in the three places called out in ATT-537:

- **Web resource list** (`StatusChip`): new amber **"In Maintenance"** chip when a resource has an active maintenance and no active session.
- **Attractap firmware resource list**: amber border (`0xF5A524`) for resources under maintenance.
- **Attractap lock screen**: shows **"In Wartung"** (amber) when the resource is under maintenance.

Status priority everywhere mirrors the resource details view: **in use > maintenance > available**.

## Implementation

- `StatusChip` now also calls `useResourceMaintenancesServiceFindMaintenances({ resourceId, includeActive: true })` and renders a `warning`-colored chip when active maintenances exist. Added `status.maintenance` translations (en/de).
- Firmware `Lockscreen::setUsageInfo` gains an `isUnderMaintenance` arg; `application_state` passes `resource.isUnderMaintenance` (already parsed from the API into `ResourceBrief`). Resource list screen adds the maintenance border branch.

## Testing

- Added 4 `StatusChip` unit tests (available / in use / maintenance / in-use-wins-over-maintenance).
- Pre-commit hook ran `nx affected` lint, typecheck, build, test for `frontend` + `attractap-firmware` — passed.

## Linear

https://linear.app/attraccess/issue/ATT-537/ressource-in-maintenance-should-not-be-marked-available

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Surface maintenance status across web and firmware resource views and align status priority with the resource details view.

New Features:
- Show a maintenance status chip in the web resource list when a resource has active maintenance and no active session.
- Indicate maintenance state on Attractap firmware resource list items using an amber border and update the lock screen to display an amber "In Wartung" status.

Tests:
- Add unit tests for the StatusChip to cover available, in-use, maintenance, and priority handling between usage and maintenance states.