### PR TITLE
feat(ATT-522): RabbitMQ plugin — MQTT user management (CRUD + permissions)

### DIFF
--- a/apps/plugins/rabbitmq/backend/plugin.ts
+++ b/apps/plugins/rabbitmq/backend/plugin.ts
@@ -11,6 +11,9 @@ import { Auth } from '@attraccess/plugins-backend-sdk';
 import { Controller, DynamicModule, Get, Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { RabbitmqDetectionController } from './rabbitmq-detection.controller';
 import { RabbitmqDetectionService } from './rabbitmq-detection.service';
+import { RabbitmqManagementClient } from './rabbitmq-management-client';
+import { RabbitmqUsersController } from './rabbitmq-users.controller';
+import { RabbitmqUsersService } from './rabbitmq-users.service';
 
 // The host hands each plugin its PluginContext under this token. Recreate it
 // locally (do not import the value) so the artifact has no runtime dependency on
@@ -52,11 +55,13 @@ const plugin: PluginBackendModule = {
   register(context: PluginContext): DynamicModule {
     return {
       module: RabbitmqPluginModule,
-      controllers: [RabbitmqController, RabbitmqDetectionController],
+      controllers: [RabbitmqController, RabbitmqDetectionController, RabbitmqUsersController],
       providers: [
         { provide: PLUGIN_CONTEXT, useValue: context },
         RabbitmqService,
         RabbitmqDetectionService,
+        RabbitmqManagementClient,
+        RabbitmqUsersService,
       ],
     };
   },

--- a/apps/plugins/rabbitmq/backend/rabbitmq-management-client.ts
+++ b/apps/plugins/rabbitmq/backend/rabbitmq-management-client.ts
@@ -1,0 +1,166 @@
+// Thin HTTP client for the RabbitMQ management API (ATT-522).
+//
+// Wraps fetch with the conventions every management call shares: base URL
+// derived from the generic MQTT config (the management API listens on its own
+// port, 15672/15671 by convention), Basic auth from the MQTT server
+// credentials, a request timeout, and translation of upstream failures into
+// HTTP exceptions whose messages tell the operator what actually went wrong
+// (unreachable broker, rejected credentials, missing management privileges, …).
+import type { MqttServerConnectionConfig } from '@attraccess/plugins-backend-sdk';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+
+const MGMT_PORT_HTTP = 15672;
+const MGMT_PORT_HTTPS = 15671;
+
+// Management operations are quick; a broker that takes longer than this is
+// treated as unreachable instead of stalling the request.
+const REQUEST_TIMEOUT_MS = 10_000;
+
+// RabbitMQ error envelope: failures answer `{"error": "...", "reason": "..."}`.
+interface RabbitmqErrorBody {
+  error?: string;
+  reason?: string;
+}
+
+@Injectable()
+export class RabbitmqManagementClient {
+  // Builds the management API base URL from the generic MQTT config (same
+  // convention as RabbitmqDetectionService).
+  managementApiBase(config: MqttServerConnectionConfig): string {
+    const scheme = config.useTls ? 'https' : 'http';
+    const port = config.useTls ? MGMT_PORT_HTTPS : MGMT_PORT_HTTP;
+    return `${scheme}://${config.host}:${port}`;
+  }
+
+  // Performs one management API request. `path` is relative to `/api`, with
+  // every variable segment already URL-encoded by the caller. Returns the
+  // parsed JSON body (or null for empty responses, e.g. 201/204).
+  async request<T>(
+    config: MqttServerConnectionConfig,
+    method: 'GET' | 'PUT' | 'DELETE',
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const base = this.managementApiBase(config);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    let response: Response;
+    try {
+      response = await fetch(`${base}/api${path}`, {
+        method,
+        headers: {
+          accept: 'application/json',
+          ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+          ...this.authHeader(config),
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      throw new HttpException(
+        `Cannot reach the RabbitMQ management API at ${base}: ${this.describeNetworkError(error)}`,
+        HttpStatus.BAD_GATEWAY
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+      throw await this.toHttpException(response);
+    }
+
+    return this.parseBody<T>(response);
+  }
+
+  private authHeader(config: MqttServerConnectionConfig): Record<string, string> {
+    if (config.username === null) {
+      return {};
+    }
+    const credentials = `${config.username}:${config.password ?? ''}`;
+    const encoded = Buffer.from(credentials, 'utf8').toString('base64');
+    return { authorization: `Basic ${encoded}` };
+  }
+
+  // Maps an upstream error response to an exception with an actionable
+  // message. Auth failures surface as 502 (not 401/403) so the host frontend
+  // doesn't mistake them for an expired Attraccess session.
+  private async toHttpException(response: Response): Promise<HttpException> {
+    const upstream = await this.parseErrorBody(response);
+    const reason = upstream?.reason || upstream?.error || '';
+
+    if (response.status === 401) {
+      return new HttpException(
+        'The RabbitMQ management API rejected the configured MQTT server credentials (401). ' +
+          'Check the username/password configured for this MQTT server.',
+        HttpStatus.BAD_GATEWAY
+      );
+    }
+
+    if (response.status === 403 || /not.?authori[sz]ed/i.test(reason)) {
+      return new HttpException(
+        'The configured MQTT server user lacks management privileges on RabbitMQ' +
+          (reason ? ` (${reason})` : '') +
+          '. User management requires a user with the "administrator" tag.',
+        HttpStatus.BAD_GATEWAY
+      );
+    }
+
+    if (response.status === 404) {
+      return new HttpException(
+        `Not found on the RabbitMQ side${reason ? `: ${reason}` : '.'}`,
+        HttpStatus.NOT_FOUND
+      );
+    }
+
+    if (response.status === 400) {
+      return new HttpException(
+        `RabbitMQ rejected the request${reason ? `: ${reason}` : '.'}`,
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    return new HttpException(
+      `RabbitMQ management API request failed (HTTP ${response.status})${reason ? `: ${reason}` : '.'}`,
+      HttpStatus.BAD_GATEWAY
+    );
+  }
+
+  private async parseBody<T>(response: Response): Promise<T> {
+    const text = await response.text();
+    if (text.length === 0) {
+      return null as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new HttpException(
+        'The RabbitMQ management API returned a response that is not valid JSON.',
+        HttpStatus.BAD_GATEWAY
+      );
+    }
+  }
+
+  private async parseErrorBody(response: Response): Promise<RabbitmqErrorBody | null> {
+    try {
+      return (await response.json()) as RabbitmqErrorBody;
+    } catch {
+      return null;
+    }
+  }
+
+  private describeNetworkError(error: unknown): string {
+    if (error instanceof Error) {
+      if (error.name === 'AbortError') {
+        return `no response within ${REQUEST_TIMEOUT_MS}ms`;
+      }
+      // Node's fetch wraps the interesting part (ECONNREFUSED etc.) in `cause`.
+      const cause = (error as { cause?: unknown }).cause;
+      if (cause instanceof Error && cause.message) {
+        return cause.message;
+      }
+      return error.message;
+    }
+    return 'unknown network error';
+  }
+}

--- a/apps/plugins/rabbitmq/backend/rabbitmq-users.controller.ts
+++ b/apps/plugins/rabbitmq/backend/rabbitmq-users.controller.ts
@@ -1,0 +1,80 @@
+// HTTP surface for RabbitMQ user management (ATT-522).
+//
+// Mounts the user CRUD + permission routes into the host API under
+// `/rabbitmq/users/...`, gated by the same access level as the host MQTT
+// servers controller. The frontend user-management panel (MQTT server detail
+// slot) is the only consumer.
+//
+// The vhost travels as a query parameter (not a path segment) because the
+// default RabbitMQ vhost is literally "/", which does not survive as a path
+// parameter.
+import { Auth } from '@attraccess/plugins-backend-sdk';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Param,
+  ParseIntPipe,
+  Put,
+  Query,
+} from '@nestjs/common';
+import { RabbitmqUsersService } from './rabbitmq-users.service';
+import type { RabbitmqUserList, SetRabbitmqPermissionDto, UpsertRabbitmqUserDto } from './rabbitmq-users.types';
+
+@Auth('canManageResources')
+@Controller('rabbitmq')
+export class RabbitmqUsersController {
+  // esbuild does not emit decorator metadata, so Nest cannot infer constructor
+  // types for injection — always inject by an explicit token.
+  constructor(@Inject(RabbitmqUsersService) private readonly users: RabbitmqUsersService) {}
+
+  @Get('users/:mqttServerId')
+  list(@Param('mqttServerId', ParseIntPipe) mqttServerId: number): Promise<RabbitmqUserList> {
+    return this.users.listUsers(mqttServerId);
+  }
+
+  @Put('users/:mqttServerId/:username')
+  upsert(
+    @Param('mqttServerId', ParseIntPipe) mqttServerId: number,
+    @Param('username') username: string,
+    @Body() dto: UpsertRabbitmqUserDto
+  ): Promise<void> {
+    return this.users.upsertUser(mqttServerId, username, dto ?? {});
+  }
+
+  @Delete('users/:mqttServerId/:username')
+  remove(
+    @Param('mqttServerId', ParseIntPipe) mqttServerId: number,
+    @Param('username') username: string
+  ): Promise<void> {
+    return this.users.deleteUser(mqttServerId, username);
+  }
+
+  @Put('users/:mqttServerId/:username/permissions')
+  setPermissions(
+    @Param('mqttServerId', ParseIntPipe) mqttServerId: number,
+    @Param('username') username: string,
+    @Body() dto: SetRabbitmqPermissionDto
+  ): Promise<void> {
+    if (!dto || typeof dto.vhost !== 'string') {
+      throw new HttpException('A vhost is required.', HttpStatus.BAD_REQUEST);
+    }
+    return this.users.setPermissions(mqttServerId, username, dto);
+  }
+
+  @Delete('users/:mqttServerId/:username/permissions')
+  clearPermissions(
+    @Param('mqttServerId', ParseIntPipe) mqttServerId: number,
+    @Param('username') username: string,
+    @Query('vhost') vhost?: string
+  ): Promise<void> {
+    if (typeof vhost !== 'string' || vhost.length === 0) {
+      throw new HttpException('A vhost query parameter is required.', HttpStatus.BAD_REQUEST);
+    }
+    return this.users.clearPermissions(mqttServerId, username, vhost);
+  }
+}

--- a/apps/plugins/rabbitmq/backend/rabbitmq-users.service.ts
+++ b/apps/plugins/rabbitmq/backend/rabbitmq-users.service.ts
@@ -1,0 +1,218 @@
+// RabbitMQ user management — plugin-side business logic (ATT-522).
+//
+// Translates the plugin's user-management surface into RabbitMQ management API
+// calls. As with detection, all RabbitMQ knowledge lives here in the plugin:
+// the core only hands us a generic MqttServerConnectionConfig through the
+// sanctioned ACCESS_MQTT_SERVERS hook, and the management API is reached with
+// the MQTT server's own credentials.
+import type { MqttServerConnectionConfig, PluginContext } from '@attraccess/plugins-backend-sdk';
+import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { RabbitmqManagementClient } from './rabbitmq-management-client';
+import type {
+  RabbitmqPermission,
+  RabbitmqUser,
+  RabbitmqUserList,
+  SetRabbitmqPermissionDto,
+  UpsertRabbitmqUserDto,
+} from './rabbitmq-users.types';
+
+const PLUGIN_CONTEXT = Symbol.for('attraccess.plugin.context');
+
+// Raw shapes returned by the RabbitMQ management API. Only the fields we read.
+interface RawUser {
+  name: string;
+  // Array on RabbitMQ >= 3.9, comma-separated string on older brokers.
+  tags?: string[] | string;
+  password_hash?: string;
+  hashing_algorithm?: string;
+}
+
+interface RawPermission {
+  user: string;
+  vhost: string;
+  configure: string;
+  write: string;
+  read: string;
+}
+
+interface RawVhost {
+  name: string;
+}
+
+// Body of PUT /api/users/:name. RabbitMQ replaces the whole user record, so an
+// update that should keep the password re-sends the stored hash.
+interface PutUserBody {
+  tags: string;
+  password?: string;
+  password_hash?: string;
+  hashing_algorithm?: string;
+}
+
+@Injectable()
+export class RabbitmqUsersService {
+  constructor(
+    @Inject(PLUGIN_CONTEXT) private readonly context: PluginContext,
+    @Inject(RabbitmqManagementClient) private readonly client: RabbitmqManagementClient
+  ) {}
+
+  // Lists all users with their per-vhost permissions, plus the vhost list for
+  // the UI's vhost choices. Three management calls, joined here.
+  async listUsers(mqttServerId: number): Promise<RabbitmqUserList> {
+    const config = await this.requireConfig(mqttServerId);
+
+    const [rawUsers, rawPermissions, rawVhosts] = await Promise.all([
+      this.client.request<RawUser[]>(config, 'GET', '/users'),
+      this.client.request<RawPermission[]>(config, 'GET', '/permissions'),
+      this.client.request<RawVhost[]>(config, 'GET', '/vhosts'),
+    ]);
+
+    const permissionsByUser = new Map<string, RabbitmqPermission[]>();
+    for (const permission of rawPermissions ?? []) {
+      const list = permissionsByUser.get(permission.user) ?? [];
+      list.push({
+        vhost: permission.vhost,
+        configure: permission.configure,
+        write: permission.write,
+        read: permission.read,
+      });
+      permissionsByUser.set(permission.user, list);
+    }
+
+    const users: RabbitmqUser[] = (rawUsers ?? []).map((user) => ({
+      name: user.name,
+      tags: this.normalizeTags(user.tags),
+      permissions: permissionsByUser.get(user.name) ?? [],
+    }));
+    users.sort((a, b) => a.name.localeCompare(b.name));
+
+    return {
+      mqttServerId,
+      users,
+      vhosts: (rawVhosts ?? []).map((vhost) => vhost.name).sort((a, b) => a.localeCompare(b)),
+    };
+  }
+
+  // Creates or updates one user, optionally applying per-vhost permissions in
+  // the same operation (used by the create form's "default MQTT permissions").
+  async upsertUser(mqttServerId: number, username: string, dto: UpsertRabbitmqUserDto): Promise<void> {
+    this.assertValidName(username, 'Username');
+    const config = await this.requireConfig(mqttServerId);
+
+    const existing = await this.findUser(config, username);
+    const password = dto.password?.length ? dto.password : undefined;
+
+    if (!existing && !password) {
+      throw new HttpException('Password is required when creating a new user.', HttpStatus.BAD_REQUEST);
+    }
+
+    const body: PutUserBody = { tags: (dto.tags ?? this.normalizeTags(existing?.tags)).join(',') };
+    if (password) {
+      body.password = password;
+    } else if (existing?.password_hash) {
+      // PUT replaces the record — re-send the stored hash to keep the password.
+      body.password_hash = existing.password_hash;
+      if (existing.hashing_algorithm) {
+        body.hashing_algorithm = existing.hashing_algorithm;
+      }
+    }
+
+    await this.client.request(config, 'PUT', `/users/${encodeURIComponent(username)}`, body);
+
+    for (const permission of dto.permissions ?? []) {
+      await this.putPermission(config, username, permission);
+    }
+  }
+
+  async deleteUser(mqttServerId: number, username: string): Promise<void> {
+    this.assertValidName(username, 'Username');
+    const config = await this.requireConfig(mqttServerId);
+
+    if (config.username !== null && config.username === username) {
+      // Deleting the account the management calls run as would lock the plugin
+      // (and the broker connection) out.
+      throw new HttpException(
+        'Refusing to delete the user the MQTT server connection is configured with.',
+        HttpStatus.BAD_REQUEST
+      );
+    }
+
+    // RabbitMQ drops the user's permissions together with the user.
+    await this.client.request(config, 'DELETE', `/users/${encodeURIComponent(username)}`);
+  }
+
+  async setPermissions(mqttServerId: number, username: string, dto: SetRabbitmqPermissionDto): Promise<void> {
+    this.assertValidName(username, 'Username');
+    this.assertValidName(dto.vhost, 'Vhost');
+    const config = await this.requireConfig(mqttServerId);
+    await this.putPermission(config, username, dto);
+  }
+
+  async clearPermissions(mqttServerId: number, username: string, vhost: string): Promise<void> {
+    this.assertValidName(username, 'Username');
+    this.assertValidName(vhost, 'Vhost');
+    const config = await this.requireConfig(mqttServerId);
+    await this.client.request(
+      config,
+      'DELETE',
+      `/permissions/${encodeURIComponent(vhost)}/${encodeURIComponent(username)}`
+    );
+  }
+
+  private async putPermission(
+    config: MqttServerConnectionConfig,
+    username: string,
+    permission: RabbitmqPermission | SetRabbitmqPermissionDto
+  ): Promise<void> {
+    await this.client.request(
+      config,
+      'PUT',
+      `/permissions/${encodeURIComponent(permission.vhost)}/${encodeURIComponent(username)}`,
+      {
+        configure: permission.configure ?? '',
+        write: permission.write ?? '',
+        read: permission.read ?? '',
+      }
+    );
+  }
+
+  // Reads one user; null when the broker doesn't know the name.
+  private async findUser(config: MqttServerConnectionConfig, username: string): Promise<RawUser | null> {
+    try {
+      return await this.client.request<RawUser>(config, 'GET', `/users/${encodeURIComponent(username)}`);
+    } catch (error) {
+      if (error instanceof HttpException && error.getStatus() === HttpStatus.NOT_FOUND) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private async requireConfig(mqttServerId: number): Promise<MqttServerConnectionConfig> {
+    // ACCESS_MQTT_SERVERS gates this call; the core resolves + decrypts the
+    // credentials and hands us a broker-agnostic config.
+    const config = await this.context.getMqttServerConfig(mqttServerId);
+    if (!config) {
+      throw new HttpException('MQTT server not found.', HttpStatus.NOT_FOUND);
+    }
+    return config;
+  }
+
+  private normalizeTags(tags: RawUser['tags']): string[] {
+    if (Array.isArray(tags)) {
+      return tags.filter((tag) => tag.length > 0);
+    }
+    if (typeof tags === 'string' && tags.length > 0) {
+      return tags.split(',').map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+    }
+    return [];
+  }
+
+  private assertValidName(value: string, label: string): void {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new HttpException(`${label} must not be empty.`, HttpStatus.BAD_REQUEST);
+    }
+    if (value.length > 255) {
+      throw new HttpException(`${label} must be at most 255 characters.`, HttpStatus.BAD_REQUEST);
+    }
+  }
+}

--- a/apps/plugins/rabbitmq/backend/rabbitmq-users.types.ts
+++ b/apps/plugins/rabbitmq/backend/rabbitmq-users.types.ts
@@ -1,0 +1,58 @@
+// Shared types for RabbitMQ user management (ATT-522).
+//
+// Mirrored on the frontend in frontend/src/users-api.ts — the backend and
+// frontend are separate bundles with no shared module (same approach as
+// rabbitmq-detection.types.ts).
+
+// Permissions one user holds on one vhost. The three fields are RabbitMQ
+// permission regexes (configure / write / read).
+export interface RabbitmqPermission {
+  readonly vhost: string;
+  readonly configure: string;
+  readonly write: string;
+  readonly read: string;
+}
+
+// One RabbitMQ user as the plugin presents it: name, tags and the permissions
+// across all vhosts, joined from GET /api/users + GET /api/permissions.
+export interface RabbitmqUser {
+  readonly name: string;
+  readonly tags: string[];
+  readonly permissions: RabbitmqPermission[];
+}
+
+// Response of GET /rabbitmq/users/:mqttServerId. Includes the vhost list so the
+// UI can offer vhost choices without an extra round trip.
+export interface RabbitmqUserList {
+  readonly mqttServerId: number;
+  readonly users: RabbitmqUser[];
+  readonly vhosts: string[];
+}
+
+// Body of PUT /rabbitmq/users/:mqttServerId/:username (create or update).
+// - `password` is required when the user does not exist yet; on update an
+//   absent/empty password keeps the current one (we re-send the stored hash).
+// - `tags` replaces the user's tags (empty array = no tags).
+// - `permissions`, when present, is applied per vhost after the user upsert.
+export interface UpsertRabbitmqUserDto {
+  password?: string;
+  tags?: string[];
+  permissions?: RabbitmqPermission[];
+}
+
+// Body of PUT /rabbitmq/users/:mqttServerId/:username/permissions.
+export interface SetRabbitmqPermissionDto {
+  vhost: string;
+  configure: string;
+  write: string;
+  read: string;
+}
+
+// The permissions an MQTT client needs on a RabbitMQ broker: it may only
+// (re)declare its own subscription queues, and publish/consume via the topic
+// exchange. Documented in .env.docker-compose at the repo root.
+export const DEFAULT_MQTT_PERMISSIONS = {
+  configure: '^mqtt-subscription-.*$',
+  write: '^(amq\\.topic|mqtt-subscription-.*)$',
+  read: '^(amq\\.topic|mqtt-subscription-.*)$',
+} as const;

--- a/apps/plugins/rabbitmq/frontend/src/RabbitmqPermissionsModal.tsx
+++ b/apps/plugins/rabbitmq/frontend/src/RabbitmqPermissionsModal.tsx
@@ -1,0 +1,277 @@
+// Per-vhost permission editor for one RabbitMQ user (ATT-522).
+//
+// Shows one editable block per vhost the user has permissions on. Each block
+// edits the three RabbitMQ permission regexes (configure / write / read) and
+// saves or removes that vhost's permissions individually. A footer row adds
+// permissions on another vhost, prefilled with the default MQTT permissions.
+import {
+  Alert,
+  AlertContent,
+  AlertDescription,
+  Button,
+  Input,
+  Label,
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalContainer,
+  ModalDialog,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  TextField,
+} from '@heroui/react';
+import { PlusIcon, Trash2Icon } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import {
+  DEFAULT_MQTT_PERMISSIONS,
+  clearPermissions,
+  setPermissions,
+  type RabbitmqPermission,
+  type RabbitmqUser,
+} from './users-api';
+
+export interface RabbitmqPermissionsModalProps {
+  mqttServerId: number;
+  isOpen: boolean;
+  user: RabbitmqUser | null;
+  vhosts: string[];
+  onClose: () => void;
+  // Called after every successful change so the panel reflects the broker.
+  onSaved: () => void;
+}
+
+interface PermissionRow extends RabbitmqPermission {
+  // Rows added via "Add vhost" don't exist on the broker until saved — their
+  // remove button only drops the row locally.
+  persisted: boolean;
+}
+
+function PermissionEditor({
+  row,
+  busy,
+  onChange,
+  onSave,
+  onRemove,
+}: {
+  row: PermissionRow;
+  busy: boolean;
+  onChange: (next: PermissionRow) => void;
+  onSave: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-lg border border-default-200 dark:border-default-100 p-3"
+      data-cy={`rabbitmq-permissions-row-${row.vhost}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-semibold text-default-700">
+          Vhost <code>{row.vhost}</code>
+        </span>
+        <Button
+          isIconOnly
+          size="sm"
+          variant="ghost"
+          aria-label={`Remove permissions on ${row.vhost}`}
+          onPress={onRemove}
+          isDisabled={busy}
+          data-cy={`rabbitmq-permissions-remove-button-${row.vhost}`}
+        >
+          <Trash2Icon className="w-4 h-4 text-danger" />
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        <TextField value={row.configure} onChange={(v) => onChange({ ...row, configure: v })}>
+          <Label>Configure</Label>
+          <Input autoComplete="off" data-cy={`rabbitmq-permissions-configure-input-${row.vhost}`} />
+        </TextField>
+        <TextField value={row.write} onChange={(v) => onChange({ ...row, write: v })}>
+          <Label>Write</Label>
+          <Input autoComplete="off" data-cy={`rabbitmq-permissions-write-input-${row.vhost}`} />
+        </TextField>
+        <TextField value={row.read} onChange={(v) => onChange({ ...row, read: v })}>
+          <Label>Read</Label>
+          <Input autoComplete="off" data-cy={`rabbitmq-permissions-read-input-${row.vhost}`} />
+        </TextField>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button
+          size="sm"
+          variant="ghost"
+          onPress={() => onChange({ ...row, ...DEFAULT_MQTT_PERMISSIONS })}
+          isDisabled={busy}
+          data-cy={`rabbitmq-permissions-mqtt-defaults-button-${row.vhost}`}
+        >
+          Use MQTT defaults
+        </Button>
+        <Button
+          size="sm"
+          variant="primary"
+          onPress={onSave}
+          isPending={busy}
+          data-cy={`rabbitmq-permissions-save-button-${row.vhost}`}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function RabbitmqPermissionsModal({
+  mqttServerId,
+  isOpen,
+  user,
+  vhosts,
+  onClose,
+  onSaved,
+}: RabbitmqPermissionsModalProps) {
+  const [rows, setRows] = useState<PermissionRow[]>([]);
+  const [newVhost, setNewVhost] = useState('');
+  const [busyVhost, setBusyVhost] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed from the user whenever the modal opens.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setRows((user?.permissions ?? []).map((permission) => ({ ...permission, persisted: true })));
+    setNewVhost('');
+    setBusyVhost(null);
+    setError(null);
+  }, [isOpen, user]);
+
+  if (!user) {
+    return null;
+  }
+
+  const updateRow = (index: number, next: PermissionRow) => {
+    setRows((current) => current.map((row, i) => (i === index ? next : row)));
+  };
+
+  const saveRow = async (index: number) => {
+    const row = rows[index];
+    setBusyVhost(row.vhost);
+    setError(null);
+    try {
+      await setPermissions(mqttServerId, user.name, {
+        vhost: row.vhost,
+        configure: row.configure,
+        write: row.write,
+        read: row.read,
+      });
+      updateRow(index, { ...row, persisted: true });
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Saving permissions failed.');
+    } finally {
+      setBusyVhost(null);
+    }
+  };
+
+  const removeRow = async (index: number) => {
+    const row = rows[index];
+    if (!row.persisted) {
+      setRows((current) => current.filter((_, i) => i !== index));
+      return;
+    }
+    setBusyVhost(row.vhost);
+    setError(null);
+    try {
+      await clearPermissions(mqttServerId, user.name, row.vhost);
+      setRows((current) => current.filter((_, i) => i !== index));
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Removing permissions failed.');
+    } finally {
+      setBusyVhost(null);
+    }
+  };
+
+  const addVhost = () => {
+    const vhost = newVhost.trim();
+    if (vhost.length === 0) {
+      return;
+    }
+    if (rows.some((row) => row.vhost === vhost)) {
+      setError(`Permissions for vhost "${vhost}" are already listed.`);
+      return;
+    }
+    setRows((current) => [...current, { vhost, persisted: false, ...DEFAULT_MQTT_PERMISSIONS }]);
+    setNewVhost('');
+    setError(null);
+  };
+
+  const unusedVhosts = vhosts.filter((vhost) => !rows.some((row) => row.vhost === vhost));
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      data-cy={`rabbitmq-permissions-modal-${mqttServerId}`}
+    >
+      <ModalBackdrop>
+        <ModalContainer size="lg">
+          <ModalDialog>
+            <ModalHeader>
+              <ModalHeading>Permissions of "{user.name}"</ModalHeading>
+            </ModalHeader>
+            <ModalBody className="flex flex-col gap-4 w-full">
+              {rows.length === 0 && (
+                <p className="text-sm text-default-500" data-cy="rabbitmq-permissions-empty">
+                  This user has no permissions on any vhost — it cannot connect yet.
+                </p>
+              )}
+
+              {rows.map((row, index) => (
+                <PermissionEditor
+                  key={row.vhost}
+                  row={row}
+                  busy={busyVhost === row.vhost}
+                  onChange={(next) => updateRow(index, next)}
+                  onSave={() => saveRow(index)}
+                  onRemove={() => removeRow(index)}
+                />
+              ))}
+
+              <div className="flex items-end gap-2">
+                <TextField value={newVhost} onChange={setNewVhost} className="flex-1">
+                  <Label>Add vhost{unusedVhosts.length > 0 ? ` (available: ${unusedVhosts.join(', ')})` : ''}</Label>
+                  <Input placeholder="/" autoComplete="off" data-cy="rabbitmq-permissions-add-vhost-input" />
+                </TextField>
+                <Button
+                  variant="secondary"
+                  onPress={addVhost}
+                  isDisabled={newVhost.trim().length === 0}
+                  data-cy="rabbitmq-permissions-add-vhost-button"
+                >
+                  <PlusIcon className="w-4 h-4" />
+                  Add
+                </Button>
+              </div>
+
+              {error && (
+                <Alert status="danger" data-cy="rabbitmq-permissions-error-alert">
+                  <AlertContent>
+                    <AlertDescription>{error}</AlertDescription>
+                  </AlertContent>
+                </Alert>
+              )}
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="secondary" onPress={onClose} data-cy="rabbitmq-permissions-close-button">
+                Close
+              </Button>
+            </ModalFooter>
+          </ModalDialog>
+        </ModalContainer>
+      </ModalBackdrop>
+    </Modal>
+  );
+}

--- a/apps/plugins/rabbitmq/frontend/src/RabbitmqUserFormModal.tsx
+++ b/apps/plugins/rabbitmq/frontend/src/RabbitmqUserFormModal.tsx
@@ -1,0 +1,221 @@
+// Create / edit form for one RabbitMQ user (ATT-522).
+//
+// Create mode (user == null): username + password are required, and the form
+// offers to grant the default MQTT permissions on a chosen vhost so a freshly
+// created user can immediately connect over MQTT.
+// Edit mode: the username is fixed, the password is optional (blank keeps the
+// current one) and tags can be changed. Permissions are edited in their own
+// modal (RabbitmqPermissionsModal).
+import {
+  Alert,
+  AlertContent,
+  AlertDescription,
+  Button,
+  Checkbox,
+  Form,
+  Input,
+  Label,
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalContainer,
+  ModalDialog,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  TextField,
+} from '@heroui/react';
+import { useEffect, useState } from 'react';
+import { DEFAULT_MQTT_PERMISSIONS, upsertUser, type RabbitmqUser, type UpsertRabbitmqUserBody } from './users-api';
+
+export interface RabbitmqUserFormModalProps {
+  mqttServerId: number;
+  isOpen: boolean;
+  // The user being edited; null means create.
+  user: RabbitmqUser | null;
+  // Known vhosts, used as a hint for the default-permissions vhost field.
+  vhosts: string[];
+  onClose: () => void;
+  // Called after a successful save so the panel can reload the list.
+  onSaved: () => void;
+}
+
+function parseTags(value: string): string[] {
+  return value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+export function RabbitmqUserFormModal({
+  mqttServerId,
+  isOpen,
+  user,
+  vhosts,
+  onClose,
+  onSaved,
+}: RabbitmqUserFormModalProps) {
+  const isEdit = user !== null;
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [tags, setTags] = useState('');
+  const [grantMqttDefaults, setGrantMqttDefaults] = useState(true);
+  const [vhost, setVhost] = useState('/');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed the form whenever it opens (for another user, or again after a
+  // cancel) — modal state outlives a single open/close cycle.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setUsername(user?.name ?? '');
+    setPassword('');
+    setTags(user?.tags.join(', ') ?? '');
+    setGrantMqttDefaults(true);
+    setVhost(vhosts.includes('/') || vhosts.length === 0 ? '/' : vhosts[0]);
+    setError(null);
+  }, [isOpen, user, vhosts]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = username.trim();
+    if (name.length === 0) {
+      setError('Username is required.');
+      return;
+    }
+    if (!isEdit && password.length === 0) {
+      setError('Password is required when creating a user.');
+      return;
+    }
+
+    const body: UpsertRabbitmqUserBody = { tags: parseTags(tags) };
+    if (password.length > 0) {
+      body.password = password;
+    }
+    if (!isEdit && grantMqttDefaults && vhost.trim().length > 0) {
+      body.permissions = [{ vhost: vhost.trim(), ...DEFAULT_MQTT_PERMISSIONS }];
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await upsertUser(mqttServerId, name, body);
+      onSaved();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Saving the user failed.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      data-cy={`rabbitmq-user-form-modal-${mqttServerId}`}
+    >
+      <ModalBackdrop>
+        <ModalContainer size="md">
+          <ModalDialog>
+            <ModalHeader>
+              <ModalHeading>{isEdit ? `Edit user "${user.name}"` : 'Create RabbitMQ user'}</ModalHeading>
+            </ModalHeader>
+            <Form onSubmit={handleSubmit}>
+              <ModalBody className="flex flex-col gap-4 w-full">
+                <TextField
+                  value={username}
+                  onChange={setUsername}
+                  className="w-full"
+                  isDisabled={isEdit}
+                >
+                  <Label>Username</Label>
+                  <Input
+                    name="rabbitmq-username"
+                    placeholder="e.g. shop-floor-sensor"
+                    autoComplete="off"
+                    data-cy="rabbitmq-user-form-username-input"
+                  />
+                </TextField>
+
+                <TextField value={password} onChange={setPassword} className="w-full">
+                  <Label>{isEdit ? 'New password (leave blank to keep current)' : 'Password'}</Label>
+                  <Input
+                    name="rabbitmq-password"
+                    type="password"
+                    autoComplete="new-password"
+                    data-cy="rabbitmq-user-form-password-input"
+                  />
+                </TextField>
+
+                <TextField value={tags} onChange={setTags} className="w-full">
+                  <Label>Tags (comma-separated, e.g. management, administrator)</Label>
+                  <Input
+                    name="rabbitmq-tags"
+                    placeholder="none"
+                    autoComplete="off"
+                    data-cy="rabbitmq-user-form-tags-input"
+                  />
+                </TextField>
+
+                {!isEdit && (
+                  <div className="flex flex-col gap-3 rounded-lg border border-default-200 dark:border-default-100 p-3">
+                    <Checkbox
+                      isSelected={grantMqttDefaults}
+                      onChange={setGrantMqttDefaults}
+                      data-cy="rabbitmq-user-form-mqtt-defaults-checkbox"
+                    >
+                      Grant default MQTT permissions
+                    </Checkbox>
+                    <p className="text-xs text-default-500">
+                      Allows the user to publish and subscribe over MQTT: configure{' '}
+                      <code>{DEFAULT_MQTT_PERMISSIONS.configure}</code>, write/read{' '}
+                      <code>{DEFAULT_MQTT_PERMISSIONS.write}</code>.
+                    </p>
+                    {grantMqttDefaults && (
+                      <TextField value={vhost} onChange={setVhost} className="w-full">
+                        <Label>Vhost{vhosts.length > 0 ? ` (available: ${vhosts.join(', ')})` : ''}</Label>
+                        <Input
+                          name="rabbitmq-vhost"
+                          placeholder="/"
+                          autoComplete="off"
+                          data-cy="rabbitmq-user-form-vhost-input"
+                        />
+                      </TextField>
+                    )}
+                  </div>
+                )}
+
+                {error && (
+                  <Alert status="danger" data-cy="rabbitmq-user-form-error-alert">
+                    <AlertContent>
+                      <AlertDescription>{error}</AlertDescription>
+                    </AlertContent>
+                  </Alert>
+                )}
+              </ModalBody>
+              <ModalFooter>
+                <Button variant="secondary" onPress={onClose} data-cy="rabbitmq-user-form-cancel-button">
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  type="submit"
+                  isPending={saving}
+                  data-cy="rabbitmq-user-form-save-button"
+                >
+                  {isEdit ? 'Save changes' : 'Create user'}
+                </Button>
+              </ModalFooter>
+            </Form>
+          </ModalDialog>
+        </ModalContainer>
+      </ModalBackdrop>
+    </Modal>
+  );
+}

--- a/apps/plugins/rabbitmq/frontend/src/RabbitmqUserPanel.tsx
+++ b/apps/plugins/rabbitmq/frontend/src/RabbitmqUserPanel.tsx
@@ -1,0 +1,334 @@
+// RabbitMQ user-management panel for the MQTT server detail slot (ATT-522).
+//
+// Appears below the status panel for MQTT servers detected as RabbitMQ brokers
+// with working management credentials. Lists the broker's users with their
+// tags and per-vhost permissions, and offers create / edit / permission /
+// delete actions. All operations go through the plugin backend, which talks to
+// the RabbitMQ management HTTP API with the MQTT server's credentials.
+import {
+  Alert,
+  AlertContent,
+  AlertDescription,
+  Button,
+  Card,
+  Chip,
+  Modal,
+  ModalBackdrop,
+  ModalBody,
+  ModalContainer,
+  ModalDialog,
+  ModalFooter,
+  ModalHeader,
+  ModalHeading,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableContent,
+  TableHeader,
+  TableRow,
+  TableScrollContainer,
+} from '@heroui/react';
+import { KeyRoundIcon, PencilIcon, PlusIcon, RefreshCwIcon, Trash2Icon, UsersIcon } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDetection } from './detection';
+import { deleteUser, fetchUsers, type RabbitmqUser, type RabbitmqUserList } from './users-api';
+import { RabbitmqPermissionsModal } from './RabbitmqPermissionsModal';
+import { RabbitmqUserFormModal } from './RabbitmqUserFormModal';
+
+function PermissionChips({ user }: { user: RabbitmqUser }) {
+  if (user.permissions.length === 0) {
+    return <span className="text-xs text-default-400">none</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {user.permissions.map((permission) => (
+        <Chip key={permission.vhost} size="sm" variant="soft" title={
+          `configure: ${permission.configure}\nwrite: ${permission.write}\nread: ${permission.read}`
+        }>
+          {permission.vhost}
+        </Chip>
+      ))}
+    </div>
+  );
+}
+
+export function RabbitmqUserPanel({ mqttServerId }: { mqttServerId: number }) {
+  const { result } = useDetection(mqttServerId);
+
+  const [data, setData] = useState<RabbitmqUserList | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Modal state. `formUser` doubles as the mode flag (null = create).
+  const [formOpen, setFormOpen] = useState(false);
+  const [formUser, setFormUser] = useState<RabbitmqUser | null>(null);
+  const [permissionsUser, setPermissionsUser] = useState<RabbitmqUser | null>(null);
+  const [userToDelete, setUserToDelete] = useState<RabbitmqUser | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  // The panel can unmount while a fetch is in flight (navigation away) — drop
+  // the result instead of calling setState on an unmounted component.
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const list = await fetchUsers(mqttServerId);
+      if (mounted.current) {
+        setData(list);
+        // Keep the permissions modal's user in sync after edits.
+        setPermissionsUser((current) =>
+          current ? list.users.find((user) => user.name === current.name) ?? current : null
+        );
+      }
+    } catch (err) {
+      if (mounted.current) {
+        setLoadError(err instanceof Error ? err.message : 'Loading users failed.');
+      }
+    } finally {
+      if (mounted.current) {
+        setLoading(false);
+      }
+    }
+  }, [mqttServerId]);
+
+  const manageable = result?.isRabbitMQ === true && result.authOk;
+
+  useEffect(() => {
+    if (manageable) {
+      void reload();
+    }
+  }, [manageable, reload]);
+
+  // Render nothing unless the server is positively detected as RabbitMQ with
+  // working management credentials — the status panel already explains
+  // detection / auth problems.
+  if (!manageable) {
+    return null;
+  }
+
+  const confirmDelete = async () => {
+    if (!userToDelete) {
+      return;
+    }
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await deleteUser(mqttServerId, userToDelete.name);
+      setUserToDelete(null);
+      void reload();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Deleting the user failed.');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Card
+      data-cy={`rabbitmq-user-panel-${mqttServerId}`}
+      className="w-full border border-default-200 dark:border-default-100"
+    >
+      <Card.Header className="flex flex-row items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <UsersIcon className="w-5 h-5 text-primary" />
+          <p className="text-base font-semibold text-default-700">RabbitMQ users</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            isIconOnly
+            size="sm"
+            variant="ghost"
+            aria-label="Reload RabbitMQ users"
+            onPress={() => void reload()}
+            isDisabled={loading}
+            data-cy={`rabbitmq-user-panel-reload-${mqttServerId}`}
+          >
+            {loading ? <Spinner size="sm" /> : <RefreshCwIcon className="w-4 h-4" />}
+          </Button>
+          <Button
+            size="sm"
+            variant="primary"
+            onPress={() => {
+              setFormUser(null);
+              setFormOpen(true);
+            }}
+            data-cy={`rabbitmq-user-panel-create-button-${mqttServerId}`}
+          >
+            <PlusIcon className="w-4 h-4" />
+            Add user
+          </Button>
+        </div>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-3">
+        {loadError && (
+          <Alert status="danger" data-cy="rabbitmq-user-panel-error-alert">
+            <AlertContent>
+              <AlertDescription>{loadError}</AlertDescription>
+            </AlertContent>
+          </Alert>
+        )}
+
+        {!data && !loadError && (
+          <div className="flex items-center justify-center p-4">
+            <Spinner data-cy="rabbitmq-user-panel-loading-spinner" />
+          </div>
+        )}
+
+        {data && (
+          <Table data-cy="rabbitmq-user-panel-table">
+            <TableScrollContainer>
+              <TableContent aria-label="RabbitMQ users">
+                <TableHeader>
+                  <TableColumn isRowHeader>Username</TableColumn>
+                  <TableColumn>Tags</TableColumn>
+                  <TableColumn>Vhost access</TableColumn>
+                  <TableColumn>Actions</TableColumn>
+                </TableHeader>
+                <TableBody items={data.users}>
+                  {(user) => (
+                    <TableRow key={user.name} id={user.name}>
+                      <TableCell className="whitespace-nowrap font-medium">{user.name}</TableCell>
+                      <TableCell>
+                        {user.tags.length === 0 ? (
+                          <span className="text-xs text-default-400">none</span>
+                        ) : (
+                          <div className="flex flex-wrap gap-1">
+                            {user.tags.map((tag) => (
+                              <Chip key={tag} size="sm" color="accent" variant="soft">
+                                {tag}
+                              </Chip>
+                            ))}
+                          </div>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <PermissionChips user={user} />
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-row gap-1">
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            variant="ghost"
+                            aria-label={`Edit user ${user.name}`}
+                            onPress={() => {
+                              setFormUser(user);
+                              setFormOpen(true);
+                            }}
+                            data-cy={`rabbitmq-user-edit-button-${user.name}`}
+                          >
+                            <PencilIcon className="w-4 h-4" />
+                          </Button>
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            variant="ghost"
+                            aria-label={`Edit permissions of ${user.name}`}
+                            onPress={() => setPermissionsUser(user)}
+                            data-cy={`rabbitmq-user-permissions-button-${user.name}`}
+                          >
+                            <KeyRoundIcon className="w-4 h-4" />
+                          </Button>
+                          <Button
+                            isIconOnly
+                            size="sm"
+                            variant="ghost"
+                            aria-label={`Delete user ${user.name}`}
+                            onPress={() => {
+                              setDeleteError(null);
+                              setUserToDelete(user);
+                            }}
+                            data-cy={`rabbitmq-user-delete-button-${user.name}`}
+                          >
+                            <Trash2Icon className="w-4 h-4 text-danger" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </TableContent>
+            </TableScrollContainer>
+          </Table>
+        )}
+      </Card.Content>
+
+      <RabbitmqUserFormModal
+        mqttServerId={mqttServerId}
+        isOpen={formOpen}
+        user={formUser}
+        vhosts={data?.vhosts ?? []}
+        onClose={() => setFormOpen(false)}
+        onSaved={() => void reload()}
+      />
+
+      <RabbitmqPermissionsModal
+        mqttServerId={mqttServerId}
+        isOpen={permissionsUser !== null}
+        user={permissionsUser}
+        vhosts={data?.vhosts ?? []}
+        onClose={() => setPermissionsUser(null)}
+        onSaved={() => void reload()}
+      />
+
+      <Modal
+        isOpen={userToDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setUserToDelete(null);
+        }}
+        data-cy={`rabbitmq-user-delete-modal-${mqttServerId}`}
+      >
+        <ModalBackdrop>
+          <ModalContainer size="sm">
+            <ModalDialog>
+              {({ close }) => (
+                <>
+                  <ModalHeader>
+                    <ModalHeading>Delete user</ModalHeading>
+                  </ModalHeader>
+                  <ModalBody className="flex flex-col gap-3">
+                    <p>
+                      Delete the RabbitMQ user <strong>{userToDelete?.name}</strong>? Connected clients using this
+                      account will be disconnected and its permissions removed.
+                    </p>
+                    {deleteError && (
+                      <Alert status="danger" data-cy="rabbitmq-user-delete-error-alert">
+                        <AlertContent>
+                          <AlertDescription>{deleteError}</AlertDescription>
+                        </AlertContent>
+                      </Alert>
+                    )}
+                  </ModalBody>
+                  <ModalFooter>
+                    <Button variant="secondary" onPress={close} data-cy="rabbitmq-user-delete-cancel-button">
+                      Cancel
+                    </Button>
+                    <Button
+                      variant="danger"
+                      onPress={() => void confirmDelete()}
+                      isPending={deleting}
+                      data-cy="rabbitmq-user-delete-confirm-button"
+                    >
+                      Delete
+                    </Button>
+                  </ModalFooter>
+                </>
+              )}
+            </ModalDialog>
+          </ModalContainer>
+        </ModalBackdrop>
+      </Modal>
+    </Card>
+  );
+}

--- a/apps/plugins/rabbitmq/frontend/src/plugin.tsx
+++ b/apps/plugins/rabbitmq/frontend/src/plugin.tsx
@@ -15,8 +15,10 @@ import type {
   RouteConfig,
 } from '@attraccess/plugins-frontend-sdk';
 import type { IPluginStore } from 'react-pluggable';
+import { useDetection } from './detection';
 import { RabbitmqListBadge } from './RabbitmqListBadge';
 import { RabbitmqStatusPanel } from './RabbitmqStatusPanel';
+import { RabbitmqUserPanel } from './RabbitmqUserPanel';
 
 // Host slot ids exposed by the MQTT UI. The SDK is vendor-agnostic and does not
 // export them, and the host owns them in apps/frontend (which a plugin cannot
@@ -31,6 +33,25 @@ interface MqttServerSlotContext {
   [key: string]: unknown;
 }
 
+// Everything the plugin contributes to the MQTT server detail view: the
+// connection-status panel (ATT-521) plus the user-management panel (ATT-522).
+// Returns null (no wrapper element) for non-RabbitMQ servers so the host
+// layout is unchanged unless a RabbitMQ broker is positively detected.
+function RabbitmqDetailSlot({ mqttServerId }: { mqttServerId: number }) {
+  const { result } = useDetection(mqttServerId);
+
+  if (!result?.isRabbitMQ) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-4 w-full">
+      <RabbitmqStatusPanel mqttServerId={mqttServerId} />
+      <RabbitmqUserPanel mqttServerId={mqttServerId} />
+    </div>
+  );
+}
+
 function RabbitmqPage() {
   return (
     <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto">
@@ -41,8 +62,9 @@ function RabbitmqPage() {
       <Card className="border border-default-200 dark:border-default-100">
         <Card.Content>
           <p className="text-sm text-default-500">
-            RabbitMQ management plugin. RabbitMQ MQTT servers now show a detection badge and connection-status
-            panel in the MQTT settings. Management features are coming soon.
+            RabbitMQ management plugin. RabbitMQ MQTT servers show a detection badge and connection-status panel in
+            the MQTT settings, and broker users can be managed (create, edit, permissions, delete) from the MQTT
+            server detail view.
           </p>
         </Card.Content>
       </Card>
@@ -102,7 +124,10 @@ export default class RabbitmqPlugin implements AttraccessFrontendPlugin {
       {
         slotId: MQTT_SERVER_DETAIL_SLOT,
         key: 'rabbitmq-mqtt-detail',
-        render: (context) => <RabbitmqStatusPanel mqttServerId={context.mqttServerId} />,
+        // Status first, user management below it (ATT-522). The wrapper
+        // renders nothing unless the server is detected as RabbitMQ, so the
+        // detail view keeps its layout for other brokers.
+        render: (context) => <RabbitmqDetailSlot mqttServerId={context.mqttServerId} />,
       },
       {
         slotId: MQTT_SERVER_LIST_ROW_SLOT,

--- a/apps/plugins/rabbitmq/frontend/src/users-api.ts
+++ b/apps/plugins/rabbitmq/frontend/src/users-api.ts
@@ -1,0 +1,102 @@
+// Frontend access to the plugin's RabbitMQ user-management endpoints (ATT-522).
+//
+// The backend half (apps/plugins/rabbitmq/backend) mounts the routes under
+// `/rabbitmq/users/...` in the host API. Shapes are restated here (the backend
+// and frontend are separate bundles with no shared module), mirroring
+// backend/rabbitmq-users.types.ts.
+
+export interface RabbitmqPermission {
+  vhost: string;
+  configure: string;
+  write: string;
+  read: string;
+}
+
+export interface RabbitmqUser {
+  name: string;
+  tags: string[];
+  permissions: RabbitmqPermission[];
+}
+
+export interface RabbitmqUserList {
+  mqttServerId: number;
+  users: RabbitmqUser[];
+  vhosts: string[];
+}
+
+export interface UpsertRabbitmqUserBody {
+  password?: string;
+  tags?: string[];
+  permissions?: RabbitmqPermission[];
+}
+
+// The permissions an MQTT client needs on a RabbitMQ broker (mirrors the
+// backend's DEFAULT_MQTT_PERMISSIONS, documented in .env.docker-compose).
+export const DEFAULT_MQTT_PERMISSIONS = {
+  configure: '^mqtt-subscription-.*$',
+  write: '^(amq\\.topic|mqtt-subscription-.*)$',
+  read: '^(amq\\.topic|mqtt-subscription-.*)$',
+} as const;
+
+// Host mounts plugin controllers under `/api`; cookies carry the session.
+const BASE = '/api/rabbitmq/users';
+
+// The backend wraps upstream failures in HTTP exceptions whose `message`
+// explains what went wrong (broker unreachable, missing management
+// privileges, …) — surface that text instead of a bare status code.
+async function parseError(res: Response): Promise<Error> {
+  try {
+    const body = (await res.json()) as { message?: string | string[] };
+    const message = Array.isArray(body.message) ? body.message.join(', ') : body.message;
+    if (message) {
+      return new Error(message);
+    }
+  } catch {
+    // Non-JSON error body — fall through to the generic message.
+  }
+  return new Error(`Request failed (HTTP ${res.status}).`);
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { credentials: 'include', ...init });
+  if (!res.ok) {
+    throw await parseError(res);
+  }
+  const text = await res.text();
+  return (text.length > 0 ? JSON.parse(text) : null) as T;
+}
+
+export function fetchUsers(mqttServerId: number): Promise<RabbitmqUserList> {
+  return request<RabbitmqUserList>(`${BASE}/${mqttServerId}`);
+}
+
+export function upsertUser(mqttServerId: number, username: string, body: UpsertRabbitmqUserBody): Promise<void> {
+  return request<void>(`${BASE}/${mqttServerId}/${encodeURIComponent(username)}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export function deleteUser(mqttServerId: number, username: string): Promise<void> {
+  return request<void>(`${BASE}/${mqttServerId}/${encodeURIComponent(username)}`, { method: 'DELETE' });
+}
+
+export function setPermissions(
+  mqttServerId: number,
+  username: string,
+  permission: RabbitmqPermission
+): Promise<void> {
+  return request<void>(`${BASE}/${mqttServerId}/${encodeURIComponent(username)}/permissions`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(permission),
+  });
+}
+
+export function clearPermissions(mqttServerId: number, username: string, vhost: string): Promise<void> {
+  return request<void>(
+    `${BASE}/${mqttServerId}/${encodeURIComponent(username)}/permissions?vhost=${encodeURIComponent(vhost)}`,
+    { method: 'DELETE' }
+  );
+}


### PR DESCRIPTION
Closes #1256 (ATT-522). Builds on ATT-521 (#1327).

## What

Adds RabbitMQ (MQTT) user management to the RabbitMQ management plugin — list, create, update (password + tags), delete users and edit per-vhost permissions, all from the MQTT server detail view. All logic and management-API calls live in the plugin; core untouched.

## Backend (plugin)

- `RabbitmqManagementClient` — shared wrapper for the RabbitMQ management HTTP API: base URL derived from the generic MQTT server config (15672/15671), Basic auth from the server credentials, 10s timeout, and error mapping that surfaces actionable messages (broker unreachable, credentials rejected, missing `administrator` tag → 502 instead of 401 so the host session handling isn't confused).
- `RabbitmqUsersService` / `RabbitmqUsersController` under `/api/rabbitmq/users/:mqttServerId` (gated by `canManageResources`, same as the host MQTT controllers):
  - `GET` list users joined with per-vhost permissions + vhost list
  - `PUT :username` create/update — keeps the existing password by re-sending the stored hash when no new password is given; optional permissions applied in the same call
  - `DELETE :username` — refuses to delete the account the MQTT connection itself uses
  - `PUT/DELETE :username/permissions` per-vhost (vhost as body/query param since the default vhost is literally `/`)
- Default MQTT permissions per Jan's comment, as documented in `.env.docker-compose`: configure `^mqtt-subscription-.*$`, write/read `^(amq\.topic|mqtt-subscription-.*)$`.

## Frontend (plugin, MQTT detail slot)

- User table (tags, vhost access chips) with reload + create/edit/permissions/delete actions; renders only for servers positively detected as RabbitMQ with working management credentials.
- Create form grants the default MQTT permissions on a chosen vhost by default; edit form changes password (optional) and tags.
- Permissions modal edits the three permission regexes per vhost, with a "Use MQTT defaults" shortcut and add/remove vhost.
- Backend error messages surface verbatim in alerts.

## Verification

- `nx run plugin-rabbitmq:lint` / `build-backend` / `build-frontend` pass.
- Browser verification against a real RabbitMQ 4.3 broker in progress — screenshots follow.

<!-- generated-by-cyrus -->