### PR TITLE
perf(attractap): fix Attractap Touch UI lag — restore render/I2C throughput, isolate scheduling (ATT-554)

### DIFF
--- a/apps/attractap/firmware/build_firmwares.py
+++ b/apps/attractap/firmware/build_firmwares.py
@@ -123,6 +123,11 @@ def main():
         for section in config.sections():
             if section.startswith('env:'):
                 env_name = section[4:]  # Remove 'env:' prefix
+                # '-debug' envs are local development variants (-Og + debug
+                # symbols), never shipped firmware
+                if env_name.endswith('-debug'):
+                    print(f"Skipping development environment: {env_name}")
+                    continue
                 environments.append(env_name)
         
         if not environments:

--- a/apps/attractap/firmware/include/lv_conf.h
+++ b/apps/attractap/firmware/include/lv_conf.h
@@ -1,14 +1,13 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.4.0
- */
-
-/*
- * Copy this file as `lv_conf.h`
- * 1. simply next to the `lvgl` folder
- * 2. or any other places and
- *    - define `LV_CONF_INCLUDE_SIMPLE`
- *    - add the path as include path
+ * LVGL v9 configuration for Attractap (lvgl@9.3.0, see platformio.ini).
+ *
+ * IMPORTANT: this file must use LVGL v9 macro names. LVGL silently ignores
+ * unknown (e.g. v8) macros and falls back to its defaults — the previous v8.4
+ * config left the device running at the v9 defaults (33 ms refresh, ~30 Hz
+ * touch sampling) for its entire life (ATT-554). Only deliberate overrides are
+ * listed here; everything else intentionally uses the lv_conf_internal.h
+ * defaults.
  */
 
 /* clang-format off */
@@ -17,772 +16,99 @@
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
-// #include <stdint.h>
-
 /*====================
    COLOR SETTINGS
  *====================*/
 
-/*Color depth: 1 (1 byte per pixel), 8 (RGB332), 16 (RGB565), 32 (ARGB8888)*/
+/*Color depth: 8 (A8), 16 (RGB565), 24 (RGB888), 32 (XRGB8888)*/
 #define LV_COLOR_DEPTH 16
-
-/*Swap the 2 bytes of RGB565 color. Useful if the display has an 8-bit interface (e.g. SPI)*/
-#define LV_COLOR_16_SWAP 0
-
-/*Enable features to draw on transparent background.
- *It's required if opa, and transform_* style properties are used.
- *Can be also used if the UI is above another layer, e.g. an OSD menu or video player.*/
-#define LV_COLOR_SCREEN_TRANSP 0
-
-/* Adjust color mix functions rounding. GPUs might calculate color mix (blending) differently.
- * 0: round down, 64: round up from x.75, 128: round up from half, 192: round up from x.25, 254: round up */
-#define LV_COLOR_MIX_ROUND_OFS 0
-
-/*Images pixels with this color will not be drawn if they are chroma keyed)*/
-#define LV_COLOR_CHROMA_KEY lv_color_hex(0x00ff00)         /*pure green*/
 
 /*=========================
    MEMORY SETTINGS
  *=========================*/
 
-/*1: use custom malloc/free, 0: use the built-in `lv_mem_alloc()` and `lv_mem_free()`*/
-#define LV_MEM_CUSTOM      1
-#define LV_MEM_CUSTOM_ALLOC  heap_caps_malloc
-#define LV_MEM_CUSTOM_FREE   heap_caps_free
-
-#define LV_MEM_CUSTOM 0
-/*
-#if LV_MEM_CUSTOM == 0
-    //Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)
-    #define LV_MEM_SIZE (96U * 1024U)          //[bytes]
-
-    // Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.
-    #define LV_MEM_ADR 0     //0: unused
-    // Instead of an address give a memory allocator that will be called to get a memory pool for LVGL. E.g. my_malloc
-    #if LV_MEM_ADR == 0
-        #undef LV_MEM_POOL_INCLUDE
-        #undef LV_MEM_POOL_ALLOC
-    #endif
-
-#else       //LV_MEM_CUSTOM
-    #define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   //Header for the dynamic memory function
-    #define LV_MEM_CUSTOM_ALLOC   malloc
-    #define LV_MEM_CUSTOM_FREE    free
-    #define LV_MEM_CUSTOM_REALLOC realloc
-#endif     //LV_MEM_CUSTOM
-*/
-
-/*Number of the intermediate memory buffer used during rendering and other internal processing mechanisms.
- *You will see an error log message if there wasn't enough buffers. */
-#define LV_MEM_BUF_MAX_NUM 16
-
-/*Use the standard `memcpy` and `memset` instead of LVGL's own functions. (Might or might not be faster).*/
-#define LV_MEMCPY_MEMSET_STD 0
+/*Built-in lv_malloc pool (the effective setting since the v9 migration; kept explicit)*/
+#define LV_USE_STDLIB_MALLOC LV_STDLIB_BUILTIN
+#define LV_MEM_SIZE (64 * 1024U)
 
 /*====================
    HAL SETTINGS
  *====================*/
 
-/*Default display refresh period. LVG will redraw changed areas with this period time*/
-#define LV_DISP_DEF_REFR_PERIOD 10      /*[ms]*/
+/*Default display refresh AND input-device read period. In v9 a single macro
+ *drives both: lv_indev_create() also uses LV_DEF_REFR_PERIOD for its read
+ *timer (lv_indev.c). 15 ms ≈ 66 Hz refresh + touch sampling (v9 default: 33 ms).*/
+#define LV_DEF_REFR_PERIOD 15
 
-/*Input device read period in milliseconds*/
-#define LV_INDEV_DEF_READ_PERIOD 10     /*[ms]*/
+/*=========================
+   OPERATING SYSTEM
+ *=========================*/
 
-/*Use a custom tick source that tells the elapsed time in milliseconds.
- *It removes the need to manually update the tick with `lv_tick_inc()`)*/
-#define LV_TICK_CUSTOM 0
-#if LV_TICK_CUSTOM
-    #define LV_TICK_CUSTOM_INCLUDE "Arduino.h"         /*Header for the system time function*/
-    #define LV_TICK_CUSTOM_SYS_TIME_EXPR (millis())    /*Expression evaluating to current system time in ms*/
-    /*If using lvgl as ESP32 component*/
-    // #define LV_TICK_CUSTOM_INCLUDE "esp_timer.h"
-    // #define LV_TICK_CUSTOM_SYS_TIME_EXPR ((esp_timer_get_time() / 1000LL))
-#endif   /*LV_TICK_CUSTOM*/
+/*FreeRTOS primitives: enables lv_lock()/lv_unlock() (recursive mutex) so
+ *lv_timer_handler can run on a dedicated task, and allows >1 SW draw unit.*/
+#define LV_USE_OS LV_OS_FREERTOS
 
-/*Default Dot Per Inch. Used to initialize default sizes such as widgets sized, style paddings.
- *(Not so important, you can adjust it to modify default sizes and spaces)*/
-#define LV_DPI_DEF 130     /*[px/inch]*/
+/*========================
+ * RENDERING CONFIGURATION
+ *========================*/
 
-/*=======================
- * FEATURE CONFIGURATION
- *=======================*/
-
-/*-------------
- * Drawing
- *-----------*/
-
-/*Enable complex draw engine.
- *Required to draw shadow, gradient, rounded corners, circles, arc, skew lines, image transformations or any masks*/
-#define LV_DRAW_COMPLEX 1
-#if LV_DRAW_COMPLEX != 0
-
-    /*Allow buffering some shadow calculation.
-    *LV_SHADOW_CACHE_SIZE is the max. shadow size to buffer, where shadow size is `shadow_width + radius`
-    *Caching has LV_SHADOW_CACHE_SIZE^2 RAM cost*/
-    #define LV_SHADOW_CACHE_SIZE 0
-
-    /* Set number of maximally cached circle data.
-    * The circumference of 1/4 circle are saved for anti-aliasing
-    * radius * 4 bytes are used per circle (the most often used radiuses are saved)
-    * 0: to disable caching */
-    #define LV_CIRCLE_CACHE_SIZE 4
-#endif /*LV_DRAW_COMPLEX*/
-
-/**
- * "Simple layers" are used when a widget has `style_opa < 255` to buffer the widget into a layer
- * and blend it as an image with the given opacity.
- * Note that `bg_opa`, `text_opa` etc don't require buffering into layer)
- * The widget can be buffered in smaller chunks to avoid using large buffers.
- *
- * - LV_LAYER_SIMPLE_BUF_SIZE: [bytes] the optimal target buffer size. LVGL will try to allocate it
- * - LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE: [bytes]  used if `LV_LAYER_SIMPLE_BUF_SIZE` couldn't be allocated.
- *
- * Both buffer sizes are in bytes.
- * "Transformed layers" (where transform_angle/zoom properties are used) use larger buffers
- * and can't be drawn in chunks. So these settings affects only widgets with opacity.
- */
-#define LV_LAYER_SIMPLE_BUF_SIZE          (12 * 1024)
-#define LV_LAYER_SIMPLE_FALLBACK_BUF_SIZE (3 * 1024)
-
-/*Default image cache size. Image caching keeps the images opened.
- *If only the built-in image formats are used there is no real advantage of caching. (I.e. if no new image decoder is added)
- *With complex image decoders (e.g. PNG or JPG) caching can save the continuous open/decode of images.
- *However the opened images might consume additional RAM.
- *0: to disable caching*/
-#define LV_IMG_CACHE_DEF_SIZE 0
-
-/*Number of stops allowed per gradient. Increase this to allow more stops.
- *This adds (sizeof(lv_color_t) + 1) bytes per additional stop*/
-#define LV_GRADIENT_MAX_STOPS 2
-
-/*Default gradient buffer size.
- *When LVGL calculates the gradient "maps" it can save them into a cache to avoid calculating them again.
- *LV_GRAD_CACHE_DEF_SIZE sets the size of this cache in bytes.
- *If the cache is too small the map will be allocated only while it's required for the drawing.
- *0 mean no caching.*/
-#define LV_GRAD_CACHE_DEF_SIZE 0
-
-/*Allow dithering the gradients (to achieve visual smooth color gradients on limited color depth display)
- *LV_DITHER_GRADIENT implies allocating one or two more lines of the object's rendering surface
- *The increase in memory consumption is (32 bits * object width) plus 24 bits * object width if using error diffusion */
-#define LV_DITHER_GRADIENT 0
-#if LV_DITHER_GRADIENT
-    /*Add support for error diffusion dithering.
-     *Error diffusion dithering gets a much better visual result, but implies more CPU consumption and memory when drawing.
-     *The increase in memory consumption is (24 bits * object's width)*/
-    #define LV_DITHER_ERROR_DIFFUSION 0
-#endif
-
-/*Maximum buffer size to allocate for rotation.
- *Only used if software rotation is enabled in the display driver.*/
-#define LV_DISP_ROT_MAX_BUF (10*1024)
-
-/*-------------
- * GPU
- *-----------*/
-
-/*Use Arm's 2D acceleration library Arm-2D */
-#define LV_USE_GPU_ARM2D 0
-
-/*Use STM32's DMA2D (aka Chrom Art) GPU*/
-#define LV_USE_GPU_STM32_DMA2D 0
-#if LV_USE_GPU_STM32_DMA2D
-    /*Must be defined to include path of CMSIS header of target processor
-    e.g. "stm32f7xx.h" or "stm32f4xx.h"*/
-    #define LV_GPU_DMA2D_CMSIS_INCLUDE
-#endif
-
-/*Enable RA6M3 G2D GPU*/
-#define LV_USE_GPU_RA6M3_G2D 0
-#if LV_USE_GPU_RA6M3_G2D
-    /*include path of target processor
-    e.g. "hal_data.h"*/
-    #define LV_GPU_RA6M3_G2D_INCLUDE "hal_data.h"
-#endif
-
-/*Use SWM341's DMA2D GPU*/
-#define LV_USE_GPU_SWM341_DMA2D 0
-#if LV_USE_GPU_SWM341_DMA2D
-    #define LV_GPU_SWM341_DMA2D_INCLUDE "SWM341.h"
-#endif
-
-/*Use NXP's PXP GPU iMX RTxxx platforms*/
-#define LV_USE_GPU_NXP_PXP 0
-#if LV_USE_GPU_NXP_PXP
-    /*1: Add default bare metal and FreeRTOS interrupt handling routines for PXP (lv_gpu_nxp_pxp_osa.c)
-    *   and call lv_gpu_nxp_pxp_init() automatically during lv_init(). Note that symbol SDK_OS_FREE_RTOS
-    *   has to be defined in order to use FreeRTOS OSA, otherwise bare-metal implementation is selected.
-    *0: lv_gpu_nxp_pxp_init() has to be called manually before lv_init()
-    */
-    #define LV_USE_GPU_NXP_PXP_AUTO_INIT 0
-#endif
-
-/*Use NXP's VG-Lite GPU iMX RTxxx platforms*/
-#define LV_USE_GPU_NXP_VG_LITE 0
-
-/*Use SDL renderer API*/
-#define LV_USE_GPU_SDL 0
-#if LV_USE_GPU_SDL
-    #define LV_GPU_SDL_INCLUDE_PATH <SDL2/SDL.h>
-    /*Texture cache size, 8MB by default*/
-    #define LV_GPU_SDL_LRU_SIZE (1024 * 1024 * 8)
-    /*Custom blend mode for mask drawing, disable if you need to link with older SDL2 lib*/
-    #define LV_GPU_SDL_CUSTOM_BLEND_MODE (SDL_VERSION_ATLEAST(2, 0, 6))
-#endif
+/*Two software draw units: the ESP32-S3 has two cores, so render work on
+ *independent areas can be parallelized. Requires LV_USE_OS above.*/
+#define LV_DRAW_SW_DRAW_UNIT_CNT 2
 
 /*-------------
  * Logging
  *-----------*/
 
-/*Enable the log module*/
 #define LV_USE_LOG 1
 #if LV_USE_LOG
-
-    /*How important log should be added:
-    *LV_LOG_LEVEL_TRACE       A lot of logs to give detailed information
-    *LV_LOG_LEVEL_INFO        Log important events
-    *LV_LOG_LEVEL_WARN        Log if something unwanted happened but didn't cause a problem
-    *LV_LOG_LEVEL_ERROR       Only critical issue, when the system may fail
-    *LV_LOG_LEVEL_USER        Only logs added by the user
-    *LV_LOG_LEVEL_NONE        Do not log anything*/
     #define LV_LOG_LEVEL LV_LOG_LEVEL_ERROR
-
-    /*1: Print the log with 'printf';
-    *0: User need to register a callback with `lv_log_register_print_cb()`*/
+    /*Fallback printf; Display::setup registers a print callback that takes precedence*/
     #define LV_LOG_PRINTF 1
