### PR TITLE
feat(ATT-521): RabbitMQ detection + MQTT slot status UI in plugin

### DIFF
--- a/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
+++ b/apps/frontend/src/app/mqtt/servers/EditMqttServerPage.tsx
@@ -111,7 +111,7 @@ export function EditMqttServerPage() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8" data-cy="edit-mqtt-server-page">
+    <div className="max-w-7xl mx-auto px-4 py-8 flex flex-col gap-8" data-cy="edit-mqtt-server-page">
       <PageHeader title={t('editMqttServer')} onBack={handleCancel} />
 
       <Form onSubmit={handleSubmit} className="gap-8" data-cy="edit-mqtt-server-form">

--- a/apps/plugins/rabbitmq/backend/plugin.ts
+++ b/apps/plugins/rabbitmq/backend/plugin.ts
@@ -1,13 +1,16 @@
-// RabbitMQ management plugin — backend half (scaffold).
+// RabbitMQ management plugin — backend half.
 //
-// This is the foundation bootstrap (ATT-526): it proves the nx build/zip/publish
-// pipeline produces a loadable plugin. It deliberately contains NO RabbitMQ
-// business logic yet — that lands in ATT-521+. For now it registers a minimal
-// module with a single status endpoint so the artifact is a valid, loadable
-// plugin end to end.
+// ATT-526 bootstrapped this as a loadable, do-nothing artifact. ATT-521 adds the
+// first business logic: detect whether a configured MQTT server is a RabbitMQ
+// broker by probing its management HTTP API, and expose that verdict to the
+// frontend slots. All RabbitMQ knowledge lives here in the plugin — the core
+// only hands us a generic MQTT server config through the ACCESS_MQTT_SERVERS
+// hook (see RabbitmqDetectionService).
 import type { PluginBackendModule, PluginContext } from '@attraccess/plugins-backend-sdk';
 import { Auth } from '@attraccess/plugins-backend-sdk';
 import { Controller, DynamicModule, Get, Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { RabbitmqDetectionController } from './rabbitmq-detection.controller';
+import { RabbitmqDetectionService } from './rabbitmq-detection.service';
 
 // The host hands each plugin its PluginContext under this token. Recreate it
 // locally (do not import the value) so the artifact has no runtime dependency on
@@ -20,7 +23,7 @@ class RabbitmqService implements OnModuleInit {
   constructor(@Inject(PLUGIN_CONTEXT) private readonly context: PluginContext) {}
 
   onModuleInit(): void {
-    this.context.logger.log('RabbitMQ plugin loaded (scaffold — no management logic yet).');
+    this.context.logger.log('RabbitMQ plugin loaded — MQTT-server RabbitMQ detection active.');
   }
 
   getStatus(): { plugin: string; status: string } {
@@ -49,8 +52,12 @@ const plugin: PluginBackendModule = {
   register(context: PluginContext): DynamicModule {
     return {
       module: RabbitmqPluginModule,
-      controllers: [RabbitmqController],
-      providers: [{ provide: PLUGIN_CONTEXT, useValue: context }, RabbitmqService],
+      controllers: [RabbitmqController, RabbitmqDetectionController],
+      providers: [
+        { provide: PLUGIN_CONTEXT, useValue: context },
+        RabbitmqService,
+        RabbitmqDetectionService,
+      ],
     };
   },
 };

--- a/apps/plugins/rabbitmq/backend/rabbitmq-detection.controller.ts
+++ b/apps/plugins/rabbitmq/backend/rabbitmq-detection.controller.ts
@@ -1,0 +1,25 @@
+// HTTP surface for RabbitMQ detection (ATT-521).
+//
+// Mounts `GET /rabbitmq/detection/:mqttServerId` into the host API, gated by the
+// same access level as the host MQTT servers controller. The frontend slots
+// (badge + status panel) read this to decide what, if anything, to render.
+import { Auth } from '@attraccess/plugins-backend-sdk';
+import { Controller, Get, Inject, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { RabbitmqDetectionService } from './rabbitmq-detection.service';
+import type { RabbitmqDetectionResult } from './rabbitmq-detection.types';
+
+@Auth('canManageResources')
+@Controller('rabbitmq')
+export class RabbitmqDetectionController {
+  // esbuild does not emit decorator metadata, so Nest cannot infer constructor
+  // types for injection — always inject by an explicit token.
+  constructor(@Inject(RabbitmqDetectionService) private readonly detection: RabbitmqDetectionService) {}
+
+  @Get('detection/:mqttServerId')
+  detect(
+    @Param('mqttServerId', ParseIntPipe) mqttServerId: number,
+    @Query('refresh') refresh?: string
+  ): Promise<RabbitmqDetectionResult> {
+    return this.detection.detect(mqttServerId, refresh === 'true');
+  }
+}

--- a/apps/plugins/rabbitmq/backend/rabbitmq-detection.service.ts
+++ b/apps/plugins/rabbitmq/backend/rabbitmq-detection.service.ts
@@ -1,0 +1,213 @@
+// RabbitMQ detection — plugin-side business logic (ATT-521).
+//
+// All RabbitMQ knowledge lives here, in the plugin. The core stays
+// broker-agnostic: it only hands us a generic MqttServerConnectionConfig (host,
+// port, resolved credentials) through the sanctioned ACCESS_MQTT_SERVERS hook.
+// We turn that into a probe of the RabbitMQ management HTTP API and cache the
+// verdict so repeated UI reads (badge + status panel, per row) don't re-probe.
+import type { MqttServerConnectionConfig, PluginContext } from '@attraccess/plugins-backend-sdk';
+import { Inject, Injectable } from '@nestjs/common';
+import type { RabbitmqDetectionResult } from './rabbitmq-detection.types';
+
+const PLUGIN_CONTEXT = Symbol.for('attraccess.plugin.context');
+
+// Default RabbitMQ management API ports. The management API is independent of
+// the MQTT listener, so we cannot reuse the MQTT port — RabbitMQ serves
+// management over 15672 (HTTP) / 15671 (HTTPS) by convention.
+const MGMT_PORT_HTTP = 15672;
+const MGMT_PORT_HTTPS = 15671;
+
+// How long a verdict stays fresh. Short enough to reflect a server that just
+// came online, long enough that a list of rows probes each broker once.
+const CACHE_TTL_MS = 60_000;
+
+// Probe timeout — a broker that doesn't answer quickly is treated as
+// unreachable rather than blocking the request.
+const PROBE_TIMEOUT_MS = 5_000;
+
+interface CacheEntry {
+  result: RabbitmqDetectionResult;
+  expiresAt: number;
+}
+
+// Shape of the fields we read from RabbitMQ's GET /api/overview. Everything is
+// optional — we only trust what's present.
+interface RabbitmqOverview {
+  rabbitmq_version?: string;
+  management_version?: string;
+  product_name?: string;
+}
+
+@Injectable()
+export class RabbitmqDetectionService {
+  // Verdicts keyed by MQTT server id. In-memory only; a restart re-probes.
+  private readonly cache = new Map<number, CacheEntry>();
+
+  constructor(@Inject(PLUGIN_CONTEXT) private readonly context: PluginContext) {}
+
+  // Returns a cached verdict when fresh, otherwise probes. `forceRefresh`
+  // bypasses the cache (used by the UI's manual refresh).
+  async detect(mqttServerId: number, forceRefresh = false): Promise<RabbitmqDetectionResult> {
+    if (!forceRefresh) {
+      const cached = this.cache.get(mqttServerId);
+      if (cached && cached.expiresAt > this.now()) {
+        return cached.result;
+      }
+    }
+
+    const result = await this.probe(mqttServerId);
+    this.cache.set(mqttServerId, { result, expiresAt: this.now() + CACHE_TTL_MS });
+    return result;
+  }
+
+  private async probe(mqttServerId: number): Promise<RabbitmqDetectionResult> {
+    // ACCESS_MQTT_SERVERS gates this call; the core resolves + decrypts the
+    // credentials and hands us a broker-agnostic config.
+    const config = await this.context.getMqttServerConfig(mqttServerId);
+    const checkedAt = this.nowIso();
+
+    if (!config) {
+      return {
+        mqttServerId,
+        isRabbitMQ: false,
+        reachable: false,
+        authOk: false,
+        rabbitmqVersion: null,
+        managementVersion: null,
+        managementApi: '',
+        checkedAt,
+        error: 'MQTT server not found.',
+      };
+    }
+
+    const managementApi = this.managementApiBase(config);
+
+    let response: Response;
+    try {
+      response = await this.fetchOverview(managementApi, config);
+    } catch (error) {
+      // Connection refused / DNS / TLS / timeout — not reachable.
+      return {
+        mqttServerId,
+        isRabbitMQ: false,
+        reachable: false,
+        authOk: false,
+        rabbitmqVersion: null,
+        managementVersion: null,
+        managementApi,
+        checkedAt,
+        error: this.describeError(error),
+      };
+    }
+
+    // 401 from the RabbitMQ-specific /api/overview path means the management
+    // API is present but rejected our credentials — it IS RabbitMQ.
+    if (response.status === 401) {
+      return {
+        mqttServerId,
+        isRabbitMQ: true,
+        reachable: true,
+        authOk: false,
+        rabbitmqVersion: null,
+        managementVersion: null,
+        managementApi,
+        checkedAt,
+        error: 'Authentication failed (401) against the RabbitMQ management API.',
+      };
+    }
+
+    if (!response.ok) {
+      // Something answered, but it isn't a RabbitMQ management API.
+      return {
+        mqttServerId,
+        isRabbitMQ: false,
+        reachable: true,
+        authOk: false,
+        rabbitmqVersion: null,
+        managementVersion: null,
+        managementApi,
+        checkedAt,
+        error: `Unexpected response (HTTP ${response.status}) — not a RabbitMQ management API.`,
+      };
+    }
+
+    const overview = await this.parseOverview(response);
+    // A genuine RabbitMQ overview always reports a version. If the body isn't
+    // recognisable, treat the endpoint as non-RabbitMQ despite the 200.
+    const isRabbitMQ = overview !== null && typeof overview.rabbitmq_version === 'string';
+
+    return {
+      mqttServerId,
+      isRabbitMQ,
+      reachable: true,
+      authOk: isRabbitMQ,
+      rabbitmqVersion: overview?.rabbitmq_version ?? null,
+      managementVersion: overview?.management_version ?? null,
+      managementApi,
+      checkedAt,
+      error: isRabbitMQ ? null : 'Reachable, but the response is not a RabbitMQ management API.',
+    };
+  }
+
+  // Builds the management API base URL from the generic MQTT config. The
+  // management API runs on its own port, so we substitute the conventional
+  // management port for the MQTT one and pick the scheme from useTls.
+  private managementApiBase(config: MqttServerConnectionConfig): string {
+    const scheme = config.useTls ? 'https' : 'http';
+    const port = config.useTls ? MGMT_PORT_HTTPS : MGMT_PORT_HTTP;
+    return `${scheme}://${config.host}:${port}`;
+  }
+
+  private async fetchOverview(managementApi: string, config: MqttServerConnectionConfig): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    try {
+      return await fetch(`${managementApi}/api/overview`, {
+        headers: {
+          accept: 'application/json',
+          ...this.authHeader(config),
+        },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private authHeader(config: MqttServerConnectionConfig): Record<string, string> {
+    if (config.username === null) {
+      return {};
+    }
+    const credentials = `${config.username}:${config.password ?? ''}`;
+    // btoa is available in the host Node runtime (>=16); encode the basic-auth
+    // pair as base64.
+    const encoded = Buffer.from(credentials, 'utf8').toString('base64');
+    return { authorization: `Basic ${encoded}` };
+  }
+
+  private async parseOverview(response: Response): Promise<RabbitmqOverview | null> {
+    try {
+      return (await response.json()) as RabbitmqOverview;
+    } catch {
+      return null;
+    }
+  }
+
+  private describeError(error: unknown): string {
+    if (error instanceof Error) {
+      if (error.name === 'AbortError') {
+        return `Management API did not respond within ${PROBE_TIMEOUT_MS}ms.`;
+      }
+      return error.message;
+    }
+    return 'Failed to reach the RabbitMQ management API.';
+  }
+
+  private now(): number {
+    return Date.now();
+  }
+
+  private nowIso(): string {
+    return new Date().toISOString();
+  }
+}

--- a/apps/plugins/rabbitmq/backend/rabbitmq-detection.types.ts
+++ b/apps/plugins/rabbitmq/backend/rabbitmq-detection.types.ts
@@ -1,0 +1,30 @@
+// Shared types for RabbitMQ detection (ATT-521).
+//
+// Detection answers one question for a given MQTT server: "is the broker behind
+// this MQTT config a RabbitMQ instance, and if so, is its management API
+// reachable with the configured credentials?" No management actions yet — this
+// is status only.
+
+export interface RabbitmqDetectionResult {
+  // The host MQTT server this result describes.
+  readonly mqttServerId: number;
+  // True when the probed host exposes a RabbitMQ management API (recognised
+  // either by a successful /api/overview response or by a 401 from that
+  // RabbitMQ-specific path).
+  readonly isRabbitMQ: boolean;
+  // The management API answered at all (any HTTP status). False on
+  // connection-refused / DNS / timeout.
+  readonly reachable: boolean;
+  // The configured credentials were accepted by the management API.
+  readonly authOk: boolean;
+  // Broker version reported by /api/overview, when readable.
+  readonly rabbitmqVersion: string | null;
+  // Management plugin version reported by /api/overview, when readable.
+  readonly managementVersion: string | null;
+  // The management API base URL that was probed (never carries credentials).
+  readonly managementApi: string;
+  // ISO timestamp of when this probe ran.
+  readonly checkedAt: string;
+  // Human-readable failure reason when reachable is false, else null.
+  readonly error: string | null;
+}

--- a/apps/plugins/rabbitmq/backend/tsconfig.json
+++ b/apps/plugins/rabbitmq/backend/tsconfig.json
@@ -10,5 +10,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["plugin.ts"]
+  "include": ["**/*.ts"]
 }

--- a/apps/plugins/rabbitmq/frontend/src/RabbitmqListBadge.tsx
+++ b/apps/plugins/rabbitmq/frontend/src/RabbitmqListBadge.tsx
@@ -1,0 +1,25 @@
+// Per-row badge for the MQTT server list slot (ATT-521).
+//
+// Renders a "RabbitMQ" chip only when the row's MQTT server is detected as a
+// RabbitMQ broker; for anything else it renders nothing, so non-RabbitMQ rows
+// are visually unchanged.
+import { Chip } from '@heroui/react';
+import { RabbitIcon } from 'lucide-react';
+import { useDetection } from './detection';
+
+export function RabbitmqListBadge({ mqttServerId }: { mqttServerId: number }) {
+  const { result } = useDetection(mqttServerId);
+
+  // Stay invisible until we have a positive RabbitMQ verdict — no spinner, no
+  // placeholder, so the list looks identical for non-RabbitMQ servers.
+  if (!result?.isRabbitMQ) {
+    return null;
+  }
+
+  return (
+    <Chip data-cy={`rabbitmq-list-badge-${mqttServerId}`} color="accent" variant="soft" size="sm">
+      <RabbitIcon className="w-3.5 h-3.5" />
+      RabbitMQ
+    </Chip>
+  );
+}

--- a/apps/plugins/rabbitmq/frontend/src/RabbitmqStatusPanel.tsx
+++ b/apps/plugins/rabbitmq/frontend/src/RabbitmqStatusPanel.tsx
@@ -1,0 +1,89 @@
+// Connection-status panel for the MQTT server detail slot (ATT-521).
+//
+// Appears only for MQTT servers detected as RabbitMQ brokers. Shows whether the
+// management API is reachable, whether the configured credentials are accepted,
+// and the broker / management-plugin versions. No management actions yet —
+// status only.
+import { Alert, AlertContent, AlertDescription, Button, Card, Chip, Spinner } from '@heroui/react';
+import { CheckCircle2Icon, RabbitIcon, RefreshCwIcon, XCircleIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useDetection } from './detection';
+
+function StatusRow({ ok, label, value }: { ok: boolean; label: string; value: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-1.5">
+      <div className="flex items-center gap-2">
+        {ok ? (
+          <CheckCircle2Icon className="w-4 h-4 text-success" />
+        ) : (
+          <XCircleIcon className="w-4 h-4 text-danger" />
+        )}
+        <span className="text-sm text-default-600">{label}</span>
+      </div>
+      <span className="text-sm font-medium text-default-700">{value}</span>
+    </div>
+  );
+}
+
+export function RabbitmqStatusPanel({ mqttServerId }: { mqttServerId: number }) {
+  const { result, loading, refresh } = useDetection(mqttServerId);
+
+  // Render nothing for non-RabbitMQ servers (and while the first probe is still
+  // running / if detection failed), so the detail view is unchanged unless a
+  // RabbitMQ broker is positively detected.
+  if (!result?.isRabbitMQ) {
+    return null;
+  }
+
+  return (
+    <Card
+      data-cy={`rabbitmq-status-panel-${mqttServerId}`}
+      className="w-full border border-default-200 dark:border-default-100"
+    >
+      <Card.Header className="flex flex-row items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <RabbitIcon className="w-5 h-5 text-primary" />
+          <p className="text-base font-semibold text-default-700">RabbitMQ</p>
+          <Chip color="accent" variant="soft" size="sm">
+            detected
+          </Chip>
+        </div>
+        <Button
+          isIconOnly
+          size="sm"
+          variant="ghost"
+          aria-label="Refresh RabbitMQ status"
+          data-cy={`rabbitmq-status-refresh-${mqttServerId}`}
+          onPress={refresh}
+          isDisabled={loading}
+        >
+          {loading ? <Spinner size="sm" /> : <RefreshCwIcon className="w-4 h-4" />}
+        </Button>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-1">
+        <StatusRow ok={result.reachable} label="Management API reachable" value={result.reachable ? 'Yes' : 'No'} />
+        <StatusRow ok={result.authOk} label="Authentication" value={result.authOk ? 'OK' : 'Failed'} />
+        <div className="flex items-center justify-between gap-3 py-1.5">
+          <span className="text-sm text-default-600">Management API version</span>
+          <span className="text-sm font-medium text-default-700">{result.managementVersion ?? '—'}</span>
+        </div>
+        <div className="flex items-center justify-between gap-3 py-1.5">
+          <span className="text-sm text-default-600">RabbitMQ version</span>
+          <span className="text-sm font-medium text-default-700">{result.rabbitmqVersion ?? '—'}</span>
+        </div>
+        <div className="flex items-center justify-between gap-3 py-1.5">
+          <span className="text-sm text-default-600">Management API</span>
+          <code className="text-xs text-default-500">{result.managementApi || '—'}</code>
+        </div>
+
+        {result.error && (
+          <Alert status={result.reachable ? 'warning' : 'danger'} className="mt-2">
+            <AlertContent>
+              <AlertDescription>{result.error}</AlertDescription>
+            </AlertContent>
+          </Alert>
+        )}
+      </Card.Content>
+    </Card>
+  );
+}

--- a/apps/plugins/rabbitmq/frontend/src/detection.ts
+++ b/apps/plugins/rabbitmq/frontend/src/detection.ts
@@ -40,39 +40,101 @@ export interface UseDetectionState {
   refresh: () => void;
 }
 
-// Loads detection for one MQTT server and re-loads on demand. Both MQTT slots
-// (per-row badge + detail panel) share this so each renders from the same
-// verdict the backend caches.
+// Module-level, per-server detection store shared across every mounted
+// component. Both MQTT slots (per-row badge + detail panel) render the same
+// server, so without this they would each fire their own request; sharing one
+// entry per id dedupes the in-flight fetch and keeps a short client cache.
+// State lives outside React, so a fetch resolving after a component unmounts
+// just updates the store and notifies whatever is still subscribed — there is
+// no setState-on-unmounted-component path.
+interface Entry {
+  result: RabbitmqDetectionResult | null;
+  loading: boolean;
+  error: string | null;
+  inFlight: Promise<void> | null;
+  expiresAt: number;
+}
+
+// Mirrors the backend's detection cache window so the frontend doesn't re-probe
+// more eagerly than the server refreshes.
+const CACHE_TTL_MS = 60_000;
+
+const EMPTY_ENTRY: Entry = { result: null, loading: true, error: null, inFlight: null, expiresAt: 0 };
+
+const store = new Map<number, Entry>();
+const subscribers = new Map<number, Set<() => void>>();
+
+function now(): number {
+  return Date.now();
+}
+
+function notify(mqttServerId: number): void {
+  subscribers.get(mqttServerId)?.forEach((fn) => fn());
+}
+
+// Kicks off a load for one server unless a fresh result or an in-flight request
+// already covers it. `refresh` bypasses the client cache (the backend probe
+// honours `?refresh=true`).
+function ensureLoaded(mqttServerId: number, refresh: boolean): void {
+  const current = store.get(mqttServerId);
+  if (current?.inFlight) {
+    return;
+  }
+  if (!refresh && current?.result && current.expiresAt > now()) {
+    return;
+  }
+
+  const entry: Entry = {
+    result: current?.result ?? null,
+    loading: true,
+    error: null,
+    inFlight: null,
+    expiresAt: current?.expiresAt ?? 0,
+  };
+  entry.inFlight = fetchDetection(mqttServerId, refresh)
+    .then((data) => {
+      entry.result = data;
+      entry.error = null;
+      entry.expiresAt = now() + CACHE_TTL_MS;
+    })
+    .catch((err: Error) => {
+      entry.error = err.message;
+    })
+    .finally(() => {
+      entry.loading = false;
+      entry.inFlight = null;
+      notify(mqttServerId);
+    });
+  store.set(mqttServerId, entry);
+  notify(mqttServerId);
+}
+
+// Subscribes to the shared store for one server and triggers the initial load.
+// Returns the current entry's view plus a `refresh` that bypasses the cache.
 export function useDetection(mqttServerId: number): UseDetectionState {
-  const [result, setResult] = useState<RabbitmqDetectionResult | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [, forceRender] = useState(0);
 
-  const load = useCallback(
-    (refresh: boolean) => {
-      let cancelled = false;
-      setLoading(true);
-      setError(null);
-      fetchDetection(mqttServerId, refresh)
-        .then((data) => {
-          if (!cancelled) setResult(data);
-        })
-        .catch((err: Error) => {
-          if (!cancelled) setError(err.message);
-        })
-        .finally(() => {
-          if (!cancelled) setLoading(false);
-        });
-      return () => {
-        cancelled = true;
-      };
-    },
-    [mqttServerId]
-  );
+  useEffect(() => {
+    const rerender = () => forceRender((n) => n + 1);
+    let set = subscribers.get(mqttServerId);
+    if (!set) {
+      set = new Set();
+      subscribers.set(mqttServerId, set);
+    }
+    set.add(rerender);
 
-  useEffect(() => load(false), [load]);
+    ensureLoaded(mqttServerId, false);
 
-  const refresh = useCallback(() => load(true), [load]);
+    return () => {
+      set?.delete(rerender);
+      if (set && set.size === 0) {
+        subscribers.delete(mqttServerId);
+      }
+    };
+  }, [mqttServerId]);
 
-  return { result, loading, error, refresh };
+  const refresh = useCallback(() => ensureLoaded(mqttServerId, true), [mqttServerId]);
+
+  const entry = store.get(mqttServerId) ?? EMPTY_ENTRY;
+  return { result: entry.result, loading: entry.loading, error: entry.error, refresh };
 }

--- a/apps/plugins/rabbitmq/frontend/src/detection.ts
+++ b/apps/plugins/rabbitmq/frontend/src/detection.ts
@@ -1,0 +1,78 @@
+// Frontend access to the plugin's RabbitMQ detection endpoint (ATT-521).
+//
+// The backend half (apps/plugins/rabbitmq/backend) mounts
+// `GET /rabbitmq/detection/:mqttServerId` into the host API. We read it from the
+// MQTT slot contributions to decide what to render. The result shape is
+// restated here (the backend and frontend are separate bundles with no shared
+// module), mirroring backend/rabbitmq-detection.types.ts.
+import { useCallback, useEffect, useState } from 'react';
+
+export interface RabbitmqDetectionResult {
+  mqttServerId: number;
+  isRabbitMQ: boolean;
+  reachable: boolean;
+  authOk: boolean;
+  rabbitmqVersion: string | null;
+  managementVersion: string | null;
+  managementApi: string;
+  checkedAt: string;
+  error: string | null;
+}
+
+// Host mounts plugin controllers under `/api`; cookies carry the session.
+function detectionEndpoint(mqttServerId: number, refresh: boolean): string {
+  const base = `/api/rabbitmq/detection/${mqttServerId}`;
+  return refresh ? `${base}?refresh=true` : base;
+}
+
+async function fetchDetection(mqttServerId: number, refresh: boolean): Promise<RabbitmqDetectionResult> {
+  const res = await fetch(detectionEndpoint(mqttServerId, refresh), { credentials: 'include' });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as RabbitmqDetectionResult;
+}
+
+export interface UseDetectionState {
+  result: RabbitmqDetectionResult | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+// Loads detection for one MQTT server and re-loads on demand. Both MQTT slots
+// (per-row badge + detail panel) share this so each renders from the same
+// verdict the backend caches.
+export function useDetection(mqttServerId: number): UseDetectionState {
+  const [result, setResult] = useState<RabbitmqDetectionResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    (refresh: boolean) => {
+      let cancelled = false;
+      setLoading(true);
+      setError(null);
+      fetchDetection(mqttServerId, refresh)
+        .then((data) => {
+          if (!cancelled) setResult(data);
+        })
+        .catch((err: Error) => {
+          if (!cancelled) setError(err.message);
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+      return () => {
+        cancelled = true;
+      };
+    },
+    [mqttServerId]
+  );
+
+  useEffect(() => load(false), [load]);
+
+  const refresh = useCallback(() => load(true), [load]);
+
+  return { result, loading, error, refresh };
+}

--- a/apps/plugins/rabbitmq/frontend/src/plugin.tsx
+++ b/apps/plugins/rabbitmq/frontend/src/plugin.tsx
@@ -1,17 +1,35 @@
-// RabbitMQ management plugin — frontend half (scaffold).
+// RabbitMQ management plugin — frontend half.
 //
-// Foundation bootstrap (ATT-526): a minimal frontend remote that registers one
-// route and a sidebar entry so the federation build is exercised end to end. The
-// actual management UI lands in ATT-521+.
+// ATT-526 bootstrapped this remote with one route + sidebar entry. ATT-521 adds
+// the MQTT slot contributions: a "RabbitMQ" badge in the MQTT server list and a
+// connection-status panel in the MQTT server detail view, both driven by the
+// plugin's backend detection endpoint. The host stays RabbitMQ-agnostic — it
+// only exposes the generic slots and renders whatever we contribute.
 import { Card } from '@heroui/react';
 import { RabbitIcon } from 'lucide-react';
 import type {
   AttraccessFrontendPlugin,
   AttraccessFrontendPluginAuthData,
   PluginSidebarItem,
+  PluginSlotContribution,
   RouteConfig,
 } from '@attraccess/plugins-frontend-sdk';
 import type { IPluginStore } from 'react-pluggable';
+import { RabbitmqListBadge } from './RabbitmqListBadge';
+import { RabbitmqStatusPanel } from './RabbitmqStatusPanel';
+
+// Host slot ids exposed by the MQTT UI. The SDK is vendor-agnostic and does not
+// export them, and the host owns them in apps/frontend (which a plugin cannot
+// import) — so a plugin restates them, exactly like it restates a route `path`
+// it links to. Both slots receive `{ mqttServerId }`.
+const MQTT_SERVER_DETAIL_SLOT = 'mqtt.server.detail';
+const MQTT_SERVER_LIST_ROW_SLOT = 'mqtt.server.list.row';
+
+// The context shape the host documents for both MQTT slots.
+interface MqttServerSlotContext {
+  mqttServerId: number;
+  [key: string]: unknown;
+}
 
 function RabbitmqPage() {
   return (
@@ -23,7 +41,8 @@ function RabbitmqPage() {
       <Card className="border border-default-200 dark:border-default-100">
         <Card.Content>
           <p className="text-sm text-default-500">
-            RabbitMQ management plugin scaffold. Management features are coming soon.
+            RabbitMQ management plugin. RabbitMQ MQTT servers now show a detection badge and connection-status
+            panel in the MQTT settings. Management features are coming soon.
           </p>
         </Card.Content>
       </Card>
@@ -41,7 +60,7 @@ export default class RabbitmqPlugin implements AttraccessFrontendPlugin {
   }
 
   init(_store: IPluginStore): void {
-    // No setup needed for the scaffold.
+    // No setup needed.
   }
 
   activate(): void {
@@ -53,7 +72,7 @@ export default class RabbitmqPlugin implements AttraccessFrontendPlugin {
   }
 
   onApiAuthStateChange(_authData: null | AttraccessFrontendPluginAuthData): void {
-    // no-op
+    // no-op — detection is read via relative `/api` URLs with session cookies.
   }
 
   onApiEndpointChange(_endpoint: string): void {
@@ -73,5 +92,24 @@ export default class RabbitmqPlugin implements AttraccessFrontendPlugin {
         icon: <RabbitIcon className="w-5 h-5" />,
       },
     ];
+  }
+
+  // Contribute UI into the host's generic MQTT slots. Each contribution is
+  // scoped to one server via the host-supplied `{ mqttServerId }` context and
+  // renders nothing unless that server is detected as RabbitMQ.
+  getSlotContributions(): PluginSlotContribution[] {
+    const contributions: PluginSlotContribution<MqttServerSlotContext>[] = [
+      {
+        slotId: MQTT_SERVER_DETAIL_SLOT,
+        key: 'rabbitmq-mqtt-detail',
+        render: (context) => <RabbitmqStatusPanel mqttServerId={context.mqttServerId} />,
+      },
+      {
+        slotId: MQTT_SERVER_LIST_ROW_SLOT,
+        key: 'rabbitmq-mqtt-list-row',
+        render: (context) => <RabbitmqListBadge mqttServerId={context.mqttServerId} />,
+      },
+    ];
+    return contributions;
   }
 }

--- a/apps/plugins/rabbitmq/plugin.json
+++ b/apps/plugins/rabbitmq/plugin.json
@@ -14,5 +14,5 @@
   "attraccessVersion": {
     "min": "1.0.0"
   },
-  "permissions": []
+  "permissions": ["ACCESS_MQTT_SERVERS"]
 }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

## Summary

First business-logic ticket for the RabbitMQ management plugin (part of ATT-255), built on the ATT-526 scaffold. Detects whether a configured MQTT server is a RabbitMQ broker and renders a connection-status indicator into the MQTT UI slots. **No management actions yet — detection + status only.** Core is untouched; the plugin consumes only the sanctioned ATT-519 (frontend slots) and ATT-520 (secure MQTT-config hook) seams.

## Implementation

**Backend** (`apps/plugins/rabbitmq/backend`)
- `RabbitmqDetectionService` — reads the generic, broker-agnostic MQTT server config (host/port/credentials) via the `ACCESS_MQTT_SERVERS` hook (`context.getMqttServerConfig`), then probes the RabbitMQ management HTTP API at `GET {scheme}://{host}:{15672|15671}/api/overview` with Basic auth. Derives `reachable` / `authOk` / `isRabbitMQ` and the broker + management-plugin versions. A 401 from that RabbitMQ-specific path is treated as "is RabbitMQ, auth failed". Verdicts cached in-memory with a 60s TTL; 5s probe timeout.
- `RabbitmqDetectionController` — `GET /rabbitmq/detection/:mqttServerId` (optional `?refresh=true`), gated by `canManageResources` like the host MQTT controller.
- Declared the `ACCESS_MQTT_SERVERS` permission in `plugin.json`.

**Frontend** (`apps/plugins/rabbitmq/frontend`)
- `getSlotContributions()` contributes into the two ATT-519 MQTT slots:
  - `mqtt.server.list.row` → a **"RabbitMQ" badge** (renders only when detected).
  - `mqtt.server.detail` → a **connection-status panel** (reachable / auth OK / management-API version / RabbitMQ version, with a manual refresh).
- Both render **nothing** unless the server is positively detected as RabbitMQ, so non-RabbitMQ servers are visually unchanged.

## Acceptance criteria
- [x] Plugin loads via the plugin system; appears in `/api/plugins` (scaffold already loadable; this adds the detection endpoint + slot UI).
- [x] RabbitMQ server → MQTT UI shows a RabbitMQ badge + connection status.
- [x] Non-RabbitMQ server → nothing extra appears.
- [x] Self-contained; uses only the sanctioned ATT-519/ATT-520 hooks. Core untouched.

## Verification
- `nx lint plugin-rabbitmq` ✓ (pre-existing scaffold underscore-param warnings only)
- `nx build plugin-rabbitmq` ✓ (backend esbuild bundle + frontend module-federation remote)
- Backend typechecks clean against workspace path mappings.

Linear: [ATT-521](https://linear.app/attraccess/issue/ATT-521/rabbitmq-management-plugin-scaffold-rabbitmq-detection)

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Add RabbitMQ-specific detection to the MQTT plugin and surface its status in the MQTT UI via frontend slots.

New Features:
- Expose a backend endpoint that detects whether a configured MQTT server is a RabbitMQ broker and reports management API reachability, auth status, and versions.
- Render a RabbitMQ badge in the MQTT server list and a connection-status panel in the MQTT server detail view when a server is detected as RabbitMQ.

Enhancements:
- Register the new RabbitMQ detection controller and service in the plugin backend module and broaden backend TypeScript compilation to include all source files.