### PR TITLE
feat(api): auto-promote to introduction after X supervised usages (ATT-488)

### DIFF
--- a/apps/api/src/resources/groups/introductions/resourceGroups.introductions.service.ts
+++ b/apps/api/src/resources/groups/introductions/resourceGroups.introductions.service.ts
@@ -70,6 +70,8 @@ export class ResourceGroupsIntroductionsService {
       existingIntroduction = await this.createOne(groupId, userId, tutorUserId);
     } else if (tutorUserId != null && existingIntroduction.tutorUserId !== tutorUserId) {
       await this.resourceIntroductionRepository.update(existingIntroduction.id, { tutorUserId });
+      // Keep the in-memory entity in sync so subsequent history/logging sees the updated tutor.
+      existingIntroduction.tutorUserId = tutorUserId;
     }
 
     const historyItem = this.resourceIntroductionHistoryItemRepository.create({

--- a/apps/api/src/resources/groups/introductions/resourceGroups.introductions.service.ts
+++ b/apps/api/src/resources/groups/introductions/resourceGroups.introductions.service.ts
@@ -42,10 +42,11 @@ export class ResourceGroupsIntroductionsService {
     });
   }
 
-  private async createOne(groupId: number, userId: number): Promise<ResourceIntroduction> {
+  private async createOne(groupId: number, userId: number, tutorUserId?: number): Promise<ResourceIntroduction> {
     const introduction = await this.resourceIntroductionRepository.create({
       resourceGroup: { id: groupId },
       receiverUser: { id: userId },
+      ...(tutorUserId != null ? { tutorUser: { id: tutorUserId } } : {}),
     });
 
     return await this.resourceIntroductionRepository.save(introduction);
@@ -56,6 +57,7 @@ export class ResourceGroupsIntroductionsService {
     userId: number,
     nextStatus: IntroductionHistoryAction,
     data?: UpdateResourceGroupIntroductionDto,
+    tutorUserId?: number,
   ): Promise<ResourceIntroductionHistoryItem> {
     let existingIntroduction = await this.resourceIntroductionRepository.findOne({
       where: {
@@ -64,7 +66,11 @@ export class ResourceGroupsIntroductionsService {
       },
     });
 
-    existingIntroduction ??= await this.createOne(groupId, userId);
+    if (!existingIntroduction) {
+      existingIntroduction = await this.createOne(groupId, userId, tutorUserId);
+    } else if (tutorUserId != null && existingIntroduction.tutorUserId !== tutorUserId) {
+      await this.resourceIntroductionRepository.update(existingIntroduction.id, { tutorUserId });
+    }
 
     const historyItem = this.resourceIntroductionHistoryItemRepository.create({
       introduction: existingIntroduction,
@@ -95,8 +101,15 @@ export class ResourceGroupsIntroductionsService {
     groupId: number,
     userId: number,
     data?: UpdateResourceGroupIntroductionDto,
+    options?: { tutorUserId?: number },
   ): Promise<ResourceIntroductionHistoryItem> {
-    return await this.updateIntroductionStatus(groupId, userId, IntroductionHistoryAction.GRANT, data);
+    return await this.updateIntroductionStatus(
+      groupId,
+      userId,
+      IntroductionHistoryAction.GRANT,
+      data,
+      options?.tutorUserId,
+    );
   }
 
   public async revoke(

--- a/apps/api/src/resources/introductions/resouceIntroductions.service.ts
+++ b/apps/api/src/resources/introductions/resouceIntroductions.service.ts
@@ -120,6 +120,8 @@ export class ResourceIntroductionsService {
       resourceIntroduction = await this.createOne(resourceId, userId, tutorUserId);
     } else if (tutorUserId != null && resourceIntroduction.tutorUserId !== tutorUserId) {
       await this.resourceIntroductionRepository.update(resourceIntroduction.id, { tutorUserId });
+      // Keep the in-memory entity in sync so subsequent history/logging sees the updated tutor.
+      resourceIntroduction.tutorUserId = tutorUserId;
     }
 
     this.logger.debug(`Creating new history item with action: ${nextStatus}`);

--- a/apps/api/src/resources/introductions/resouceIntroductions.service.ts
+++ b/apps/api/src/resources/introductions/resouceIntroductions.service.ts
@@ -91,11 +91,12 @@ export class ResourceIntroductionsService {
     return historyItem;
   }
 
-  private async createOne(resourceId: number, userId: number): Promise<ResourceIntroduction> {
+  private async createOne(resourceId: number, userId: number, tutorUserId?: number): Promise<ResourceIntroduction> {
     this.logger.debug(`Creating new introduction for resourceId: ${resourceId}, userId: ${userId}`);
     const introduction = this.resourceIntroductionRepository.create({
       resource: { id: resourceId },
       receiverUser: { id: userId },
+      ...(tutorUserId != null ? { tutorUser: { id: tutorUserId } } : {}),
     });
 
     const savedIntroduction = await this.resourceIntroductionRepository.save(introduction);
@@ -109,13 +110,16 @@ export class ResourceIntroductionsService {
     userId: number,
     nextStatus: IntroductionHistoryAction,
     data?: UpdateResourceIntroductionDto,
+    tutorUserId?: number,
   ) {
     this.logger.debug(`Updating introduction status to ${nextStatus} for resourceId: ${resourceId}, userId: ${userId}`);
     let resourceIntroduction = await this.getIntroductionOfUser(resourceId, userId);
 
     if (!resourceIntroduction) {
       this.logger.debug('No existing introduction found, creating new one');
-      resourceIntroduction = await this.createOne(resourceId, userId);
+      resourceIntroduction = await this.createOne(resourceId, userId, tutorUserId);
+    } else if (tutorUserId != null && resourceIntroduction.tutorUserId !== tutorUserId) {
+      await this.resourceIntroductionRepository.update(resourceIntroduction.id, { tutorUserId });
     }
 
     this.logger.debug(`Creating new history item with action: ${nextStatus}`);
@@ -166,9 +170,16 @@ export class ResourceIntroductionsService {
     resourceId: number,
     userId: number,
     data?: UpdateResourceIntroductionDto,
+    options?: { tutorUserId?: number },
   ): Promise<ResourceIntroductionHistoryItem> {
     this.logger.debug(`Granting introduction for resourceId: ${resourceId}, userId: ${userId}`);
-    const result = await this.updateIntroductionStatus(resourceId, userId, IntroductionHistoryAction.GRANT, data);
+    const result = await this.updateIntroductionStatus(
+      resourceId,
+      userId,
+      IntroductionHistoryAction.GRANT,
+      data,
+      options?.tutorUserId,
+    );
     this.metricsService.resourceIntroductionsTotal.inc();
     this.logger.debug(`Grant operation completed for resourceId: ${resourceId}, userId: ${userId}`);
     return result;

--- a/apps/api/src/resources/usage/events/resource-usage.events.ts
+++ b/apps/api/src/resources/usage/events/resource-usage.events.ts
@@ -51,3 +51,19 @@ export class SupervisedUsageStartedEvent {
     public readonly usageId: number
   ) {}
 }
+
+/**
+ * Emitted whenever a supervised usage session ends successfully. Consumed by the supervised-usage
+ * auto-promotion listener (ATT-488), which counts the user's completed supervised sessions and
+ * auto-creates an introduction once the configured threshold is reached.
+ */
+export class SupervisedUsageEndedEvent {
+  public static readonly EVENT_NAME = 'resource.usage.supervised_ended';
+
+  constructor(
+    public readonly resourceId: number,
+    public readonly userId: number,
+    public readonly supervisorUserId: number,
+    public readonly usageId: number
+  ) {}
+}

--- a/apps/api/src/resources/usage/resourceUsage.module.ts
+++ b/apps/api/src/resources/usage/resourceUsage.module.ts
@@ -4,6 +4,7 @@ import { ResourceUsageService } from './resourceUsage.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Resource, ResourceIntroducer, ResourceUsage, User } from '@attraccess/database-entities';
 import { ResourceUsageNoteNotificationListener } from './resource-usage-note-notification.listener';
+import { SupervisedUsageAutoPromotionListener } from './supervised-usage-auto-promotion.listener';
 import { EmailModule } from '../../email/email.module';
 import { ResourceIntroducersModule } from '../introducers/resourceIntroducers.module';
 import { ResourceIntroductionsModule } from '../introductions/resourceIntroductions.module';
@@ -32,7 +33,7 @@ import { ResourceRetrainingModule } from '../retraining/resourceRetraining.modul
     ResourceHealthModule,
   ],
   controllers: [ResourceUsageController],
-  providers: [ResourceUsageService, ResourceUsageNoteNotificationListener],
+  providers: [ResourceUsageService, ResourceUsageNoteNotificationListener, SupervisedUsageAutoPromotionListener],
   exports: [ResourceUsageService],
 })
 export class ResourceUsageModule {}

--- a/apps/api/src/resources/usage/resourceUsage.service.spec.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.spec.ts
@@ -31,6 +31,7 @@ import {
   ResourceUsageTakenOverEvent,
   ResourceUsageNoteAddedEvent,
   SupervisedUsageStartedEvent,
+  SupervisedUsageEndedEvent,
 } from './events/resource-usage.events';
 import { BillingService } from '../../billing/billing.service';
 import { InsufficientBalanceError } from '../../billing/errors/insufficient-balance.error';
@@ -1336,6 +1337,66 @@ describe('ResourceUsageService', () => {
         expect.objectContaining({ endNotes: prefixedNotes }),
         expect.anything(),
       );
+    });
+
+    it('emits the auto-promotion counter event when a supervised session ends', async () => {
+      const dto: EndUsageSessionDto = {};
+      const sessionOwner = { id: 60, username: 'student' } as User;
+      const supervisorUser = { id: 61, username: 'supervisor' } as User;
+      const mockActiveSession = {
+        id: 9,
+        resourceId: 40,
+        userId: sessionOwner.id,
+        supervisorUserId: supervisorUser.id,
+        startTime: new Date(),
+        user: sessionOwner,
+      } as ResourceUsage;
+      const mockUpdatedSession = { ...mockActiveSession, endTime: new Date() };
+
+      resourceUsageRepository.findOne
+        .mockResolvedValueOnce(mockActiveSession)
+        .mockResolvedValueOnce(mockUpdatedSession)
+        .mockResolvedValueOnce(mockUpdatedSession);
+
+      (transactionalEntityManager.createQueryBuilder as jest.Mock).mockReturnValue(
+        createMockQueryBuilder(null) as unknown as SelectQueryBuilder<ResourceUsage>,
+      );
+
+      await service.endSession(mockActiveSession.resourceId, supervisorUser, dto);
+
+      const endedEmit = eventEmitter.emit.mock.calls.find((c) => c[0] === SupervisedUsageEndedEvent.EVENT_NAME);
+      expect(endedEmit).toBeDefined();
+      const payload = endedEmit?.[1] as SupervisedUsageEndedEvent;
+      expect(payload).toBeInstanceOf(SupervisedUsageEndedEvent);
+      expect(payload).toMatchObject({ resourceId: 40, userId: 60, supervisorUserId: 61, usageId: 9 });
+    });
+
+    it('does not emit the auto-promotion counter event for an unsupervised session end', async () => {
+      const dto: EndUsageSessionDto = {};
+      const sessionOwner = { id: 60, username: 'student' } as User;
+      const mockActiveSession = {
+        id: 9,
+        resourceId: 40,
+        userId: sessionOwner.id,
+        supervisorUserId: null,
+        startTime: new Date(),
+        user: sessionOwner,
+      } as ResourceUsage;
+      const mockUpdatedSession = { ...mockActiveSession, endTime: new Date() };
+
+      resourceUsageRepository.findOne
+        .mockResolvedValueOnce(mockActiveSession)
+        .mockResolvedValueOnce(mockUpdatedSession)
+        .mockResolvedValueOnce(mockUpdatedSession);
+
+      (transactionalEntityManager.createQueryBuilder as jest.Mock).mockReturnValue(
+        createMockQueryBuilder(null) as unknown as SelectQueryBuilder<ResourceUsage>,
+      );
+
+      await service.endSession(mockActiveSession.resourceId, sessionOwner, dto);
+
+      const endedEmit = eventEmitter.emit.mock.calls.find((c) => c[0] === SupervisedUsageEndedEvent.EVENT_NAME);
+      expect(endedEmit).toBeUndefined();
     });
   });
 

--- a/apps/api/src/resources/usage/resourceUsage.service.ts
+++ b/apps/api/src/resources/usage/resourceUsage.service.ts
@@ -24,6 +24,7 @@ import {
   ResourceUsageTakenOverEvent,
   ResourceUsageNoteAddedEvent,
   SupervisedUsageStartedEvent,
+  SupervisedUsageEndedEvent,
 } from './events/resource-usage.events';
 import { ResourceIntroductionsService } from '../introductions/resouceIntroductions.service';
 import { ResourceIntroducersService } from '../introducers/resourceIntroducers.service';
@@ -707,6 +708,20 @@ export class ResourceUsageService {
     }
 
     this.emitSystemUsageEvent(SystemEvent.RESOURCE_USAGE_ENDED, updatedUsage?.resource, updatedUsage?.user);
+
+    // Counter signal for supervised-usage auto-promotion (ATT-488): every completed supervised session
+    // is counted by the listener to decide when to auto-create an introduction for the supervised user.
+    if (activeSession.supervisorUserId != null && activeSession.user?.id != null) {
+      this.eventEmitter.emit(
+        SupervisedUsageEndedEvent.EVENT_NAME,
+        new SupervisedUsageEndedEvent(
+          resourceId,
+          activeSession.user.id,
+          activeSession.supervisorUserId,
+          activeSession.id,
+        ),
+      );
+    }
 
     this.metricsService.resourceUsageSessionsTotal.inc({ action: 'end' });
     this.metricsService.resourceUsageSessionsActive.dec();

--- a/apps/api/src/resources/usage/supervised-usage-auto-promotion.listener.spec.ts
+++ b/apps/api/src/resources/usage/supervised-usage-auto-promotion.listener.spec.ts
@@ -1,0 +1,187 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { In, IsNull, Not } from 'typeorm';
+import { AutoIntroductionTarget, Resource, ResourceUsage } from '@attraccess/database-entities';
+import { SupervisedUsageAutoPromotionListener } from './supervised-usage-auto-promotion.listener';
+import { SupervisedUsageEndedEvent } from './events/resource-usage.events';
+import { ResourceIntroductionsService } from '../introductions/resouceIntroductions.service';
+import { ResourceGroupsIntroductionsService } from '../groups/introductions/resourceGroups.introductions.service';
+
+describe('SupervisedUsageAutoPromotionListener', () => {
+  let listener: SupervisedUsageAutoPromotionListener;
+  let usageRepository: { count: jest.Mock };
+  let resourceRepository: { findOne: jest.Mock; find: jest.Mock };
+  let introductionsService: { hasValidIntroduction: jest.Mock; grant: jest.Mock };
+  let groupIntroductionsService: { hasValidIntroduction: jest.Mock; grant: jest.Mock };
+
+  const RESOURCE_ID = 7;
+  const USER_ID = 11;
+  const SUPERVISOR_ID = 22;
+  const GROUP_ID = 3;
+
+  const buildResource = (overrides: Partial<Resource> = {}): Resource =>
+    ({
+      id: RESOURCE_ID,
+      supervisedUsagesUntilIntroduction: 3,
+      autoIntroductionTarget: AutoIntroductionTarget.RESOURCE,
+      autoIntroductionGroupId: null,
+      ...overrides,
+    } as Resource);
+
+  const event = new SupervisedUsageEndedEvent(RESOURCE_ID, USER_ID, SUPERVISOR_ID, 99);
+
+  beforeEach(async () => {
+    usageRepository = { count: jest.fn().mockResolvedValue(0) };
+    resourceRepository = {
+      findOne: jest.fn().mockResolvedValue(buildResource()),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    introductionsService = {
+      hasValidIntroduction: jest.fn().mockResolvedValue(false),
+      grant: jest.fn().mockResolvedValue(undefined),
+    };
+    groupIntroductionsService = {
+      hasValidIntroduction: jest.fn().mockResolvedValue(false),
+      grant: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SupervisedUsageAutoPromotionListener,
+        { provide: getRepositoryToken(ResourceUsage), useValue: usageRepository },
+        { provide: getRepositoryToken(Resource), useValue: resourceRepository },
+        { provide: ResourceIntroductionsService, useValue: introductionsService },
+        { provide: ResourceGroupsIntroductionsService, useValue: groupIntroductionsService },
+      ],
+    }).compile();
+
+    listener = module.get(SupervisedUsageAutoPromotionListener);
+  });
+
+  describe('RESOURCE target', () => {
+    it('grants a resource introduction once the threshold is reached, with the supervisor as tutor', async () => {
+      usageRepository.count.mockResolvedValue(3);
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(usageRepository.count).toHaveBeenCalledWith({
+        where: {
+          resourceId: RESOURCE_ID,
+          userId: USER_ID,
+          supervisorUserId: Not(IsNull()),
+          endTime: Not(IsNull()),
+        },
+      });
+      expect(introductionsService.grant).toHaveBeenCalledWith(RESOURCE_ID, USER_ID, undefined, {
+        tutorUserId: SUPERVISOR_ID,
+      });
+      expect(groupIntroductionsService.grant).not.toHaveBeenCalled();
+    });
+
+    it('does not grant when the threshold has not been reached', async () => {
+      usageRepository.count.mockResolvedValue(2);
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(introductionsService.grant).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: skips when a valid introduction already exists', async () => {
+      usageRepository.count.mockResolvedValue(5);
+      introductionsService.hasValidIntroduction.mockResolvedValue(true);
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(usageRepository.count).not.toHaveBeenCalled();
+      expect(introductionsService.grant).not.toHaveBeenCalled();
+    });
+
+    it('defaults to a resource introduction when the target is null', async () => {
+      resourceRepository.findOne.mockResolvedValue(buildResource({ autoIntroductionTarget: null }));
+      usageRepository.count.mockResolvedValue(3);
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(introductionsService.grant).toHaveBeenCalledWith(RESOURCE_ID, USER_ID, undefined, {
+        tutorUserId: SUPERVISOR_ID,
+      });
+    });
+  });
+
+  describe('GROUP target', () => {
+    const groupResource = () =>
+      buildResource({ autoIntroductionTarget: AutoIntroductionTarget.GROUP, autoIntroductionGroupId: GROUP_ID });
+
+    it('counts supervised usages summed across all resources in the group and grants a group introduction', async () => {
+      resourceRepository.findOne.mockResolvedValue(groupResource());
+      resourceRepository.find.mockResolvedValue([{ id: 7 }, { id: 8 }, { id: 9 }] as Resource[]);
+      usageRepository.count.mockResolvedValue(3); // group-wide sum across the three resources
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(usageRepository.count).toHaveBeenCalledWith({
+        where: {
+          resourceId: In([7, 8, 9]),
+          userId: USER_ID,
+          supervisorUserId: Not(IsNull()),
+          endTime: Not(IsNull()),
+        },
+      });
+      expect(groupIntroductionsService.grant).toHaveBeenCalledWith(GROUP_ID, USER_ID, undefined, {
+        tutorUserId: SUPERVISOR_ID,
+      });
+      expect(introductionsService.grant).not.toHaveBeenCalled();
+    });
+
+    it('does not grant when the group-wide sum is below the threshold', async () => {
+      resourceRepository.findOne.mockResolvedValue(groupResource());
+      resourceRepository.find.mockResolvedValue([{ id: 7 }, { id: 8 }] as Resource[]);
+      usageRepository.count.mockResolvedValue(2);
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(groupIntroductionsService.grant).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: skips when a valid group introduction already exists', async () => {
+      resourceRepository.findOne.mockResolvedValue(groupResource());
+      groupIntroductionsService.hasValidIntroduction.mockResolvedValue(true);
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(resourceRepository.find).not.toHaveBeenCalled();
+      expect(usageRepository.count).not.toHaveBeenCalled();
+      expect(groupIntroductionsService.grant).not.toHaveBeenCalled();
+    });
+
+    it('skips when the group target has no autoIntroductionGroupId', async () => {
+      resourceRepository.findOne.mockResolvedValue(
+        groupResource() && buildResource({ autoIntroductionTarget: AutoIntroductionTarget.GROUP, autoIntroductionGroupId: null }),
+      );
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(groupIntroductionsService.grant).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auto-promotion disabled', () => {
+    it('does nothing when supervisedUsagesUntilIntroduction is null', async () => {
+      resourceRepository.findOne.mockResolvedValue(buildResource({ supervisedUsagesUntilIntroduction: null }));
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(usageRepository.count).not.toHaveBeenCalled();
+      expect(introductionsService.grant).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the resource no longer exists', async () => {
+      resourceRepository.findOne.mockResolvedValue(null);
+
+      await listener.handleSupervisedUsageEnded(event);
+
+      expect(introductionsService.grant).not.toHaveBeenCalled();
+      expect(groupIntroductionsService.grant).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/resources/usage/supervised-usage-auto-promotion.listener.ts
+++ b/apps/api/src/resources/usage/supervised-usage-auto-promotion.listener.ts
@@ -1,0 +1,132 @@
+// Auto-promotes a user to a full introduction once they complete enough supervised sessions.
+// FEATURE: auto-promotion to introduction after X supervised usages (ATT-488)
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, IsNull, Not, Repository } from 'typeorm';
+import { AutoIntroductionTarget, Resource, ResourceUsage } from '@attraccess/database-entities';
+import { SupervisedUsageEndedEvent } from './events/resource-usage.events';
+import { ResourceIntroductionsService } from '../introductions/resouceIntroductions.service';
+import { ResourceGroupsIntroductionsService } from '../groups/introductions/resourceGroups.introductions.service';
+
+@Injectable()
+export class SupervisedUsageAutoPromotionListener {
+  private readonly logger = new Logger(SupervisedUsageAutoPromotionListener.name);
+
+  constructor(
+    @InjectRepository(ResourceUsage)
+    private readonly resourceUsageRepository: Repository<ResourceUsage>,
+    @InjectRepository(Resource)
+    private readonly resourceRepository: Repository<Resource>,
+    private readonly resourceIntroductionsService: ResourceIntroductionsService,
+    private readonly resourceGroupsIntroductionsService: ResourceGroupsIntroductionsService,
+  ) {}
+
+  @OnEvent(SupervisedUsageEndedEvent.EVENT_NAME)
+  async handleSupervisedUsageEnded(event: SupervisedUsageEndedEvent): Promise<void> {
+    try {
+      const resource = await this.resourceRepository.findOne({ where: { id: event.resourceId } });
+      if (!resource) {
+        this.logger.warn(`Supervised usage ended for missing resource ${event.resourceId}; skipping auto-promotion`);
+        return;
+      }
+
+      const threshold = resource.supervisedUsagesUntilIntroduction;
+      // null/0 disables auto-promotion.
+      if (threshold == null || threshold <= 0) {
+        return;
+      }
+
+      // null target defaults to a resource-scoped introduction.
+      const target = resource.autoIntroductionTarget ?? AutoIntroductionTarget.RESOURCE;
+
+      if (target === AutoIntroductionTarget.GROUP) {
+        await this.promoteForGroup(resource, event, threshold);
+        return;
+      }
+
+      await this.promoteForResource(event, threshold);
+    } catch (error) {
+      this.logger.error(
+        `Failed to process supervised-usage auto-promotion for resource ${event.resourceId}, user ${event.userId}: ${
+          (error as Error).message
+        }`,
+        (error as Error).stack,
+      );
+    }
+  }
+
+  private async promoteForResource(event: SupervisedUsageEndedEvent, threshold: number): Promise<void> {
+    const { resourceId, userId, supervisorUserId } = event;
+
+    // Idempotent: never create a duplicate introduction.
+    if (await this.resourceIntroductionsService.hasValidIntroduction(resourceId, userId)) {
+      return;
+    }
+
+    const count = await this.countSupervisedUsages([resourceId], userId);
+    if (count < threshold) {
+      return;
+    }
+
+    this.logger.log(
+      `Auto-promoting user ${userId} to a resource introduction for resource ${resourceId} ` +
+        `after ${count} supervised session(s) (threshold ${threshold})`,
+    );
+    await this.resourceIntroductionsService.grant(resourceId, userId, undefined, { tutorUserId: supervisorUserId });
+  }
+
+  private async promoteForGroup(
+    resource: Resource,
+    event: SupervisedUsageEndedEvent,
+    threshold: number,
+  ): Promise<void> {
+    const { userId, supervisorUserId } = event;
+    const groupId = resource.autoIntroductionGroupId;
+    if (groupId == null) {
+      this.logger.warn(
+        `Resource ${resource.id} targets a group introduction but has no autoIntroductionGroupId; skipping`,
+      );
+      return;
+    }
+
+    // Idempotent: never create a duplicate group introduction.
+    if (await this.resourceGroupsIntroductionsService.hasValidIntroduction({ groupId, userId })) {
+      return;
+    }
+
+    const resourceIds = await this.getGroupResourceIds(groupId);
+    if (resourceIds.length === 0) {
+      return;
+    }
+
+    // Group-wide: supervised usages on every resource of the group add up toward the threshold.
+    const count = await this.countSupervisedUsages(resourceIds, userId);
+    if (count < threshold) {
+      return;
+    }
+
+    this.logger.log(
+      `Auto-promoting user ${userId} to a group introduction for group ${groupId} ` +
+        `after ${count} supervised session(s) across ${resourceIds.length} resource(s) (threshold ${threshold})`,
+    );
+    await this.resourceGroupsIntroductionsService.grant(groupId, userId, undefined, { tutorUserId: supervisorUserId });
+  }
+
+  // Counts the user's completed supervised sessions across the given resources.
+  private async countSupervisedUsages(resourceIds: number[], userId: number): Promise<number> {
+    return await this.resourceUsageRepository.count({
+      where: {
+        resourceId: resourceIds.length === 1 ? resourceIds[0] : In(resourceIds),
+        userId,
+        supervisorUserId: Not(IsNull()),
+        endTime: Not(IsNull()),
+      },
+    });
+  }
+
+  private async getGroupResourceIds(groupId: number): Promise<number[]> {
+    const resources = await this.resourceRepository.find({ where: { groups: { id: groupId } } });
+    return resources.map((resource) => resource.id);
+  }
+}


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

Implements auto-promotion to a full introduction after a configurable number of **completed supervised sessions** (ATT-488).

When a supervised usage session ends, the user's completed supervised sessions are counted. Once the resource's `supervisedUsagesUntilIntroduction` threshold is reached, an introduction is auto-created — idempotently — with the responsible supervisor recorded as tutor.

## Approach

- **New trigger event** `SupervisedUsageEndedEvent` (`resource.usage.supervised_ended`), emitted by `ResourceUsageService.endSession` when the ended session had a `supervisorUserId`. The pre-existing `SupervisedUsageStartedEvent` (ATT-487) fires at the wrong moment for counting *completed* sessions, so a dedicated end-event is used.
- **New listener** `SupervisedUsageAutoPromotionListener`:
  - `null`/`0` threshold → auto-promotion disabled.
  - Counting scope follows `resource.autoIntroductionTarget` (defaults to `RESOURCE` when null):
    - `RESOURCE` → counts completed supervised usages on this resource only.
    - `GROUP` → counts completed supervised usages **summed across all resources in `autoIntroductionGroupId`**, then grants a group introduction.
  - Counts only completed supervised sessions (`supervisorUserId != null AND endTime != null`).
  - Idempotent: skips when a valid resource/group introduction already exists.
  - Tutor = the supervisor of the just-ended session (last/responsible supervisor).
- **Tutor assignment**: threaded an optional `tutorUserId` through `grant()` in both `ResourceIntroductionsService` and `ResourceGroupsIntroductionsService` so the auto-created introduction records the supervisor.

## Tests

- `supervised-usage-auto-promotion.listener.spec.ts` — threshold reached/not reached, RESOURCE per-resource count, GROUP group-wide sum across multiple resources, idempotency (resource + group), tutor assignment, null-target default, disabled (null threshold), missing resource, missing group id.
- `resourceUsage.service.spec.ts` — emits `SupervisedUsageEndedEvent` on supervised end; does not emit for unsupervised end.
- Full affected suite (lint, typecheck, build, test, e2e) passes via the pre-commit hook.

## Linear

[ATT-488](https://linear.app/attraccess/issue/ATT-488/p1-backend-auto-promotion-to-introduction-after-x-supervised-usages)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Implement automatic promotion to resource or group introductions after a configurable number of completed supervised usage sessions and emit a dedicated supervised-session-ended event to drive this flow.

New Features:
- Auto-promote users to resource introductions once they reach a configured threshold of completed supervised sessions per resource.
- Auto-promote users to group introductions based on aggregated supervised sessions across all resources in a group, following the resource’s auto-introduction target configuration.
- Record the supervising tutor on newly auto-created resource and group introductions, and update existing introductions with the latest tutor when needed.

Enhancements:
- Extend resource and resource-group introduction services to accept an optional tutor user for grant operations and persist it on introductions.
- Wire a supervised-usage auto-promotion listener into the resource usage module to react to supervised session end events.

Tests:
- Add unit tests covering supervised-usage auto-promotion listener behavior for thresholds, resource vs group scopes, idempotency, tutor assignment, and configuration edge cases.
- Extend resource usage service tests to verify supervised-session-ended events are emitted only for supervised session endings.