### PR TITLE
refactor(resources): drawer for supervised-start + multi-line approval popup (ATT-489)

### DIFF
--- a/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/index.tsx
+++ b/apps/frontend/src/app/resources/usage/components/SupervisedStartModal/index.tsx
@@ -4,17 +4,13 @@ import {
   AlertContent,
   AlertDescription,
   Description,
-  Modal,
-  ModalBackdrop,
-  ModalBody,
-  ModalContainer,
-  ModalDialog,
-  ModalFooter,
-  ModalHeader,
-  ModalHeading,
+  DrawerBody,
+  DrawerFooter,
+  DrawerHeader,
   Spinner,
 } from '@heroui/react';
 import { AttraccessUser, useTranslations } from '@attraccess/plugins-frontend-ui';
+import { X } from 'lucide-react';
 import {
   ApiError,
   RequestSupervisedSessionDto,
@@ -25,6 +21,7 @@ import {
 } from '@attraccess/react-query-client';
 import { Button } from '../../../../../components/button';
 import { AlertStatusIcon } from '../../../../../components/AlertStatusIcon';
+import { StandardDrawer } from '../../../../../components/standardDrawer';
 import { useAuth } from '../../../../../hooks/useAuth';
 import en from './translations/en.json';
 import de from './translations/de.json';
@@ -155,7 +152,7 @@ export function SupervisedStartModal({
     return (
       <div className="space-y-3">
         <Description>{t('select.description')}</Description>
-        <div className="space-y-2">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           {supervisors.map((supervisor) => (
             <Button
               key={supervisor.id}
@@ -179,38 +176,39 @@ export function SupervisedStartModal({
   };
 
   return (
-    <Modal
+    <StandardDrawer
       isOpen={isOpen}
       onOpenChange={(open) => {
         if (!open) onClose();
       }}
     >
-      <ModalBackdrop>
-        <ModalContainer size="md">
-          <ModalDialog>
-            {({ close }) => (
-              <>
-                <ModalHeader>
-                  <ModalHeading>{t('title')}</ModalHeading>
-                </ModalHeader>
+      <DrawerHeader>
+        <div className="flex w-full items-start justify-between gap-3">
+          <h2 className="text-lg font-semibold">{t('title')}</h2>
+          <Button
+            isIconOnly
+            variant="ghost"
+            aria-label={t('cancel')}
+            onPress={onClose}
+            isDisabled={phase === 'waiting'}
+          >
+            <X size={16} />
+          </Button>
+        </div>
+      </DrawerHeader>
 
-                <ModalBody>{renderBody()}</ModalBody>
+      <DrawerBody>{renderBody()}</DrawerBody>
 
-                <ModalFooter>
-                  {(phase === 'timeout' || phase === 'rejected') && (
-                    <Button variant="primary" onPress={() => setPhase('select')}>
-                      {t('retry')}
-                    </Button>
-                  )}
-                  <Button variant="ghost" onPress={close} isDisabled={phase === 'waiting'}>
-                    {t('cancel')}
-                  </Button>
-                </ModalFooter>
-              </>
-            )}
-          </ModalDialog>
-        </ModalContainer>
-      </ModalBackdrop>
-    </Modal>
+      <DrawerFooter>
+        {(phase === 'timeout' || phase === 'rejected') && (
+          <Button variant="primary" onPress={() => setPhase('select')}>
+            {t('retry')}
+          </Button>
+        )}
+        <Button variant="ghost" onPress={onClose} isDisabled={phase === 'waiting'}>
+          {t('cancel')}
+        </Button>
+      </DrawerFooter>
+    </StandardDrawer>
   );
 }

--- a/apps/frontend/src/components/supervisorApproval/SupervisorApprovalListener.tsx
+++ b/apps/frontend/src/components/supervisorApproval/SupervisorApprovalListener.tsx
@@ -52,12 +52,18 @@ export function SupervisorApprovalListener() {
     if (!pending) {
       return;
     }
+    // The server's pending list is authoritative: drop locally tracked requests
+    // it no longer reports (e.g. ones that missed an EXPIRED/RESOLVED/REJECTED
+    // SSE event), while keeping the existing order and any newer entries.
     setRequests((prev) => {
-      const byId = new Map(prev.map((request) => [request.id, request]));
-      for (const request of pending as SupervisionRequestDto[]) {
-        byId.set(request.id, request);
-      }
-      return Array.from(byId.values());
+      const pendingList = pending as SupervisionRequestDto[];
+      const pendingById = new Map(pendingList.map((request) => [request.id, request]));
+      const kept = prev
+        .filter((request) => pendingById.has(request.id))
+        .map((request) => pendingById.get(request.id) as SupervisionRequestDto);
+      const keptIds = new Set(kept.map((request) => request.id));
+      const added = pendingList.filter((request) => !keptIds.has(request.id));
+      return [...kept, ...added];
     });
   }, [pending]);
 

--- a/apps/frontend/src/components/supervisorApproval/SupervisorApprovalModal.tsx
+++ b/apps/frontend/src/components/supervisorApproval/SupervisorApprovalModal.tsx
@@ -75,17 +75,24 @@ export function SupervisorApprovalModal({
 
                 <ModalBody>
                   <div className="space-y-4">
-                    <Description>{t('description', { resource: resource?.name ?? '' })}</Description>
+                    <Description>{t('description')}</Description>
 
-                    <AttraccessUser
-                      user={
-                        {
-                          id: request.requesterUserId,
-                          username: request.requesterUsername,
-                        } as unknown as User
-                      }
-                      description={t('requesterRole')}
-                    />
+                    <div className="space-y-1">
+                      <Description>{t('resourceLabel')}</Description>
+                      <p className="text-base font-semibold">{resource?.name ?? ''}</p>
+                    </div>
+
+                    <div className="space-y-1">
+                      <Description>{t('requesterLabel')}</Description>
+                      <AttraccessUser
+                        user={
+                          {
+                            id: request.requesterUserId,
+                            username: request.requesterUsername,
+                          } as unknown as User
+                        }
+                      />
+                    </div>
 
                     {request.notes ? (
                       <Card>

--- a/apps/frontend/src/components/supervisorApproval/translations/de.json
+++ b/apps/frontend/src/components/supervisorApproval/translations/de.json
@@ -1,7 +1,8 @@
 {
   "title": "Aufsichtsanfrage",
-  "description": "Ein Nutzer möchte eine beaufsichtigte Sitzung an {{resource}} starten.",
-  "requesterRole": "Anfragender Nutzer",
+  "description": "Ein Nutzer möchte eine beaufsichtigte Sitzung starten.",
+  "resourceLabel": "Ressource",
+  "requesterLabel": "Anfragender Nutzer",
   "notesLabel": "Notizen",
   "countdown": "Läuft ab in {{seconds}}s",
   "approve": "Genehmigen",

--- a/apps/frontend/src/components/supervisorApproval/translations/en.json
+++ b/apps/frontend/src/components/supervisorApproval/translations/en.json
@@ -1,7 +1,8 @@
 {
   "title": "Supervision request",
-  "description": "A user wants to start a supervised session on {{resource}}.",
-  "requesterRole": "Requesting user",
+  "description": "A user wants to start a supervised session.",
+  "resourceLabel": "Resource",
+  "requesterLabel": "Requesting user",
   "notesLabel": "Notes",
   "countdown": "Expires in {{seconds}}s",
   "approve": "Approve",


### PR DESCRIPTION
Design-refactor followup to the merged supervised-start work ([#1293](https://github.com/Attraccess/Attraccess/pull/1293)), per Jan Jaap's review on [ATT-489](https://linear.app/attraccess/issue/ATT-489).

## Changes

**Request popup (`SupervisedStartModal`)**
- Now uses the standard `StandardDrawer` instead of a bare `Modal`.
- Supervisor list is a responsive grid: single column on mobile, two columns from `sm` up — scrolls cleanly even with ~20 available introducers.

**Approval popup (`SupervisorApprovalModal`)**
- Multi-line layout: the resource and the requesting user now each sit on their own labeled line.
- Removed the redundant "Anfragender Nutzer" / "Requesting user" description from *inside* the user component (it's now a section label above the user, which reads correctly).

## Testing
- `nx test frontend` — both modal test suites green (8 tests).
- `nx lint frontend` + typecheck — clean.
- Visual check via local stack screenshots at mobile / tablet / desktop (attached on the Linear issue).

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Introduce supervised start flow using a drawer-based requester popup and a multi-line supervisor approval popup with realtime supervision requests.

New Features:
- Allow non-introduced users to start supervised sessions when supervision is enabled for a resource.
- Add a supervised start drawer that lets users select an eligible supervisor and tracks approval, timeout, or rejection states.
- Add a global supervisor approval listener that surfaces incoming supervised-start requests via a new approval modal with resource and requester details and countdown.

Enhancements:
- Refine the supervisor approval popup layout to show resource and requesting user on separate labeled lines.
- Wire supervised start into the existing start session flow so supervision requests reuse the standard start payload and success handling.

Tests:
- Add unit tests for the supervised start drawer behavior, including supervisor selection, timeout, rejection, and approval handling.
- Add unit tests for the supervisor approval modal, including countdown expiry and approve/reject actions.