### PR TITLE
ci: require Attractap firmware version bump

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -52,6 +52,18 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: echo "$PR_TITLE" | pnpm exec commitlint
 
+  attractap-firmware-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Test Attractap firmware version check
+        run: ./scripts/attractap-firmware-version-check.spec.sh
+      - name: Ensure Attractap firmware version was bumped
+        run: ./scripts/check-attractap-firmware-version.sh "${{ env.NX_AFFECTED_BASE }}"
+
   lint-and-typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/attractap-firmware-version-check.spec.sh
+++ b/scripts/attractap-firmware-version-check.spec.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Tests for scripts/check-attractap-firmware-version.sh.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-attractap-firmware-version.sh"
+
+failures=0
+fail() {
+  echo "  ✗ $1"
+  failures=$((failures + 1))
+}
+pass() { echo "  ✓ $1"; }
+
+make_repo() {
+  local dir="$1"
+  mkdir -p "$dir/apps/attractap/firmware/src" "$dir/apps/frontend"
+  cat >"$dir/apps/attractap/firmware/platformio.ini" <<'EOF'
+[env]
+build_flags =
+	-D FIRMWARE_VERSION='"'"'"1.3.24"'"'"'
+EOF
+  echo 'void setup() {}' >"$dir/apps/attractap/firmware/src/main.cpp"
+  echo 'frontend' >"$dir/apps/frontend/README.md"
+  git -C "$dir" init --quiet
+  git -C "$dir" config user.email test@example.com
+  git -C "$dir" config user.name Test
+  git -C "$dir" add .
+  git -C "$dir" commit --quiet -m baseline
+}
+
+run_check() {
+  local repo="$1"
+  local base="$2"
+  (cd "$repo" && "$SCRIPT" "$base")
+}
+
+echo "case: firmware source changed without version bump -> fail"
+TMP="$(mktemp -d)"
+make_repo "$TMP"
+BASE="$(git -C "$TMP" rev-parse HEAD)"
+echo 'void loop() {}' >>"$TMP/apps/attractap/firmware/src/main.cpp"
+git -C "$TMP" add .
+git -C "$TMP" commit --quiet -m 'change firmware source'
+if run_check "$TMP" "$BASE" >/dev/null 2>&1; then
+  fail "expected non-zero exit when firmware source changed without FIRMWARE_VERSION change"
+else
+  pass "fails when firmware source changed without FIRMWARE_VERSION change"
+fi
+rm -rf "$TMP"
+
+echo "case: firmware source changed with version bump -> pass"
+TMP="$(mktemp -d)"
+make_repo "$TMP"
+BASE="$(git -C "$TMP" rev-parse HEAD)"
+echo 'void loop() {}' >>"$TMP/apps/attractap/firmware/src/main.cpp"
+perl -0pi -e 's/1\.3\.24/1.3.25/' "$TMP/apps/attractap/firmware/platformio.ini"
+git -C "$TMP" add .
+git -C "$TMP" commit --quiet -m 'change firmware source and version'
+if run_check "$TMP" "$BASE" >/dev/null 2>&1; then
+  pass "passes when firmware source changed with FIRMWARE_VERSION change"
+else
+  fail "expected zero exit when firmware source changed with FIRMWARE_VERSION change"
+fi
+rm -rf "$TMP"
+
+echo "case: non-firmware change -> pass"
+TMP="$(mktemp -d)"
+make_repo "$TMP"
+BASE="$(git -C "$TMP" rev-parse HEAD)"
+echo 'copy change' >>"$TMP/apps/frontend/README.md"
+git -C "$TMP" add .
+git -C "$TMP" commit --quiet -m 'change frontend docs'
+if run_check "$TMP" "$BASE" >/dev/null 2>&1; then
+  pass "passes when no firmware source changed"
+else
+  fail "expected zero exit when no firmware source changed"
+fi
+rm -rf "$TMP"
+
+if [ "$failures" -gt 0 ]; then
+  echo "✗ $failures assertion(s) failed"
+  exit 1
+fi
+echo "✓ all attractap firmware version check assertions passed"

--- a/scripts/attractap-firmware-version-check.spec.sh
+++ b/scripts/attractap-firmware-version-check.spec.sh
@@ -50,6 +50,20 @@ else
 fi
 rm -rf "$TMP"
 
+echo "case: firmware config changed without version bump -> fail"
+TMP="$(mktemp -d)"
+make_repo "$TMP"
+BASE="$(git -C "$TMP" rev-parse HEAD)"
+echo 'monitor_speed = 9600' >>"$TMP/apps/attractap/firmware/platformio.ini"
+git -C "$TMP" add .
+git -C "$TMP" commit --quiet -m 'change firmware config'
+if run_check "$TMP" "$BASE" >/dev/null 2>&1; then
+  fail "expected non-zero exit when firmware config changed without FIRMWARE_VERSION change"
+else
+  pass "fails when firmware config changed without FIRMWARE_VERSION change"
+fi
+rm -rf "$TMP"
+
 echo "case: firmware source changed with version bump -> pass"
 TMP="$(mktemp -d)"
 make_repo "$TMP"

