### PR TITLE
feat(ATT-519): add generic plugin slots to MQTT frontend

### DIFF
--- a/apps/frontend/src/app/mqtt/mqtt.slots.ts
+++ b/apps/frontend/src/app/mqtt/mqtt.slots.ts
@@ -1,0 +1,20 @@
+// Plugin extension-point ids exposed by the MQTT UI.
+//
+// These are generic, host-owned slot ids — plugins target them by string via
+// `AttraccessFrontendPlugin.getSlotContributions()`. No vendor specifics (e.g.
+// RabbitMQ) live here or in the slot contract; the core only knows "render
+// whatever plugins contribute for this MQTT server".
+//
+// Contract: both slots receive `{ mqttServerId: number }` as their context so a
+// contribution can scope its UI / data fetching to the selected server.
+
+// Detail/edit view of a single MQTT server (an "extensions" section).
+export const MQTT_SERVER_DETAIL_SLOT = 'mqtt.server.detail';
+
+// Per-row action / badge area in the MQTT server list.
+export const MQTT_SERVER_LIST_ROW_SLOT = 'mqtt.server.list.row';
+
+// Context shape passed to both MQTT server slots.
+export interface MqttServerSlotContext {
+  mqttServerId: number;
+}

--- a/apps/frontend/src/app/mqtt/mqtt.slots.ts
+++ b/apps/frontend/src/app/mqtt/mqtt.slots.ts
@@ -14,7 +14,10 @@ export const MQTT_SERVER_DETAIL_SLOT = 'mqtt.server.detail';
 // Per-row action / badge area in the MQTT server list.
 export const MQTT_SERVER_LIST_ROW_SLOT = 'mqtt.server.list.row';
 
-// Context shape passed to both MQTT server slots.
+// Context shape passed to both MQTT server slots. The index signature keeps it
+// assignable to the SDK's generic `PluginSlotContext` (Record<string, unknown>)
+// so it can parameterize `PluginSlot<MqttServerSlotContext>`.
 export interface MqttServerSlotContext {
   mqttServerId: number;
+  [key: string]: unknown;
 }