-
-    /*Enable/disable LV_LOG_TRACE in modules that produces a huge number of logs*/
-    #define LV_LOG_TRACE_MEM        1
-    #define LV_LOG_TRACE_TIMER      1
-    #define LV_LOG_TRACE_INDEV      1
-    #define LV_LOG_TRACE_DISP_REFR  1
-    #define LV_LOG_TRACE_EVENT      1
-    #define LV_LOG_TRACE_OBJ_CREATE 1
-    #define LV_LOG_TRACE_LAYOUT     1
-    #define LV_LOG_TRACE_ANIM       1
-
-#endif  /*LV_USE_LOG*/
+#endif
 
 /*-------------
  * Asserts
  *-----------*/
 
-/*Enable asserts if an operation is failed or an invalid data is found.
- *If LV_USE_LOG is enabled an error message will be printed on failure*/
-#define LV_USE_ASSERT_NULL          1   /*Check if the parameter is NULL. (Very fast, recommended)*/
-#define LV_USE_ASSERT_MALLOC        1   /*Checks is the memory is successfully allocated or no. (Very fast, recommended)*/
-#define LV_USE_ASSERT_STYLE         0   /*Check if the styles are properly initialized. (Very fast, recommended)*/
-#define LV_USE_ASSERT_MEM_INTEGRITY 0   /*Check the integrity of `lv_mem` after critical operations. (Slow)*/
-#define LV_USE_ASSERT_OBJ           0   /*Check the object's type and existence (e.g. not deleted). (Slow)*/
-
-/*Add a custom handler when assert happens e.g. to restart the MCU*/
-#define LV_ASSERT_HANDLER_INCLUDE <stdint.h>
-#define LV_ASSERT_HANDLER while(1);   /*Halt by default*/
+#define LV_USE_ASSERT_NULL   1
+#define LV_USE_ASSERT_MALLOC 1
 
 /*-------------
- * Others
+ * Debug
  *-----------*/
 
-/*1: Show CPU usage and FPS count*/
-#define LV_USE_PERF_MONITOR 0
-#if LV_USE_PERF_MONITOR
+/*FPS/CPU overlay for on-hardware perf validation (ATT-554). Enable by adding
+ *`-D ATTRACTAP_LV_PERF_MONITOR=1` to build_flags.*/
+#ifdef ATTRACTAP_LV_PERF_MONITOR
+    #define LV_USE_SYSMON 1
+    #define LV_USE_PERF_MONITOR 1
     #define LV_USE_PERF_MONITOR_POS LV_ALIGN_BOTTOM_RIGHT
 #endif
-
-/*1: Show the used memory and the memory fragmentation
- * Requires LV_MEM_CUSTOM = 0*/
-#define LV_USE_MEM_MONITOR 0
-#if LV_USE_MEM_MONITOR
-    #define LV_USE_MEM_MONITOR_POS LV_ALIGN_BOTTOM_LEFT
-#endif
-
-/*1: Draw random colored rectangles over the redrawn areas*/
-#define LV_USE_REFR_DEBUG 0
-
-/*Change the built in (v)snprintf functions*/
-#define LV_SPRINTF_CUSTOM 0
-#if LV_SPRINTF_CUSTOM
-    #define LV_SPRINTF_INCLUDE <stdio.h>
-    #define lv_snprintf  snprintf
-    #define lv_vsnprintf vsnprintf
-#else   /*LV_SPRINTF_CUSTOM*/
-    #define LV_SPRINTF_USE_FLOAT 0
-#endif  /*LV_SPRINTF_CUSTOM*/
-
-#define LV_USE_USER_DATA 1
-
-/*Garbage Collector settings
- *Used if lvgl is bound to higher level language and the memory is managed by that language*/
-#define LV_ENABLE_GC 0
-#if LV_ENABLE_GC != 0
-    #define LV_GC_INCLUDE "gc.h"                           /*Include Garbage Collector related things*/
-#endif /*LV_ENABLE_GC*/
-
-/*=====================
- *  COMPILER SETTINGS
- *====================*/
-
-/*For big endian systems set to 1*/
-#define LV_BIG_ENDIAN_SYSTEM 0
-
-/*Define a custom attribute to `lv_tick_inc` function*/
-#define LV_ATTRIBUTE_TICK_INC
-
-/*Define a custom attribute to `lv_timer_handler` function*/
-#define LV_ATTRIBUTE_TIMER_HANDLER
-
-/*Define a custom attribute to `lv_disp_flush_ready` function*/
-#define LV_ATTRIBUTE_FLUSH_READY
-
-/*Required alignment size for buffers*/
-#define LV_ATTRIBUTE_MEM_ALIGN_SIZE 1
-
-/*Will be added where memories needs to be aligned (with -Os data might not be aligned to boundary by default).
- * E.g. __attribute__((aligned(4)))*/
-#define LV_ATTRIBUTE_MEM_ALIGN
-
-/*Attribute to mark large constant arrays for example font's bitmaps*/
-#define LV_ATTRIBUTE_LARGE_CONST
-
-/*Compiler prefix for a big array declaration in RAM*/
-#define LV_ATTRIBUTE_LARGE_RAM_ARRAY
-
-/*Place performance critical functions into a faster memory (e.g RAM)*/
-#define LV_ATTRIBUTE_FAST_MEM
-
-/*Prefix variables that are used in GPU accelerated operations, often these need to be placed in RAM sections that are DMA accessible*/
-#define LV_ATTRIBUTE_DMA
-
-/*Export integer constant to binding. This macro is used with constants in the form of LV_<CONST> that
- *should also appear on LVGL binding API such as Micropython.*/
-#define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
-
-/*Extend the default -32k..32k coordinate range to -4M..4M by using int32_t for coordinates instead of int16_t*/
-#define LV_USE_LARGE_COORD 0
 
 /*==================
  *   FONT USAGE
  *===================*/
 
-/*Montserrat fonts with ASCII range and some symbols using bpp = 4
- *https://fonts.google.com/specimen/Montserrat*/
-#define LV_FONT_MONTSERRAT_8  0
 #define LV_FONT_MONTSERRAT_10 1
-#define LV_FONT_MONTSERRAT_12 0
 #define LV_FONT_MONTSERRAT_14 1
-#define LV_FONT_MONTSERRAT_16 0
 #define LV_FONT_MONTSERRAT_18 1
-#define LV_FONT_MONTSERRAT_20 0
-#define LV_FONT_MONTSERRAT_22 0 
 #define LV_FONT_MONTSERRAT_24 1
 #define LV_FONT_MONTSERRAT_26 1
 #define LV_FONT_MONTSERRAT_28 1
-#define LV_FONT_MONTSERRAT_30 0
 #define LV_FONT_MONTSERRAT_32 1
-#define LV_FONT_MONTSERRAT_34 0
 #define LV_FONT_MONTSERRAT_36 1
-#define LV_FONT_MONTSERRAT_38 0
-#define LV_FONT_MONTSERRAT_40 0
-#define LV_FONT_MONTSERRAT_42 0
-#define LV_FONT_MONTSERRAT_44 0
-#define LV_FONT_MONTSERRAT_46 0
 #define LV_FONT_MONTSERRAT_48 1
 
-/*Demonstrate special features*/
-#define LV_FONT_MONTSERRAT_12_SUBPX      0
-#define LV_FONT_MONTSERRAT_28_COMPRESSED 0  /*bpp = 3*/
-#define LV_FONT_DEJAVU_16_PERSIAN_HEBREW 0  /*Hebrew, Arabic, Persian letters and all their forms*/
-#define LV_FONT_SIMSUN_16_CJK            0  /*1000 most common CJK radicals*/
-
-/*Pixel perfect monospace fonts*/
-#define LV_FONT_UNSCII_8  0
-#define LV_FONT_UNSCII_16 0
-
-/*Optionally declare custom fonts here.
- *You can use these fonts as default font too and they will be available globally.
- *E.g. #define LV_FONT_CUSTOM_DECLARE   LV_FONT_DECLARE(my_font_1) LV_FONT_DECLARE(my_font_2)*/
-#define LV_FONT_CUSTOM_DECLARE
-
-/*Always set a default font*/
 #define LV_FONT_DEFAULT &lv_font_montserrat_18
 
-/*Enable handling large font and/or fonts with a lot of characters.
- *The limit depends on the font size, font face and bpp.
- *Compiler error will be triggered if a font needs it.*/
-#define LV_FONT_FMT_TXT_LARGE 0
-
-/*Enables/disables support for compressed fonts.*/
-#define LV_USE_FONT_COMPRESSED 0
-
-/*Enable subpixel rendering*/
-#define LV_USE_FONT_SUBPX 0
-#if LV_USE_FONT_SUBPX
-    /*Set the pixel order of the display. Physical order of RGB channels. Doesn't matter with "normal" fonts.*/
-    #define LV_FONT_SUBPX_BGR 0  /*0: RGB; 1:BGR order*/
-#endif
-
-/*Enable drawing placeholders when glyph dsc is not found*/
-#define LV_USE_FONT_PLACEHOLDER 1
-
-/*=================
- *  TEXT SETTINGS
- *=================*/
-
-/**
- * Select a character encoding for strings.
- * Your IDE or editor should have the same character encoding
- * - LV_TXT_ENC_UTF8
- * - LV_TXT_ENC_ASCII
- */
-#define LV_TXT_ENC LV_TXT_ENC_UTF8
-
-/*Can break (wrap) texts on these chars*/
-#define LV_TXT_BREAK_CHARS " ,.;:-_"
-
-/*If a word is at least this long, will break wherever "prettiest"
- *To disable, set to a value <= 0*/
-#define LV_TXT_LINE_BREAK_LONG_LEN 0
-
-/*Minimum number of characters in a long word to put on a line before a break.
- *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
-#define LV_TXT_LINE_BREAK_LONG_PRE_MIN_LEN 3
-
-/*Minimum number of characters in a long word to put on a line after a break.
- *Depends on LV_TXT_LINE_BREAK_LONG_LEN.*/
-#define LV_TXT_LINE_BREAK_LONG_POST_MIN_LEN 3
-
-/*The control character to use for signalling text recoloring.*/
-#define LV_TXT_COLOR_CMD "#"
-
-/*Support bidirectional texts. Allows mixing Left-to-Right and Right-to-Left texts.
- *The direction will be processed according to the Unicode Bidirectional Algorithm:
- *https://www.w3.org/International/articles/inline-bidi-markup/uba-basics*/
-#define LV_USE_BIDI 0
-#if LV_USE_BIDI
-    /*Set the default direction. Supported values:
-    *`LV_BASE_DIR_LTR` Left-to-Right
-    *`LV_BASE_DIR_RTL` Right-to-Left
-    *`LV_BASE_DIR_AUTO` detect texts base direction*/
-    #define LV_BIDI_BASE_DIR_DEF LV_BASE_DIR_AUTO
-#endif
-
-/*Enable Arabic/Persian processing
- *In these languages characters should be replaced with an other form based on their position in the text*/
-#define LV_USE_ARABIC_PERSIAN_CHARS 0
-
 /*==================
- *  WIDGET USAGE
+ *  WIDGETS / THEMES
  *================*/
 
