### PR TITLE
feat(ATT-160): support MIFARE DESFire EV2/EV3 cards on Attractap readers

### DIFF
--- a/apps/attractap/firmware/src/application/application_state.cpp
+++ b/apps/attractap/firmware/src/application/application_state.cpp
@@ -495,7 +495,6 @@ void Application::processEnrollment() {
       this->enrollPhase = ENROLL_PHASE_ERROR;
       this->enrollPhaseChangedMs = now;
       this->nfc.resetCardPresence();
-      this->nfc.enableCardDetection();
     }
     break;
   }
@@ -515,7 +514,8 @@ void Application::processEnrollment() {
   case ENROLL_PHASE_WRITING: {
     bool ok = this->nfc.changeKey(
         this->apiEnrollNewCardData.keyNo, this->nfc.FACTORY_KEY,
-        this->nfc.FACTORY_KEY, this->apiEnrollNewCardData.keyBytes);
+        this->nfc.FACTORY_KEY, this->apiEnrollNewCardData.keyBytes,
+        NFC::CARD_KEY_VERSION_ENROLLED);
     this->api.sendEnrollNewCard(ok);
     if (ok) {
       this->beeper.successBeep();
@@ -633,7 +633,8 @@ void Application::processReset() {
     bool ok = this->nfc.changeKey(this->apiResetNfcCardData.keyNo,
                                   this->nfc.FACTORY_KEY,
                                   this->apiResetNfcCardData.keyBytes,
-                                  this->nfc.FACTORY_KEY);
+                                  this->nfc.FACTORY_KEY,
+                                  NFC::CARD_KEY_VERSION_FREE);
     this->api.sendResetNfcCard(ok);
     if (ok) {
       this->beeper.successBeep();

--- a/apps/attractap/firmware/src/application/application_state.cpp
+++ b/apps/attractap/firmware/src/application/application_state.cpp
@@ -485,8 +485,15 @@ void Application::processEnrollment() {
       this->enrollPhase = ENROLL_PHASE_REQUESTED_KEY;
       this->enrollPhaseChangedMs = now;
     } else {
-      // Card slipped away or has no writable key — re-arm the detection loop
-      // and keep waiting.
+      // Card slipped away or has no writable key. Surface the failure instead
+      // of silently re-arming, otherwise DESFire setup/auth failures look like
+      // the reader ignored the card.
+      this->beeper.errorBeep();
+      Display::enrollmentScreen.setStatus(EnrollmentScreen::STATUS_ERROR);
+      Display::enrollmentScreen.setStatusMessage(
+          "Karte konnte nicht\nvorbereitet werden");
+      this->enrollPhase = ENROLL_PHASE_ERROR;
+      this->enrollPhaseChangedMs = now;
       this->nfc.resetCardPresence();
       this->nfc.enableCardDetection();
     }

--- a/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.cpp
+++ b/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.cpp
@@ -2539,9 +2539,8 @@ uint8_t Adafruit_PN532::ntag424_ChangeFileSettings(uint8_t fileno,
 */
 /**************************************************************************/
 uint8_t Adafruit_PN532::ntag424_ChangeKey(uint8_t *oldkey, uint8_t *newkey,
-                                          uint8_t keynumber)
+                                          uint8_t keynumber, uint8_t keyversion)
 {
-  uint8_t keyversion[1] = {0x01};
   uint8_t xorkey[16];
   for (int i = 0; i < 16; ++i)
   {
@@ -2572,14 +2571,14 @@ uint8_t Adafruit_PN532::ntag424_ChangeKey(uint8_t *oldkey, uint8_t *newkey,
   if (keynumber > 0)
   {
     memcpy(keydata, xorkey, 16);
-    memcpy(keydata + 16, keyversion, 1);
+    keydata[16] = keyversion;
     memcpy(keydata + 17, crcbytes, 4);
     keydata_length = 21;
   }
   else if (keynumber == 0)
   {
     memcpy(keydata, newkey, 16);
-    memcpy(keydata + 16, keyversion, 1);
+    keydata[16] = keyversion;
     keydata_length = 17;
   }
 #ifdef NTAG424DEBUG
@@ -3136,6 +3135,55 @@ bool Adafruit_PN532::desfire_CreateApplication(const uint8_t *aid,
 #endif
     return false;
   }
+  return true;
+}
+
+/*!
+    @brief   Send a DESFire GetKeyVersion command for the selected
+   application.
+
+    @param   keynumber    Key number in the selected application
+    @param   keyversion   Output key version byte
+
+    @return  false on fail|true on success
+*/
+/**************************************************************************/
+bool Adafruit_PN532::desfire_GetKeyVersion(uint8_t keynumber,
+                                           uint8_t *keyversion)
+{
+  uint8_t cmd_get_version[9] = {PN532_COMMAND_INDATAEXCHANGE,
+                                0x01,
+                                NTAG424_COM_CLA,
+                                DESFIRE_CMD_GET_KEY_VERSION,
+                                0x00,
+                                0x00,
+                                0x01,
+                                keynumber,
+                                0x00};
+  if (!sendCommandCheckAck(cmd_get_version, sizeof(cmd_get_version)))
+  {
+#ifdef NTAG424DEBUG
+    PN532DEBUGPRINT.println(F("Failed to receive ACK for GetKeyVersion"));
+#endif
+    return false;
+  }
+
+  /* Read the response packet: D5 41 <status> <version> 91 00 */
+  readdata(pn532_packetbuffer, 13);
+#ifdef NTAG424DEBUG
+  PN532DEBUGPRINT.print(F("GetKeyVersion response: "));
+  Adafruit_PN532::PrintHexChar(pn532_packetbuffer, 13);
+#endif
+  if (pn532_packetbuffer[7] != 0x00 || pn532_packetbuffer[9] != 0x91 ||
+      pn532_packetbuffer[10] != 0x00)
+  {
+#ifdef NTAG424DEBUG
+    PN532DEBUGPRINT.println(F("GetKeyVersion ResultError"));
+#endif
+    return false;
+  }
+
+  *keyversion = pn532_packetbuffer[8];
   return true;
 }
 

--- a/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.cpp
+++ b/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.cpp
@@ -2247,11 +2247,30 @@ uint8_t Adafruit_PN532::ntag424_Authenticate(uint8_t *key, uint8_t keyno,
     return 0;
   }
 
-// 2.) AuthenticateFirst part 1
+  return ntag424_AuthenticateEV2First(key, keyno, cmd);
+}
+
+/*!
+    @brief   Run the AuthenticateEV2First handshake against the currently
+   selected application. Shared by NTAG424 (after ISOSelectFile of the NDEF
+   application) and MIFARE DESFire EV2/EV3 (after desfire_SelectApplication).
+
+    @param   key      encryption key
+    @param   keyno    number of key to authenticate against
+    @param   cmd      0x71 or 0x77
+
+    @return  1 = success; 0 = failed
+*/
+/**************************************************************************/
+uint8_t Adafruit_PN532::ntag424_AuthenticateEV2First(uint8_t *key,
+                                                     uint8_t keyno,
+                                                     uint8_t cmd)
+{
+// AuthenticateFirst part 1
 #ifdef NTAG424DEBUG
-  PN532DEBUGPRINT.println(F("2.) AuthenticateFirst part 1"));
+  PN532DEBUGPRINT.println(F("AuthenticateFirst part 1"));
 #endif
-  cmd_len = 13;
+  int cmd_len = 13;
   uint8_t cmd_auth1[cmd_len] = {PN532_COMMAND_INDATAEXCHANGE,
                                 0x01,
                                 0x90,
@@ -3015,6 +3034,109 @@ uint8_t Adafruit_PN532::ntag424_GetVersion()
   PN532DEBUGPRINT.println(F("Card is not an NTAG424"));
 #endif
   return 0;
+}
+
+/*!
+    @brief   Send a DESFire SelectApplication to the picc (native command
+   0x5A, ISO7816-wrapped). Selecting an application terminates any active
+   authentication session.
+
+    @param   aid    3-byte application identifier, LSB first (master
+   application = 00 00 00)
+
+    @return  false on fail|true on success
+*/
+/**************************************************************************/
+bool Adafruit_PN532::desfire_SelectApplication(const uint8_t *aid)
+{
+  uint8_t cmd_select[11] = {PN532_COMMAND_INDATAEXCHANGE,
+                            0x01,
+                            NTAG424_COM_CLA,
+                            DESFIRE_CMD_SELECT_APPLICATION,
+                            0x00,
+                            0x00,
+                            0x03,
+                            aid[0],
+                            aid[1],
+                            aid[2],
+                            0x00};
+  if (!sendCommandCheckAck(cmd_select, sizeof(cmd_select)))
+  {
+#ifdef NTAG424DEBUG
+    PN532DEBUGPRINT.println(F("Failed to receive ACK for SelectApplication"));
+#endif
+    return false;
+  }
+  /* Read the response packet: D5 41 <status> 91 00 */
+  readdata(pn532_packetbuffer, 12);
+#ifdef NTAG424DEBUG
+  PN532DEBUGPRINT.print(F("SelectApplication response: "));
+  Adafruit_PN532::PrintHexChar(pn532_packetbuffer, 12);
+#endif
+  if (pn532_packetbuffer[7] != 0x00 || pn532_packetbuffer[8] != 0x91 ||
+      pn532_packetbuffer[9] != 0x00)
+  {
+#ifdef NTAG424DEBUG
+    PN532DEBUGPRINT.println(F("SelectApplication ResultError"));
+#endif
+    return false;
+  }
+  // selection invalidates any previous authentication
+  ntag424_Session.authenticated = false;
+  return true;
+}
+
+/*!
+    @brief   Send a DESFire CreateApplication to the picc (native command
+   0xCA, ISO7816-wrapped). On factory cards the default PICC master key
+   settings (0x0F) permit this without prior authentication.
+
+    @param   aid           3-byte application identifier, LSB first
+    @param   keySettings1  application master key settings
+    @param   keySettings2  number of keys | crypto method (0x80 = AES)
+
+    @return  false on fail|true on success
+*/
+/**************************************************************************/
+bool Adafruit_PN532::desfire_CreateApplication(const uint8_t *aid,
+                                               uint8_t keySettings1,
+                                               uint8_t keySettings2)
+{
+  uint8_t cmd_create[13] = {PN532_COMMAND_INDATAEXCHANGE,
+                            0x01,
+                            NTAG424_COM_CLA,
+                            DESFIRE_CMD_CREATE_APPLICATION,
+                            0x00,
+                            0x00,
+                            0x05,
+                            aid[0],
+                            aid[1],
+                            aid[2],
+                            keySettings1,
+                            keySettings2,
+                            0x00};
+  if (!sendCommandCheckAck(cmd_create, sizeof(cmd_create)))
+  {
+#ifdef NTAG424DEBUG
+    PN532DEBUGPRINT.println(F("Failed to receive ACK for CreateApplication"));
+#endif
+    return false;
+  }
+  /* Read the response packet: D5 41 <status> 91 00 */
+  readdata(pn532_packetbuffer, 12);
+#ifdef NTAG424DEBUG
+  PN532DEBUGPRINT.print(F("CreateApplication response: "));
+  Adafruit_PN532::PrintHexChar(pn532_packetbuffer, 12);
+#endif
+  if (pn532_packetbuffer[7] != 0x00 || pn532_packetbuffer[8] != 0x91 ||
+      pn532_packetbuffer[9] != 0x00)
+  {
+#ifdef NTAG424DEBUG
+    PN532DEBUGPRINT.println(F("CreateApplication ResultError"));
+#endif
+    return false;
+  }
+  return true;
 }
 
 /*!

--- a/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.h
+++ b/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.h
@@ -101,6 +101,18 @@
 
 #define NTAG424_RESPONE_GETVERSION_HWTYPE_NTAG424 \
   (0x04) ///< Response value HWType NTAG 424
+#define NTAG424_RESPONE_GETVERSION_HWTYPE_DESFIRE \
+  (0x01) ///< Response value HWType MIFARE DESFire
+
+// MIFARE DESFire native commands (ISO7816-wrapped, CLA 0x90).
+// DESFire EV2/EV3 share the NTAG424 EV2 secure messaging (AuthenticateEV2First
+// 0x71, SV1/SV2 session keys, ChangeKey 0xC4), so the ntag424_* helpers are
+// reused; only application selection/creation is DESFire specific.
+#define DESFIRE_CMD_SELECT_APPLICATION (0x5A) ///< SelectApplication
+#define DESFIRE_CMD_CREATE_APPLICATION (0xCA) ///< CreateApplication
+
+// DESFire GetVersion HWMajorVersion values (EV1 lacks AuthenticateEV2First).
+#define DESFIRE_HWMAJOR_EV2 (0x12) ///< HWMajorVersion of DESFire EV2
 
 #define NTAG424_COM_ISOCLA (0x00)          ///< ISO prefix
 #define NTAG424_CMD_ISOSELECTFILE (0xA4)   ///< ISOSelectFile
@@ -254,6 +266,8 @@ public:
   uint8_t ntag424_ReadData(uint8_t *buffer, int fileno, int offset, int size);
   uint8_t ntag424_WriteData(const uint8_t *data, int fileno, int offset, int size, uint8_t keyNo);
   uint8_t ntag424_Authenticate(uint8_t *key, uint8_t keyno, uint8_t cmd);
+  uint8_t ntag424_AuthenticateEV2First(uint8_t *key, uint8_t keyno,
+                                       uint8_t cmd);
   uint8_t ntag424_ChangeKey(uint8_t *oldkey, uint8_t *newkey,
                             uint8_t keynumber);
   uint8_t ntag424_ReadSig(uint8_t *buffer);
@@ -271,6 +285,11 @@ public:
   bool ntag424_ISOSelectFileByDFN(uint8_t *dfn);
   uint8_t ntag424_isNTAG424();
   uint8_t ntag424_GetVersion();
+
+  // MIFARE DESFire functions (EV2/EV3; reuse the EV2 secure messaging above)
+  bool desfire_SelectApplication(const uint8_t *aid);
+  bool desfire_CreateApplication(const uint8_t *aid, uint8_t keySettings1,
+                                 uint8_t keySettings2);
 
 // NTAG424 authresponse data
 #define NTAG424_AUTHRESPONSE_ENC_SIZE 32    ///< Size of encoded Auth-Response

--- a/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.h
+++ b/apps/attractap/firmware/src/nfc/Adafruit_PN532_NTAG424.h
@@ -110,6 +110,7 @@
 // reused; only application selection/creation is DESFire specific.
 #define DESFIRE_CMD_SELECT_APPLICATION (0x5A) ///< SelectApplication
 #define DESFIRE_CMD_CREATE_APPLICATION (0xCA) ///< CreateApplication
+#define DESFIRE_CMD_GET_KEY_VERSION (0x64)    ///< GetKeyVersion
 
 // DESFire GetVersion HWMajorVersion values (EV1 lacks AuthenticateEV2First).
 #define DESFIRE_HWMAJOR_EV2 (0x12) ///< HWMajorVersion of DESFire EV2
@@ -269,7 +270,7 @@ public:
   uint8_t ntag424_AuthenticateEV2First(uint8_t *key, uint8_t keyno,
                                        uint8_t cmd);
   uint8_t ntag424_ChangeKey(uint8_t *oldkey, uint8_t *newkey,
-                            uint8_t keynumber);
+                            uint8_t keynumber, uint8_t keyversion = 0x01);
   uint8_t ntag424_ReadSig(uint8_t *buffer);
   uint8_t ntag424_GetTTStatus(uint8_t *buffer);
   uint8_t ntag424_GetCardUID(uint8_t *buffer);
@@ -290,6 +291,7 @@ public:
   bool desfire_SelectApplication(const uint8_t *aid);
   bool desfire_CreateApplication(const uint8_t *aid, uint8_t keySettings1,
                                  uint8_t keySettings2);
+  bool desfire_GetKeyVersion(uint8_t keynumber, uint8_t *keyversion);
 
 // NTAG424 authresponse data
 #define NTAG424_AUTHRESPONSE_ENC_SIZE 32    ///< Size of encoded Auth-Response

--- a/apps/attractap/firmware/src/nfc/nfc.cpp
+++ b/apps/attractap/firmware/src/nfc/nfc.cpp
@@ -407,13 +407,28 @@ bool NFC::getAvailableKeyNo(uint8_t *uid, uint8_t *uidLength, uint8_t *keyNo)
     if (this->detectedCardType == CARD_TYPE_DESFIRE)
     {
         // Enrollment entry point: make sure the Attraccess application exists
-        // before scanning its key slots (factory cards get it created here).
+        // before choosing a data key slot (factory cards get it created here).
         I2CBusGuard busGuard;
         if (!this->desfireSelectAttraccessApp(true))
         {
             this->logger.error("getAvailableKeyNo failed, DESFire application unavailable");
             return false;
         }
+
+        // DESFire application keys are managed through the application master
+        // key. A freshly created Attraccess app should have the factory master
+        // key, and changeKey() will authenticate key 0 before writing key 1.
+        // Do not probe key 1 directly here: some DESFire cards reject auth on
+        // untouched non-master keys even though key 0 can change them.
+        if (!this->pn532.ntag424_AuthenticateEV2First(NFC::FACTORY_KEY, 0, 0x71))
+        {
+            this->logger.error("getAvailableKeyNo failed, DESFire app master key is not factory");
+            return false;
+        }
+
+        *keyNo = 1;
+        this->logger.info("getAvailableKeyNo, DESFire using key 1");
+        return true;
     }
 
     // check key 1 to 5, the first one that we can authenticate using factory key is an available key

--- a/apps/attractap/firmware/src/nfc/nfc.cpp
+++ b/apps/attractap/firmware/src/nfc/nfc.cpp
@@ -2,6 +2,10 @@
 
 uint8_t NFC::FACTORY_KEY[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
+// AID 0xACCE55 ("access"), transmitted LSB first per DESFire native protocol.
+const uint8_t NFC::DESFIRE_AID_ATTRACCESS[3] = {0x55, 0xCE, 0xAC};
+const uint8_t NFC::DESFIRE_AID_MASTER[3] = {0x00, 0x00, 0x00};
+
 void NFC::lock()
 {
     if (this->opMutex)
@@ -84,6 +88,56 @@ void NFC::disableCardDetection()
 void NFC::resetCardPresence()
 {
     this->foundCard = false;
+    this->detectedCardType = CARD_TYPE_UNKNOWN;
+}
+
+NFC::CardType NFC::getDetectedCardType()
+{
+    return this->detectedCardType;
+}
+
+void NFC::detectCardType()
+{
+    // GetVersion (native 0x60, ISO7816-wrapped) answers unauthenticated on
+    // both chip families and reports the hardware type. Cards that do not
+    // speak wrapped native commands leave garbage/zeroes in the version info,
+    // which fails the NXP vendor check below and lands on UNKNOWN.
+    memset(&this->pn532.ntag424_VersionInfo, 0, sizeof(this->pn532.ntag424_VersionInfo));
+    this->pn532.ntag424_GetVersion();
+
+    if (this->pn532.ntag424_VersionInfo.VendorID != 0x04)
+    {
+        this->detectedCardType = CARD_TYPE_UNKNOWN;
+        this->logger.debug("Card type: unknown (no NXP GetVersion response)");
+        return;
+    }
+
+    switch (this->pn532.ntag424_VersionInfo.HWType)
+    {
+    case NTAG424_RESPONE_GETVERSION_HWTYPE_NTAG424:
+        this->detectedCardType = CARD_TYPE_NTAG424;
+        this->logger.debug("Card type: NTAG424");
+        break;
+
+    case NTAG424_RESPONE_GETVERSION_HWTYPE_DESFIRE:
+        this->detectedCardType = CARD_TYPE_DESFIRE;
+        this->logger.debugf("Card type: MIFARE DESFire (HW version %02X.%02X)",
+                            this->pn532.ntag424_VersionInfo.HWMajorVersion,
+                            this->pn532.ntag424_VersionInfo.HWMinorVersion);
+        if (this->pn532.ntag424_VersionInfo.HWMajorVersion < DESFIRE_HWMAJOR_EV2)
+        {
+            // EV1 lacks AuthenticateEV2First (0x71); authentication and
+            // enrollment will fail. Surface why instead of failing silently.
+            this->logger.error("DESFire EV1 is not supported (requires EV2 or EV3)");
+        }
+        break;
+
+    default:
+        this->detectedCardType = CARD_TYPE_UNKNOWN;
+        this->logger.debugf("Card type: unknown (HWType 0x%02X)",
+                            this->pn532.ntag424_VersionInfo.HWType);
+        break;
+    }
 }
 
 void NFC::loop()
@@ -108,7 +162,16 @@ void NFC::handleCardDetection()
             // Keep the full AES handshake atomic on the shared bus; the removal
             // callback below must run WITHOUT the bus lock held (leaf-lock rule).
             I2CBusGuard busGuard;
-            authSuccess = this->pn532.ntag424_Authenticate(NFC::FACTORY_KEY, 0, 0x71);
+            if (this->detectedCardType == CARD_TYPE_DESFIRE)
+            {
+                // Key-independent presence probe: selecting the PICC master
+                // application answers regardless of the key configuration.
+                authSuccess = this->pn532.desfire_SelectApplication(NFC::DESFIRE_AID_MASTER);
+            }
+            else
+            {
+                authSuccess = this->pn532.ntag424_Authenticate(NFC::FACTORY_KEY, 0, 0x71);
+            }
         }
         if (!authSuccess)
         {
@@ -134,6 +197,12 @@ void NFC::handleCardDetection()
         // Atomic detection poll; the detection callback below runs lock-free.
         I2CBusGuard busGuard;
         foundCardUpdate = this->pn532.readPassiveTargetID(PN532_MIFARE_ISO14443A, cardDetectedUid, &cardDetectedUidLength, NFC::detectionPollTimeoutMs);
+        if (foundCardUpdate)
+        {
+            // Classify the card (NTAG424 vs. DESFire) while we still hold the
+            // bus; the routing of all later card operations depends on it.
+            this->detectCardType();
+        }
     }
 
     if (foundCardUpdate)
@@ -173,6 +242,51 @@ bool NFC::waitForCard(uint32_t timeoutMs)
     return true;
 }
 
+bool NFC::desfireSelectAttraccessApp(bool createIfMissing)
+{
+    if (this->pn532.desfire_SelectApplication(NFC::DESFIRE_AID_ATTRACCESS))
+    {
+        return true;
+    }
+
+    if (!createIfMissing)
+    {
+        this->logger.error("DESFire Attraccess application not selectable");
+        return false;
+    }
+
+    // Factory cards: the application does not exist yet. The default PICC
+    // master key settings (0x0F) allow CreateApplication without prior
+    // authentication; cards with hardened PICC settings fail here.
+    this->logger.info("DESFire Attraccess application missing, creating it");
+    if (!this->pn532.desfire_CreateApplication(NFC::DESFIRE_AID_ATTRACCESS,
+                                               NFC::DESFIRE_APP_KEY_SETTINGS_1,
+                                               NFC::DESFIRE_APP_KEY_SETTINGS_2))
+    {
+        this->logger.error("DESFire CreateApplication failed (PICC may require master key authentication)");
+        return false;
+    }
+
+    return this->pn532.desfire_SelectApplication(NFC::DESFIRE_AID_ATTRACCESS);
+}
+
+bool NFC::authenticateInternal(uint8_t keyNumber, uint8_t *key)
+{
+    if (this->detectedCardType == CARD_TYPE_DESFIRE)
+    {
+        // DESFire EV2/EV3: same EV2First handshake as the NTAG424, but inside
+        // the Attraccess application instead of the NTAG NDEF application.
+        if (!this->desfireSelectAttraccessApp(false))
+        {
+            return false;
+        }
+        return this->pn532.ntag424_AuthenticateEV2First(key, keyNumber, 0x71);
+    }
+
+    // NTAG424 and unknown cards: proven legacy path (ISOSelectFile + EV2First).
+    return this->pn532.ntag424_Authenticate(key, keyNumber, 0x71);
+}
+
 bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint8_t *newKey)
 {
     this->logger.info("changeKey started");
@@ -183,14 +297,15 @@ bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint
     I2CBusGuard busGuard;
 
     // Step 1: Authenticate with master key
-    bool authenticateOldKeySuccess = this->pn532.ntag424_Authenticate(masterKey, 0, 0x71);
+    bool authenticateOldKeySuccess = this->authenticateInternal(0, masterKey);
     if (!authenticateOldKeySuccess)
     {
         this->logger.error("changeKey failed, authenticate old key failed");
         return false;
     }
 
-    // Step 2: Change key
+    // Step 2: Change key (ChangeKey 0xC4 shares the EV2 secure messaging
+    // between NTAG424 and DESFire EV2/EV3)
     bool changeKeySuccess = this->pn532.ntag424_ChangeKey(oldKey, newKey, keyNumber);
     if (!changeKeySuccess)
     {
@@ -199,7 +314,7 @@ bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint
     }
 
     // Step 3: Validate by authenticating with new key
-    bool authenticateNewKeySuccess = this->pn532.ntag424_Authenticate(newKey, keyNumber, 0x71);
+    bool authenticateNewKeySuccess = this->authenticateInternal(keyNumber, newKey);
     if (!authenticateNewKeySuccess)
     {
         this->logger.error("changeKey failed, authenticate new key failed");
@@ -218,7 +333,7 @@ bool NFC::authenticate(uint8_t keyNumber, uint8_t *key)
     I2CBusGuard busGuard;
 
     // Step 1: Authenticate with key
-    bool authenticateSuccess = this->pn532.ntag424_Authenticate(key, keyNumber, 0x71);
+    bool authenticateSuccess = this->authenticateInternal(keyNumber, key);
     if (!authenticateSuccess)
     {
         this->logger.error("authenticate failed, authenticate procedure failed");
@@ -288,6 +403,18 @@ bool NFC::getAvailableKeyNo(uint8_t *uid, uint8_t *uidLength, uint8_t *keyNo)
     *uidLength = this->cardDetectedUidLength;
 
     this->logger.debug("getAvailableKeyNo, using already-detected card");
+
+    if (this->detectedCardType == CARD_TYPE_DESFIRE)
+    {
+        // Enrollment entry point: make sure the Attraccess application exists
+        // before scanning its key slots (factory cards get it created here).
+        I2CBusGuard busGuard;
+        if (!this->desfireSelectAttraccessApp(true))
+        {
+            this->logger.error("getAvailableKeyNo failed, DESFire application unavailable");
+            return false;
+        }
+    }
 
     // check key 1 to 5, the first one that we can authenticate using factory key is an available key
     for (uint8_t i = 1; i <= 5; i++)

--- a/apps/attractap/firmware/src/nfc/nfc.cpp
+++ b/apps/attractap/firmware/src/nfc/nfc.cpp
@@ -287,7 +287,7 @@ bool NFC::authenticateInternal(uint8_t keyNumber, uint8_t *key)
     return this->pn532.ntag424_Authenticate(key, keyNumber, 0x71);
 }
 
-bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint8_t *newKey)
+bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint8_t *newKey, uint8_t keyVersion)
 {
     this->logger.info("changeKey started");
 
@@ -306,7 +306,7 @@ bool NFC::changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint
 
     // Step 2: Change key (ChangeKey 0xC4 shares the EV2 secure messaging
     // between NTAG424 and DESFire EV2/EV3)
-    bool changeKeySuccess = this->pn532.ntag424_ChangeKey(oldKey, newKey, keyNumber);
+    bool changeKeySuccess = this->pn532.ntag424_ChangeKey(oldKey, newKey, keyNumber, keyVersion);
     if (!changeKeySuccess)
     {
         this->logger.error("changeKey failed, change key procedure failed");
@@ -415,20 +415,36 @@ bool NFC::getAvailableKeyNo(uint8_t *uid, uint8_t *uidLength, uint8_t *keyNo)
             return false;
         }
 
-        // DESFire application keys are managed through the application master
-        // key. A freshly created Attraccess app should have the factory master
-        // key, and changeKey() will authenticate key 0 before writing key 1.
-        // Do not probe key 1 directly here: some DESFire cards reject auth on
-        // untouched non-master keys even though key 0 can change them.
-        if (!this->pn532.ntag424_AuthenticateEV2First(NFC::FACTORY_KEY, 0, 0x71))
+        // Key versions are public metadata for the selected DESFire
+        // application. Query them before opening an EV2 secure session; plain
+        // direct commands sent after AuthenticateEV2First can be rejected by
+        // the PICC/session state.
+        for (uint8_t i = 1; i <= 5; i++)
         {
-            this->logger.error("getAvailableKeyNo failed, DESFire app master key is not factory");
-            return false;
+            uint8_t keyVersion = 0xFF;
+            if (!this->pn532.desfire_GetKeyVersion(i, &keyVersion))
+            {
+                this->logger.errorf("getAvailableKeyNo failed, DESFire key %d version unavailable", i);
+                return false;
+            }
+
+            this->logger.debugf("getAvailableKeyNo, DESFire key %d version 0x%02X", i, keyVersion);
+            if (keyVersion == NFC::CARD_KEY_VERSION_FREE)
+            {
+                if (!this->pn532.ntag424_AuthenticateEV2First(NFC::FACTORY_KEY, 0, 0x71))
+                {
+                    this->logger.error("getAvailableKeyNo failed, DESFire app master key is not factory");
+                    return false;
+                }
+
+                *keyNo = i;
+                this->logger.infof("getAvailableKeyNo, DESFire using key %d", i);
+                return true;
+            }
         }
 
-        *keyNo = 1;
-        this->logger.info("getAvailableKeyNo, DESFire using key 1");
-        return true;
+        this->logger.error("getAvailableKeyNo failed, no free DESFire key found");
+        return false;
     }
 
     // check key 1 to 5, the first one that we can authenticate using factory key is an available key

--- a/apps/attractap/firmware/src/nfc/nfc.hpp
+++ b/apps/attractap/firmware/src/nfc/nfc.hpp
@@ -41,7 +41,7 @@ public:
      */
     void loop();
 
-    bool changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint8_t *newKey);
+    bool changeKey(uint8_t keyNumber, uint8_t *masterKey, uint8_t *oldKey, uint8_t *newKey, uint8_t keyVersion = 0x01);
     bool authenticate(uint8_t keyNumber, uint8_t *key);
     void enableCardDetection();
     void setCardDetectionCallback(std::function<void(uint8_t *, uint8_t)> callback);
@@ -71,6 +71,8 @@ public:
     // (0x80 = AES | 6 keys, mirroring the NTAG424 key slots 0-5).
     static const uint8_t DESFIRE_APP_KEY_SETTINGS_1 = 0x0F;
     static const uint8_t DESFIRE_APP_KEY_SETTINGS_2 = 0x86;
+    static const uint8_t CARD_KEY_VERSION_FREE = 0x00;
+    static const uint8_t CARD_KEY_VERSION_ENROLLED = 0x01;
 
     bool isCardDetectionEnabled();
 

--- a/apps/attractap/firmware/src/nfc/nfc.hpp
+++ b/apps/attractap/firmware/src/nfc/nfc.hpp
@@ -13,6 +13,18 @@
 class NFC
 {
 public:
+    // Card technology detected at tap time (GetVersion HWType). Routing:
+    // NTAG424 keeps the proven ISOSelectFile+EV2First path; DESFire EV2/EV3
+    // run the same EV2First handshake inside the Attraccess application
+    // (selected/created via the DESFire native commands). Unknown cards fall
+    // back to the legacy NTAG424 path (pre-DESFire behavior).
+    enum CardType
+    {
+        CARD_TYPE_UNKNOWN = 0,
+        CARD_TYPE_NTAG424,
+        CARD_TYPE_DESFIRE,
+    };
+
     NFC() : logger("NFC"), pn532(PIN_PN532_IRQ, -1, &Wire)
     {
     }
@@ -43,7 +55,22 @@ public:
 
     bool getAvailableKeyNo(uint8_t *uid, uint8_t *uidLength, uint8_t *keyNo);
 
+    // Card type of the currently tracked card (valid while isCardPresent()).
+    CardType getDetectedCardType();
+
     static uint8_t FACTORY_KEY[16];
+
+    // Attraccess DESFire application (AID 0xACCE55, bytes LSB first) and the
+    // PICC-level master application (AID 0x000000).
+    static const uint8_t DESFIRE_AID_ATTRACCESS[3];
+    static const uint8_t DESFIRE_AID_MASTER[3];
+
+    // Application master key settings (0x0F = factory default: master key
+    // changeable, free directory access, free create/delete, settings
+    // changeable; ChangeKey requires app master key) and key config
+    // (0x80 = AES | 6 keys, mirroring the NTAG424 key slots 0-5).
+    static const uint8_t DESFIRE_APP_KEY_SETTINGS_1 = 0x0F;
+    static const uint8_t DESFIRE_APP_KEY_SETTINGS_2 = 0x86;
 
     bool isCardDetectionEnabled();
 
@@ -57,6 +84,21 @@ private:
 
     uint8_t cardDetectedUid[7] = {0};
     uint8_t cardDetectedUidLength = 0;
+
+    // Set by detectCardType() right after a successful detection poll.
+    CardType detectedCardType = CARD_TYPE_UNKNOWN;
+
+    // Probe the freshly detected card via GetVersion (works unauthenticated on
+    // both NTAG424 and DESFire). Caller must hold the I2C bus guard.
+    void detectCardType();
+
+    // Authenticate the tracked card with the routing described at CardType.
+    // Caller must hold opMutex and the I2C bus guard.
+    bool authenticateInternal(uint8_t keyNumber, uint8_t *key);
+
+    // Select the Attraccess application on a DESFire card, optionally creating
+    // it first (enrollment of factory cards). Caller must hold the bus guard.
+    bool desfireSelectAttraccessApp(bool createIfMissing);
 
     // Written by the NFC task, read from the main loop.
     volatile bool foundCard = false;

--- a/docs/de/attractap/nfc-cards.md
+++ b/docs/de/attractap/nfc-cards.md
@@ -57,14 +57,17 @@ Jeder Benutzer kann mehrere NFC-Karten mit seinem Konto verknuepfen. Dies ist nu
 
 ## Kartentypen
 
-Attractap-Leser unterstuetzen Standard-NFC-Karten, die mit dem PN532-Leser kompatibel sind:
+Attractap-Leser verwenden AES-verschluesselte Authentifizierung, die Karten mit Hardware-Krypto-Unterstuetzung erfordert:
 
 | Kartentyp | Unterstuetzt |
 |-----------|-------------|
-| MIFARE Classic 1K/4K | Ja |
-| MIFARE Ultralight | Ja |
-| NTAG213/215/216 | Ja |
-| Andere ISO 14443A-Karten | Ja |
+| NTAG424 DNA | Ja |
+| MIFARE DESFire EV2/EV3 | Ja |
+| MIFARE DESFire EV1 | Nein (fehlender Authentifizierungsmodus) |
+| MIFARE Classic / Ultralight / NTAG213-216 | Nein (keine AES-Authentifizierung) |
+
+> [!NOTE]
+> Auf MIFARE-DESFire-Karten speichert Attractap seine Schluessel in einer eigenen DESFire-Applikation (AID `0xACCE55`), die bei der Registrierung automatisch angelegt wird. Andere Applikationen auf der Karte (z.B. bestehende Zugangssysteme) bleiben unberuehrt.
 
 ## Administratorfunktionen
 

--- a/docs/en/attractap/nfc-cards.md
+++ b/docs/en/attractap/nfc-cards.md
@@ -57,14 +57,17 @@ Each user can have multiple NFC cards linked to their account. This is useful wh
 
 ## Card Types
 
-Attractap readers support standard NFC cards compatible with the PN532 reader:
+Attractap readers use AES-encrypted authentication, which requires cards with hardware crypto support:
 
 | Card Type | Supported |
 |-----------|-----------|
-| MIFARE Classic 1K/4K | Yes |
-| MIFARE Ultralight | Yes |
-| NTAG213/215/216 | Yes |
-| Other ISO 14443A cards | Yes |
+| NTAG424 DNA | Yes |
+| MIFARE DESFire EV2/EV3 | Yes |
+| MIFARE DESFire EV1 | No (lacks the required authentication mode) |
+| MIFARE Classic / Ultralight / NTAG213-216 | No (no AES authentication) |
+
+> [!NOTE]
+> On MIFARE DESFire cards, Attractap stores its keys in a dedicated DESFire application (AID `0xACCE55`), which is created automatically during enrollment. Other applications on the card (e.g. existing access systems) are not touched.
 
 ## Administrator Features
 


### PR DESCRIPTION
## Summary

Adds MIFARE DESFire EV2/EV3 support to the Attractap NFC reader firmware. DESFire EV2/EV3 share the NTAG424's EV2 secure messaging (AuthenticateEV2First 0x71, SV1/SV2 session keys, ChangeKey 0xC4), so the existing crypto stack is reused.

* **Card-type detection**: GetVersion at tap time (HWType `0x04` = NTAG424, `0x01` = DESFire); per-type routing in `authenticate`/`changeKey`/`getAvailableKeyNo`/presence probe
* **DESFire ops** run inside a dedicated Attraccess application (AID `0xACCE55`), created automatically during enrollment on factory cards (factory PICC key settings `0x0F` allow it)
* **Driver additions**: `desfire_SelectApplication` (0x5A) / `desfire_CreateApplication` (0xCA); EV2First handshake extracted from `ntag424_Authenticate` into reusable `ntag424_AuthenticateEV2First`
* **Presence probe** for DESFire selects the PICC master app (key-independent)
* **NTAG424 path unchanged**; unknown cards keep legacy behavior
* **DESFire EV1 explicitly out of scope** (lacks AuthenticateEV2First 0x71); detection logs an explicit "not supported" error
* Backend/frontend/WebSocket protocol intentionally untouched — PBKDF2 key derivation and enrollment/reset/auth protocol are card-type agnostic
* Docs: corrected supported-card-type tables (EN + DE)

## Build verification

All four PlatformIO environments compile successfully:

<!-- linear:table-colwidths:400,400 -->
| Env | Result |
| -- | -- |
| attractap-touch | SUCCESS |
| attractap-touch-v2 | SUCCESS |
| attractap-touch-ethernet | SUCCESS |
| attractap-lite-ethernet | SUCCESS |

## Test plan

- [ ] Hardware testing with a physical DESFire EV2/EV3 card still pending (PN532 reader required): enrollment (app creation + key change), authentication, reset
- [ ] Regression test with NTAG424 card (path unchanged)

Closes Attraccess/Attraccess#278

Made with [Cursor](<https://cursor.com>)