--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -17,6 +17,8 @@ import {
   useMqttServiceMqttServersGetAllKey,
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
+import { PluginSlot } from '../../plugins/PluginSlot';
+import { MQTT_SERVER_DETAIL_SLOT } from '../mqtt.slots';
 
 export function EditMqttServerPage() {
   const { serverId } = useParams<{ serverId: string }>();
@@ -274,6 +276,8 @@ export function EditMqttServerPage() {
           </Button>
         </div>
       </Form>
+
+      <PluginSlot slotId={MQTT_SERVER_DETAIL_SLOT} context={{ mqttServerId: server.id }} />
     </div>
   );
 }

--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -18,7 +18,7 @@ import {
 } from '@attraccess/react-query-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { PluginSlot } from '../../plugins/PluginSlot';
-import { MQTT_SERVER_DETAIL_SLOT } from '../mqtt.slots';
+import { MQTT_SERVER_DETAIL_SLOT, MqttServerSlotContext } from '../mqtt.slots';
 
 export function EditMqttServerPage() {
   const { serverId } = useParams<{ serverId: string }>();
@@ -277,7 +277,10 @@ export function EditMqttServerPage() {
         </div>
       </Form>
 
-      <PluginSlot slotId={MQTT_SERVER_DETAIL_SLOT} context={{ mqttServerId: server.id }} />
+      <PluginSlot<MqttServerSlotContext>
+        slotId={MQTT_SERVER_DETAIL_SLOT}
+        context={{ mqttServerId: server.id }}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
+++ b/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
@@ -38,7 +38,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 import { EmptyState } from '../../../components/emptyState';
 import { PluginSlot } from '../../plugins/PluginSlot';
-import { MQTT_SERVER_LIST_ROW_SLOT } from '../mqtt.slots';
+import { MQTT_SERVER_LIST_ROW_SLOT, MqttServerSlotContext } from '../mqtt.slots';
 
 export function MqttServerList() {
   const { t } = useTranslations({ en, de });
@@ -141,7 +141,7 @@ export function MqttServerList() {
                         <Trash2Icon className="w-4 h-4" />
                         {t('deleteServer')}
                       </Button>
-                      <PluginSlot
+                      <PluginSlot<MqttServerSlotContext>
                         slotId={MQTT_SERVER_LIST_ROW_SLOT}
                         context={{ mqttServerId: server.id }}
                       />

--- a/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
+++ b/apps/frontend/src/app/mqtt/servers/MqttServerList.tsx
@@ -37,6 +37,8 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { AlertStatusIcon } from '../../../components/AlertStatusIcon';
 import { EmptyState } from '../../../components/emptyState';
+import { PluginSlot } from '../../plugins/PluginSlot';
+import { MQTT_SERVER_LIST_ROW_SLOT } from '../mqtt.slots';
 
 export function MqttServerList() {
   const { t } = useTranslations({ en, de });
@@ -139,6 +141,10 @@ export function MqttServerList() {
                         <Trash2Icon className="w-4 h-4" />
                         {t('deleteServer')}
                       </Button>
+                      <PluginSlot
+                        slotId={MQTT_SERVER_LIST_ROW_SLOT}
+                        context={{ mqttServerId: server.id }}
+                      />
                     </div>
                   </TableCell>
                 </TableRow>

--- a/apps/frontend/src/app/plugins/PluginSlot.tsx
+++ b/apps/frontend/src/app/plugins/PluginSlot.tsx
@@ -9,6 +9,9 @@ import usePluginState from './plugin.state';
 interface PluginSlotBoundaryProps extends PropsWithChildren {
   pluginName?: string;
   slotId: string;
+  // Stable identifier of the specific contribution (its `key`), so a crash maps
+  // to one contribution even when a plugin mounts several into the same slot.
+  contributionKey?: string;
 }
 
 class PluginSlotBoundary extends Component<PluginSlotBoundaryProps, { hasError: boolean }> {
@@ -23,9 +26,9 @@ class PluginSlotBoundary extends Component<PluginSlotBoundaryProps, { hasError: 
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error(
-      `Attraccess Plugin System: slot "${this.props.slotId}" contribution from plugin "${
-        this.props.pluginName ?? 'unknown'
-      }" crashed`,
+      `Attraccess Plugin System: slot "${this.props.slotId}" contribution "${
+        this.props.contributionKey ?? 'unknown'
+      }" from plugin "${this.props.pluginName ?? 'unknown'}" crashed`,
       error,
       info
     );
@@ -51,19 +54,23 @@ function SlotContribution({
   return <>{contribution.render(context)}</>;
 }
 
-export interface PluginSlotProps {
+export interface PluginSlotProps<Context extends PluginSlotContext = PluginSlotContext> {
   // Host extension-point id. Plugins target this via getSlotContributions().
   slotId: string;
   // Context handed to each contribution (e.g. the selected entity id). The host
-  // owns this shape per slot; it stays a plain object so the SDK keeps no
-  // domain knowledge.
-  context?: PluginSlotContext;
+  // types this per slot (e.g. `{ mqttServerId: number }`); it stays a plain
+  // object so the SDK keeps no domain knowledge.
+  context?: Context;
 }
 
 // Generic extension point: renders every plugin contribution registered for
 // `slotId`, each wrapped in an error boundary. Renders nothing (no wrapper DOM)
 // when no plugin contributes, so the host UI is unchanged without plugins.
-export function PluginSlot({ slotId, context }: PluginSlotProps) {
+// `Context` lets the host type the context it passes per slot at the call site.
+export function PluginSlot<Context extends PluginSlotContext = PluginSlotContext>({
+  slotId,
+  context,
+}: PluginSlotProps<Context>) {
   const { plugins } = usePluginState();
 
   const contributions = useMemo(() => {
@@ -88,7 +95,7 @@ export function PluginSlot({ slotId, context }: PluginSlotProps) {
     return null;
   }
 
-  const slotContext: PluginSlotContext = context ?? {};
+  const slotContext: Context = context ?? ({} as Context);
 
   return (
     <>
@@ -97,6 +104,7 @@ export function PluginSlot({ slotId, context }: PluginSlotProps) {
           key={contribution.key ?? `${pluginName}-${index}`}
           pluginName={pluginName}
           slotId={slotId}
+          contributionKey={contribution.key}
         >
           <SlotContribution contribution={contribution} context={slotContext} />
         </PluginSlotBoundary>

--- a/apps/frontend/src/app/plugins/PluginSlot.tsx
+++ b/apps/frontend/src/app/plugins/PluginSlot.tsx
@@ -1,0 +1,106 @@
+import { PluginSlotContext, PluginSlotContribution } from '@attraccess/plugins-frontend-sdk';
+import { Component, ErrorInfo, PropsWithChildren, ReactNode, useMemo } from 'react';
+import usePluginState from './plugin.state';
+
+// Isolates a single plugin slot contribution so a throwing contribution cannot
+// crash the host page it is embedded in. Unlike a full route, an embedded slot
+// renders nothing on error (it is decoration inside a host screen, not the page
+// itself) — the failure is logged for the plugin author.
+interface PluginSlotBoundaryProps extends PropsWithChildren {
+  pluginName?: string;
+  slotId: string;
+}
+
+class PluginSlotBoundary extends Component<PluginSlotBoundaryProps, { hasError: boolean }> {
+  constructor(props: PluginSlotBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(
+      `Attraccess Plugin System: slot "${this.props.slotId}" contribution from plugin "${
+        this.props.pluginName ?? 'unknown'
+      }" crashed`,
+      error,
+      info
+    );
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
+  }
+}
+
+// Runs a contribution's render() inside the boundary's subtree so a throw during
+// render is caught by the surrounding PluginSlotBoundary.
+function SlotContribution({
+  contribution,
+  context,
+}: {
+  contribution: PluginSlotContribution;
+  context: PluginSlotContext;
+}) {
+  return <>{contribution.render(context)}</>;
+}
+
+export interface PluginSlotProps {
+  // Host extension-point id. Plugins target this via getSlotContributions().
+  slotId: string;
+  // Context handed to each contribution (e.g. the selected entity id). The host
+  // owns this shape per slot; it stays a plain object so the SDK keeps no
+  // domain knowledge.
+  context?: PluginSlotContext;
+}
+
+// Generic extension point: renders every plugin contribution registered for
+// `slotId`, each wrapped in an error boundary. Renders nothing (no wrapper DOM)
+// when no plugin contributes, so the host UI is unchanged without plugins.
+export function PluginSlot({ slotId, context }: PluginSlotProps) {
+  const { plugins } = usePluginState();
+
+  const contributions = useMemo(() => {
+    return plugins.flatMap((manifest) => {
+      let all: PluginSlotContribution[] | undefined;
+      try {
+        all = manifest.plugin.getSlotContributions?.();
+      } catch (error) {
+        console.error(
+          `Attraccess Plugin System: getSlotContributions() of plugin "${manifest.plugin.getPluginName()}" threw`,
+          error
+        );
+        return [];
+      }
+      return (all ?? [])
+        .filter((contribution) => contribution.slotId === slotId)
+        .map((contribution) => ({ contribution, pluginName: manifest.plugin.getPluginName() }));
+    });
+  }, [plugins, slotId]);
+
+  if (contributions.length === 0) {
+    return null;
+  }
+
+  const slotContext: PluginSlotContext = context ?? {};
+
+  return (
+    <>
+      {contributions.map(({ contribution, pluginName }, index) => (
+        <PluginSlotBoundary
+          key={contribution.key ?? `${pluginName}-${index}`}
+          pluginName={pluginName}
+          slotId={slotId}
+        >
+          <SlotContribution contribution={contribution} context={slotContext} />
+        </PluginSlotBoundary>
+      ))}
+    </>
+  );
+}

--- a/docs/en/plugins/developing-plugins.md
+++ b/docs/en/plugins/developing-plugins.md
@@ -351,6 +351,43 @@ route props (`path`, `element`, ...) with an `authRequired` field:
 The host wraps each plugin route in an error boundary and merges it with the
 core routes, so a route that throws cannot take down the rest of the app.
 
+### Slots (embedded extension points)
+
+Routes give a plugin its own pages. **Slots** let a plugin inject UI *into* a
+host page at a well-known point, without the host knowing anything about the
+plugin. A slot is identified by a string id the host documents (just like a
+route `path`), and the host hands each contribution a small context object
+describing where it is mounted.
+
+Implement `getSlotContributions()` and return one entry per slot you target:
+
+```tsx
+getSlotContributions(): PluginSlotContribution[] {
+  return [
+    {
+      slotId: 'mqtt.server.detail',           // host-documented id
+      key: 'my-plugin-mqtt-detail',           // stable key (optional)
+      render: (context) => <MyPanel mqttServerId={Number(context.mqttServerId)} />,
+    },
+  ];
+}
+```
+
+- `slotId` — the host extension point to render into. Unknown ids are ignored.
+- `render(context)` — returns the React node to embed. `context` is a plain
+  object whose keys the host documents per slot (e.g. the MQTT slots pass
+  `{ mqttServerId }`), so a contribution can scope itself to the right entity.
+- The host renders every matching contribution inside an error boundary, so a
+  throwing contribution is hidden and logged rather than breaking the host page.
+
+The slot contract is intentionally generic — the SDK carries no domain
+knowledge. Host slot ids available today:
+
+| Slot id | Where it renders | Context |
+|---------|------------------|---------|
+| `mqtt.server.detail` | MQTT server detail/edit view (extensions section) | `{ mqttServerId }` |
+| `mqtt.server.list.row` | MQTT server list, per-row action area | `{ mqttServerId }` |
+
 ### Packaging the frontend
 
 Build the frontend as a module federation remote exposing `./plugin`. Its

--- a/docs/en/plugins/developing-plugins.md
+++ b/docs/en/plugins/developing-plugins.md
@@ -362,14 +362,19 @@ describing where it is mounted.
 Implement `getSlotContributions()` and return one entry per slot you target:
 
 ```tsx
+// Type each contribution against the context the host documents for the slot,
+// so `context` is strongly typed with no runtime casting.
+interface MqttServerSlotContext { mqttServerId: number; [key: string]: unknown; }
+
 getSlotContributions(): PluginSlotContribution[] {
-  return [
+  const contributions: PluginSlotContribution<MqttServerSlotContext>[] = [
     {
       slotId: 'mqtt.server.detail',           // host-documented id
       key: 'my-plugin-mqtt-detail',           // stable key (optional)
-      render: (context) => <MyPanel mqttServerId={Number(context.mqttServerId)} />,
+      render: (context) => <MyPanel mqttServerId={context.mqttServerId} />,
     },
   ];
+  return contributions;
 }
 ```
 
@@ -377,6 +382,10 @@ getSlotContributions(): PluginSlotContribution[] {
 - `render(context)` — returns the React node to embed. `context` is a plain
   object whose keys the host documents per slot (e.g. the MQTT slots pass
   `{ mqttServerId }`), so a contribution can scope itself to the right entity.
+  `PluginSlotContribution<Context>` is generic over that shape, so you type it
+  once and skip per-field casts; contributions for different slots still share
+  one `PluginSlotContribution[]` array.
+- The `key` is optional but doubles as the contribution's id in host error logs.
 - The host renders every matching contribution inside an error boundary, so a
   throwing contribution is hidden and logged rather than breaking the host page.
 

--- a/examples/plugin-hello-world/README.md
+++ b/examples/plugin-hello-world/README.md
@@ -11,6 +11,7 @@ guide and exercises every core capability:
 | Event handler | [`backend/plugin.ts`](backend/plugin.ts) | Subscribes to `RESOURCE_USAGE_STARTED` via `context.onEvent` (needs `LISTEN_EVENTS`). |
 | Frontend routes | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Registers the `/hello-world` and `/hello-world/capabilities` pages through `getRoutes()`. |
 | Sidebar entry | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Adds a "Hello World" navigation item through `getSidebarItems()`. |
+| Embedded slots | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Injects UI into the MQTT server detail + list views through `getSlotContributions()`, scoped to the selected server via slot context. |
 | Host-native UI | [`frontend/src/plugin.tsx`](frontend/src/plugin.tsx) | Builds pages from the host's shared `@heroui/react` components and `lucide-react` icons, so they look native and inherit the host theme. |
 | Shared libraries | [`frontend/vite.config.ts`](frontend/vite.config.ts) | Reuses the host's `react-router-dom`, `@heroui/react` and `lucide-react` so `<Link>`s navigate without a reload and the UI uses a single, themed copy. |
 

--- a/examples/plugin-hello-world/build.mjs
+++ b/examples/plugin-hello-world/build.mjs
@@ -53,12 +53,22 @@ await esbuild({
 });
 
 // 2. Frontend — Vite module federation remote exposing `./plugin`.
-await viteBuild({
-  root: join(HERE, 'frontend'),
-  configFile: join(HERE, 'frontend/vite.config.ts'),
-  build: { outDir: join(PACKAGE, 'frontend'), emptyOutDir: true },
-  logLevel: 'info',
-});
+// `@originjs/vite-plugin-federation` resolves the `exposes` paths relative to
+// process.cwd(), not the Vite `root`, so building from anywhere but frontend/
+// fails to find `./src/plugin.tsx`. chdir into frontend/ around the build so the
+// documented `npm run build` works regardless of where it is invoked from.
+const cwdBeforeBuild = process.cwd();
+process.chdir(join(HERE, 'frontend'));
+try {
+  await viteBuild({
+    root: join(HERE, 'frontend'),
+    configFile: join(HERE, 'frontend/vite.config.ts'),
+    build: { outDir: join(PACKAGE, 'frontend'), emptyOutDir: true },
+    logLevel: 'info',
+  });
+} finally {
+  process.chdir(cwdBeforeBuild);
+}
 
 // 3. Manifest at the package root.
 cpSync(join(HERE, 'plugin.json'), join(PACKAGE, 'plugin.json'));

--- a/examples/plugin-hello-world/frontend/src/plugin.tsx
+++ b/examples/plugin-hello-world/frontend/src/plugin.tsx
@@ -181,10 +181,19 @@ function CapabilitiesPage() {
 }
 
 // Host slot ids exposed by the MQTT UI. These are documented host strings (the
-// SDK is vendor-agnostic and does not export them); a plugin targets them the
-// same way it targets a route `path`. Both slots receive `{ mqttServerId }`.
+// SDK is vendor-agnostic and does not export them, and the host owns them in
+// apps/frontend, which a plugin cannot import — so a plugin restates them, the
+// same way it restates a route `path` it links to). Both slots receive
+// `{ mqttServerId }`, declared here so each `render` is typed end-to-end with
+// no runtime casting.
 const MQTT_SERVER_DETAIL_SLOT = 'mqtt.server.detail';
 const MQTT_SERVER_LIST_ROW_SLOT = 'mqtt.server.list.row';
+
+// The context shape the host documents for both MQTT slots.
+interface MqttServerSlotContext {
+  mqttServerId: number;
+  [key: string]: unknown;
+}
 
 // Embedded into the MQTT server detail view through the generic slot mechanism.
 // Reads the host-supplied context to scope itself to the selected server.
@@ -291,17 +300,22 @@ export default class HelloWorldPlugin implements AttraccessFrontendPlugin {
   // The host stays unaware of what we render — this is the RabbitMQ-agnostic
   // extension point a real MQTT-broker plugin would build its UI on.
   getSlotContributions(): PluginSlotContribution[] {
-    return [
+    // Each contribution types its render against the slot's documented context
+    // (MqttServerSlotContext), so `context.mqttServerId` is a number with no
+    // cast. A differently-typed contribution still fits the array's element
+    // type (PluginSlotContribution<PluginSlotContext>).
+    const contributions: PluginSlotContribution<MqttServerSlotContext>[] = [
       {
         slotId: MQTT_SERVER_DETAIL_SLOT,
         key: 'hello-world-mqtt-detail',
-        render: (context) => <MqttServerDetailExtension mqttServerId={Number(context.mqttServerId)} />,
+        render: (context) => <MqttServerDetailExtension mqttServerId={context.mqttServerId} />,
       },
       {
         slotId: MQTT_SERVER_LIST_ROW_SLOT,
         key: 'hello-world-mqtt-list-row',
-        render: (context) => <MqttServerListBadge mqttServerId={Number(context.mqttServerId)} />,
+        render: (context) => <MqttServerListBadge mqttServerId={context.mqttServerId} />,
       },
     ];
+    return contributions;
   }
 }

--- a/examples/plugin-hello-world/frontend/src/plugin.tsx
+++ b/examples/plugin-hello-world/frontend/src/plugin.tsx
@@ -27,6 +27,7 @@ import {
   DatabaseIcon,
   HandIcon,
   PanelLeftIcon,
+  PlugIcon,
   RouteIcon,
   ServerIcon,
 } from 'lucide-react';
@@ -34,6 +35,7 @@ import type {
   AttraccessFrontendPlugin,
   AttraccessFrontendPluginAuthData,
   PluginSidebarItem,
+  PluginSlotContribution,
   RouteConfig,
 } from '@attraccess/plugins-frontend-sdk';
 import type { IPluginStore } from 'react-pluggable';
@@ -149,6 +151,11 @@ function CapabilitiesPage() {
       body: 'Contributes this navigation item through getSidebarItems().',
       icon: PanelLeftIcon,
     },
+    {
+      title: 'Embedded slots',
+      body: 'Injects UI into the MQTT detail + list views via getSlotContributions().',
+      icon: PlugIcon,
+    },
   ];
 
   return (
@@ -170,6 +177,48 @@ function CapabilitiesPage() {
         ))}
       </div>
     </PluginShell>
+  );
+}
+
+// Host slot ids exposed by the MQTT UI. These are documented host strings (the
+// SDK is vendor-agnostic and does not export them); a plugin targets them the
+// same way it targets a route `path`. Both slots receive `{ mqttServerId }`.
+const MQTT_SERVER_DETAIL_SLOT = 'mqtt.server.detail';
+const MQTT_SERVER_LIST_ROW_SLOT = 'mqtt.server.list.row';
+
+// Embedded into the MQTT server detail view through the generic slot mechanism.
+// Reads the host-supplied context to scope itself to the selected server.
+function MqttServerDetailExtension({ mqttServerId }: { mqttServerId: number }) {
+  return (
+    <Card
+      data-cy="hello-world-mqtt-detail-slot"
+      className="w-full border border-default-200 dark:border-default-100"
+    >
+      <Card.Header className="flex flex-row items-center gap-2">
+        <PlugIcon className="w-5 h-5 text-primary" />
+        <p className="text-base font-semibold text-default-700">Hello World plugin extension</p>
+      </Card.Header>
+      <Card.Content>
+        <p className="text-sm text-default-500">
+          This card is injected into the MQTT server detail slot via{' '}
+          <code>getSlotContributions()</code> — no core code knows about it. It is scoped to server{' '}
+          <Chip color="accent" variant="soft">
+            #{mqttServerId}
+          </Chip>
+          , passed in through the slot context.
+        </p>
+      </Card.Content>
+    </Card>
+  );
+}
+
+// Embedded into each MQTT server list row through the per-row slot.
+function MqttServerListBadge({ mqttServerId }: { mqttServerId: number }) {
+  return (
+    <Chip data-cy={`hello-world-mqtt-list-slot-${mqttServerId}`} color="accent" variant="soft">
+      <PlugIcon className="w-3.5 h-3.5" />
+      plugin
+    </Chip>
   );
 }
 
@@ -232,6 +281,26 @@ export default class HelloWorldPlugin implements AttraccessFrontendPlugin {
         label: 'Hello World',
         path: '/hello-world',
         icon: <HandIcon className="w-5 h-5" />,
+      },
+    ];
+  }
+
+  // Contribute UI into the host's generic MQTT slots. The host renders each
+  // contribution where it exposes the matching slot id and hands us a context
+  // object (here `{ mqttServerId }`) so we can render conditionally / scoped.
+  // The host stays unaware of what we render — this is the RabbitMQ-agnostic
+  // extension point a real MQTT-broker plugin would build its UI on.
+  getSlotContributions(): PluginSlotContribution[] {
+    return [
+      {
+        slotId: MQTT_SERVER_DETAIL_SLOT,
+        key: 'hello-world-mqtt-detail',
+        render: (context) => <MqttServerDetailExtension mqttServerId={Number(context.mqttServerId)} />,
+      },
+      {
+        slotId: MQTT_SERVER_LIST_ROW_SLOT,
+        key: 'hello-world-mqtt-list-row',
+        render: (context) => <MqttServerListBadge mqttServerId={Number(context.mqttServerId)} />,
       },
     ];
   }

--- a/libs/plugins-frontend-sdk/src/index.ts
+++ b/libs/plugins-frontend-sdk/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/frontend.pluggable';
 export * from './lib/frontend.routing';
+export * from './lib/frontend.slots';

--- a/libs/plugins-frontend-sdk/src/lib/frontend.pluggable.ts
+++ b/libs/plugins-frontend-sdk/src/lib/frontend.pluggable.ts
@@ -2,12 +2,14 @@ import { User } from '@attraccess/database-entities';
 import { ReactNode } from 'react';
 import { IPlugin } from 'react-pluggable';
 import { RouteConfig } from './frontend.routing';
+import { PluginSlotContribution } from './frontend.slots';
 
 export enum FrontendLocation {}
 
 export enum FRONTEND_FUNCTION {
   GET_ROUTES = 'GET_ROUTES',
   GET_SIDEBAR_ITEMS = 'GET_SIDEBAR_ITEMS',
+  GET_SLOT_CONTRIBUTIONS = 'GET_SLOT_CONTRIBUTIONS',
 }
 
 // A navigation entry a plugin contributes to the app sidebar. The host renders
@@ -36,4 +38,7 @@ export interface AttraccessFrontendPlugin extends IPlugin {
   getRoutes?(): RouteConfig[];
   // Optional. Return the sidebar navigation entries this plugin contributes.
   getSidebarItems?(): PluginSidebarItem[];
+  // Optional. Return the contributions this plugin renders into host slots
+  // (generic embedded extension points). See frontend.slots.ts.
+  getSlotContributions?(): PluginSlotContribution[];
 }

--- a/libs/plugins-frontend-sdk/src/lib/frontend.slots.ts
+++ b/libs/plugins-frontend-sdk/src/lib/frontend.slots.ts
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+
+// Generic, host-agnostic extension-point mechanism.
+//
+// The host renders named "slots" at well-known points in its UI and hands each
+// slot a context object describing where it is being mounted. Plugins return
+// contributions for the slots they care about via
+// `AttraccessFrontendPlugin.getSlotContributions()`, and the host renders each
+// contribution's `render(context)` inside an error boundary.
+//
+// The host owns both the concrete slot ids and the shape of the context it
+// passes per slot — this contract stays deliberately agnostic about both, so no
+// domain knowledge (RabbitMQ, MQTT, or anything else) leaks into the SDK. A slot
+// id is just a documented string the host exposes, exactly like a route `path`.
+
+// Identifies a host extension point. The host defines the concrete ids it
+// exposes and documents the context shape for each.
+export type PluginSlotId = string;
+
+// Opaque, host-supplied context passed to a contribution at render time. The
+// host documents the keys it provides per slot; plugins narrow as needed.
+export type PluginSlotContext = Record<string, unknown>;
+
+export interface PluginSlotContribution {
+  // The slot this contribution targets (must match a host slot id).
+  slotId: PluginSlotId;
+  // Optional stable React key, useful when a plugin contributes to a slot that
+  // the host mounts many times (e.g. once per list row).
+  key?: string;
+  // Render the contributed UI for one mount of the slot, given its context.
+  render(context: PluginSlotContext): ReactNode;
+}

--- a/libs/plugins-frontend-sdk/src/lib/frontend.slots.ts
+++ b/libs/plugins-frontend-sdk/src/lib/frontend.slots.ts
@@ -21,12 +21,20 @@ export type PluginSlotId = string;
 // host documents the keys it provides per slot; plugins narrow as needed.
 export type PluginSlotContext = Record<string, unknown>;
 
-export interface PluginSlotContribution {
+// A single contribution into a host slot. `Context` lets a plugin type its
+// `render` against the exact shape the host documents for that slot (e.g. the
+// MQTT slots' `{ mqttServerId: number }`), so no runtime casting is needed. It
+// defaults to the opaque `PluginSlotContext`, and a contribution typed to a
+// narrower context is still assignable to `PluginSlotContribution[]` (the
+// return type of `getSlotContributions`), so a plugin can mix differently-typed
+// contributions in one array while keeping each `render` strongly typed.
+export interface PluginSlotContribution<Context extends PluginSlotContext = PluginSlotContext> {
   // The slot this contribution targets (must match a host slot id).
   slotId: PluginSlotId;
-  // Optional stable React key, useful when a plugin contributes to a slot that
-  // the host mounts many times (e.g. once per list row).
+  // Optional stable key. Useful both as a React key when a plugin contributes
+  // to a slot the host mounts many times (e.g. once per list row) and as a
+  // stable identifier for the contribution in host error logs.
   key?: string;
   // Render the contributed UI for one mount of the slot, given its context.
-  render(context: PluginSlotContext): ReactNode;
+  render(context: Context): ReactNode;
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Adds a generic, host-agnostic **plugin slot** mechanism so plugins can inject UI into the MQTT server **detail** and **list** views — without the core knowing anything RabbitMQ-specific. This is core-change ticket #1 of 2 for [ATT-255](https://linear.app/attraccess/issue/ATT-519/add-plugin-extension-points-to-the-mqtt-frontend); it stays deliberately vendor-agnostic.

## Approach

- **SDK** (`libs/plugins-frontend-sdk`): new `PluginSlotContribution` contract (`frontend.slots.ts`) and an optional `getSlotContributions()` on `AttraccessFrontendPlugin`. Slot ids and per-slot context are host-owned plain values — no domain knowledge leaks into the SDK.
- **Host** (`apps/frontend`): a generic `<PluginSlot slotId context>` renders every contribution registered for a slot id, each wrapped in an error boundary. It renders **nothing** (no wrapper DOM) when no plugin contributes, so existing MQTT UI is unchanged.
- **Host slots**: `mqtt.server.detail` (detail/edit extensions section) and `mqtt.server.list.row` (per-row action area), both passing `{ mqttServerId }` as context.
- **Example plugin**: `plugin-hello-world` demonstrates both slots via `getSlotContributions()`.
- **Docs**: documents the slot mechanism + the available host slot ids.
- **build.mjs**: `chdir` into `frontend/` so the documented `npm run build` works from the example root (`@originjs/vite-plugin-federation` resolves `exposes` relative to cwd).

## Acceptance criteria

- ✅ Example plugin renders arbitrary content into both MQTT slots.
- ✅ No RabbitMQ-specific code in core; slot contract is generic.
- ✅ Existing MQTT UI unchanged when no plugin contributes (slot returns `null`).

## Testing

- `nx run-many -t typecheck lint` for `frontend` + `plugins-frontend-sdk` — pass.
- Pre-commit hook ran lint/typecheck/build/test/e2e for affected projects — pass.
- End-to-end verified in a running stack with the example plugin installed: both slots render live, scoped to the selected server (screenshots below).

## Screenshots

Verified with the `plugin-hello-world` example installed. The list shows a per-row `plugin` chip; the detail view shows a `Hello World plugin extension` card scoped to the selected server.

**Desktop (1440×900)**

| MQTT list (per-row slot) | MQTT detail (detail slot) |
|---|---|
| ![list desktop](https://public.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/70a64616-8147-4520-aebe-4c68d8fcd4e4/1ec560bd-22cc-42d9-909d-7ba2df8f1587) | ![detail desktop](https://public.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/2431d83b-d0ea-43ad-b020-81140eb5e0d4/1cc9c9cd-7ffc-4dd8-97aa-9af0efa0557b) |

**Tablet (768×1024)**

| MQTT list | MQTT detail |
|---|---|
| ![list tablet](https://public.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/a9f860cc-350d-4c2f-8482-093fe4f0dea0/e0804340-0877-4bda-bd93-7d3ab33b94c1) | ![detail tablet](https://public.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/81f1e4b7-034a-4ebc-a804-e4a8a2cb8290/5b999012-be69-416c-81b6-1bbbcb28da8a) |

**Mobile (390×844, light mode — slot inherits host theme)**

| MQTT list | MQTT detail |
|---|---|
| ![list mobile](https://public.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/fbf81031-6c00-4c49-ba67-07a208b2ac61/fe5f282d-aa7f-48de-87ee-c4184fad9224) | ![detail mobile](https://public.linear.app/9efe0176-e907-41d4-8718-7ffc6d482f74/db038ed2-55ba-43c7-8c02-86ccb19ff7e8/4943d26c-d231-4c1d-9b3f-52da28603481) |

Linear: [ATT-519](https://linear.app/attraccess/issue/ATT-519/add-plugin-extension-points-to-the-mqtt-frontend)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
