### PR TITLE
fix(ci): run PR workflow on merge_group for merge queue

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -3,11 +3,15 @@ name: Pull Requests
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
+    types: [checks_requested]
 
 env:
   GHCR_IMAGE_NAME: ${{ vars.GHCR_IMAGE_NAME }}
   DOCKERHUB_IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGE_NAME }}
   DOCKER_BUILDKIT: 1
+  # merge_group has no pull_request payload; base_sha is the queue target (main).
+  NX_AFFECTED_BASE: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || format('origin/{0}', github.event.pull_request.base.ref) }}
 
 permissions:
   contents: read
@@ -35,6 +39,7 @@ jobs:
           fi
 
   commitlint:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -56,9 +61,9 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Lint affected projects
-        run: pnpm nx affected --target=lint --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }} --exclude=tag:scope:hardware,tag:type:plugin
+        run: pnpm nx affected --target=lint --parallel=5 --base=${{ env.NX_AFFECTED_BASE }} --exclude=tag:scope:hardware,tag:type:plugin
       - name: Typecheck affected projects
-        run: pnpm nx affected --target=typecheck --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }} --exclude=tag:scope:hardware,tag:type:plugin
+        run: pnpm nx affected --target=typecheck --parallel=5 --base=${{ env.NX_AFFECTED_BASE }} --exclude=tag:scope:hardware,tag:type:plugin
 
   test:
     runs-on: ubuntu-latest
@@ -69,7 +74,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Test affected projects
-        run: pnpm nx affected --target=test,e2e --parallel=5 --base=origin/${{ github.event.pull_request.base.ref }} --exclude=tag:scope:hardware,tag:type:plugin
+        run: pnpm nx affected --target=test,e2e --parallel=5 --base=${{ env.NX_AFFECTED_BASE }} --exclude=tag:scope:hardware,tag:type:plugin
 
   plugins:
     runs-on: ubuntu-latest
@@ -84,9 +89,9 @@ jobs:
       # exclude keeps the affected set restricted to plugin apps, so a PR that
       # touches no plugin (or shared global) runs nothing here.
       - name: Lint affected plugin apps
-        run: pnpm nx affected --target=lint --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --exclude='*,!tag:type:plugin'
+        run: pnpm nx affected --target=lint --parallel=3 --base=${{ env.NX_AFFECTED_BASE }} --exclude='*,!tag:type:plugin'
       - name: Build + zip affected plugin apps
-        run: pnpm nx affected --target=package --parallel=3 --base=origin/${{ github.event.pull_request.base.ref }} --exclude='*,!tag:type:plugin'
+        run: pnpm nx affected --target=package --parallel=3 --base=${{ env.NX_AFFECTED_BASE }} --exclude='*,!tag:type:plugin'
 
       - name: Collect plugin ZIPs into a flat directory
         id: collect
@@ -109,7 +114,7 @@ jobs:
 
       - name: Upload plugin ZIPs
         uses: actions/upload-artifact@v4
-        if: always() && steps.collect.outputs.has_plugins == 'true'
+        if: github.event_name == 'pull_request' && always() && steps.collect.outputs.has_plugins == 'true'
         with:
           name: plugins-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
           path: dist/plugin-zips/*.zip
@@ -118,7 +123,7 @@ jobs:
 
       - name: Build PR comment body
         id: comment-body
-        if: always()
+        if: github.event_name == 'pull_request' && always()
         run: |
           set -euo pipefail
           shopt -s nullglob globstar
@@ -146,7 +151,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post sticky PR comment with plugin artifacts
-        if: always()
+        if: github.event_name == 'pull_request' && always()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: plugin-artifacts
@@ -195,6 +200,15 @@ jobs:
         id: vars
         run: echo "SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
 
+      - name: Set image tag suffix
+        id: image-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "suffix=mq-${{ steps.vars.outputs.SHORT_SHA }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=pr-${{ github.event.pull_request.number }}-${{ steps.vars.outputs.SHORT_SHA }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -205,14 +219,15 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ env.GHCR_IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.vars.outputs.SHORT_SHA }}
-            ${{ env.DOCKERHUB_IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.vars.outputs.SHORT_SHA }}
+            ghcr.io/${{ env.GHCR_IMAGE_NAME }}:${{ steps.image-tag.outputs.suffix }}
+            ${{ env.DOCKERHUB_IMAGE_NAME }}:${{ steps.image-tag.outputs.suffix }}
           build-args: |
             NODE_VERSION=${{ steps.node-version.outputs.NODE_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Post image URL comment to PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |
@@ -222,8 +237,8 @@ jobs:
               repo: context.repo.repo,
               body: `🐳 Docker images built and pushed:
 
-            GitHub Container Registry: \`ghcr.io/${{ env.GHCR_IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.vars.outputs.SHORT_SHA }}\`
-            Docker Hub: \`${{ env.DOCKERHUB_IMAGE_NAME }}:pr-${{ github.event.number }}-${{ steps.vars.outputs.SHORT_SHA }}\`
+            GitHub Container Registry: \`ghcr.io/${{ env.GHCR_IMAGE_NAME }}:${{ steps.image-tag.outputs.suffix }}\`
+            Docker Hub: \`${{ env.DOCKERHUB_IMAGE_NAME }}:${{ steps.image-tag.outputs.suffix }}\`
 
             Image Digest: \`${{ steps.build-and-push.outputs.digest }}\``
             })


### PR DESCRIPTION
## Summary
- Add `merge_group: types: [checks_requested]` to the Pull Requests workflow so required checks run on speculative merge commits
- Use `merge_group.base_sha` for `nx affected` on queue runs; skip PR-only steps (commitlint, artifact comments, docker PR comments)
- Tag merge-queue images as `mq-<sha>` instead of `pr-<n>-<sha>`

## Why
Merge queue entries were stuck in `AWAITING_CHECKS` because `precommit-check` and `containerize` only ran on `pull_request` events — zero `merge_group` workflow runs existed.

## Merge note
**This PR must land on `main` before the merge queue can process anything.** Bypass the merge queue for this one (ruleset allows maintainer bypass) or push directly to `main`. After merge, re-queue stuck PRs (#1292, #1301, #1323, #1335) if checks don't auto-retrigger.

## Test plan
- [ ] PR CI passes (`precommit-check`, `containerize`)
- [ ] After merge to `main`, confirm `merge_group` workflow runs appear for queued PRs
- [ ] Verify merge queue entries leave `AWAITING_CHECKS` and merge after checks pass (+ 15 min wait)

Made with [Cursor](https://cursor.com)