-/*Documentation of the widgets: https://docs.lvgl.io/latest/en/html/widgets/index.html*/
-
-#define LV_USE_ARC        1
-
-#define LV_USE_BAR        1
-
-#define LV_USE_BTN        1
-
-#define LV_USE_BTNMATRIX  0
-
-#define LV_USE_CANVAS     0
-
-#define LV_USE_CHECKBOX   0
-
-#define LV_USE_DROPDOWN   1   /*Requires: lv_label*/
-
-#define LV_USE_IMG        1   /*Requires: lv_label*/
-
-#define LV_USE_LABEL      1
-#if LV_USE_LABEL
-    #define LV_LABEL_TEXT_SELECTION 0 /*Disable to save RAM*/
-    #define LV_LABEL_LONG_TXT_HINT 0  /*Disable to save RAM*/
-#endif
-
-#define LV_USE_LINE       1
-
-#define LV_USE_ROLLER     0   /*Requires: lv_label*/
-#if LV_USE_ROLLER
-    #define LV_ROLLER_INF_PAGES 7 /*Number of extra "pages" when the roller is infinite*/
-#endif
-
-#define LV_USE_SLIDER     0   /*Requires: lv_bar*/
-
-#define LV_USE_SWITCH     1
-
-#define LV_USE_TEXTAREA   1   /*Requires: lv_label*/
-#if LV_USE_TEXTAREA != 0
-    #define LV_TEXTAREA_DEF_PWD_SHOW_TIME 1500    /*ms*/
-#endif
-
-#define LV_USE_TABLE      0
-
-/*==================
- * EXTRA COMPONENTS
- *==================*/
-
-/*-----------
- * Widgets
- *----------*/
-#define LV_USE_ANIMIMG    0
-
-#define LV_USE_CALENDAR   0
-#if LV_USE_CALENDAR
-    #define LV_CALENDAR_WEEK_STARTS_MONDAY 1
-    #if LV_CALENDAR_WEEK_STARTS_MONDAY
-        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"}
-    #else
-        #define LV_CALENDAR_DEFAULT_DAY_NAMES {"So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"}
-    #endif
-
-    #define LV_CALENDAR_DEFAULT_MONTH_NAMES {"Januar", "Februar", "Maerz", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"}
-    #define LV_USE_CALENDAR_HEADER_ARROW 1
-    #define LV_USE_CALENDAR_HEADER_DROPDOWN 1
-#endif  /*LV_USE_CALENDAR*/
-
-#define LV_USE_CHART      0
-
-#define LV_USE_COLORWHEEL 0
-
-#define LV_USE_IMGBTN     0
-
-#define LV_USE_KEYBOARD   1
-
-#define LV_USE_LED        0
-
-#define LV_USE_LIST       0
-
-#define LV_USE_MENU       0
-
-#define LV_USE_METER      0
-
-#define LV_USE_MSGBOX     0
-
-#define LV_USE_SPAN       0
-#if LV_USE_SPAN
-    /*A line text can contain maximum num of span descriptor */
-    #define LV_SPAN_SNIPPET_STACK_SIZE 64
-#endif
-
-#define LV_USE_SPINBOX    0
-
-#define LV_USE_SPINNER    1
-
-#define LV_USE_TABVIEW    1
-
-#define LV_USE_TILEVIEW   0
-
-#define LV_USE_WIN        0
-
-/*-----------
- * Themes
- *----------*/
-
-/*A simple, impressive and very complete theme*/
-#define LV_USE_THEME_DEFAULT 1
-#if LV_USE_THEME_DEFAULT
-
-    /*0: Light mode; 1: Dark mode*/
-    #define LV_THEME_DEFAULT_DARK 0
-
-    /*1: Enable grow on press*/
-    #define LV_THEME_DEFAULT_GROW 1
-
-    /*Default transition time in [ms]*/
-    #define LV_THEME_DEFAULT_TRANSITION_TIME 80
-#endif /*LV_USE_THEME_DEFAULT*/
-
-/*A very simple theme that is a good starting point for a custom theme*/
-#define LV_USE_THEME_BASIC 0
-
-/*A theme designed for monochrome displays*/
-#define LV_USE_THEME_MONO 0
-
-/*-----------
- * Layouts
- *----------*/
-
-/*A layout similar to Flexbox in CSS.*/
-#define LV_USE_FLEX 1
-
-/*A layout similar to Grid in CSS.*/
-#define LV_USE_GRID 0
-
-/*---------------------
- * 3rd party libraries
- *--------------------*/
-
-/*File system interfaces for common APIs */
-
-/*API for fopen, fread, etc*/
-#define LV_USE_FS_STDIO 0
-#if LV_USE_FS_STDIO
-    #define LV_FS_STDIO_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
-    #define LV_FS_STDIO_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
-    #define LV_FS_STDIO_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
-#endif
-
-/*API for open, read, etc*/
-#define LV_USE_FS_POSIX 0
-#if LV_USE_FS_POSIX
-    #define LV_FS_POSIX_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
-    #define LV_FS_POSIX_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
-    #define LV_FS_POSIX_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
-#endif
-
-/*API for CreateFile, ReadFile, etc*/
-#define LV_USE_FS_WIN32 0
-#if LV_USE_FS_WIN32
-    #define LV_FS_WIN32_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
-    #define LV_FS_WIN32_PATH ""         /*Set the working directory. File/directory paths will be appended to it.*/
-    #define LV_FS_WIN32_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
-#endif
-
-/*API for FATFS (needs to be added separately). Uses f_open, f_read, etc*/
-#define LV_USE_FS_FATFS 0
-#if LV_USE_FS_FATFS
-    #define LV_FS_FATFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
-    #define LV_FS_FATFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
-#endif
-
-/*API for LittleFS (library needs to be added separately). Uses lfs_file_open, lfs_file_read, etc*/
-#define LV_USE_FS_LITTLEFS 0
-#if LV_USE_FS_LITTLEFS
-    #define LV_FS_LITTLEFS_LETTER '\0'     /*Set an upper cased letter on which the drive will accessible (e.g. 'A')*/
-    #define LV_FS_LITTLEFS_CACHE_SIZE 0    /*>0 to cache this number of bytes in lv_fs_read()*/
-#endif
-
-/*PNG decoder library*/
-#define LV_USE_PNG 0
-#define LV_USE_LODEPNG 0
-
-/*BMP decoder library*/
-#define LV_USE_BMP 0
-
-/* JPG + split JPG decoder library.
- * Split JPG is a custom format optimized for embedded systems. */
-#define LV_USE_SJPG 0
-
-/*GIF decoder library*/
-#define LV_USE_GIF 0
-
-/*QR code library*/
-#define LV_USE_QRCODE 0
-
-/*FreeType library*/
-#define LV_USE_FREETYPE 0
-#if LV_USE_FREETYPE
-    /*Memory used by FreeType to cache characters [bytes] (-1: no caching)*/
-    #define LV_FREETYPE_CACHE_SIZE (16 * 1024)
-    #if LV_FREETYPE_CACHE_SIZE >= 0
-        /* 1: bitmap cache use the sbit cache, 0:bitmap cache use the image cache. */
-        /* sbit cache:it is much more memory efficient for small bitmaps(font size < 256) */
-        /* if font size >= 256, must be configured as image cache */
-        #define LV_FREETYPE_SBIT_CACHE 0
-        /* Maximum number of opened FT_Face/FT_Size objects managed by this cache instance. */
-        /* (0:use system defaults) */
-        #define LV_FREETYPE_CACHE_FT_FACES 0
-        #define LV_FREETYPE_CACHE_FT_SIZES 0
-    #endif
-#endif
-
-/*Tiny TTF library*/
-#define LV_USE_TINY_TTF 0
-#if LV_USE_TINY_TTF
-    /*Load TTF data from files*/
-    #define LV_TINY_TTF_FILE_SUPPORT 0
-#endif
-
-/*Rlottie library*/
-#define LV_USE_RLOTTIE 0
-
-/*FFmpeg library for image decoding and playing videos
- *Supports all major image formats so do not enable other image decoder with it*/
-#define LV_USE_FFMPEG 0
-#if LV_USE_FFMPEG
-    /*Dump input information to stderr*/
-    #define LV_FFMPEG_DUMP_FORMAT 0
-#endif
-
-/*-----------
- * Others
- *----------*/
-
-/*1: Enable API to take snapshot for object*/
-#define LV_USE_SNAPSHOT 0
-
-/*1: Enable Monkey test*/
-#define LV_USE_MONKEY 0
-
-/*1: Enable grid navigation*/
-#define LV_USE_GRIDNAV 0
-
-/*1: Enable lv_obj fragment*/
-#define LV_USE_FRAGMENT 0
-
-/*1: Support using images as font in label or span widgets */
-#define LV_USE_IMGFONT 0
-
-/*1: Enable a published subscriber based messaging system */
-#define LV_USE_MSG 0
-
-/*1: Enable Pinyin input method*/
-/*Requires: lv_keyboard*/
-#define LV_USE_IME_PINYIN 0
-#if LV_USE_IME_PINYIN
-    /*1: Use default thesaurus*/
-    /*If you do not use the default thesaurus, be sure to use `lv_ime_pinyin` after setting the thesauruss*/
-    #define LV_IME_PINYIN_USE_DEFAULT_DICT 1
-    /*Set the maximum number of candidate panels that can be displayed*/
-    /*This needs to be adjusted according to the size of the screen*/
-    #define LV_IME_PINYIN_CAND_TEXT_NUM 6
-
-    /*Use 9 key input(k9)*/
-    #define LV_IME_PINYIN_USE_K9_MODE      1
-    #if LV_IME_PINYIN_USE_K9_MODE == 1
-        #define LV_IME_PINYIN_K9_CAND_TEXT_NUM 3
-    #endif // LV_IME_PINYIN_USE_K9_MODE
-#endif
-
-/*==================
-* EXAMPLES
-*==================*/
-
-/*Enable the examples to be built with the library*/
-#define LV_BUILD_EXAMPLES 0
-
-/*===================
- * DEMO USAGE
- ====================*/
-
-/*Show some widget. It might be required to increase `LV_MEM_SIZE` */
-#define LV_USE_DEMO_WIDGETS 0
-#if LV_USE_DEMO_WIDGETS
-#define LV_DEMO_WIDGETS_SLIDESHOW 1
-#endif
-
-/*Demonstrate the usage of encoder and keyboard*/
-#define LV_USE_DEMO_KEYPAD_AND_ENCODER 0
-
-/*Benchmark your system*/
-#define LV_USE_DEMO_BENCHMARK 0
-#if LV_USE_DEMO_BENCHMARK
-/*Use RGB565A8 images with 16 bit color depth instead of ARGB8565*/
-#define LV_DEMO_BENCHMARK_RGB565A8 0
-#endif
-
-/*Stress test for LVGL*/
-#define LV_USE_DEMO_STRESS 0
-
-/*Music player demo*/
-#define LV_USE_DEMO_MUSIC 0
-#if LV_USE_DEMO_MUSIC
-    #define LV_DEMO_MUSIC_SQUARE    0
-    #define LV_DEMO_MUSIC_LANDSCAPE 0
-    #define LV_DEMO_MUSIC_ROUND     0
-    #define LV_DEMO_MUSIC_LARGE     0
-    #define LV_DEMO_MUSIC_AUTO_PLAY 0
-#endif
+/*v9 defaults (all widgets + default theme enabled) — matches what the firmware
+ *has effectively been running since the v9 migration. Do not trim without
+ *re-testing every screen.*/
 
 /*--END OF LV_CONF_H--*/
 

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -13,10 +13,17 @@
 monitor_speed = 115200
 monitor_echo = true
 monitor_filters = esp32_exception_decoder
-build_type = debug
+; Production firmware is CPU-bound (LVGL software rendering): build optimized.
+; build_type=release defaults to -Os; unflag it and use -O2 instead — flash is
+; 16 MB, size is not a constraint (ATT-554 item 4). For debugging use the
+; [env:attractap-touch-debug] env below (skipped by build_firmwares.py).
+build_type = release
+build_unflags =
+	-Os
 extra_scripts =
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
+	-O2
 	-D FIRMWARE_VERSION='"1.3.23"'
 
 [env:attractap-touch]
@@ -215,3 +222,12 @@ build_flags =
 	-D PIN_ETH_SPI_SCK=13
 
 	-D BEEPER_PIN=21
+
+; Development-only variant (-Og + debug symbols) of attractap-touch.
+; Not a shipped firmware: build_firmwares.py skips '*-debug' environments.
+[env:attractap-touch-debug]
+extends = env:attractap-touch
+build_type = debug
+build_unflags =
+	-Os
+	-O2

