### PR TITLE
feat(monitoring): human-readable Grafana alert notifications (ATT-552)

### DIFF
--- a/monitoring/grafana/provisioning/alerting/contactpoints.yaml
+++ b/monitoring/grafana/provisioning/alerting/contactpoints.yaml
@@ -14,4 +14,7 @@ contactPoints:
         settings:
           apiToken: $__env{PUSHOVER_API_TOKEN}
           userKey: $__env{PUSHOVER_USER_KEY}
+          # Human-readable formatting (templates defined in templates.yaml).
+          title: '{{ template "attraccess.pushover.title" . }}'
+          message: '{{ template "attraccess.pushover.message" . }}'
         disableResolveMessage: false

--- a/monitoring/grafana/provisioning/alerting/templates.yaml
+++ b/monitoring/grafana/provisioning/alerting/templates.yaml
@@ -1,0 +1,35 @@
+apiVersion: 1
+
+# Human-readable notification templates for the Pushover contact point
+# (contactpoints.yaml references these by name). Pushover renders messages as
+# HTML (Grafana sends html=1), so <b>/<a> tags below are formatted, not literal.
+# Without these, Grafana's built-in default template produces a single dense
+# line ("Value: A=0.96... Labels: - alertname = ... Annotations: - ...") that is
+# hard to read on a phone.
+templates:
+  - orgId: 1
+    name: attraccess.pushover.title
+    template: |-
+      {{ define "attraccess.pushover.title" -}}
+      {{ if eq .Status "firing" }}🔥 FIRING{{ if gt (len .Alerts.Firing) 1 }} ({{ len .Alerts.Firing }}){{ end }}{{ else }}✅ RESOLVED{{ end }}: {{ if .CommonLabels.alertname }}{{ .CommonLabels.alertname }}{{ else }}{{ .CommonLabels.grafana_folder }}{{ end }}
+      {{- end }}
+
+  - orgId: 1
+    name: attraccess.pushover.message
+    template: |-
+      {{ define "attraccess.pushover.message" -}}
+      {{ range .Alerts -}}
+      {{ if eq .Status "firing" }}🔥 <b>FIRING</b>{{ else }}✅ <b>RESOLVED</b>{{ end }}
+      <b>{{ if .Annotations.summary }}{{ .Annotations.summary }}{{ else }}{{ .Labels.alertname }}{{ end }}</b>
+      {{ if .Annotations.description }}{{ .Annotations.description }}
+      {{ end }}
+      {{- if .Labels.severity }}Severity: {{ .Labels.severity }}
+      {{ end -}}
+      {{ if .Labels.instance }}Instance: {{ .Labels.instance }}
+      {{ end -}}
+      Since: {{ .StartsAt.Format "15:04 02 Jan 2006 MST" }}
+      {{ if .Annotations.runbook_url }}<a href="{{ .Annotations.runbook_url }}">Runbook</a> · {{ end -}}
+      {{ if .SilenceURL }}<a href="{{ .SilenceURL }}">Silence</a>{{ end -}}
+      {{ if .PanelURL }} · <a href="{{ .PanelURL }}">View</a>{{ else if .DashboardURL }} · <a href="{{ .DashboardURL }}">View</a>{{ else if .GeneratorURL }} · <a href="{{ .GeneratorURL }}">View</a>{{ end }}
+      {{ end -}}
+      {{ end }}


### PR DESCRIPTION
## Problem

Grafana's built-in default template renders Pushover alerts as a single dense line that is hard to read on a phone (from ATT-552):

> **Firing** Value: A=0.9691203203685499, C=1 Labels: - alertname = HighMemoryUsage - grafana_folder = Attraccess Alerts - instance = attraccess:3000 - job = attraccess - severity = warning Annotations: - description = V8 heap usage... Source: ... Silence: ...

## Change

- Add `monitoring/grafana/provisioning/alerting/templates.yaml` with two named notification templates (`attraccess.pushover.title`, `attraccess.pushover.message`).
- Wire them into the Pushover contact point's `title`/`message` settings in `contactpoints.yaml`.

Pushover receives `html=1` from Grafana, so the `<b>`/`<a>` tags render as formatting/links rather than literal text.

## Rendered result (same HighMemoryUsage alert)

**Title:** `🔥 FIRING: HighMemoryUsage`

**Message:**
```
🔥 FIRING
High heap memory usage
V8 heap usage has been above 90% for 10 minutes.
Severity: warning
Instance: attraccess:3000
Since: 14:05 09 Jun 2026 UTC
Silence · View
```

Resolved alerts render with `✅ RESOLVED`; grouped alerts list each instance and the title shows the count (`🔥 FIRING (2): HighMemoryUsage`).

## Verification

- Executed the exact template strings through Go's `text/template` engine (same engine Grafana uses) against mock alert data mirroring Grafana's `ExtendedData`/`ExtendedAlert` model — firing, resolved, and grouped cases all parse and render cleanly with no stray blank lines.
- YAML-validated all alerting provisioning files.
- `scripts/grafana-provisioning-prepare.spec.sh` still passes (the new templates file requires no secrets, so it stays present even when Pushover provisioning is stripped, and references nothing — harmless).

## Notes

- No secrets in the new file. Templates without a contact point are inert, so the opt-in stripping in `prepare-provisioning.sh` needs no change.

<!-- generated-by-cyrus -->

## Summary by Sourcery

New Features:
- Add Grafana alert notification templates for Pushover alert titles and messages to improve readability on mobile devices.