### PR TITLE
fix(monitoring): guard prepare-provisioning.sh call so init survives image skew (ATT-549)

### DIFF
--- a/coolify.docker-compose.yml
+++ b/coolify.docker-compose.yml
@@ -91,6 +91,11 @@ services:
       - PROMETHEUS_METRICS_API_KEY=${PROMETHEUS_METRICS_API_KEY:-}
       # Pushover alerting is opt-in: prepare-provisioning.sh strips the
       # secret-requiring contact point + policy when these are unset (ATT-539).
+      # The script call below is guarded with `[ -f ... ]` because Coolify pulls
+      # the image (ATTRACCESS_IMAGE, default :latest) independently of this
+      # compose file, so an older image may predate the script. Such an image
+      # also lacks the secret-requiring files, so skipping the strip is safe and
+      # init must not hard-fail (ATT-549).
       - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
       - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
     command:
@@ -102,7 +107,9 @@ services:
         fi &&
         cp -rT /app/share/monitoring/grafana/provisioning /grafana-provisioning &&
         cp -rT /app/share/monitoring/grafana/dashboards /grafana-dashboards &&
-        sh /app/share/monitoring/grafana/prepare-provisioning.sh /grafana-provisioning
+        if [ -f /app/share/monitoring/grafana/prepare-provisioning.sh ]; then
+          sh /app/share/monitoring/grafana/prepare-provisioning.sh /grafana-provisioning;
+        fi
     volumes:
       - prometheus-config:/prometheus-config
       - grafana-provisioning:/grafana-provisioning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,10 @@ services:
     environment:
       # Pushover alerting is opt-in: prepare-provisioning.sh strips the
       # secret-requiring contact point + policy when these are unset (ATT-539).
+      # The script call below is guarded with `[ -f ... ]` because this compose
+      # file can run against an older image that predates the script; in that
+      # case the provisioning bundle also lacks the secret-requiring files, so
+      # skipping the strip is safe and init must not hard-fail (ATT-549).
       - PUSHOVER_API_TOKEN=${PUSHOVER_API_TOKEN:-}
       - PUSHOVER_USER_KEY=${PUSHOVER_USER_KEY:-}
     command:
@@ -49,7 +53,9 @@ services:
         set -e &&
         cp -rT /app/share/monitoring/grafana/provisioning /grafana-provisioning &&
         cp -rT /app/share/monitoring/grafana/dashboards /grafana-dashboards &&
-        sh /app/share/monitoring/grafana/prepare-provisioning.sh /grafana-provisioning
+        if [ -f /app/share/monitoring/grafana/prepare-provisioning.sh ]; then
+          sh /app/share/monitoring/grafana/prepare-provisioning.sh /grafana-provisioning;
+        fi
     volumes:
       - prometheus-config:/prometheus-config
       - grafana-provisioning:/grafana-provisioning


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

`monitoring-init` failed with:

```
sh: 0: cannot open /app/share/monitoring/grafana/prepare-provisioning.sh: No such file
```

taking the whole Grafana/Prometheus stack down with it.

### Root cause

The init command runs `prepare-provisioning.sh` from the **attraccess image** (`/app/share/monitoring/grafana/`), but the compose file is deployed **independently of the image version**:

- `coolify.docker-compose.yml` pulls `${ATTRACCESS_IMAGE:-attraccess/attraccess:latest}`.
- `:latest` is only built on **release** (`release.yml`); nightly publishes `:nightly-latest`.
- `prepare-provisioning.sh` was added **after v1.7.0** (ATT-539, `c5dfeada`, not in any tag).

So a deployment on the current compose + the released `:latest` image calls a script that image doesn't contain. The earlier `cp` of the provisioning/dashboards dirs succeeds (those predate the script), then `sh <missing script>` aborts the command under `set -e` — and `grafana`/`prometheus` `depends_on` the init, so monitoring never starts.

### Fix

Guard the script invocation with `[ -f ... ]` in both image-consuming compose files:

```sh
if [ -f /app/share/monitoring/grafana/prepare-provisioning.sh ]; then
  sh /app/share/monitoring/grafana/prepare-provisioning.sh /grafana-provisioning;
fi
```

An image old enough to lack the script **also lacks** the secret-requiring alerting files (`contactpoints.yaml`/`policies.yaml`, added in the same post-v1.7.0 series), so skipping the strip is safe — nothing to strip. A present-but-failing script still aborts under `set -e`.

`services.docker-compose.yml` is **not** affected: it bind-mounts `./monitoring/grafana` from the repo checkout, so the script is always in sync with the compose file.

## Testing

- Reproduced the failure: simulated the released-image layout (provisioning dirs present, no script) → init aborts with the exact ticket error; with the guard → init completes (exit 0).
- New-image case: guard runs the script, strips Pushover files when secrets unset, keeps them when set; a present-but-failing script still aborts.
- `scripts/grafana-provisioning-prepare.spec.sh` → all assertions pass.
- `docker compose config` parses both files; rendered init command passes `sh -n`.

## Linear

https://linear.app/attraccess/issue/ATT-549/grafana-monitoring-init-broken

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Bug Fixes:
- Prevent monitoring-init from aborting when the prepare-provisioning.sh script is absent in older Grafana images by making its execution conditional on the script file’s presence.