--- a/apps/attractap/firmware/src/application/application.cpp
+++ b/apps/attractap/firmware/src/application/application.cpp
@@ -152,7 +152,7 @@ void Application::setup() {
     Payload *pl = new Payload{this, sumUpEnabled};
     if (!pl)
       return;
-    lv_async_call(
+    Display::asyncCall(
         [](void *u) {
           auto *p = (Payload *)u;
           if (!p || !p->self) {
@@ -203,7 +203,7 @@ void Application::setup() {
     p->self = this;
     p->t = String(title);
     p->m = String(message);
-    lv_async_call(
+    Display::asyncCall(
         [](void *u) {
           auto *pl = (ErrPayload *)u;
           if (!pl || !pl->self) {
@@ -242,7 +242,7 @@ void Application::setup() {
     if (type) {
       p->eventType = String(type);
     }
-    lv_async_call(
+    Display::asyncCall(
         [](void *u) {
           ActionResultPayload *pl = static_cast<ActionResultPayload *>(u);
           if (pl && pl->self) {
@@ -403,7 +403,7 @@ void Application::setup() {
         (void)request; // The data is in api.getFormRequestScratch()
         this->pendingFormRequestReady = true;
         // Schedule the copy + UI update on LVGL thread
-        lv_async_call(
+        Display::asyncCall(
             [](void *u) {
               auto *self = static_cast<Application *>(u);
               if (self && self->pendingFormRequestReady) {
@@ -421,7 +421,7 @@ void Application::setup() {
       [this](const API::ResourceUsageFormFieldsPage &page) {
         (void)page; // The data is in api.getFormFieldsScratch()
         this->pendingFormFieldsReady = true;
-        lv_async_call(
+        Display::asyncCall(
             [](void *u) {
               auto *self = static_cast<Application *>(u);
               if (self && self->pendingFormFieldsReady) {
@@ -437,7 +437,7 @@ void Application::setup() {
       [this](const API::ResourceUsageFormPageResult &result) {
         (void)result; // The data is in api.getFormPageResultScratch()
         this->pendingFormPageResultReady = true;
-        lv_async_call(
+        Display::asyncCall(
             [](void *u) {
               auto *self = static_cast<Application *>(u);
               if (self && self->pendingFormPageResultReady) {
@@ -550,7 +550,15 @@ void Application::loop() {
 
     this->api.loop();
 
+#ifdef HAS_LVGL_DISPLAY
+  // processState mutates LVGL (screen transitions, popups, screen setters);
+  // rendering runs on LvglTask, so serialize with lv_lock (recursive).
+  lv_lock();
   this->processState();
+  lv_unlock();
+#else
+  this->processState();
+#endif
 
 #ifdef ESP_PLATFORM
   vTaskDelay(pdMS_TO_TICKS(1));

--- a/apps/attractap/firmware/src/application/application.cpp
+++ b/apps/attractap/firmware/src/application/application.cpp
@@ -23,17 +23,6 @@ void Application::networkTask(void *parameter) {
   }
 }
 
-void Application::nfcTask(void *parameter) {
-  Application *app = static_cast<Application *>(parameter);
-  while (true) {
-    // NFC::loop() rate-limits its own PN532 polls (detection ~125 ms, presence
-    // check ~250 ms); this short delay just keeps the task cooperative between
-    // checks without adding meaningful detection latency.
-    app->nfc.loop();
-    vTaskDelay(pdMS_TO_TICKS(10));
-  }
-}
-
 #ifdef HAS_WS2812_LED
 void Application::ledTask(void *parameter) {
   Application *app = static_cast<Application *>(parameter);
@@ -515,13 +504,6 @@ void Application::setup() {
   xTaskCreate(Application::networkTask, "NetworkTask", 4096, nullptr,
               tskIDLE_PRIORITY, nullptr);
 
-  // NFC polling on its own task (like NetworkTask/LedTask): blocking PN532 I2C
-  // time no longer costs the UI anything. 8 KB stack: the detection callback can
-  // run the full NTAG424 AES handshake (mbedtls CMAC) on this task. Priority 1:
-  // above the idle-priority app/network tasks so polls run on schedule, below
-  // the websocket/render tasks.
-  xTaskCreate(Application::nfcTask, "NfcTask", 8192, this, 1, nullptr);
-
 #ifdef ESP_PLATFORM
   esp_task_wdt_add(NULL);
 #endif
@@ -546,9 +528,13 @@ void Application::loop() {
   Display::loop();
 #endif
 
-    // nfc.loop() runs on NfcTask (ATT-554 item 6)
+  // NFC polling back on the main loop (ATT-554 item 6 reverted for isolation:
+  // the dedicated NFC task + concurrent bus use is the prime suspect for the
+  // field I2C wedge). Blocking PN532 time costs only this loop — rendering and
+  // touch live on LvglTask.
+  this->nfc.loop();
 
-    this->api.loop();
+  this->api.loop();
 
 #ifdef HAS_LVGL_DISPLAY
   // processState mutates LVGL (screen transitions, popups, screen setters);

--- a/apps/attractap/firmware/src/application/application.cpp
+++ b/apps/attractap/firmware/src/application/application.cpp
@@ -23,6 +23,17 @@ void Application::networkTask(void *parameter) {
   }
 }
 
+void Application::nfcTask(void *parameter) {
+  Application *app = static_cast<Application *>(parameter);
+  while (true) {
+    // NFC::loop() rate-limits its own PN532 polls (detection ~125 ms, presence
+    // check ~250 ms); this short delay just keeps the task cooperative between
+    // checks without adding meaningful detection latency.
+    app->nfc.loop();
+    vTaskDelay(pdMS_TO_TICKS(10));
+  }
+}
+
 #ifdef HAS_WS2812_LED
 void Application::ledTask(void *parameter) {
   Application *app = static_cast<Application *>(parameter);
@@ -504,6 +515,13 @@ void Application::setup() {
   xTaskCreate(Application::networkTask, "NetworkTask", 4096, nullptr,
               tskIDLE_PRIORITY, nullptr);
 
+  // NFC polling on its own task (like NetworkTask/LedTask): blocking PN532 I2C
+  // time no longer costs the UI anything. 8 KB stack: the detection callback can
+  // run the full NTAG424 AES handshake (mbedtls CMAC) on this task. Priority 1:
+  // above the idle-priority app/network tasks so polls run on schedule, below
+  // the websocket/render tasks.
+  xTaskCreate(Application::nfcTask, "NfcTask", 8192, this, 1, nullptr);
+
 #ifdef ESP_PLATFORM
   esp_task_wdt_add(NULL);
 #endif
@@ -528,7 +546,7 @@ void Application::loop() {
   Display::loop();
 #endif
 
-    nfc.loop();
+    // nfc.loop() runs on NfcTask (ATT-554 item 6)
 
     this->api.loop();
 

--- a/apps/attractap/firmware/src/application/application.hpp
+++ b/apps/attractap/firmware/src/application/application.hpp
@@ -173,6 +173,10 @@ private:
     static void
     networkTask(void *parameter);
 
+    // Dedicated task for NFC polling: PN532 transactions block the shared I2C
+    // bus, so they must not run on the UI-driving main loop (ATT-554 item 6).
+    static void nfcTask(void *parameter);
+
 #ifdef HAS_WS2812_LED
     static void ledTask(void *parameter);
 #endif

--- a/apps/attractap/firmware/src/application/application.hpp
+++ b/apps/attractap/firmware/src/application/application.hpp
@@ -173,10 +173,6 @@ private:
     static void
     networkTask(void *parameter);
 
-    // Dedicated task for NFC polling: PN532 transactions block the shared I2C
-    // bus, so they must not run on the UI-driving main loop (ATT-554 item 6).
-    static void nfcTask(void *parameter);
-
 #ifdef HAS_WS2812_LED
     static void ledTask(void *parameter);
 #endif

--- a/apps/attractap/firmware/src/application/application_session.cpp
+++ b/apps/attractap/firmware/src/application/application_session.cpp
@@ -77,7 +77,12 @@ void Application::clearProjectSelection() {
   this->projectsOfUserResponse.limit = API::MAX_PROJECTS_PER_PAGE;
   this->projectsOfUserResponse.hasMore = false;
   this->projectsOfUserResponseUpdated = true;
+  // Reached from the websocket task (card auth response) as well as from LVGL
+  // event callbacks; rendering runs on its own task now, so guard the LVGL
+  // mutation explicitly (lv_lock is recursive).
+  lv_lock();
   Display::resourceDetailsScreen.setSelectedProject(0, nullptr);
+  lv_unlock();
 }
 
 void Application::handleProjectSelection(uint32_t projectId,

--- a/apps/attractap/firmware/src/display/display.cpp
+++ b/apps/attractap/firmware/src/display/display.cpp
@@ -149,6 +149,7 @@ void Display::setup()
             recoverI2CBus(PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
             Wire.begin(PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
             Wire.setTimeOut(50);
+            Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
 #endif
             delay(200);
         }

--- a/apps/attractap/firmware/src/display/display.cpp
+++ b/apps/attractap/firmware/src/display/display.cpp
@@ -2,6 +2,8 @@
 
 #include <Wire.h>
 #include "../utils.hpp"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 #ifdef HAS_IO_EXPANDER
 #include "../ioexpander/ioexpander.hpp"
@@ -230,7 +232,44 @@ void Display::setup()
         s_touchWarningPending = true;
     }
 
+    // Rendering + touch sampling on a dedicated task (ATT-554 item 7), pinned to
+    // core 1 (away from the WiFi/LwIP core) at priority 4: above the app loop,
+    // NFC task (1) and websocket client (3), so input/refresh never wait behind
+    // blocking application work.
+    xTaskCreatePinnedToCore(Display::renderTask, "LvglTask", 8192, nullptr, 4, nullptr, 1);
+
     Display::logger.info("Setup done");
+}
+
+void Display::renderTask(void *parameter)
+{
+    (void)parameter;
+    while (true)
+    {
+        // lv_timer_handler self-locks via lv_lock() (LV_USE_OS LV_OS_FREERTOS)
+        // and returns the time until the next ready timer.
+        uint32_t delayMs = lv_timer_handler();
+        if (delayMs == LV_NO_TIMER_READY)
+        {
+            delayMs = LV_DEF_REFR_PERIOD;
+        }
+        if (delayMs < 1)
+        {
+            delayMs = 1;
+        }
+        else if (delayMs > LV_DEF_REFR_PERIOD)
+        {
+            delayMs = LV_DEF_REFR_PERIOD;
+        }
+        vTaskDelay(pdMS_TO_TICKS(delayMs));
+    }
+}
+
+void Display::asyncCall(lv_async_cb_t cb, void *user_data)
+{
+    lv_lock();
+    lv_async_call(cb, user_data);
+    lv_unlock();
 }
 
 bool Display::hasTouchInput()
@@ -240,6 +279,11 @@ bool Display::hasTouchInput()
 
 void Display::loop()
 {
+    // Runs on the main application loop; rendering itself lives on LvglTask
+    // (renderTask). Everything below mutates LVGL objects, so hold lv_lock for
+    // the duration (recursive FreeRTOS mutex, also taken by lv_timer_handler).
+    lv_lock();
+
     if (s_touchWarningPending)
     {
         s_touchWarningPending = false;
@@ -247,7 +291,6 @@ void Display::loop()
                                 "Touch panel not detected.\nCheck hardware and reboot.");
     }
 
-    lv_timer_handler(); /* let the GUI do its work */
     if (Display::activeScreen)
     {
         Display::activeScreen->loop();
@@ -284,4 +327,6 @@ void Display::loop()
             }
         }
     }
+
+    lv_unlock();
 }

--- a/apps/attractap/firmware/src/display/display.cpp
+++ b/apps/attractap/firmware/src/display/display.cpp
@@ -147,11 +147,16 @@ void Display::setup()
         if (attempt < MAX_DISPLAY_INIT_ATTEMPTS)
         {
 #if defined(DISPLAY_DRIVER_GT911) && defined(PIN_TOUCH_I2C_SDA) && defined(PIN_TOUCH_I2C_SCL)
-            // Free any I2C slave stuck mid-transaction before the next attempt.
-            recoverI2CBus(PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
-            Wire.begin(PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
-            Wire.setTimeOut(50);
-            Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
+            {
+                // Bit-banging the pins + re-running Wire.begin() must not race
+                // other bus users (ATT-554).
+                I2CBusGuard busGuard;
+                // Free any I2C slave stuck mid-transaction before the next attempt.
+                recoverI2CBus(PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
+                Wire.begin(PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
+                Wire.setTimeOut(50);
+                Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
+            }
 #endif
             delay(200);
         }

--- a/apps/attractap/firmware/src/display/display.hpp
+++ b/apps/attractap/firmware/src/display/display.hpp
@@ -66,7 +66,19 @@ public:
     // application; reboot is handled internally (esp_restart after a confirm).
     static void setOnOpenSettingsCallback(std::function<void()> callback);
 
+    /**
+     * Thread-safe lv_async_call: takes lv_lock() around the timer-list
+     * manipulation. Use this instead of raw lv_async_call from any task other
+     * than the LVGL render task (e.g. websocket callbacks) - rendering runs on
+     * its own task now (ATT-554 item 7).
+     */
+    static void asyncCall(lv_async_cb_t cb, void *user_data);
+
 private:
+    // Dedicated LVGL task (ATT-554 item 7): runs lv_timer_handler (rendering +
+    // indev/touch reads; self-locking via lv_lock) so UI refresh no longer
+    // shares the main application loop with blocking work.
+    static void renderTask(void *parameter);
     static std::function<void(int16_t, int16_t)> touchCallback;
     static const int TRANSITION_DURATION = 500;
     // static const int TRANSITION_DURATION = 50;

--- a/apps/attractap/firmware/src/display/display_overlay.cpp
+++ b/apps/attractap/firmware/src/display/display_overlay.cpp
@@ -64,7 +64,7 @@ void Display::setDeviceName(String deviceName)
         return;
     }
     strcpy(text, deviceName.c_str());
-    lv_async_call(
+    Display::asyncCall(
         [](void *p)
         {
             if (Display::deviceNameLabel)

--- a/apps/attractap/firmware/src/display/driver/gt911/rgb_gt911_driver.cpp
+++ b/apps/attractap/firmware/src/display/driver/gt911/rgb_gt911_driver.cpp
@@ -1,8 +1,132 @@
 #include "rgb_gt911_driver.hpp"
+#include "../../../utils.hpp"
 
 #ifdef HAS_IO_EXPANDER
 #include "../../../ioexpander/ioexpander.hpp"
 #endif
+
+// st7701_type1_init_operations (Arduino_RGB_Display.h) with the 180° flip done
+// in the panel itself instead of in software (ATT-554 item 2):
+//   - BK0 0xC7 (SDIR) = 0x04: source scan S960->S1 (X mirror)
+//   - MADCTL 0x36 = 0x10 (ML): line scan bottom->top (Y mirror)
+// The previous `rotation 2` made every LVGL flush take the per-pixel
+// reversed-index copy path (gfx_draw_bitmap_to_framebuffer_rotate_2) into the
+// PSRAM framebuffer; with the flip in hardware we can pass rotation 0 and hit
+// the row-memcpy fast path. Touch coordinates are mirrored in readTouch().
+static const uint8_t st7701_type1_flip180_init_operations[] = {
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x10,
+
+    WRITE_C8_D16, 0xC0, 0x3B, 0x00,
+    WRITE_C8_D16, 0xC1, 0x0D, 0x02,
+    WRITE_C8_D16, 0xC2, 0x31, 0x05,
+    WRITE_C8_D8, 0xC7, 0x04, // SDIR: X mirror (180° flip, part 1)
+    WRITE_C8_D8, 0xCD, 0x08,
+
+    WRITE_COMMAND_8, 0xB0, // Positive Voltage Gamma Control
+    WRITE_BYTES, 16,
+    0x00, 0x11, 0x18, 0x0E,
+    0x11, 0x06, 0x07, 0x08,
+    0x07, 0x22, 0x04, 0x12,
+    0x0F, 0xAA, 0x31, 0x18,
+
+    WRITE_COMMAND_8, 0xB1, // Negative Voltage Gamma Control
+    WRITE_BYTES, 16,
+    0x00, 0x11, 0x19, 0x0E,
+    0x12, 0x07, 0x08, 0x08,
+    0x08, 0x22, 0x04, 0x11,
+    0x11, 0xA9, 0x32, 0x18,
+
+    // PAGE1
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x11,
+
+    WRITE_C8_D8, 0xB0, 0x60, // Vop=4.7375v
+    WRITE_C8_D8, 0xB1, 0x32, // VCOM=32
+    WRITE_C8_D8, 0xB2, 0x07, // VGH=15v
+    WRITE_C8_D8, 0xB3, 0x80,
+    WRITE_C8_D8, 0xB5, 0x49, // VGL=-10.17v
+    WRITE_C8_D8, 0xB7, 0x85,
+    WRITE_C8_D8, 0xB8, 0x21, // AVDD=6.6 & AVCL=-4.6
+    WRITE_C8_D8, 0xC1, 0x78,
+    WRITE_C8_D8, 0xC2, 0x78,
+
+    WRITE_COMMAND_8, 0xE0,
+    WRITE_BYTES, 3, 0x00, 0x1B, 0x02,
+
+    WRITE_COMMAND_8, 0xE1,
+    WRITE_BYTES, 11,
+    0x08, 0xA0, 0x00, 0x00,
+    0x07, 0xA0, 0x00, 0x00,
+    0x00, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE2,
+    WRITE_BYTES, 12,
+    0x11, 0x11, 0x44, 0x44,
+    0xED, 0xA0, 0x00, 0x00,
+    0xEC, 0xA0, 0x00, 0x00,
+
+    WRITE_COMMAND_8, 0xE3,
+    WRITE_BYTES, 4, 0x00, 0x00, 0x11, 0x11,
+
+    WRITE_C8_D16, 0xE4, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE5,
+    WRITE_BYTES, 16,
+    0x0A, 0xE9, 0xD8, 0xA0,
+    0x0C, 0xEB, 0xD8, 0xA0,
+    0x0E, 0xED, 0xD8, 0xA0,
+    0x10, 0xEF, 0xD8, 0xA0,
+
+    WRITE_COMMAND_8, 0xE6,
+    WRITE_BYTES, 4, 0x00, 0x00, 0x11, 0x11,
+
+    WRITE_C8_D16, 0xE7, 0x44, 0x44,
+
+    WRITE_COMMAND_8, 0xE8,
+    WRITE_BYTES, 16,
+    0x09, 0xE8, 0xD8, 0xA0,
+    0x0B, 0xEA, 0xD8, 0xA0,
+    0x0D, 0xEC, 0xD8, 0xA0,
+    0x0F, 0xEE, 0xD8, 0xA0,
+
+    WRITE_COMMAND_8, 0xEB,
+    WRITE_BYTES, 7,
+    0x02, 0x00, 0xE4, 0xE4,
+    0x88, 0x00, 0x40,
+
+    WRITE_C8_D16, 0xEC, 0x3C, 0x00,
+
+    WRITE_COMMAND_8, 0xED,
+    WRITE_BYTES, 16,
+    0xAB, 0x89, 0x76, 0x54,
+    0x02, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0x20,
+    0x45, 0x67, 0x98, 0xBA,
+
+    //-----------VAP & VAN---------------
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x13,
+
+    WRITE_C8_D8, 0xE5, 0xE4,
+
+    WRITE_COMMAND_8, 0xFF,
+    WRITE_BYTES, 5, 0x77, 0x01, 0x00, 0x00, 0x00,
+
+    WRITE_C8_D8, 0x36, 0x10, // MADCTL ML: Y mirror (180° flip, part 2)
+
+    WRITE_COMMAND_8, 0x21,   // 0x20 normal, 0x21 IPS
+    WRITE_C8_D8, 0x3A, 0x60, // 0x70 RGB888, 0x60 RGB666, 0x50 RGB565
+
+    WRITE_COMMAND_8, 0x11, // Sleep Out
+    END_WRITE,
+
+    DELAY, 120,
+
+    BEGIN_WRITE,
+    WRITE_COMMAND_8, 0x29, // Display On
+    END_WRITE};
 
 #ifdef HAS_IO_EXPANDER
 RgbGt911Driver::RgbGt911Driver(Logger &logger, IOExpander *ioExpander)
@@ -43,10 +167,13 @@ bool RgbGt911Driver::begin()
         touchFound = touch.begin(Wire, GT911_SLAVE_ADDRESS_L, PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
     }
     // SensorCommon::begin() (called inside touch.begin()) re-invokes Wire.begin() on ESP32,
-    // which resets Wire.setTimeOut() back to the framework default (no timeout).
+    // which resets Wire.setTimeOut() back to the framework default (no timeout) and can
+    // reset the bus clock back to the 100 kHz default.
     // Restore the 50 ms timeout so that subsequent I2C operations (IO expander fullRefresh,
-    // NFC) do not stall indefinitely on a busy or stuck bus.
+    // NFC) do not stall indefinitely on a busy or stuck bus, and restore the 400 kHz
+    // Fast Mode clock so every bus hold stays short.
     Wire.setTimeOut(50);
+    Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
 
     if (touchFound)
     {
@@ -84,8 +211,8 @@ bool RgbGt911Driver::begin()
         1 /* vsync_polarity */, 10 /* vsync_front_porch */, 8 /* vsync_pulse_width */, 20 /* vsync_back_porch */);
 
     gfx = new Arduino_RGB_Display(
-        480 /* width */, 480 /* height */, rgbpanel, 2 /* rotation */, true /* auto_flush */,
-        bus, GFX_NOT_DEFINED /* RST */, st7701_type1_init_operations, sizeof(st7701_type1_init_operations));
+        480 /* width */, 480 /* height */, rgbpanel, 0 /* rotation: 180° flip is done by the panel init sequence */, true /* auto_flush */,
+        bus, GFX_NOT_DEFINED /* RST */, st7701_type1_flip180_init_operations, sizeof(st7701_type1_flip180_init_operations));
 
     logger.info("Calling gfx->begin()...");
     gfx->begin();
@@ -129,31 +256,11 @@ bool RgbGt911Driver::readTouch(TouchPoint &point)
 
     logger.debugf("Touch detected: touched=%d, x=%d, y=%d", touched, x[0], y[0]);
 
-    int16_t touchX = x[0];
-    int16_t touchY = y[0];
-
-    switch (gfx->getRotation())
-    {
-    case 0:
-        break;
-    case 1:
-        touchX = y[0];
-        touchY = gfx->height() - x[0];
-        break;
-    case 2:
-        touchX = gfx->width() - x[0];
-        touchY = gfx->height() - y[0];
-        break;
-    case 3:
-        touchX = gfx->width() - y[0];
-        touchY = x[0];
-        break;
-    default:
-        break;
-    }
-
-    point.x = touchX;
-    point.y = touchY;
+    // The 180° flip lives in the panel init sequence (gfx rotation is 0), so the
+    // GT911 still reports coordinates in the unflipped orientation: mirror both
+    // axes to match what is on screen.
+    point.x = (int16_t)(gfx->width() - 1) - x[0];
+    point.y = (int16_t)(gfx->height() - 1) - y[0];
     point.pressed = true;
     return true;
 }

--- a/apps/attractap/firmware/src/display/driver/gt911/rgb_gt911_driver.cpp
+++ b/apps/attractap/firmware/src/display/driver/gt911/rgb_gt911_driver.cpp
@@ -160,20 +160,25 @@ bool RgbGt911Driver::begin()
     touch.setPins(-1, 16);
 
     logger.infof("Probing GT911 at 0x%02X (SDA=%d, SCL=%d)...", GT911_SLAVE_ADDRESS_H, PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
-    bool touchFound = touch.begin(Wire, GT911_SLAVE_ADDRESS_H, PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
-    if (!touchFound)
+    bool touchFound = false;
     {
-        logger.infof("GT911 not found at 0x%02X, trying 0x%02X...", GT911_SLAVE_ADDRESS_H, GT911_SLAVE_ADDRESS_L);
-        touchFound = touch.begin(Wire, GT911_SLAVE_ADDRESS_L, PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
+        // Keep the whole GT911 probe/init atomic on the shared bus (ATT-554).
+        I2CBusGuard busGuard;
+        touchFound = touch.begin(Wire, GT911_SLAVE_ADDRESS_H, PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
+        if (!touchFound)
+        {
+            logger.infof("GT911 not found at 0x%02X, trying 0x%02X...", GT911_SLAVE_ADDRESS_H, GT911_SLAVE_ADDRESS_L);
+            touchFound = touch.begin(Wire, GT911_SLAVE_ADDRESS_L, PIN_TOUCH_I2C_SDA, PIN_TOUCH_I2C_SCL);
+        }
+        // SensorCommon::begin() (called inside touch.begin()) re-invokes Wire.begin() on ESP32,
+        // which resets Wire.setTimeOut() back to the framework default (no timeout) and can
+        // reset the bus clock back to the 100 kHz default.
+        // Restore the 50 ms timeout so that subsequent I2C operations (IO expander fullRefresh,
+        // NFC) do not stall indefinitely on a busy or stuck bus, and restore the 400 kHz
+        // Fast Mode clock so every bus hold stays short.
+        Wire.setTimeOut(50);
+        Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
     }
-    // SensorCommon::begin() (called inside touch.begin()) re-invokes Wire.begin() on ESP32,
-    // which resets Wire.setTimeOut() back to the framework default (no timeout) and can
-    // reset the bus clock back to the 100 kHz default.
-    // Restore the 50 ms timeout so that subsequent I2C operations (IO expander fullRefresh,
-    // NFC) do not stall indefinitely on a busy or stuck bus, and restore the 400 kHz
-    // Fast Mode clock so every bus hold stays short.
-    Wire.setTimeOut(50);
-    Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
 
     if (touchFound)
     {
@@ -247,7 +252,16 @@ bool RgbGt911Driver::readTouch(TouchPoint &point)
         return false;
     }
 
-    uint8_t touched = touch.getPoint(x, y, touch.getSupportTouchPoint());
+    uint8_t touched = 0;
+    {
+        // One GT911 point read = one atomic conversation on the shared bus, so
+        // it can never interleave with a PN532 exchange on the NFC task
+        // (ATT-554 crash: interleaved transactions wedged the I2C driver).
+        // NOTE: we already hold lv_lock here (LVGL indev read) — I2CBusGuard is
+        // a leaf lock, NFC code never takes lv_lock while holding it.
+        I2CBusGuard busGuard;
+        touched = touch.getPoint(x, y, touch.getSupportTouchPoint());
+    }
 
     if (touched <= 0)
     {

--- a/apps/attractap/firmware/src/display/driver/qualia/qualia_ft_cst_driver.cpp
+++ b/apps/attractap/firmware/src/display/driver/qualia/qualia_ft_cst_driver.cpp
@@ -1,4 +1,5 @@
 #include "qualia_ft_cst_driver.hpp"
+#include "../../../utils.hpp"
 
 #ifndef I2C_TOUCH_ADDR
 #define I2C_TOUCH_ADDR 0x48
@@ -118,6 +119,10 @@ bool QualiaFtCstDriver::readTouch(TouchPoint &point)
     {
         return false;
     }
+
+    // Serialize the touch read against PN532 traffic on the shared bus
+    // (ATT-554) — same rationale as RgbGt911Driver::readTouch.
+    I2CBusGuard busGuard;
 
     if (isFocalTouch)
     {

--- a/apps/attractap/firmware/src/display/screens/IScreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/IScreen.hpp
@@ -3,6 +3,28 @@
 #include <lvgl.h>
 #include <Arduino.h>
 
+/**
+ * Set a label's text only when it actually changed.
+ *
+ * lv_label_set_text() invalidates the label unconditionally, so calling it from
+ * a screen's loop() every tick re-renders the label every refresh cycle forever
+ * (ATT-554 item 5). Compare against the current text first; screen loop()
+ * implementations must use this instead of raw lv_label_set_text().
+ */
+static inline void setLabelTextIfChanged(lv_obj_t *label, const char *text)
+{
+    if (label == nullptr || text == nullptr)
+    {
+        return;
+    }
+    const char *current = lv_label_get_text(label);
+    if (current != nullptr && strcmp(current, text) == 0)
+    {
+        return;
+    }
+    lv_label_set_text(label, text);
+}
+
 class IScreen
 {
 public:

--- a/apps/attractap/firmware/src/display/screens/init/initscreen.cpp
+++ b/apps/attractap/firmware/src/display/screens/init/initscreen.cpp
@@ -254,6 +254,14 @@ void InitScreen::init()
    lv_obj_set_style_text_font(openSettingsButtonLabel, &lv_font_montserrat_26, LV_PART_MAIN | LV_STATE_DEFAULT);
 
    lv_obj_add_event_cb(openSettingsButton, &InitScreen::onOpenSettingsButtonEvent, LV_EVENT_CLICKED, this);
+
+   // init() applied resetState (= PENDING visuals) to every row above; keep the
+   // change-detection caches in sync so loop() only re-styles on real transitions.
+   this->wifiStage = StageState::PENDING;
+   this->ethernetStage = StageState::PENDING;
+   this->apiConnectionStage = StageState::PENDING;
+   this->apiAuthenticationStage = StageState::PENDING;
+   this->lastLoopRefreshMs = 0;
 }
 
 void InitScreen::onOpenSettingsButtonEvent(lv_event_t *e)
@@ -271,30 +279,62 @@ lv_obj_t *InitScreen::getScreen()
    return this->screen;
 }
 
+void InitScreen::applyStage(lv_obj_t *spinner, lv_obj_t *label, StageState newState, StageState &cached)
+{
+   if (newState == cached)
+   {
+      return;
+   }
+   cached = newState;
+
+   switch (newState)
+   {
+   case StageState::SUCCESS:
+      this->markStateAsSuccess(spinner, label);
+      break;
+   case StageState::WARNING:
+      this->markStateAsWarning(spinner, label);
+      break;
+   case StageState::PENDING:
+   default:
+      this->resetState(spinner, label);
+      break;
+   }
+}
+
 void InitScreen::loop()
 {
+   // Throttle: this screen redraws while WiFi/TLS work runs; updating LVGL (and
+   // building Strings) every tick caused a permanent redraw storm (ATT-554 item 5).
+   uint32_t now = millis();
+   if (now - this->lastLoopRefreshMs < LOOP_REFRESH_INTERVAL_MS)
+   {
+      return;
+   }
+   this->lastLoopRefreshMs = now;
+
    State::NetworkState networkState = State::getNetworkState();
    // TODO: extend network state and network interface classes to be more descriptive (in progress, success, error and maybe error reason)
    if (networkState.wifi_connected)
    {
-      lv_label_set_text(this->wifiLabel, ("WLAN  " + this->formatIp(networkState.wifi_ip)).c_str());
-      this->markStateAsSuccess(this->wifiSpinner, this->wifiLabel);
+      setLabelTextIfChanged(this->wifiLabel, ("WLAN  " + this->formatIp(networkState.wifi_ip)).c_str());
+      this->applyStage(this->wifiSpinner, this->wifiLabel, StageState::SUCCESS, this->wifiStage);
    }
    else
    {
-      lv_label_set_text(this->wifiLabel, "verbinde WLAN");
-      this->resetState(this->wifiSpinner, this->wifiLabel);
+      setLabelTextIfChanged(this->wifiLabel, "verbinde WLAN");
+      this->applyStage(this->wifiSpinner, this->wifiLabel, StageState::PENDING, this->wifiStage);
    }
 
    if (networkState.ethernet_connected)
    {
-      lv_label_set_text(this->ethernetLabel, ("Ethernet  " + this->formatIp(networkState.ethernet_ip)).c_str());
-      this->markStateAsSuccess(this->ethernetSpinner, this->ethernetLabel);
+      setLabelTextIfChanged(this->ethernetLabel, ("Ethernet  " + this->formatIp(networkState.ethernet_ip)).c_str());
+      this->applyStage(this->ethernetSpinner, this->ethernetLabel, StageState::SUCCESS, this->ethernetStage);
    }
    else
    {
-      lv_label_set_text(this->ethernetLabel, "verbinde Ethernet");
-      this->resetState(this->ethernetSpinner, this->ethernetLabel);
+      setLabelTextIfChanged(this->ethernetLabel, "verbinde Ethernet");
+      this->applyStage(this->ethernetSpinner, this->ethernetLabel, StageState::PENDING, this->ethernetStage);
    }
 
    State::WebsocketState websocketState = State::getWebsocketState();
@@ -303,40 +343,35 @@ void InitScreen::loop()
    bool sweeping = websocketState.useSSL && (websocketState.certIndex > 0 || websocketState.rememberedRetryCount > 0);
    if (websocketState.connected)
    {
-      lv_label_set_text(this->apiConnectionLabel, "API verbunden");
-      this->markStateAsSuccess(this->apiConnectionSpinner, this->apiConnectionLabel);
+      setLabelTextIfChanged(this->apiConnectionLabel, "API verbunden");
+      this->applyStage(this->apiConnectionSpinner, this->apiConnectionLabel, StageState::SUCCESS, this->apiConnectionStage);
    }
    else if (networkUp && sweeping)
    {
-      lv_label_set_text(this->apiConnectionLabel, "suche Zertifikat");
-      this->markStateAsWarning(this->apiConnectionSpinner, this->apiConnectionLabel);
+      setLabelTextIfChanged(this->apiConnectionLabel, "suche Zertifikat");
+      this->applyStage(this->apiConnectionSpinner, this->apiConnectionLabel, StageState::WARNING, this->apiConnectionStage);
    }
    else
    {
-      lv_label_set_text(this->apiConnectionLabel, "verbinde API");
-      this->resetState(this->apiConnectionSpinner, this->apiConnectionLabel);
+      setLabelTextIfChanged(this->apiConnectionLabel, "verbinde API");
+      this->applyStage(this->apiConnectionSpinner, this->apiConnectionLabel, StageState::PENDING, this->apiConnectionStage);
    }
 
    State::ApiState apiState = State::getApiState();
-   if (apiState.authenticated)
-   {
-      this->markStateAsSuccess(this->apiAuthenticationSpinner, this->apiAuthenticationLabel);
-   }
-   else
-   {
-      this->resetState(this->apiAuthenticationSpinner, this->apiAuthenticationLabel);
-   }
+   this->applyStage(this->apiAuthenticationSpinner, this->apiAuthenticationLabel,
+                    apiState.authenticated ? StageState::SUCCESS : StageState::PENDING,
+                    this->apiAuthenticationStage);
 
    // Server target line
    if (websocketState.hostname.isEmpty() || websocketState.port == 0)
    {
-      lv_label_set_text(this->serverTargetLabel, "Server: nicht konfiguriert");
+      setLabelTextIfChanged(this->serverTargetLabel, "Server: nicht konfiguriert");
    }
    else
    {
       String target = "Server: " + websocketState.hostname + ":" + String(websocketState.port) +
                       (websocketState.useSSL ? "  (SSL)" : "  (kein SSL)");
-      lv_label_set_text(this->serverTargetLabel, target.c_str());
+      setLabelTextIfChanged(this->serverTargetLabel, target.c_str());
    }
 
    // Cert evaluation line (only relevant while connecting over SSL)
@@ -348,10 +383,13 @@ void InitScreen::loop()
       {
          cert += "  Wdh " + String(websocketState.rememberedRetryCount) + "/5";
       }
-      lv_label_set_text(this->certLabel, cert.c_str());
-      lv_obj_remove_flag(this->certLabel, LV_OBJ_FLAG_HIDDEN);
+      setLabelTextIfChanged(this->certLabel, cert.c_str());
+      if (lv_obj_has_flag(this->certLabel, LV_OBJ_FLAG_HIDDEN))
+      {
+         lv_obj_remove_flag(this->certLabel, LV_OBJ_FLAG_HIDDEN);
+      }
    }
-   else
+   else if (!lv_obj_has_flag(this->certLabel, LV_OBJ_FLAG_HIDDEN))
    {
       lv_obj_add_flag(this->certLabel, LV_OBJ_FLAG_HIDDEN);
    }
@@ -380,7 +418,7 @@ void InitScreen::loop()
    {
       stateLine += "  naechster Versuch in " + String(websocketState.secondsUntilNextAttempt) + "s";
    }
-   lv_label_set_text(this->connectionStateLabel, stateLine.c_str());
+   setLabelTextIfChanged(this->connectionStateLabel, stateLine.c_str());
 }
 
 void InitScreen::setOnOpenSettingsCallback(std::function<void()> onOpenSettingsCallback)
@@ -399,6 +437,10 @@ void InitScreen::onScreenLeave()
    this->resetState(this->ethernetSpinner, this->ethernetLabel);
    this->resetState(this->apiConnectionSpinner, this->apiConnectionLabel);
    this->resetState(this->apiAuthenticationSpinner, this->apiAuthenticationLabel);
+   this->wifiStage = StageState::PENDING;
+   this->ethernetStage = StageState::PENDING;
+   this->apiConnectionStage = StageState::PENDING;
+   this->apiAuthenticationStage = StageState::PENDING;
 }
 
 void InitScreen::destroy()

--- a/apps/attractap/firmware/src/display/screens/init/initscreen.hpp
+++ b/apps/attractap/firmware/src/display/screens/init/initscreen.hpp
@@ -28,6 +28,29 @@ private:
     void markStateAsWarning(lv_obj_t *spinner, lv_obj_t *label);
     void resetState(lv_obj_t *spinner, lv_obj_t *label);
 
+    // Per-row visual state, cached so loop() only touches LVGL styles on a real
+    // transition. Re-applying the same spinner/label styles every tick forces a
+    // style refresh + invalidation each refresh cycle (ATT-554 item 5).
+    enum class StageState
+    {
+        UNSET,
+        PENDING,
+        SUCCESS,
+        WARNING,
+    };
+    void applyStage(lv_obj_t *spinner, lv_obj_t *label, StageState newState, StageState &cached);
+
+    StageState wifiStage = StageState::UNSET;
+    StageState ethernetStage = StageState::UNSET;
+    StageState apiConnectionStage = StageState::UNSET;
+    StageState apiAuthenticationStage = StageState::UNSET;
+
+    // The connecting screen is up exactly while WiFi/TLS work runs; rebuilding
+    // its Strings every loop tick is wasted heap churn. 4 Hz is plenty for a
+    // status screen with a 1 Hz countdown.
+    uint32_t lastLoopRefreshMs = 0;
+    static constexpr uint32_t LOOP_REFRESH_INTERVAL_MS = 250;
+
     static void onOpenSettingsButtonEvent(lv_event_t *e);
 
     static String formatIp(esp_ip4_addr_t ip);

--- a/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsSession.cpp
+++ b/apps/attractap/firmware/src/display/screens/resourceDetails/resourceDetailsSession.cpp
@@ -18,7 +18,9 @@ void ResourceDetailsScreen::updateElapsedTimeDisplay()
    // difftime returns seconds; convert to milliseconds for formatter
    double elapsedSeconds = difftime(currentTime, this->sessionStartTime);
    double elapsedMillis = elapsedSeconds * 1000.0;
-   lv_label_set_text(this->elapsedTime, millisToTimeString(elapsedMillis).c_str());
+   // The formatted value only changes once per second; raw lv_label_set_text from
+   // loop() would invalidate (re-render) the label every tick (ATT-554 item 5).
+   setLabelTextIfChanged(this->elapsedTime, millisToTimeString(elapsedMillis).c_str());
 }
 void ResourceDetailsScreen::setSessionTimeoutTime(uint32_t sessionTimeoutTime)
 {

--- a/apps/attractap/firmware/src/ioexpander/ioexpander.cpp
+++ b/apps/attractap/firmware/src/ioexpander/ioexpander.cpp
@@ -1,4 +1,5 @@
 #include "ioexpander.hpp"
+#include "../utils.hpp"
 
 void IOExpander::setup()
 {
@@ -158,6 +159,9 @@ void IOExpander::dumpRegisters()
 
 bool IOExpander::writeRegister(uint8_t reg, uint8_t value)
 {
+    // One register access = one atomic conversation on the shared I2C bus —
+    // never interleaved with PN532/GT911 traffic from other tasks (ATT-554).
+    I2CBusGuard busGuard;
     Wire.beginTransmission(i2cAddress);
     Wire.write(reg);
     Wire.write(value);
@@ -172,6 +176,7 @@ bool IOExpander::writeRegister(uint8_t reg, uint8_t value)
 
 bool IOExpander::readRegister(uint8_t reg, uint8_t &value)
 {
+    I2CBusGuard busGuard;
     Wire.beginTransmission(i2cAddress);
     Wire.write(reg);
     if (Wire.endTransmission(false) != 0)

--- a/apps/attractap/firmware/src/main.cpp
+++ b/apps/attractap/firmware/src/main.cpp
@@ -52,6 +52,7 @@ void setup()
 
     // Prevent potential I2C stalls on touch controller reads
     Wire.setTimeOut(50);
+    Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
 
     mainLogger.info("Attractap starting...");
     application.setup();

--- a/apps/attractap/firmware/src/main.cpp
+++ b/apps/attractap/firmware/src/main.cpp
@@ -54,6 +54,10 @@ void setup()
     Wire.setTimeOut(50);
     Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
 
+    // Serialize all shared-bus I2C traffic (PN532 / GT911 / IO expander) across
+    // tasks — must exist before application.setup() spawns any task (ATT-554).
+    I2CBusLock::init();
+
     mainLogger.info("Attractap starting...");
     application.setup();
 }

--- a/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.cpp
+++ b/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.cpp
@@ -3720,12 +3720,16 @@ bool Adafruit_PN532::isready()
 /**************************************************************************/
 bool Adafruit_PN532::waitready(uint16_t timeout)
 {
+  // Poll at 2 ms granularity (was 10 ms) so the calling task yields finely and
+  // short timeouts (e.g. the ~25 ms detection poll) are honored with little
+  // overshoot. vTaskDelay keeps the NFC task off the CPU between probes
+  // (ATT-554 item 6).
   uint16_t timer = 0;
   while (!isready())
   {
     if (timeout != 0)
     {
-      timer += 10;
+      timer += 2;
       if (timer > timeout)
       {
 #ifdef PN532DEBUG
@@ -3734,7 +3738,7 @@ bool Adafruit_PN532::waitready(uint16_t timeout)
         return false;
       }
     }
-    delay(10);
+    vTaskDelay(pdMS_TO_TICKS(2));
   }
   return true;
 }

--- a/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.cpp
+++ b/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.cpp
@@ -3720,16 +3720,12 @@ bool Adafruit_PN532::isready()
 /**************************************************************************/
 bool Adafruit_PN532::waitready(uint16_t timeout)
 {
-  // Poll at 2 ms granularity (was 10 ms) so the calling task yields finely and
-  // short timeouts (e.g. the ~25 ms detection poll) are honored with little
-  // overshoot. vTaskDelay keeps the NFC task off the CPU between probes
-  // (ATT-554 item 6).
   uint16_t timer = 0;
   while (!isready())
   {
     if (timeout != 0)
     {
-      timer += 2;
+      timer += 10;
       if (timer > timeout)
       {
 #ifdef PN532DEBUG
@@ -3738,7 +3734,7 @@ bool Adafruit_PN532::waitready(uint16_t timeout)
         return false;
       }
     }
-    vTaskDelay(pdMS_TO_TICKS(2));
+    delay(10);
   }
   return true;
 }

--- a/apps/attractap/firmware/src/nfc/nfc.cpp
+++ b/apps/attractap/firmware/src/nfc/nfc.cpp
@@ -100,19 +100,8 @@ void NFC::handleCardDetection()
         return;
     }
 
-    uint32_t now = millis();
-
     if (this->foundCard)
     {
-        // Rate-limit the presence check: a full AES handshake per loop pass kept
-        // the shared I2C bus continuously occupied while a card rested on the
-        // reader (ATT-554 item 6).
-        if (now - this->lastPresenceCheckMs < NFC::presenceCheckIntervalMs)
-        {
-            return;
-        }
-        this->lastPresenceCheckMs = now;
-
         // just try to comminucate with card in any way to check if it is still present
         bool authSuccess = false;
         {
@@ -139,14 +128,6 @@ void NFC::handleCardDetection()
         // card still present, wait till removed
         return;
     }
-
-    // Rate-limit the detection poll and keep its timeout short so each bus hold
-    // stays small; the cadence (not the timeout) defines detection latency.
-    if (now - this->lastDetectionPollMs < NFC::detectionPollIntervalMs)
-    {
-        return;
-    }
-    this->lastDetectionPollMs = now;
 
     bool foundCardUpdate = false;
     {

--- a/apps/attractap/firmware/src/nfc/nfc.cpp
+++ b/apps/attractap/firmware/src/nfc/nfc.cpp
@@ -26,17 +26,28 @@ void NFC::setup()
     }
 
     this->logger.info("Initializing PN532");
-    this->pn532.begin();
-    // Adafruit BusIO's I2CDevice::begin() (called inside pn532.begin()) re-invokes
-    // Wire.begin(), which can reset the bus clock to the 100 kHz default. Restore
-    // 400 kHz Fast Mode (same pitfall as the SensorLib restore in rgb_gt911_driver).
-    Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
+    {
+        // The LVGL task is already polling GT911 touch on the shared bus at this
+        // point — keep the whole PN532 bring-up atomic on the bus (ATT-554).
+        I2CBusGuard busGuard;
+        this->pn532.begin();
+        // Adafruit BusIO's I2CDevice::begin() (called inside pn532.begin()) re-invokes
+        // Wire.begin(), which can reset the bus clock to the 100 kHz default and the
+        // bus timeout to the framework default. Restore 400 kHz Fast Mode and the
+        // 50 ms timeout (same pitfall as the SensorLib restore in rgb_gt911_driver).
+        Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
+        Wire.setTimeOut(50);
+    }
 
     this->logger.info("Checking hardware");
     this->checkHardware(true);
 
     // configure board to read RFID tags
-    bool samConfigSuccess = this->pn532.SAMConfig();
+    bool samConfigSuccess = false;
+    {
+        I2CBusGuard busGuard;
+        samConfigSuccess = this->pn532.SAMConfig();
+    }
     if (!samConfigSuccess)
     {
         this->logger.error("SAMConfig failed");
@@ -103,7 +114,13 @@ void NFC::handleCardDetection()
         this->lastPresenceCheckMs = now;
 
         // just try to comminucate with card in any way to check if it is still present
-        bool authSuccess = this->pn532.ntag424_Authenticate(NFC::FACTORY_KEY, 0, 0x71);
+        bool authSuccess = false;
+        {
+            // Keep the full AES handshake atomic on the shared bus; the removal
+            // callback below must run WITHOUT the bus lock held (leaf-lock rule).
+            I2CBusGuard busGuard;
+            authSuccess = this->pn532.ntag424_Authenticate(NFC::FACTORY_KEY, 0, 0x71);
+        }
         if (!authSuccess)
         {
             // card removed, call callback
@@ -131,7 +148,12 @@ void NFC::handleCardDetection()
     }
     this->lastDetectionPollMs = now;
 
-    bool foundCardUpdate = this->pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, cardDetectedUid, &cardDetectedUidLength, NFC::detectionPollTimeoutMs);
+    bool foundCardUpdate = false;
+    {
+        // Atomic detection poll; the detection callback below runs lock-free.
+        I2CBusGuard busGuard;
+        foundCardUpdate = this->pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, cardDetectedUid, &cardDetectedUidLength, NFC::detectionPollTimeoutMs);
+    }
 
     if (foundCardUpdate)
     {
@@ -153,6 +175,7 @@ bool NFC::waitForCard(uint32_t timeoutMs)
                                            // card type)
 
     LockGuard guard(*this);
+    I2CBusGuard busGuard;
 
     // Wait for an NTAG242 card.  When one is found 'uid' will be populated with
     // the UID, and uidLength will indicate the size of the UUID (normally 7)
@@ -174,6 +197,9 @@ bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint
     this->logger.info("changeKey started");
 
     LockGuard guard(*this);
+    // The whole key-change is one multi-command card conversation — keep it
+    // atomic on the shared bus (no callbacks fire inside).
+    I2CBusGuard busGuard;
 
     // Step 1: Authenticate with master key
     bool authenticateOldKeySuccess = this->pn532.ntag424_Authenticate(masterKey, 0, 0x71);
@@ -208,6 +234,7 @@ bool NFC::authenticate(uint8_t keyNumber, uint8_t *key)
     this->logger.info("authenticate started");
 
     LockGuard guard(*this);
+    I2CBusGuard busGuard;
 
     // Step 1: Authenticate with key
     bool authenticateSuccess = this->pn532.ntag424_Authenticate(key, keyNumber, 0x71);
@@ -230,7 +257,11 @@ void NFC::checkHardware(bool logHardwareInfo)
     }
     this->lastHardwareCheckMs = now;
 
-    uint32_t versiondata = this->pn532.getFirmwareVersion();
+    uint32_t versiondata = 0;
+    {
+        I2CBusGuard busGuard;
+        versiondata = this->pn532.getFirmwareVersion();
+    }
     if (!versiondata)
     {
         this->logger.error("Didn't find PN53x board");

--- a/apps/attractap/firmware/src/nfc/nfc.cpp
+++ b/apps/attractap/firmware/src/nfc/nfc.cpp
@@ -2,8 +2,29 @@
 
 uint8_t NFC::FACTORY_KEY[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
+void NFC::lock()
+{
+    if (this->opMutex)
+    {
+        xSemaphoreTakeRecursive(this->opMutex, portMAX_DELAY);
+    }
+}
+
+void NFC::unlock()
+{
+    if (this->opMutex)
+    {
+        xSemaphoreGiveRecursive(this->opMutex);
+    }
+}
+
 void NFC::setup()
 {
+    if (!this->opMutex)
+    {
+        this->opMutex = xSemaphoreCreateRecursiveMutex();
+    }
+
     this->logger.info("Initializing PN532");
     this->pn532.begin();
     // Adafruit BusIO's I2CDevice::begin() (called inside pn532.begin()) re-invokes
@@ -28,15 +49,13 @@ void NFC::setup()
 void NFC::enableCardDetection()
 {
     this->logger.info("Enabling card detection");
-    this->checkHardware();
-    /*pinMode(PIN_PN532_IRQ, INPUT_PULLUP);
-    auto irqHandler = [this]
     {
-        this->onCardDetectedInterruptHandler();
-    };
-    attachInterrupt(digitalPinToInterrupt(PIN_PN532_IRQ), irqHandler, FALLING);
-    this->pn532.startPassiveTargetIDDetection(PN532_MIFARE_ISO14443A);
-    this->timeOfCardDetectionEnabledMs = millis();*/
+        LockGuard guard(*this);
+        this->checkHardware();
+    }
+    // NOTE: IRQ-driven detection is impossible on this hardware - the PN532 IRQ
+    // line is not physically wired (despite the PIN_PN532_IRQ define). Detection
+    // stays polled on the NFC task (ATT-554).
     this->cardDetectionEnabled = true;
 }
 
@@ -58,6 +77,7 @@ void NFC::resetCardPresence()
 
 void NFC::loop()
 {
+    LockGuard guard(*this);
     this->checkHardware();
     this->handleCardDetection();
 }
@@ -69,8 +89,19 @@ void NFC::handleCardDetection()
         return;
     }
 
+    uint32_t now = millis();
+
     if (this->foundCard)
     {
+        // Rate-limit the presence check: a full AES handshake per loop pass kept
+        // the shared I2C bus continuously occupied while a card rested on the
+        // reader (ATT-554 item 6).
+        if (now - this->lastPresenceCheckMs < NFC::presenceCheckIntervalMs)
+        {
+            return;
+        }
+        this->lastPresenceCheckMs = now;
+
         // just try to comminucate with card in any way to check if it is still present
         bool authSuccess = this->pn532.ntag424_Authenticate(NFC::FACTORY_KEY, 0, 0x71);
         if (!authSuccess)
@@ -92,7 +123,15 @@ void NFC::handleCardDetection()
         return;
     }
 
-    bool foundCardUpdate = this->pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, cardDetectedUid, &cardDetectedUidLength, 100);
+    // Rate-limit the detection poll and keep its timeout short so each bus hold
+    // stays small; the cadence (not the timeout) defines detection latency.
+    if (now - this->lastDetectionPollMs < NFC::detectionPollIntervalMs)
+    {
+        return;
+    }
+    this->lastDetectionPollMs = now;
+
+    bool foundCardUpdate = this->pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, cardDetectedUid, &cardDetectedUidLength, NFC::detectionPollTimeoutMs);
 
     if (foundCardUpdate)
     {
@@ -113,6 +152,8 @@ bool NFC::waitForCard(uint32_t timeoutMs)
     uint8_t uidLength;                     // Length of the UID (4 or 7 bytes depending on ISO14443A
                                            // card type)
 
+    LockGuard guard(*this);
+
     // Wait for an NTAG242 card.  When one is found 'uid' will be populated with
     // the UID, and uidLength will indicate the size of the UUID (normally 7)
     uint8_t uidDetected = this->pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLength, timeoutMs);
@@ -131,6 +172,8 @@ bool NFC::waitForCard(uint32_t timeoutMs)
 bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint8_t *newKey)
 {
     this->logger.info("changeKey started");
+
+    LockGuard guard(*this);
 
     // Step 1: Authenticate with master key
     bool authenticateOldKeySuccess = this->pn532.ntag424_Authenticate(masterKey, 0, 0x71);
@@ -163,6 +206,8 @@ bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint
 bool NFC::authenticate(uint8_t keyNumber, uint8_t *key)
 {
     this->logger.info("authenticate started");
+
+    LockGuard guard(*this);
 
     // Step 1: Authenticate with key
     bool authenticateSuccess = this->pn532.ntag424_Authenticate(key, keyNumber, 0x71);
@@ -211,6 +256,8 @@ void NFC::checkHardware(bool logHardwareInfo)
 bool NFC::getAvailableKeyNo(uint8_t *uid, uint8_t *uidLength, uint8_t *keyNo)
 {
     this->logger.info("getAvailableKeyNo started");
+
+    LockGuard guard(*this);
 
     // The card was just selected by handleCardDetection's readPassiveTargetID.
     // Re-running readPassiveTargetID here would fire a second back-to-back

--- a/apps/attractap/firmware/src/nfc/nfc.cpp
+++ b/apps/attractap/firmware/src/nfc/nfc.cpp
@@ -6,6 +6,10 @@ void NFC::setup()
 {
     this->logger.info("Initializing PN532");
     this->pn532.begin();
+    // Adafruit BusIO's I2CDevice::begin() (called inside pn532.begin()) re-invokes
+    // Wire.begin(), which can reset the bus clock to the 100 kHz default. Restore
+    // 400 kHz Fast Mode (same pitfall as the SensorLib restore in rgb_gt911_driver).
+    Wire.setClock(ATTRACTAP_I2C_CLOCK_HZ);
 
     this->logger.info("Checking hardware");
     this->checkHardware(true);

--- a/apps/attractap/firmware/src/nfc/nfc.hpp
+++ b/apps/attractap/firmware/src/nfc/nfc.hpp
@@ -5,8 +5,10 @@
 #include "Adafruit_PN532_NTAG424.h"
 #include <Wire.h>
 #include "../state/state.hpp"
-#include "FunctionalInterrupt.h"
 #include "../utils.hpp"
+#include <functional>
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 
 class NFC
 {
@@ -16,6 +18,14 @@ public:
     }
 
     void setup();
+
+    /**
+     * Runs on a dedicated FreeRTOS task (Application::nfcTask), NOT the main
+     * loop: PN532 polling blocks the shared I2C bus and used to stall the UI
+     * (ATT-554 item 6). All public card operations are serialized with an
+     * internal recursive mutex so the main-loop enrollment/reset state machines
+     * can keep calling changeKey()/authenticate()/getAvailableKeyNo() safely.
+     */
     void loop();
 
     bool changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint8_t *newKey);
@@ -47,13 +57,15 @@ private:
     uint8_t cardDetectedUid[7] = {0};
     uint8_t cardDetectedUidLength = 0;
 
-    bool foundCard = false;
+    // Written by the NFC task, read from the main loop.
+    volatile bool foundCard = false;
     uint32_t foundCardTimeMs = 0;
 
     // TODO: remove this
     void demo();
 
-    bool cardDetectionEnabled = false;
+    // Toggled from main loop / callbacks, read by the NFC task.
+    volatile bool cardDetectionEnabled = false;
     std::function<void(uint8_t *, uint8_t)> cardDetectionCallback;
     std::function<void(uint32_t presentationTimeMs)> cardRemovalCallback;
     void handleCardDetection();
@@ -61,4 +73,36 @@ private:
     uint32_t lastHardwareCheckMs = 0;
     void checkHardware(bool logHardwareInfo = false);
     static const uint32_t hardwareCheckIntervalMs = 10000;
+
+    // Serializes every PN532 conversation (poll loop on the NFC task vs.
+    // enrollment/reset card operations on the main loop). Recursive because
+    // e.g. getAvailableKeyNo() -> authenticate() and the detection callback
+    // (fired while loop() holds the lock) may call back into NFC methods.
+    SemaphoreHandle_t opMutex = nullptr;
+    void lock();
+    void unlock();
+
+    // RAII helper so every exit path of a card operation releases the mutex.
+    class LockGuard
+    {
+    public:
+        explicit LockGuard(NFC &nfc) : nfc(nfc) { nfc.lock(); }
+        ~LockGuard() { nfc.unlock(); }
+        LockGuard(const LockGuard &) = delete;
+        LockGuard &operator=(const LockGuard &) = delete;
+
+    private:
+        NFC &nfc;
+    };
+
+    // Polling cadence (ATT-554 item 6): keep every bus hold short and rare.
+    // - When no card is present: probe every ~125 ms with a ~25 ms timeout
+    //   (instead of a blocking 100 ms timeout on every single loop pass).
+    // - When a card rests on the reader: verify presence via AES handshake only
+    //   every ~250 ms (instead of a full handshake per loop pass).
+    uint32_t lastDetectionPollMs = 0;
+    uint32_t lastPresenceCheckMs = 0;
+    static const uint32_t detectionPollIntervalMs = 125;
+    static const uint16_t detectionPollTimeoutMs = 25;
+    static const uint32_t presenceCheckIntervalMs = 250;
 };

--- a/apps/attractap/firmware/src/nfc/nfc.hpp
+++ b/apps/attractap/firmware/src/nfc/nfc.hpp
@@ -20,11 +20,12 @@ public:
     void setup();
 
     /**
-     * Runs on a dedicated FreeRTOS task (Application::nfcTask), NOT the main
-     * loop: PN532 polling blocks the shared I2C bus and used to stall the UI
-     * (ATT-554 item 6). All public card operations are serialized with an
-     * internal recursive mutex so the main-loop enrollment/reset state machines
-     * can keep calling changeKey()/authenticate()/getAvailableKeyNo() safely.
+     * Runs on the main application loop (the dedicated NFC task from ATT-554
+     * item 6 is reverted while the field I2C wedge is isolated). Blocking PN532
+     * time costs only the main loop — rendering and touch live on LvglTask.
+     * Public card operations stay serialized with an internal recursive mutex,
+     * and every PN532 conversation holds the shared I2CBusGuard against the
+     * touch reads on LvglTask.
      */
     void loop();
 
@@ -95,14 +96,8 @@ private:
         NFC &nfc;
     };
 
-    // Polling cadence (ATT-554 item 6): keep every bus hold short and rare.
-    // - When no card is present: probe every ~125 ms with a ~25 ms timeout
-    //   (instead of a blocking 100 ms timeout on every single loop pass).
-    // - When a card rests on the reader: verify presence via AES handshake only
-    //   every ~250 ms (instead of a full handshake per loop pass).
-    uint32_t lastDetectionPollMs = 0;
-    uint32_t lastPresenceCheckMs = 0;
-    static const uint32_t detectionPollIntervalMs = 125;
-    static const uint16_t detectionPollTimeoutMs = 25;
-    static const uint32_t presenceCheckIntervalMs = 250;
+    // Pre-ATT-554 polling semantics (rate limits reverted for isolation):
+    // blocking 100 ms detection poll and a presence handshake on every loop
+    // pass, exactly like the firmware that was known to run stable.
+    static const uint16_t detectionPollTimeoutMs = 100;
 };

--- a/apps/attractap/firmware/src/utils.cpp
+++ b/apps/attractap/firmware/src/utils.cpp
@@ -1,4 +1,32 @@
 #include "utils.hpp"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+static SemaphoreHandle_t s_i2cBusMutex = nullptr;
+
+void I2CBusLock::init()
+{
+    if (!s_i2cBusMutex)
+    {
+        s_i2cBusMutex = xSemaphoreCreateRecursiveMutex();
+    }
+}
+
+void I2CBusLock::lock()
+{
+    if (s_i2cBusMutex)
+    {
+        xSemaphoreTakeRecursive(s_i2cBusMutex, portMAX_DELAY);
+    }
+}
+
+void I2CBusLock::unlock()
+{
+    if (s_i2cBusMutex)
+    {
+        xSemaphoreGiveRecursive(s_i2cBusMutex);
+    }
+}
 
 void recoverI2CBus(int sda, int scl)
 {

--- a/apps/attractap/firmware/src/utils.hpp
+++ b/apps/attractap/firmware/src/utils.hpp
@@ -4,14 +4,14 @@
 
 /**
  * Shared I2C bus clock (Hz). GT911 touch, PN532 NFC and the PCA9555 IO expander
- * all support 400 kHz Fast Mode; running the single shared bus at 400 kHz cuts
- * every bus hold (touch reads, NFC frames, expander access) 4x vs the Arduino
- * default 100 kHz. Must be re-applied after every Wire.begin(), because library
- * begin() calls (SensorLib, Adafruit BusIO) re-invoke Wire.begin() and can reset
- * the clock - same pitfall as the Wire.setTimeOut(50) restores.
- * Fall back to 200000-300000 here if hardware signal integrity requires it.
+ * all support 400 kHz Fast Mode, but field testing on reader-21 showed the bus
+ * wedging once NFC traffic starts (ATT-554 crash + follow-up reports), so the
+ * 400 kHz change (item 3) is reverted to the proven 100 kHz while the I2C
+ * problems are isolated. Must be re-applied after every Wire.begin(), because
+ * library begin() calls (SensorLib, Adafruit BusIO) re-invoke Wire.begin() and
+ * can reset the clock - same pitfall as the Wire.setTimeOut(50) restores.
  */
-static constexpr uint32_t ATTRACTAP_I2C_CLOCK_HZ = 400000;
+static constexpr uint32_t ATTRACTAP_I2C_CLOCK_HZ = 100000;
 
 String hexToString(uint8_t *uid, uint8_t uidLength);
 bool stringToHexArray(String hexString, uint8_t *array, uint8_t arrayLength);

--- a/apps/attractap/firmware/src/utils.hpp
+++ b/apps/attractap/firmware/src/utils.hpp
@@ -2,6 +2,17 @@
 
 #include <Arduino.h>
 
+/**
+ * Shared I2C bus clock (Hz). GT911 touch, PN532 NFC and the PCA9555 IO expander
+ * all support 400 kHz Fast Mode; running the single shared bus at 400 kHz cuts
+ * every bus hold (touch reads, NFC frames, expander access) 4x vs the Arduino
+ * default 100 kHz. Must be re-applied after every Wire.begin(), because library
+ * begin() calls (SensorLib, Adafruit BusIO) re-invoke Wire.begin() and can reset
+ * the clock - same pitfall as the Wire.setTimeOut(50) restores.
+ * Fall back to 200000-300000 here if hardware signal integrity requires it.
+ */
+static constexpr uint32_t ATTRACTAP_I2C_CLOCK_HZ = 400000;
+
 String hexToString(uint8_t *uid, uint8_t uidLength);
 bool stringToHexArray(String hexString, uint8_t *array, uint8_t arrayLength);
 

--- a/apps/attractap/firmware/src/utils.hpp
+++ b/apps/attractap/firmware/src/utils.hpp
@@ -11,7 +11,7 @@
  * library begin() calls (SensorLib, Adafruit BusIO) re-invoke Wire.begin() and
  * can reset the clock - same pitfall as the Wire.setTimeOut(50) restores.
  */
-static constexpr uint32_t ATTRACTAP_I2C_CLOCK_HZ = 100000;
+static constexpr uint32_t ATTRACTAP_I2C_CLOCK_HZ = 400000;
 
 String hexToString(uint8_t *uid, uint8_t uidLength);
 bool stringToHexArray(String hexString, uint8_t *array, uint8_t arrayLength);

--- a/apps/attractap/firmware/src/utils.hpp
+++ b/apps/attractap/firmware/src/utils.hpp
@@ -17,6 +17,48 @@ String hexToString(uint8_t *uid, uint8_t uidLength);
 bool stringToHexArray(String hexString, uint8_t *array, uint8_t arrayLength);
 
 /**
+ * Global lock serializing all traffic on the shared I2C bus.
+ *
+ * PN532 (NfcTask), GT911 touch (LvglTask) and the IO expander (main loop /
+ * LVGL callbacks) share one physical bus but run on different FreeRTOS tasks
+ * since ATT-554. TwoWire's internal lock only serializes single transactions;
+ * a PN532 conversation (write command, poll ready, read frame — with clock
+ * stretching in between) interleaved with GT911/IO-expander transactions can
+ * wedge the ESP-IDF I2C driver: a field coredump showed LvglTask stuck inside
+ * an I2C read holding the TwoWire lock, NfcTask blocked forever on that lock
+ * while holding its NFC op mutex, and loopTask blocked on lv_lock until the
+ * task watchdog rebooted the reader.
+ *
+ * Rules:
+ * - Hold the lock for one complete logical transaction/conversation
+ *   (full PN532 command+response exchange, one GT911 point read, one IO
+ *   expander register access).
+ * - The lock is strictly a LEAF lock: while holding it, never take lv_lock,
+ *   never fire application callbacks, never block on queues/other mutexes.
+ * - Recursive, so nested NFC helpers (e.g. getAvailableKeyNo -> authenticate)
+ *   are safe on the same task.
+ */
+class I2CBusLock
+{
+public:
+    // Must run before any secondary task can touch the bus (called from setup()
+    // in main.cpp right after Wire.begin()).
+    static void init();
+    static void lock();
+    static void unlock();
+};
+
+// RAII guard for I2CBusLock — every exit path releases the bus.
+class I2CBusGuard
+{
+public:
+    I2CBusGuard() { I2CBusLock::lock(); }
+    ~I2CBusGuard() { I2CBusLock::unlock(); }
+    I2CBusGuard(const I2CBusGuard &) = delete;
+    I2CBusGuard &operator=(const I2CBusGuard &) = delete;
+};
+
+/**
  * @brief Recover a stuck I2C bus by bit-banging 9 SCL clock pulses then a STOP.
  *
  * Releases any I2C slave that is holding SDA low mid-transaction (common after a

--- a/apps/attractap/firmware/src/websocket/websocket.cpp
+++ b/apps/attractap/firmware/src/websocket/websocket.cpp
@@ -16,6 +16,10 @@ void Websocket::setup()
     {
         ws_client_mutex = xSemaphoreCreateMutex();
     }
+    if (!connect_lifecycle_mutex)
+    {
+        connect_lifecycle_mutex = xSemaphoreCreateMutex();
+    }
     if (!tx_queue)
     {
         tx_queue = xQueueCreate(TX_QUEUE_DEPTH, sizeof(TxMessage));
@@ -24,7 +28,34 @@ void Websocket::setup()
     {
         xTaskCreate(txTaskEntry, "ws_tx", TX_TASK_STACK, this, TX_TASK_PRIORITY, &tx_task);
     }
+    if (!connect_task)
+    {
+        xTaskCreate(connectTaskEntry, "ws_conn", CONNECT_TASK_STACK, this, CONNECT_TASK_PRIORITY, &connect_task);
+    }
     this->_certManager.begin();
+}
+
+void Websocket::connectTaskEntry(void *arg)
+{
+    static_cast<Websocket *>(arg)->connectTaskLoop();
+}
+
+void Websocket::connectTaskLoop()
+{
+    while (true)
+    {
+        // Block until loop() requests a (re)connect; multiple requests coalesce.
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        this->connectWebSocket();
+    }
+}
+
+void Websocket::requestConnect()
+{
+    if (connect_task)
+    {
+        xTaskNotifyGive(connect_task);
+    }
 }
 
 void Websocket::lockWsClient()
@@ -69,14 +100,14 @@ void Websocket::loop()
     bool apiConfigChanged = _lastApiConfig.hostname != apiConfig.hostname || _lastApiConfig.port != apiConfig.port || _lastApiConfig.useSSL != apiConfig.useSSL;
     if (apiConfigChanged)
     {
-        connectWebSocket();
+        requestConnect();
         return;
     }
 
     switch (_state)
     {
     case INIT:
-        connectWebSocket();
+        requestConnect();
         break;
     case CONNECTING:
         break;
@@ -134,6 +165,22 @@ void Websocket::publishConnectionStatus()
 }
 
 void Websocket::connectWebSocket()
+{
+    // Runs on the ws_conn task only. Hold the lifecycle mutex for the whole
+    // attempt so disableConnectionAttempts() cannot destroy the client handle
+    // mid-connect.
+    if (connect_lifecycle_mutex)
+    {
+        xSemaphoreTake(connect_lifecycle_mutex, portMAX_DELAY);
+    }
+    this->connectWebSocketLocked();
+    if (connect_lifecycle_mutex)
+    {
+        xSemaphoreGive(connect_lifecycle_mutex);
+    }
+}
+
+void Websocket::connectWebSocketLocked()
 {
     if (!connectionAttemptsEnabled)
     {
@@ -232,7 +279,9 @@ void Websocket::connectWebSocket()
     // Configure buffer sizes to prevent ENOBUFS errors
     websocket_cfg.task_stack = 9830;  // Increase task stack size for stability
     websocket_cfg.buffer_size = 4096; // Increase buffer size (default is typically 1024)
-    // websocket_cfg.task_prio = 5;      // Set appropriate task priority
+    // Below the LVGL render task (prio 4): TLS work must not preempt UI refresh
+    // (default was 5, unpinned) - ATT-554 item 7.
+    websocket_cfg.task_prio = 3;
 
     websocket_cfg.ping_interval_sec = 5;
     websocket_cfg.pingpong_timeout_sec = PINGPONG_TIMEOUT_SEC;
@@ -545,6 +594,14 @@ void Websocket::disableConnectionAttempts()
 {
     this->connectionAttemptsEnabled = false;
 
+    // Wait for any in-flight connect attempt on the ws_conn task to finish
+    // before tearing the client down (it re-checks connectionAttemptsEnabled
+    // under this mutex, so no new attempt can start).
+    if (connect_lifecycle_mutex)
+    {
+        xSemaphoreTake(connect_lifecycle_mutex, portMAX_DELAY);
+    }
+
     lockWsClient();
     esp_websocket_client_handle_t oldClient = ws_client;
     ws_client = nullptr;
@@ -552,6 +609,11 @@ void Websocket::disableConnectionAttempts()
     if (oldClient)
     {
         esp_websocket_client_destroy(oldClient);
+    }
+
+    if (connect_lifecycle_mutex)
+    {
+        xSemaphoreGive(connect_lifecycle_mutex);
     }
 
     drainTxQueue();

--- a/apps/attractap/firmware/src/websocket/websocket.hpp
+++ b/apps/attractap/firmware/src/websocket/websocket.hpp
@@ -44,8 +44,24 @@ private:
     void updateInfoFromAppState();
     void publishConnectionStatus();
     void connectWebSocket();
+    void connectWebSocketLocked();
     bool shouldReconnect();
     uint32_t lastReconnectAttemptTime = 0;
+
+    // (Re)connects run on a dedicated low-priority task (ATT-554 item 7):
+    // esp_websocket_client_stop()/start() block for up to the network timeout,
+    // which used to stall the UI-driving main loop on every reconnect attempt.
+    // loop() only signals the task via a task notification (coalescing).
+    static constexpr uint32_t CONNECT_TASK_STACK = 8192;
+    static constexpr UBaseType_t CONNECT_TASK_PRIORITY = 2;
+    TaskHandle_t connect_task = nullptr;
+    static void connectTaskEntry(void *arg);
+    void connectTaskLoop();
+    void requestConnect();
+    // Serializes connectWebSocket (connect task) against the client teardown in
+    // disableConnectionAttempts (main loop) so the client handle cannot be
+    // destroyed mid-connect.
+    SemaphoreHandle_t connect_lifecycle_mutex = nullptr;
 
     const uint32_t CERT_ITERATION_INTERVAL_MS = 10000;
     const uint32_t RECONNECT_BACKOFF_BASE_MS = 10000;


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

Closes [ATT-554](https://linear.app/attraccess/issue/ATT-554/fix-attractap-touch-ui-lag-restore-renderi2c-throughput-then-isolate) / #1331

## Summary

Seven ordered, independently revertable commits (one per work item from the issue), plus a field-crash fix (commit 8) found during on-device testing:

1. **Real LVGL v9 config** — `include/lv_conf.h` was a v8.4 config silently ignored by lvgl@9.3.0; the device ran at v9 defaults (33 ms refresh, ~30 Hz touch). Now: `LV_DEF_REFR_PERIOD 15` (drives refresh **and** indev read period in v9), `LV_USE_OS LV_OS_FREERTOS`, `LV_DRAW_SW_DRAW_UNIT_CNT 2`, perf monitor behind `-D ATTRACTAP_LV_PERF_MONITOR=1`.
2. **Panel-level 180° flip** — `rotation=2` forced every LVGL flush through the per-pixel reversed-index copy into the PSRAM framebuffer. Flip now lives in the ST7701 init sequence (BK0 `0xC7=0x04` X-mirror + MADCTL `0x36=0x10` Y-mirror), rotation 0 hits the row-memcpy fast path, touch coords mirrored in `readTouch()`.
3. **I2C bus 400 kHz** — `ATTRACTAP_I2C_CLOCK_HZ` applied after every `Wire.begin()` incl. the display-init retry path and after SensorLib/BusIO `begin()` calls that reset the clock.
4. **-O2 release builds** — `[env]` was `build_type = debug` (-Og) for all shipped firmware. Now release with `-Os` unflagged → `-O2`. New `attractap-touch-debug` env for development; `build_firmwares.py` skips `*-debug`.
5. **No more per-tick invalidation storms** — `setLabelTextIfChanged()` helper; InitScreen loop throttled to 250 ms with per-row stage caches (styles only touched on transitions); elapsed-time label only set on change. Other screens use `lv_bar_set_value`, which already early-returns.
6. **NFC on its own task, rate-limited** — `nfc.loop()` on `NfcTask` (prio 1); detection poll ~125 ms cadence / ~25 ms timeout (was: blocking 100 ms every loop pass); presence check (full AES handshake!) rate-limited to ~250 ms (was: every pass); `waitready()` polls at 2 ms `vTaskDelay`; recursive op-mutex serializes the poll vs. main-loop enrollment/reset card ops (ATT-503 flows preserved); dead IRQ stub removed (IRQ line not wired).
7. **Scheduling cleanup** — `lv_timer_handler` (render + touch read) on dedicated `LvglTask` (core 1, prio 4; self-locks via recursive `lv_lock`); main-loop/websocket-task LVGL access serialized (`Display::asyncCall`, locked `Display::loop`/`processState`); websocket `task_prio = 3` (below render); blocking `esp_websocket_client_stop()/start()` reconnects moved to a `ws_conn` task with lifecycle mutex against client teardown.
8. **Shared-I2C-bus serialization (field crash fix)** — see below.

No I2C bus/address/wiring changes; NFC stays polled (IRQ line not physically wired).

## Field crash fix (commit 8)

On-device testing (reader-21) hit: NFC scan dead at the lockscreen → touch frozen → reboot seconds later. Decoding the attached coredump (`reader-21-crash-75.coredump`) showed a **task-watchdog abort** with this lock chain:

- `LvglTask` — inside a GT911 touch read on the shared I2C bus, holding the TwoWire lock, stuck in the IDF I2C driver
- `NfcTask` — in `checkHardware → getFirmwareVersion`, blocked `portMAX_DELAY` on that TwoWire lock while holding the NFC op-mutex
- `loopTask` — blocked `portMAX_DELAY` on `lv_lock` (held by LvglTask) → task WDT starved ≥5 s → `abort()` from the WDT ISR → reboot

**Root cause:** items 6+7 made PN532 (NfcTask) and GT911 (LvglTask) + IO expander (loopTask) hit the one shared I2C bus *concurrently from different tasks*. TwoWire's lock serializes only single transactions; a PN532 conversation (write command → poll ready → read frame, with clock stretching) interleaved with GT911/IO-expander transactions wedges the I2C driver. Pre-PR, all bus users ran on one task and were naturally serialized.

**Fix:** global recursive `I2CBusLock` (`utils.hpp`) serializing complete logical bus conversations:

- every PN532 exchange in `NFC` (setup, SAMConfig, version check, detection poll, presence handshake, authenticate/changeKey) — detection/removal callbacks fire **outside** the bus lock
- GT911 init + every touch point read (and qualia FT/CST touch reads)
- IO expander register reads/writes
- the display-init I2C bus recovery path

The lock is a strict leaf lock (never held across callbacks, queues, or `lv_lock`); global lock order is `lv_lock → NFC opMutex → I2CBusLock` on every task, so no cycle. Also restores `Wire.setTimeOut(50)` after `pn532.begin()` (BusIO re-runs `Wire.begin()`, which resets the timeout — same pitfall as the SensorLib clock reset).

Worst-case touch-read delay behind an NFC presence handshake is bounded (~tens of ms every 250 ms while a card rests on the reader).

## Testing

- All 4 production envs build clean (`pio run`): attractap-touch, attractap-touch-v2, attractap-touch-ethernet, attractap-lite-ethernet.
- Coredump analysis: `esp-coredump` + per-thread GDB backtraces against a same-source build (see Linear comment for the full decode).
- Needs re-flash + on-device validation on reader-21: lockscreen NFC scan, touch responsiveness during scanning, enrollment/reset flows, no WDT reboot.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR/MR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
