### PR TITLE
feat(attractap): surface reader network quality

### DIFF
--- a/apps/attractap/firmware/src/display/display.cpp
+++ b/apps/attractap/firmware/src/display/display.cpp
@@ -39,6 +39,9 @@ std::function<void()> Display::onTransitionComplete = nullptr;
 String Display::deviceNameInitValue = "Attractap";
 
 lv_obj_t *Display::deviceNameLabel = NULL;
+lv_obj_t *Display::networkQualityContainer = NULL;
+lv_obj_t *Display::networkQualityLabel = NULL;
+State::NetworkQuality Display::networkQualityOverlayValue = State::NETWORK_QUALITY_GOOD;
 BootScreen Display::bootScreen;
 SetPinScreen Display::setPinScreen;
 ConnectionConfigurationScreen Display::connectionConfigurationScreen;
@@ -295,6 +298,8 @@ void Display::loop()
         Display::showErrorPopup("Touch Unavailable",
                                 "Touch panel not detected.\nCheck hardware and reboot.");
     }
+
+    Display::updateNetworkQualityOverlay();
 
     if (Display::activeScreen)
     {

--- a/apps/attractap/firmware/src/display/display.hpp
+++ b/apps/attractap/firmware/src/display/display.hpp
@@ -102,8 +102,12 @@ private:
     static uint32_t tick_cb();
 
     static void initDeviceOverlay();
+    static void updateNetworkQualityOverlay();
     static lv_obj_t *deviceNameLabel;
     static String deviceNameInitValue;
+    static lv_obj_t *networkQualityContainer;
+    static lv_obj_t *networkQualityLabel;
+    static State::NetworkQuality networkQualityOverlayValue;
 
     static lv_obj_t *activePopup;
     static lv_timer_t *popupAutoCloseTimer;

--- a/apps/attractap/firmware/src/display/display_overlay.cpp
+++ b/apps/attractap/firmware/src/display/display_overlay.cpp
@@ -47,6 +47,61 @@ void Display::initDeviceOverlay()
     lv_obj_set_style_text_color(firmwareLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_opa(firmwareLabel, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_font(firmwareLabel, &lv_font_montserrat_10, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+    Display::networkQualityContainer = lv_obj_create(top);
+    lv_obj_remove_style_all(Display::networkQualityContainer);
+    lv_obj_set_size(Display::networkQualityContainer, 62, 30);
+    lv_obj_set_align(Display::networkQualityContainer, LV_ALIGN_TOP_RIGHT);
+    lv_obj_set_x(Display::networkQualityContainer, -12);
+    lv_obj_set_y(Display::networkQualityContainer, 12);
+    lv_obj_set_style_radius(Display::networkQualityContainer, 15, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(Display::networkQualityContainer, 225, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_border_width(Display::networkQualityContainer, 2, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_border_color(Display::networkQualityContainer, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_flex_flow(Display::networkQualityContainer, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(Display::networkQualityContainer, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_remove_flag(Display::networkQualityContainer, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_remove_flag(Display::networkQualityContainer, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(Display::networkQualityContainer, LV_OBJ_FLAG_HIDDEN);
+
+    Display::networkQualityLabel = lv_label_create(Display::networkQualityContainer);
+    lv_label_set_text(Display::networkQualityLabel, "! NET");
+    lv_obj_set_style_text_color(Display::networkQualityLabel, lv_color_hex(0xFFFFFF), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_text_font(Display::networkQualityLabel, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+}
+
+void Display::updateNetworkQualityOverlay()
+{
+    if (!Display::networkQualityContainer || !Display::networkQualityLabel)
+    {
+        return;
+    }
+
+    State::NetworkQualityState qualityState = State::getNetworkQualityState();
+    if (qualityState.quality == Display::networkQualityOverlayValue)
+    {
+        return;
+    }
+
+    Display::networkQualityOverlayValue = qualityState.quality;
+
+    switch (qualityState.quality)
+    {
+    case State::NETWORK_QUALITY_GOOD:
+        lv_obj_add_flag(Display::networkQualityContainer, LV_OBJ_FLAG_HIDDEN);
+        break;
+    case State::NETWORK_QUALITY_DEGRADED:
+        lv_obj_remove_flag(Display::networkQualityContainer, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_bg_color(Display::networkQualityContainer, lv_color_hex(0xD97706), LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_label_set_text(Display::networkQualityLabel, "! NET");
+        break;
+    case State::NETWORK_QUALITY_OFFLINE:
+    default:
+        lv_obj_remove_flag(Display::networkQualityContainer, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_set_style_bg_color(Display::networkQualityContainer, lv_color_hex(0xDC2626), LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_label_set_text(Display::networkQualityLabel, "x NET");
+        break;
+    }
 }
 
 void Display::setDeviceName(String deviceName)

--- a/apps/attractap/firmware/src/state/state.cpp
+++ b/apps/attractap/firmware/src/state/state.cpp
@@ -31,6 +31,13 @@ bool State::wifi_connected = false;
 String State::wifi_ssid = "";
 esp_ip4_addr_t State::ethernet_ip = {};
 bool State::ethernet_connected = false;
+State::NetworkQuality State::network_quality = State::NETWORK_QUALITY_OFFLINE;
+uint32_t State::network_quality_last_inbound_age_ms = 0;
+uint8_t State::network_quality_reconnects_last_minute = 0;
+uint8_t State::network_quality_tx_queue_depth = 0;
+uint8_t State::network_quality_tx_queue_full_events_last_minute = 0;
+uint8_t State::network_quality_send_failures_last_minute = 0;
+uint8_t State::network_quality_liveness_timeouts_last_minute = 0;
 String State::websocket_hostname = "";
 uint16_t State::websocket_port = 0;
 bool State::websocket_use_ssl = false;
@@ -69,6 +76,39 @@ State::NetworkState State::getNetworkState()
 
     state.ethernet_connected = ethernet_connected;
     state.ethernet_ip = ethernet_ip;
+
+    return state;
+}
+
+void State::setNetworkQualityState(NetworkQuality quality,
+                                   uint32_t lastInboundAgeMs,
+                                   uint8_t reconnectsLastMinute,
+                                   uint8_t txQueueDepth,
+                                   uint8_t txQueueFullEventsLastMinute,
+                                   uint8_t sendFailuresLastMinute,
+                                   uint8_t livenessTimeoutsLastMinute)
+{
+    StateLock lock(state_mutex);
+    network_quality = quality;
+    network_quality_last_inbound_age_ms = lastInboundAgeMs;
+    network_quality_reconnects_last_minute = reconnectsLastMinute;
+    network_quality_tx_queue_depth = txQueueDepth;
+    network_quality_tx_queue_full_events_last_minute = txQueueFullEventsLastMinute;
+    network_quality_send_failures_last_minute = sendFailuresLastMinute;
+    network_quality_liveness_timeouts_last_minute = livenessTimeoutsLastMinute;
+}
+
+State::NetworkQualityState State::getNetworkQualityState()
+{
+    StateLock lock(state_mutex);
+    NetworkQualityState state;
+    state.quality = network_quality;
+    state.lastInboundAgeMs = network_quality_last_inbound_age_ms;
+    state.reconnectsLastMinute = network_quality_reconnects_last_minute;
+    state.txQueueDepth = network_quality_tx_queue_depth;
+    state.txQueueFullEventsLastMinute = network_quality_tx_queue_full_events_last_minute;
+    state.sendFailuresLastMinute = network_quality_send_failures_last_minute;
+    state.livenessTimeoutsLastMinute = network_quality_liveness_timeouts_last_minute;
 
     return state;
 }

--- a/apps/attractap/firmware/src/state/state.hpp
+++ b/apps/attractap/firmware/src/state/state.hpp
@@ -21,6 +21,33 @@ public:
     };
     static NetworkState getNetworkState();
 
+    enum NetworkQuality
+    {
+        NETWORK_QUALITY_GOOD,
+        NETWORK_QUALITY_DEGRADED,
+        NETWORK_QUALITY_OFFLINE,
+    };
+
+    struct NetworkQualityState
+    {
+        NetworkQuality quality;
+        uint32_t lastInboundAgeMs;
+        uint8_t reconnectsLastMinute;
+        uint8_t txQueueDepth;
+        uint8_t txQueueFullEventsLastMinute;
+        uint8_t sendFailuresLastMinute;
+        uint8_t livenessTimeoutsLastMinute;
+    };
+
+    static void setNetworkQualityState(NetworkQuality quality,
+                                       uint32_t lastInboundAgeMs,
+                                       uint8_t reconnectsLastMinute,
+                                       uint8_t txQueueDepth,
+                                       uint8_t txQueueFullEventsLastMinute,
+                                       uint8_t sendFailuresLastMinute,
+                                       uint8_t livenessTimeoutsLastMinute);
+    static NetworkQualityState getNetworkQualityState();
+
     // Connection phase of the websocket client. Mirrors Websocket::ConnectionState
     // so the connecting screen can show where the device is without depending on
     // the websocket header.
@@ -71,6 +98,14 @@ private:
 
     static esp_ip4_addr_t ethernet_ip;
     static bool ethernet_connected;
+
+    static NetworkQuality network_quality;
+    static uint32_t network_quality_last_inbound_age_ms;
+    static uint8_t network_quality_reconnects_last_minute;
+    static uint8_t network_quality_tx_queue_depth;
+    static uint8_t network_quality_tx_queue_full_events_last_minute;
+    static uint8_t network_quality_send_failures_last_minute;
+    static uint8_t network_quality_liveness_timeouts_last_minute;
 
     static String websocket_hostname;
     static uint16_t websocket_port;

--- a/apps/attractap/firmware/src/websocket/websocket.cpp
+++ b/apps/attractap/firmware/src/websocket/websocket.cpp
@@ -90,6 +90,7 @@ void Websocket::loop()
 
     this->updateInfoFromAppState();
     this->publishConnectionStatus();
+    this->publishNetworkQuality();
 
     if (!network_is_connected)
     {
@@ -115,6 +116,7 @@ void Websocket::loop()
         if (millis() - this->lastInboundFrameTime > this->INBOUND_LIVENESS_TIMEOUT_MS)
         {
             logger.error("No inbound frames within liveness timeout, forcing reconnect");
+            recordNetworkQualityEvent(this->livenessTimeoutEventTimes, this->livenessTimeoutEventNextIndex);
             setState(INIT);
         }
         break;
@@ -162,6 +164,53 @@ void Websocket::publishConnectionStatus()
         }
     }
     State::setWebsocketNextAttemptSeconds(secondsUntilNext);
+}
+
+void Websocket::publishNetworkQuality()
+{
+    uint32_t nowMs = millis();
+    uint32_t inboundAgeMs = (this->lastInboundFrameTime == 0) ? 0 : nowMs - this->lastInboundFrameTime;
+    uint8_t txDepth = this->tx_queue ? (uint8_t)uxQueueMessagesWaiting(this->tx_queue) : 0;
+    uint8_t reconnects = countRecentNetworkQualityEvents(this->reconnectEventTimes, nowMs);
+    uint8_t queueFull = countRecentNetworkQualityEvents(this->txQueueFullEventTimes, nowMs);
+    uint8_t sendFailures = countRecentNetworkQualityEvents(this->sendFailureEventTimes, nowMs);
+    uint8_t livenessTimeouts = countRecentNetworkQualityEvents(this->livenessTimeoutEventTimes, nowMs);
+
+    State::NetworkQuality quality = State::NETWORK_QUALITY_GOOD;
+    if (!this->network_is_connected || this->_state != CONNECTED)
+    {
+        quality = State::NETWORK_QUALITY_OFFLINE;
+    }
+    else if ((this->lastInboundFrameTime != 0 && inboundAgeMs >= this->INBOUND_DEGRADED_AFTER_MS) ||
+             reconnects >= 2 ||
+             queueFull > 0 ||
+             sendFailures > 0 ||
+             livenessTimeouts > 0 ||
+             txDepth >= (TX_QUEUE_DEPTH / 2))
+    {
+        quality = State::NETWORK_QUALITY_DEGRADED;
+    }
+
+    State::setNetworkQualityState(quality, inboundAgeMs, reconnects, txDepth, queueFull, sendFailures, livenessTimeouts);
+}
+
+void Websocket::recordNetworkQualityEvent(uint32_t *events, uint8_t &nextIndex)
+{
+    events[nextIndex] = millis();
+    nextIndex = (uint8_t)((nextIndex + 1) % QUALITY_EVENT_SLOTS);
+}
+
+uint8_t Websocket::countRecentNetworkQualityEvents(const uint32_t *events, uint32_t nowMs) const
+{
+    uint8_t count = 0;
+    for (size_t i = 0; i < QUALITY_EVENT_SLOTS; i++)
+    {
+        if (events[i] != 0 && nowMs - events[i] <= this->QUALITY_EVENT_WINDOW_MS)
+        {
+            count++;
+        }
+    }
+    return count;
 }
 
 void Websocket::connectWebSocket()
@@ -401,12 +450,11 @@ void Websocket::processWebSocketEvent(esp_event_base_t base, int32_t event_id, v
 
     AttraccessApiConfig apiConfig = Settings::getAttraccessApiConfig();
 
-    this->lastInboundFrameTime = millis();
-
     switch (event_id)
     {
     case WEBSOCKET_EVENT_CONNECTED:
         logger.info("WebSocket connected");
+        this->lastInboundFrameTime = millis();
         this->consecutiveConnectFailures = 0;
         {
             this->_certManager.markSuccess();
@@ -417,12 +465,14 @@ void Websocket::processWebSocketEvent(esp_event_base_t base, int32_t event_id, v
 
     case WEBSOCKET_EVENT_CLOSED:
         logger.info("WebSocket closed");
+        recordNetworkQualityEvent(this->reconnectEventTimes, this->reconnectEventNextIndex);
         setState(INIT);
         break;
 
     case WEBSOCKET_EVENT_DISCONNECTED:
     {
         logger.info("WebSocket disconnected");
+        recordNetworkQualityEvent(this->reconnectEventTimes, this->reconnectEventNextIndex);
         if (apiConfig.useSSL && !this->_certManager.markFailure())
         {
             // Still iterating the certificate list: retry fast so a working cert near
@@ -441,6 +491,7 @@ void Websocket::processWebSocketEvent(esp_event_base_t base, int32_t event_id, v
     }
 
     case WEBSOCKET_EVENT_DATA:
+        this->lastInboundFrameTime = millis();
         if (data->op_code == 0x01)
         { // Text frame
             if (this->messageCallbackRaw)
@@ -461,6 +512,7 @@ void Websocket::processWebSocketEvent(esp_event_base_t base, int32_t event_id, v
 
     case WEBSOCKET_EVENT_ERROR:
         logger.error("WebSocket error");
+        recordNetworkQualityEvent(this->reconnectEventTimes, this->reconnectEventNextIndex);
         setState(INIT);
         break;
 
@@ -501,6 +553,7 @@ void Websocket::enqueueMessage(const char *data, size_t length)
     if (xQueueSend(tx_queue, &msg, 0) != pdTRUE)
     {
         logger.error("enqueueMessage: tx queue full, dropping message");
+        recordNetworkQualityEvent(this->txQueueFullEventTimes, this->txQueueFullEventNextIndex);
         free(copy);
     }
 }
@@ -534,6 +587,7 @@ void Websocket::txTaskLoop()
         if (ret == -1)
         {
             logger.error("ws tx: send failed");
+            recordNetworkQualityEvent(this->sendFailureEventTimes, this->sendFailureEventNextIndex);
         }
         free(msg.data);
     }
@@ -573,6 +627,7 @@ void Websocket::setState(ConnectionState state)
     State::setWebsocketPhase(phase);
 
     State::setWebsocketState(state == CONNECTED, this->_lastApiConfig.hostname, this->_lastApiConfig.port, this->_lastApiConfig.useSSL);
+    publishNetworkQuality();
 }
 
 void Websocket::setMessageCallbackRaw(std::function<void(const char *, size_t)> callback)

--- a/apps/attractap/firmware/src/websocket/websocket.hpp
+++ b/apps/attractap/firmware/src/websocket/websocket.hpp
@@ -43,6 +43,9 @@ private:
 
     void updateInfoFromAppState();
     void publishConnectionStatus();
+    void publishNetworkQuality();
+    void recordNetworkQualityEvent(uint32_t *events, uint8_t &nextIndex);
+    uint8_t countRecentNetworkQualityEvents(const uint32_t *events, uint32_t nowMs) const;
     void connectWebSocket();
     void connectWebSocketLocked();
     bool shouldReconnect();
@@ -89,7 +92,18 @@ private:
     void handleConnectFailure(const char *reason);
 
     uint32_t lastInboundFrameTime = 0;
+    const uint32_t INBOUND_DEGRADED_AFTER_MS = 12000;
     const uint32_t INBOUND_LIVENESS_TIMEOUT_MS = 20000;
+    const uint32_t QUALITY_EVENT_WINDOW_MS = 60000;
+    static constexpr size_t QUALITY_EVENT_SLOTS = 8;
+    uint32_t reconnectEventTimes[QUALITY_EVENT_SLOTS] = {};
+    uint32_t txQueueFullEventTimes[QUALITY_EVENT_SLOTS] = {};
+    uint32_t sendFailureEventTimes[QUALITY_EVENT_SLOTS] = {};
+    uint32_t livenessTimeoutEventTimes[QUALITY_EVENT_SLOTS] = {};
+    uint8_t reconnectEventNextIndex = 0;
+    uint8_t txQueueFullEventNextIndex = 0;
+    uint8_t sendFailureEventNextIndex = 0;
+    uint8_t livenessTimeoutEventNextIndex = 0;
     const int PINGPONG_TIMEOUT_SEC = 10;
 
     bool network_is_connected = false;


### PR DESCRIPTION
### Motivation
- The reader should surface link quality so users understand when sluggishness is caused by the network (ATT-511). 
- Provide a small non-intrusive UI cue on-device (good / degraded / offline) driven by existing websocket and transport signals.

### Description
- Introduced a new shared network-quality model in `State` with `NetworkQuality` enum and `NetworkQualityState` plus `setNetworkQualityState` / `getNetworkQualityState` accessors (files changed: `state.hpp`, `state.cpp`).
- Enhanced the websocket client to collect recent network events (reconnects, tx-queue-full, send failures, liveness timeouts, inbound-frame age) and classify quality with heuristics (`publishNetworkQuality`, event ring buffers, helpers) and record events on disconnect/close/tx failures (files changed: `websocket.hpp`, `websocket.cpp`).
- Added a persistent top-right LVGL overlay that shows nothing when quality is good, an amber `! NET` for degraded, and a red `x NET` for offline, and wired the display loop to refresh it (`display.hpp`, `display.cpp`, `display_overlay.cpp`).

### Testing
- `git diff --check` succeeded with no whitespace or merge-check errors reported.  
- `pnpm nx run attractap-firmware:build` was executed but the firmware build step could not complete because PlatformIO attempted to download the `platformio/espressif32` platform and failed with an `HTTPClientError`, so a full firmware build/run could not be validated in this environment.  
- A direct PlatformIO build (`~/.local/bin/platformio run -e attractap-touch-v2`) was attempted and likewise failed due to the same PlatformIO platform download error, preventing runtime verification or screenshots of the LVGL overlay.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bc714d6608321aebe6f27025db1d5)