### PR TITLE
fix(ATT-555): extract coredump build id so symbolication matches the right ELF

### DIFF
--- a/apps/api/src/attractap/attractap.service.ts
+++ b/apps/api/src/attractap/attractap.service.ts
@@ -271,9 +271,10 @@ export class AttractapService {
   ): Promise<void> {
     try {
       const reader = await this.readerRepository.findOne({ where: { id: readerId } });
+      // No explicit buildId: the symbolication service extracts the truncated app ELF
+      // SHA256 from the coredump itself and matches it against published firmware ELFs.
       const result = await this.coredumpSymbolicationService.symbolicate(coredump, {
         variant: reader?.firmware?.variant ?? null,
-        buildId: null,
       });
       await this.crashReportRepository.update(report.id, {
         coredumpBuildId: result.buildId,

--- a/apps/api/src/attractap/coredump-symbolication.service.spec.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.spec.ts
@@ -150,6 +150,28 @@ describe('CoredumpSymbolicationService', () => {
     expect(result.buildId).toBeNull();
   });
 
+  it('does not report the fallback ELF metadata build id when symbolication fails', async () => {
+    const binDir = tempDir();
+    const fakeTool = join(binDir, 'fake-esp-coredump');
+    // Produces no output, so runTool rejects and symbolication is reported as failed
+    writeFileSync(fakeTool, '#!/bin/sh\nexit 1\n');
+    chmodSync(fakeTool, 0o755);
+    process.env.ESP_COREDUMP_CMD = fakeTool;
+
+    const elfPath = join(binDir, 'fw.elf');
+    writeFileSync(elfPath, 'elf');
+    const service = makeService({
+      resolveElfFile: jest
+        .fn()
+        .mockReturnValue({ path: elfPath, firmware: { chip: 'esp32s3', buildId: 'f6899cb1067e5043' } }),
+    });
+
+    // No extractable build id → variant fallback → tool failure must not surface the ELF's build id
+    const result = await service.symbolicate(Buffer.from('no marker here'), { variant: 'eth' });
+    expect(result.status).toBe('failed');
+    expect(result.buildId).toBeNull();
+  });
+
   it('prefers an explicitly provided build id over extraction', async () => {
     const resolveElfFile = jest.fn().mockReturnValue(null);
     const service = makeService({ resolveElfFile });

--- a/apps/api/src/attractap/coredump-symbolication.service.spec.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.spec.ts
@@ -8,6 +8,43 @@ function makeService(firmware: Partial<AttractapFirmwareService>): CoredumpSymbo
   return new CoredumpSymbolicationService(firmware as AttractapFirmwareService);
 }
 
+/**
+ * Builds a coredump buffer matching the real ESP32 flash format produced by esp-idf:
+ * 20-byte flash header, inner ELF, and an ESP_CORE_DUMP_INFO ELF note whose payload is
+ * a u32 version followed by the truncated app ELF SHA256 as a zero-terminated ASCII
+ * hex string (esp_core_dump_elf.c).
+ */
+function buildCoredumpFixture(sha: string | null): Buffer {
+  // Flash header: data_len, version, tasks_num, tcb_sz, mem_segs_num
+  const flashHeader = Buffer.alloc(20);
+  flashHeader.writeUInt32LE(4096, 0);
+  flashHeader.writeUInt32LE(0x00010000, 4); // ELF format version
+  flashHeader.writeUInt32LE(12, 8);
+  flashHeader.writeUInt32LE(352, 12);
+  flashHeader.writeUInt32LE(2, 16);
+
+  // Minimal Elf32_Ehdr (magic + zero padding)
+  const elfHeader = Buffer.concat([Buffer.from('\x7fELF', 'latin1'), Buffer.alloc(48)]);
+
+  // ELF note: namesz/descsz/type header, 4-byte-padded name and desc
+  const name = Buffer.from('ESP_CORE_DUMP_INFO\0', 'latin1');
+  const namePadded = Buffer.concat([name, Buffer.alloc((4 - (name.length % 4)) % 4)]);
+  const desc = Buffer.concat([
+    Buffer.from([0x00, 0x02, 0x00, 0x00]), // note payload version (u32)
+    sha === null ? Buffer.alloc(0) : Buffer.from(`${sha}\0`, 'latin1'),
+  ]);
+  const descPadded = Buffer.concat([desc, Buffer.alloc((4 - (desc.length % 4)) % 4)]);
+  const noteHeader = Buffer.alloc(12);
+  noteHeader.writeUInt32LE(name.length, 0);
+  noteHeader.writeUInt32LE(desc.length, 4);
+  noteHeader.writeUInt32LE(8266, 8); // ELF_ESP_CORE_DUMP_INFO_TYPE
+
+  // Trailing task/memory segments (binary noise, must not be mistaken for a build id)
+  const trailingMemory = Buffer.alloc(64, 0xa5);
+
+  return Buffer.concat([flashHeader, elfHeader, noteHeader, namePadded, descPadded, trailingMemory]);
+}
+
 describe('CoredumpSymbolicationService', () => {
   const tempDirs: string[] = [];
   const originalCmd = process.env.ESP_COREDUMP_CMD;
@@ -42,6 +79,88 @@ describe('CoredumpSymbolicationService', () => {
     const result = await service.symbolicate(Buffer.from('core'), { variant: 'eth', buildId: null });
     expect(result.status).toBe('failed');
     expect(result.backtrace).toContain('No matching firmware ELF');
+  });
+
+  describe('extractBuildId', () => {
+    it('extracts the truncated app ELF SHA256 from a coredump', () => {
+      const service = makeService({});
+      expect(service.extractBuildId(buildCoredumpFixture('f6899cb1067e5043'))).toBe('f6899cb1067e5043');
+    });
+
+    it('normalizes the build id to lowercase', () => {
+      const service = makeService({});
+      expect(service.extractBuildId(buildCoredumpFixture('F6899CB1067E5043'))).toBe('f6899cb1067e5043');
+    });
+
+    it('returns null when the coredump has no ESP_CORE_DUMP_INFO note', () => {
+      const service = makeService({});
+      expect(service.extractBuildId(Buffer.alloc(256, 0xa5))).toBeNull();
+    });
+
+    it('returns null when the note carries no sha (truncated dump)', () => {
+      const service = makeService({});
+      expect(service.extractBuildId(buildCoredumpFixture(null))).toBeNull();
+    });
+  });
+
+  it('extracts the build id from the coredump and resolves the ELF strictly by it', async () => {
+    const binDir = tempDir();
+    const fakeTool = join(binDir, 'fake-esp-coredump');
+    writeFileSync(fakeTool, '#!/bin/sh\necho "#0 0x42066718 in ApplicationLoop::tick() at main.cpp:212"\n');
+    chmodSync(fakeTool, 0o755);
+    process.env.ESP_COREDUMP_CMD = fakeTool;
+
+    const elfPath = join(binDir, 'fw.elf');
+    writeFileSync(elfPath, 'elf');
+    const resolveElfFile = jest
+      .fn()
+      .mockReturnValue({ path: elfPath, firmware: { chip: 'esp32s3', buildId: 'f6899cb1067e5043' } });
+    const service = makeService({ resolveElfFile });
+
+    const result = await service.symbolicate(buildCoredumpFixture('f6899cb1067e5043'), { variant: 'eth' });
+
+    expect(resolveElfFile).toHaveBeenCalledTimes(1);
+    expect(resolveElfFile).toHaveBeenCalledWith({ buildId: 'f6899cb1067e5043' });
+    expect(result.status).toBe('success');
+    expect(result.buildId).toBe('f6899cb1067e5043');
+  });
+
+  it('fails with a message naming the build id when no ELF matches it (no variant fallback)', async () => {
+    const resolveElfFile = jest.fn().mockReturnValue(null);
+    const service = makeService({ resolveElfFile });
+
+    const result = await service.symbolicate(buildCoredumpFixture('aaaabbbbccccdddd'), { variant: 'eth' });
+
+    expect(resolveElfFile).toHaveBeenCalledTimes(1);
+    expect(resolveElfFile).toHaveBeenCalledWith({ buildId: 'aaaabbbbccccdddd' });
+    expect(result.status).toBe('failed');
+    expect(result.backtrace).toContain('aaaabbbbccccdddd');
+    expect(result.buildId).toBe('aaaabbbbccccdddd');
+  });
+
+  it('falls back to variant matching only when no build id can be extracted', async () => {
+    const resolveElfFile = jest.fn().mockReturnValue(null);
+    const service = makeService({ resolveElfFile });
+
+    const result = await service.symbolicate(Buffer.from('no marker here'), { variant: 'eth' });
+
+    expect(resolveElfFile).toHaveBeenCalledWith({ variant: 'eth' });
+    expect(result.status).toBe('failed');
+    expect(result.backtrace).toContain('No matching firmware ELF');
+    expect(result.buildId).toBeNull();
+  });
+
+  it('prefers an explicitly provided build id over extraction', async () => {
+    const resolveElfFile = jest.fn().mockReturnValue(null);
+    const service = makeService({ resolveElfFile });
+
+    const result = await service.symbolicate(buildCoredumpFixture('f6899cb1067e5043'), {
+      variant: 'eth',
+      buildId: '1111222233334444',
+    });
+
+    expect(resolveElfFile).toHaveBeenCalledWith({ buildId: '1111222233334444' });
+    expect(result.buildId).toBe('1111222233334444');
   });
 
   it('returns unavailable when the esp-coredump tool is missing', async () => {

--- a/apps/api/src/attractap/coredump-symbolication.service.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.ts
@@ -16,6 +16,15 @@ export interface SymbolicationResult {
 const SYMBOLICATION_TIMEOUT_MS = 30000;
 const MAX_OUTPUT_BYTES = 2 * 1024 * 1024;
 
+// ELF note name written by esp-idf's core dump component (esp_core_dump_elf.c).
+// Its note payload contains the truncated app ELF SHA256 as a plain ASCII hex string.
+const ESP_CORE_DUMP_INFO_MARKER = Buffer.from('ESP_CORE_DUMP_INFO', 'ascii');
+// Note payload: u32 version + zero-terminated ASCII sha. Scan a small window after the
+// marker so we never pick up unrelated hex sequences elsewhere in the dump.
+const BUILD_ID_SCAN_WINDOW_BYTES = 128;
+// esp-idf truncates the app ELF SHA256 to CONFIG_APP_RETRIEVE_LEN_ELF_SHA hex chars (default 16).
+const BUILD_ID_PATTERN = /[0-9a-fA-F]{16,64}/;
+
 @Injectable()
 export class CoredumpSymbolicationService {
   private readonly logger = new Logger(CoredumpSymbolicationService.name);
@@ -31,16 +40,37 @@ export class CoredumpSymbolicationService {
       return { status: 'skipped', backtrace: null, buildId: options.buildId ?? null };
     }
 
-    const elf = this.firmwareService.resolveElfFile({ buildId: options.buildId, variant: options.variant });
-    if (!elf) {
+    const buildId = options.buildId ?? this.extractBuildId(coredump);
+
+    let elf: ReturnType<AttractapFirmwareService['resolveElfFile']> = null;
+    if (buildId) {
+      // Strict match on the build id embedded in the coredump. A variant-matched ELF for a
+      // different build would only produce esp-coredump's misleading SHA-mismatch failure.
+      elf = this.firmwareService.resolveElfFile({ buildId });
+      if (!elf) {
+        this.logger.warn(
+          `No firmware ELF matching coredump build id ${buildId} (variant=${options.variant ?? 'n/a'})`,
+        );
+        return {
+          status: 'failed',
+          backtrace: `No firmware ELF matching coredump build id ${buildId} was found on the server, so the coredump could not be symbolized. The reader is likely running a build that was never published with an ELF (e.g. a local development build).`,
+          buildId,
+        };
+      }
+    } else {
+      // Last resort: the dump is too truncated/corrupted to carry a build id, so try the
+      // server's ELF for the reader's variant. esp-coredump will still verify the SHA itself.
       this.logger.warn(
-        `No matching ELF for coredump (variant=${options.variant ?? 'n/a'}, buildId=${options.buildId ?? 'n/a'})`,
+        `Could not extract build id from coredump; falling back to variant match (variant=${options.variant ?? 'n/a'})`,
       );
-      return {
-        status: 'failed',
-        backtrace: 'No matching firmware ELF was found on the server, so the coredump could not be symbolized.',
-        buildId: options.buildId ?? null,
-      };
+      elf = this.firmwareService.resolveElfFile({ variant: options.variant });
+      if (!elf) {
+        return {
+          status: 'failed',
+          backtrace: 'No matching firmware ELF was found on the server, so the coredump could not be symbolized.',
+          buildId: null,
+        };
+      }
     }
 
     const workingDir = await mkdtemp(join(tmpdir(), 'attractap-coredump-'));
@@ -52,19 +82,42 @@ export class CoredumpSymbolicationService {
       return {
         status: 'success',
         backtrace: output,
-        buildId: elf.firmware.buildId ?? options.buildId ?? null,
+        buildId: elf.firmware.buildId ?? buildId ?? null,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (this.isToolMissing(message)) {
         this.logger.error(`esp-coredump tool not available: ${message}`);
-        return { status: 'unavailable', backtrace: null, buildId: options.buildId ?? null };
+        return { status: 'unavailable', backtrace: null, buildId: buildId ?? null };
       }
       this.logger.error(`Coredump symbolication failed: ${message}`);
-      return { status: 'failed', backtrace: message, buildId: elf.firmware.buildId ?? options.buildId ?? null };
+      return { status: 'failed', backtrace: message, buildId: elf.firmware.buildId ?? buildId ?? null };
     } finally {
       await rm(workingDir, { recursive: true, force: true }).catch(() => undefined);
     }
+  }
+
+  /**
+   * Extracts the truncated app ELF SHA256 ("build id") from a raw ESP32 coredump.
+   *
+   * The flash-format coredump (20-byte header + inner ELF) contains an ELF note named
+   * ESP_CORE_DUMP_INFO whose payload is a u32 version followed by the truncated app ELF
+   * SHA256 as a zero-terminated ASCII hex string (CONFIG_APP_RETRIEVE_LEN_ELF_SHA chars,
+   * 16 by default). We locate the note name and scan a small window after it.
+   */
+  public extractBuildId(coredump: Buffer): string | null {
+    const markerIndex = coredump.indexOf(ESP_CORE_DUMP_INFO_MARKER);
+    if (markerIndex === -1) {
+      return null;
+    }
+
+    const windowStart = markerIndex + ESP_CORE_DUMP_INFO_MARKER.length;
+    const window = coredump
+      .subarray(windowStart, windowStart + BUILD_ID_SCAN_WINDOW_BYTES)
+      .toString('latin1');
+
+    const match = window.match(BUILD_ID_PATTERN);
+    return match ? match[0].toLowerCase() : null;
   }
 
   private runTool(elfPath: string, corePath: string, chip: string | null): Promise<string> {

--- a/apps/api/src/attractap/coredump-symbolication.service.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.ts
@@ -82,6 +82,8 @@ export class CoredumpSymbolicationService {
       return {
         status: 'success',
         backtrace: output,
+        // esp-coredump verified the ELF's SHA against the dump, so the ELF's (full) build id
+        // is the coredump's build id — even when the ELF was resolved via variant fallback.
         buildId: elf.firmware.buildId ?? buildId ?? null,
       };
     } catch (error) {
@@ -91,7 +93,9 @@ export class CoredumpSymbolicationService {
         return { status: 'unavailable', backtrace: null, buildId: buildId ?? null };
       }
       this.logger.error(`Coredump symbolication failed: ${message}`);
-      return { status: 'failed', backtrace: message, buildId: elf.firmware.buildId ?? buildId ?? null };
+      // Unverified: only report a build id that actually came from the coredump, not the
+      // metadata of an ELF that esp-coredump may have just rejected.
+      return { status: 'failed', backtrace: message, buildId: buildId ?? null };
     } finally {
       await rm(workingDir, { recursive: true, force: true }).catch(() => undefined);
     }


### PR DESCRIPTION
Assignee: @jappyjan ([jappy](https://linear.app/attraccess/profiles/jappy))

Fixes [ATT-555](https://linear.app/attraccess/issue/ATT-555/attractap-coredump-symbolication-never-works-server-passes-buildid) / closes #1334

## Problem

`attractap.service.ts` called the symbolication service with a hardcoded `buildId: null`. Consequences:

- `AttractapFirmwareService.getFirmwareByBuildId()` (correct two-way prefix matching of the truncated 16-hex-char SHA against the full 64-char SHA in `firmwares.json`) was dead code.
- `resolveElfFile()` always fell back to *any* variant-matched ELF — i.e. the server's currently bundled build.
- `esp-coredump info_corefile` then hard-failed its SHA check (`coredump SHA256(...) != app SHA256(...)`) → `symbolicationStatus: failed` for effectively every crash report.

## Fix

- **`CoredumpSymbolicationService.extractBuildId()`**: extracts the truncated app ELF SHA256 from the coredump itself — locates the `ESP_CORE_DUMP_INFO` ELF note (written by esp-idf's `esp_core_dump_elf.c`) and reads the ASCII hex sha from its payload.
- **`symbolicate()`** now resolves the ELF **strictly by extracted build id**. If no published firmware matches, it fails fast with a message naming the build id ("likely a local/unpublished build") instead of running esp-coredump against a wrong ELF and surfacing the misleading SHA-mismatch trace.
- **Variant fallback** kept only as a last resort for dumps too truncated/corrupted to carry a build id (esp-coredump still verifies the SHA itself in that path).
- Call site passes only the variant; the hardcoded `buildId: null` is gone. An explicitly provided `buildId` still takes precedence over extraction.

## Testing

- New unit tests in `coredump-symbolication.service.spec.ts` (12 total, all passing): build-id extraction from a fixture replicating the real flash-format dump (20-byte header + inner ELF + `ESP_CORE_DUMP_INFO` note with u32 version + zero-terminated ASCII sha), lowercase normalization, missing/truncated note handling, strict build-id resolution, no-match failure naming the build id, variant fallback only without extractable build id, explicit-buildId precedence.
- Full `api` suite: 141 suites / 1490 tests pass. Lint clean. Build compiles.

API-only change, no frontend/UI impact — no screenshots applicable.

---
> **Tip:** I will respond to comments that @ mention @giesela-schlepptop on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->

## Summary by Sourcery

Improve ESP32 coredump symbolication by extracting and using the embedded build id from dumps instead of relying solely on variant matching.

Bug Fixes:
- Ensure coredump symbolication uses the correct firmware ELF by matching on the coredump’s embedded build id rather than a variant-only fallback that could select the wrong ELF.

Enhancements:
- Add logic to parse the ESP_CORE_DUMP_INFO note from ESP32 coredumps and extract the truncated app ELF SHA256 as the build id.
- Adjust symbolication result handling to propagate the resolved or extracted build id through success, failure, and tool-unavailable outcomes.
- Update the Attractap service to stop passing a hardcoded null build id and rely on automatic extraction from the coredump.

Tests:
- Extend coredump symbolication unit tests with realistic ESP32 coredump fixtures and scenarios covering build-id extraction, fallback behavior, and precedence of explicitly provided build ids.