### PR TITLE
fix: prevent attractap alert nodata noise

### DIFF
--- a/docs/de/monitoring/metrics-reference.md
+++ b/docs/de/monitoring/metrics-reference.md
@@ -102,8 +102,11 @@ attraccess_resource_maintenance_overdue > 0
 sum by (reset_reason) (increase(attraccess_attractap_crash_reports_total[1h]))
 
 # Alarmsignal: alle Lesegeräte offline (waren aber kürzlich verbunden)
-attraccess_attractap_devices_connected == 0
-  and max_over_time(attraccess_attractap_devices_connected[1h]) > 0
+sum(
+  (attraccess_attractap_devices_connected == bool 0)
+  *
+  (max_over_time(attraccess_attractap_devices_connected[1h]) > bool 0)
+) or vector(0)
 ```
 
 ## Abrechnungs-Metriken

--- a/docs/en/monitoring/metrics-reference.md
+++ b/docs/en/monitoring/metrics-reference.md
@@ -102,8 +102,11 @@ attraccess_resource_maintenance_overdue > 0
 sum by (reset_reason) (increase(attraccess_attractap_crash_reports_total[1h]))
 
 # Alert signal: all readers offline (but some were connected recently)
-attraccess_attractap_devices_connected == 0
-  and max_over_time(attraccess_attractap_devices_connected[1h]) > 0
+sum(
+  (attraccess_attractap_devices_connected == bool 0)
+  *
+  (max_over_time(attraccess_attractap_devices_connected[1h]) > bool 0)
+) or vector(0)
 ```
 
 ## Billing Metrics

--- a/monitoring/grafana/dashboards/attraccess-system-health.json
+++ b/monitoring/grafana/dashboards/attraccess-system-health.json
@@ -576,7 +576,7 @@
       ]
     },
     {
-      "title": "Heap Used",
+      "title": "Host RAM Used",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -632,8 +632,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "100 * nodejs_heap_size_used_bytes{job=\"attraccess\"} / nodejs_heap_size_total_bytes{job=\"attraccess\"}",
-          "legendFormat": "Heap %"
+          "expr": "100 * (1 - (node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"}))",
+          "legendFormat": "host RAM %"
         }
       ]
     },

--- a/monitoring/grafana/dashboards/node-runtime.json
+++ b/monitoring/grafana/dashboards/node-runtime.json
@@ -132,7 +132,7 @@
       ]
     },
     {
-      "title": "Heap Used %",
+      "title": "Host RAM Used %",
       "type": "gauge",
       "gridPos": {
         "h": 8,
@@ -175,9 +175,9 @@
       },
       "targets": [
         {
-          "expr": "100 * nodejs_heap_size_used_bytes{job=\"attraccess\"} / nodejs_heap_size_total_bytes{job=\"attraccess\"}",
+          "expr": "100 * (1 - (node_memory_MemAvailable_bytes{job=\"node-exporter\"} / node_memory_MemTotal_bytes{job=\"node-exporter\"}))",
           "refId": "A",
-          "legendFormat": "heap used %"
+          "legendFormat": "host RAM %"
         }
       ]
     },

--- a/monitoring/grafana/provisioning/alerting/rules.yaml
+++ b/monitoring/grafana/provisioning/alerting/rules.yaml
@@ -315,7 +315,7 @@ groups:
         title: AttractapAllReadersOffline
         condition: C
         for: 5m
-        noDataState: NoData
+        noDataState: OK
         execErrState: Error
         labels:
           severity: critical
@@ -330,7 +330,7 @@ groups:
             datasourceUid: attraccess-prometheus
             model:
               refId: A
-              expr: 'attraccess_attractap_devices_connected{job="attraccess"} == 0 and max_over_time(attraccess_attractap_devices_connected{job="attraccess"}[1h]) > 0'
+              expr: 'sum((attraccess_attractap_devices_connected{job="attraccess"} == bool 0) * (max_over_time(attraccess_attractap_devices_connected{job="attraccess"}[1h]) > bool 0)) or vector(0)'
               instant: true
               range: false
               datasource:
@@ -351,8 +351,8 @@ groups:
               conditions:
                 - type: query
                   evaluator:
-                    type: lt
-                    params: [1]
+                    type: gt
+                    params: [0]
                   operator:
                     type: and
                   query:
@@ -365,7 +365,7 @@ groups:
         title: AttractapReaderCrashes
         condition: C
         for: 5m
-        noDataState: NoData
+        noDataState: OK
         execErrState: Error
         labels:
           severity: warning
@@ -380,7 +380,7 @@ groups:
             datasourceUid: attraccess-prometheus
             model:
               refId: A
-              expr: 'sum(increase(attraccess_attractap_crash_reports_total{job="attraccess"}[1h]))'
+              expr: 'sum(increase(attraccess_attractap_crash_reports_total{job="attraccess"}[1h])) or vector(0)'
               instant: true
               range: false
               datasource:


### PR DESCRIPTION
## Summary

- changes the Attractap all-readers-offline alert to return a stable `0`/`1` value instead of an empty vector when readers are connected
- sets the Attractap offline/crash alert `noDataState` to `OK` to avoid misleading `DatasourceNoData` notifications
- replaces prominent heap percentage panels with host RAM usage in the System Health and Node Runtime dashboards
- updates EN/DE monitoring docs with the safer Attractap alert PromQL

## Root Cause

`AttractapAllReadersOffline` used an `and` expression that returns no series when readers are connected. Grafana interpreted that healthy empty result as `NoData` and emitted `DatasourceNoData` notifications using the rule summary text, which looked like readers were offline even while the frontend showed recent reader activity.

## Validation

- `pnpm jest apps/api/src/metrics/monitoring-consistency.spec.ts --runInBand`
- `ruby -e 'require "yaml"; YAML.load_file("monitoring/grafana/provisioning/alerting/rules.yaml"); puts "yaml ok"'`
- `node -e 'const fs=require("fs"); for (const f of ["monitoring/grafana/dashboards/attraccess-system-health.json","monitoring/grafana/dashboards/node-runtime.json"]) JSON.parse(fs.readFileSync(f,"utf8")); console.log("json ok")'`
- live Prometheus checks for the updated Attractap and host RAM expressions
