### PR TITLE
feat(frontend): replace OTP inputs with HeroUI InputOTP (ATT-550)

### DIFF
--- a/apps/frontend/src/app/account/two-factor/index.tsx
+++ b/apps/frontend/src/app/account/two-factor/index.tsx
@@ -1,5 +1,6 @@
 import { Alert, AlertContent, AlertDescription, AlertTitle, Input, Label, Skeleton, TextField } from '@heroui/react';
 import { Button } from '../../../components/button';
+import { OneTimeCodeInput } from '../../../components/OneTimeCodeInput';
 import { QRCode } from 'react-qrcode-logo';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslations } from '@attraccess/plugins-frontend-ui';
@@ -123,10 +124,13 @@ export function TwoFactorCard() {
                 <Input />
               </TextField>
 
-              <TextField value={setupCode} onChange={setSetupCode} isDisabled={isBusy}>
-                <Label>{t('setup.codeLabel')}</Label>
-                <Input inputMode="numeric" autoComplete="one-time-code" maxLength={6} />
-              </TextField>
+              <OneTimeCodeInput
+                label={t('setup.codeLabel')}
+                value={setupCode}
+                onChange={setSetupCode}
+                isDisabled={isBusy}
+                data-cy="two-factor-setup-code-input"
+              />
 
               <Button onPress={handleVerify} isPending={isVerifying} isDisabled={isBusy || !setupCode.trim()}>
                 {t('setup.verifyButton')}
@@ -138,10 +142,13 @@ export function TwoFactorCard() {
 
       {!showSetup && (
         <div className="flex flex-col gap-4">
-          <TextField value={disableCode} onChange={setDisableCode} isDisabled={isBusy}>
-            <Label>{t('disable.codeLabel')}</Label>
-            <Input inputMode="numeric" autoComplete="one-time-code" maxLength={6} />
-          </TextField>
+          <OneTimeCodeInput
+            label={t('disable.codeLabel')}
+            value={disableCode}
+            onChange={setDisableCode}
+            isDisabled={isBusy}
+            data-cy="two-factor-disable-code-input"
+          />
           <Button variant="danger" onPress={handleDisable} isPending={isDisabling} isDisabled={isBusy || !disableCode.trim()}>
             {t('disable.button')}
           </Button>

--- a/apps/frontend/src/app/unauthorized/loginForm.tsx
+++ b/apps/frontend/src/app/unauthorized/loginForm.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { isValidEmail } from '../../utils/email';
 import { ArrowRight, LogInIcon } from 'lucide-react';
-import { Accordion, AccordionItem, AccordionHeading, AccordionTrigger, AccordionPanel, AccordionBody, AlertContent, AlertDescription, AlertTitle, Description, Input, Label, Skeleton, TextField } from '@heroui/react';
+import { Accordion, AccordionItem, AccordionHeading, AccordionTrigger, AccordionPanel, AccordionBody, AlertContent, AlertDescription, AlertTitle, Input, Label, Skeleton, TextField } from '@heroui/react';
 import { Button } from '../../components/button';
+import { OneTimeCodeInput } from '../../components/OneTimeCodeInput';
 import { Alert } from '@heroui/react';
 import { TExists, TFunction, useTranslations } from '@attraccess/plugins-frontend-ui';
 import { PasswordInput } from '../../components/PasswordInput';
@@ -89,6 +90,7 @@ function LoginFormContent(props: LoginFormProps & { t: TFunction; tExists: TExis
   const { onForgotPassword, t, tExists } = props;
 
   const { mutate: login, isPending, error } = useLogin();
+  const [twoFactorCode, setTwoFactorCode] = useState('');
   const [resendEmail, setResendEmail] = useState('');
   const [resendSuccess, setResendSuccess] = useState(false);
   const [resendError, setResendError] = useState<{ title: string; description: string } | null>(null);
@@ -157,7 +159,6 @@ function LoginFormContent(props: LoginFormProps & { t: TFunction; tExists: TExis
       const formData = new FormData(event.currentTarget as HTMLFormElement);
       const username = formData.get('username');
       const password = formData.get('password');
-      const twoFactorCode = formData.get('twoFactorCode');
 
       if (typeof username !== 'string' || typeof password !== 'string') {
         return;
@@ -169,11 +170,11 @@ function LoginFormContent(props: LoginFormProps & { t: TFunction; tExists: TExis
       login({
         username,
         password,
-        twoFactorCode: typeof twoFactorCode === 'string' ? twoFactorCode.trim() || undefined : undefined,
+        twoFactorCode: twoFactorCode.trim() || undefined,
         tokenLocation: 'cookie',
       });
     },
-    [login],
+    [login, twoFactorCode],
   );
 
   const arrowRight = <ArrowRight className="group-hover:translate-x-1 transition-transform" />;
@@ -193,11 +194,16 @@ function LoginFormContent(props: LoginFormProps & { t: TFunction; tExists: TExis
         data-cy="login-form-password-input"
         autoComplete="current-password"
       />
-      <TextField isDisabled={isPending}>
-        <Label>{t('twoFactorCode')}</Label>
-        <Input id="twoFactorCode" name="twoFactorCode" type="text" inputMode="numeric" autoComplete="one-time-code" maxLength={6} data-cy="login-form-two-factor-input" />
-        <Description>{t('twoFactorHelper')}</Description>
-      </TextField>
+      <OneTimeCodeInput
+        id="twoFactorCode"
+        name="twoFactorCode"
+        label={t('twoFactorCode')}
+        description={t('twoFactorHelper')}
+        value={twoFactorCode}
+        onChange={setTwoFactorCode}
+        isDisabled={isPending}
+        data-cy="login-form-two-factor-input"
+      />
       <div className="flex items-center justify-between">
         <Button variant="secondary"
           onPress={onForgotPassword}

--- a/apps/frontend/src/app/unauthorized/loginForm.tsx
+++ b/apps/frontend/src/app/unauthorized/loginForm.tsx
@@ -194,9 +194,8 @@ function LoginFormContent(props: LoginFormProps & { t: TFunction; tExists: TExis
         data-cy="login-form-password-input"
         autoComplete="current-password"
       />
+      {/* Value sourced purely from React state (twoFactorCode), not FormData. */}
       <OneTimeCodeInput
-        id="twoFactorCode"
-        name="twoFactorCode"
         label={t('twoFactorCode')}
         description={t('twoFactorHelper')}
         value={twoFactorCode}

--- a/apps/frontend/src/components/OneTimeCodeInput/OneTimeCodeInput.tsx
+++ b/apps/frontend/src/components/OneTimeCodeInput/OneTimeCodeInput.tsx
@@ -1,0 +1,64 @@
+import React, { useId } from 'react';
+import { Description, InputOTP, Label, REGEXP_ONLY_DIGITS } from '@heroui/react';
+
+export interface OneTimeCodeInputProps {
+  label?: React.ReactNode;
+  description?: React.ReactNode;
+  /** Controlled value of the code. */
+  value?: string;
+  onChange?: (value: string) => void;
+  /** Number of digits. Defaults to 6. */
+  length?: number;
+  name?: string;
+  id?: string;
+  isDisabled?: boolean;
+  autoFocus?: boolean;
+  'data-cy'?: string;
+}
+
+/**
+ * One-time-code (OTP/2FA) input rendered as individual digit slots.
+ * Wraps HeroUI's `InputOTP` and restricts entry to numeric digits.
+ */
+export const OneTimeCodeInput: React.FC<OneTimeCodeInputProps> = ({
+  label,
+  description,
+  value,
+  onChange,
+  length = 6,
+  name,
+  id,
+  isDisabled,
+  autoFocus,
+  'data-cy': dataCy,
+}) => {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const slots = Array.from({ length }, (_, index) => index);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label && <Label htmlFor={inputId}>{label}</Label>}
+      <InputOTP
+        id={inputId}
+        name={name}
+        value={value}
+        onChange={onChange}
+        maxLength={length}
+        pattern={REGEXP_ONLY_DIGITS}
+        inputMode="numeric"
+        autoComplete="one-time-code"
+        isDisabled={isDisabled}
+        autoFocus={autoFocus}
+        data-cy={dataCy}
+      >
+        <InputOTP.Group>
+          {slots.map((index) => (
+            <InputOTP.Slot key={index} index={index} />
+          ))}
+        </InputOTP.Group>
+      </InputOTP>
+      {description && <Description>{description}</Description>}
+    </div>
+  );
+};

--- a/apps/frontend/src/components/OneTimeCodeInput/OneTimeCodeInput.tsx
+++ b/apps/frontend/src/components/OneTimeCodeInput/OneTimeCodeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import React, { useId, useMemo } from 'react';
 import { Description, InputOTP, Label, REGEXP_ONLY_DIGITS } from '@heroui/react';
 
 export interface OneTimeCodeInputProps {
@@ -34,7 +34,7 @@ export const OneTimeCodeInput: React.FC<OneTimeCodeInputProps> = ({
 }) => {
   const generatedId = useId();
   const inputId = id ?? generatedId;
-  const slots = Array.from({ length }, (_, index) => index);
+  const slots = useMemo(() => Array.from({ length }, (_, index) => index), [length]);
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -42,7 +42,8 @@ export const OneTimeCodeInput: React.FC<OneTimeCodeInputProps> = ({
       <InputOTP
         id={inputId}
         name={name}
-        value={value}
+        // Normalize to keep InputOTP consistently controlled (never undefined).
+        value={value ?? ''}
         onChange={onChange}
         maxLength={length}
         pattern={REGEXP_ONLY_DIGITS}

--- a/apps/frontend/src/components/OneTimeCodeInput/index.ts
+++ b/apps/frontend/src/components/OneTimeCodeInput/index.ts
@@ -1,0 +1,2 @@
+export { OneTimeCodeInput } from './OneTimeCodeInput';
+export type { OneTimeCodeInputProps } from './OneTimeCodeInput';


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary
Replaces the plain text `<Input maxLength={6}>` one-time-code fields with HeroUI's dedicated `InputOTP` component (digit-slot OTP input), per [ATT-550](https://linear.app/attraccess/issue/ATT-550/replace-otp-inputs-with-proper-otp-input).

A new reusable `OneTimeCodeInput` component wraps `InputOTP` (6 numeric digit slots, `pattern={REGEXP_ONLY_DIGITS}`, `inputMode="numeric"`, `autoComplete="one-time-code"`) and is used at all three one-time-code entry points:

- **Login** — 2FA "Authenticator code" field (now controlled state instead of read from `FormData`)
- **2FA setup** — verification code field
- **2FA disable** — confirmation code field

## Files
- `apps/frontend/src/components/OneTimeCodeInput/` — new reusable component
- `apps/frontend/src/app/unauthorized/loginForm.tsx`
- `apps/frontend/src/app/account/two-factor/index.tsx`

## Testing
- `nx typecheck frontend` ✅
- `nx lint frontend` ✅ (no new warnings)
- `nx test frontend` ✅ (11/11 loginForm tests pass)
- Manual browser verification of all three OTP fields on desktop (1440×900) and mobile (390×844) — screenshots in the Linear issue.

Link: https://linear.app/attraccess/issue/ATT-550/replace-otp-inputs-with-proper-otp-input

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Introduce a reusable one-time-code input component based on HeroUI InputOTP and adopt it across login and two-factor authentication flows.

New Features:
- Add a shared OneTimeCodeInput component that renders numeric OTP codes as individual digit slots with configurable length.

Enhancements:
- Refactor login and two-factor authentication forms to use the new OneTimeCodeInput component instead of plain text inputs, switching the login OTP field to controlled state.