--- a/scripts/check-attractap-firmware-version.sh
+++ b/scripts/check-attractap-firmware-version.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Fail when Attractap firmware source changes without updating FIRMWARE_VERSION.
+
+set -euo pipefail
+
+BASE="${1:-${NX_AFFECTED_BASE:-origin/main}}"
+VERSION_FILE="apps/attractap/firmware/platformio.ini"
+
+if ! git rev-parse --verify "${BASE}^{commit}" >/dev/null 2>&1; then
+  echo "Could not resolve base ref: ${BASE}" >&2
+  exit 1
+fi
+
+mapfile -t changed_files < <(git diff --name-only "${BASE}...HEAD" --)
+
+firmware_source_changed=false
+for file in "${changed_files[@]}"; do
+  case "$file" in
+    apps/attractap/firmware/src/*|\
+    apps/attractap/firmware/include/*|\
+    apps/attractap/firmware/lib/*|\
+    apps/attractap/firmware/boards/*|\
+    apps/attractap/firmware/tools/*|\
+    apps/attractap/firmware/test/*|\
+    apps/attractap/firmware/build_firmwares.py|\
+    apps/attractap/firmware/partitions.csv|\
+    apps/attractap/firmware/sdkconfig.defaults)
+      firmware_source_changed=true
+      break
+      ;;
+  esac
+done
+
+if [ "$firmware_source_changed" != "true" ]; then
+  echo "No Attractap firmware source changes detected."
+  exit 0
+fi
+
+if git diff --unified=0 "${BASE}...HEAD" -- "$VERSION_FILE" | grep -E '^[+-].*FIRMWARE_VERSION=' >/dev/null; then
+  echo "Attractap firmware source changed and FIRMWARE_VERSION was updated."
+  exit 0
+fi
+
+echo "Attractap firmware source changed, but ${VERSION_FILE} did not update FIRMWARE_VERSION." >&2
+echo "Please bump the -D FIRMWARE_VERSION value when changing firmware source code." >&2
+echo "Changed firmware files:" >&2
+for file in "${changed_files[@]}"; do
+  case "$file" in
+    apps/attractap/firmware/src/*|\
+    apps/attractap/firmware/include/*|\
+    apps/attractap/firmware/lib/*|\
+    apps/attractap/firmware/boards/*|\
+    apps/attractap/firmware/tools/*|\
+    apps/attractap/firmware/test/*|\
+    apps/attractap/firmware/build_firmwares.py|\
+    apps/attractap/firmware/partitions.csv|\
+    apps/attractap/firmware/sdkconfig.defaults)
+      echo "  - $file" >&2
+      ;;
+  esac
+done
+exit 1

--- a/scripts/check-attractap-firmware-version.sh
+++ b/scripts/check-attractap-firmware-version.sh
@@ -16,15 +16,7 @@ mapfile -t changed_files < <(git diff --name-only "${BASE}...HEAD" --)
 firmware_source_changed=false
 for file in "${changed_files[@]}"; do
   case "$file" in
-    apps/attractap/firmware/src/*|\
-    apps/attractap/firmware/include/*|\
-    apps/attractap/firmware/lib/*|\
-    apps/attractap/firmware/boards/*|\
-    apps/attractap/firmware/tools/*|\
-    apps/attractap/firmware/test/*|\
-    apps/attractap/firmware/build_firmwares.py|\
-    apps/attractap/firmware/partitions.csv|\
-    apps/attractap/firmware/sdkconfig.defaults)
+    apps/attractap/firmware/*)
       firmware_source_changed=true
       break
       ;;
@@ -46,15 +38,7 @@ echo "Please bump the -D FIRMWARE_VERSION value when changing firmware source co
 echo "Changed firmware files:" >&2
 for file in "${changed_files[@]}"; do
   case "$file" in
-    apps/attractap/firmware/src/*|\
-    apps/attractap/firmware/include/*|\
-    apps/attractap/firmware/lib/*|\
-    apps/attractap/firmware/boards/*|\
-    apps/attractap/firmware/tools/*|\
-    apps/attractap/firmware/test/*|\
-    apps/attractap/firmware/build_firmwares.py|\
-    apps/attractap/firmware/partitions.csv|\
-    apps/attractap/firmware/sdkconfig.defaults)
+    apps/attractap/firmware/*)
       echo "  - $file" >&2
       ;;
   esac


### PR DESCRIPTION
## Summary
- Add a CI guard that fails when Attractap firmware source files change without a FIRMWARE_VERSION update.
- Add a shell regression spec covering missing bump, valid bump, and non-firmware changes.
- Wire the guard into the pull request workflow using NX_AFFECTED_BASE.

## Test Plan
- bash scripts/attractap-firmware-version-check.spec.sh
- bash scripts/check-attractap-firmware-version.sh origin/main
- git diff --check

Linear: ATT-558