### PR TITLE
fix(tools): harden chaos-ap presets for GL.iNet

### DIFF
--- a/tools/chaos-ap/README.md
+++ b/tools/chaos-ap/README.md
@@ -24,12 +24,16 @@ ground truth for validating the matching reader-side fix.
 opkg update && opkg install kmod-sched tc
 ```
 
+If `tc` or the `netem` scheduler is missing, the `netem` preset now falls back
+to iptables random loss (`-m statistic --mode random --probability ...`). The
+fallback reproduces packet loss only; it cannot add latency.
+
 ## Presets
 
 | Preset | Reproduces | Mechanism |
 | --- | --- | --- |
-| `blackhole` | **ATT-464** half-open sockets | `iptables -A FORWARD ... -j DROP` — silently drops packets with no RST, so the reader's TCP stays half-open |
-| `netem` | **ATT-469** stalls / slow paths | `tc qdisc add dev <if> root netem delay 2000ms loss 30%` |
+| `blackhole` | **ATT-464** half-open sockets | creates `CHAOS_AP_BLACKHOLE` and inserts a `FORWARD` jump at rule 1, then silently drops packets with no RST |
+| `netem` | **ATT-469** stalls / slow paths | `tc qdisc add dev <if> root netem delay 2000ms loss 30%`; falls back to `CHAOS_AP_LOSS` + iptables statistic loss when netem is unavailable |
 | `flap` | **ATT-465 / ATT-467** reconnect churn | kills the SSID (`wifi down <radio>`) and brings it back on a randomized 15–30s interval |
 | `dhcp-wedge` | **ATT-468** DHCP wedge | `uci set dhcp.<section>.ignore=1` — SSID and DNS stay up, but no leases are handed out |
 
@@ -56,6 +60,9 @@ READER_IP=192.168.8.123 ./chaos-ap.sh blackhole on
 # ATT-469: 2s latency + 30% loss on the LAN bridge facing the readers
 IFACE=br-lan DELAY=2000ms LOSS=30% ./chaos-ap.sh netem on
 
+# Bridged reader/server on the same LAN: enable bridge-nf automatically when possible
+READER_IP=192.168.8.123 SERVER_IP=192.168.8.50 ./chaos-ap.sh blackhole on
+
 # ATT-465/467: flap the SSID, down 5s, up for a random 15-30s
 RADIO=radio0 FLAP_DOWN=5 FLAP_MIN=15 FLAP_MAX=30 ./chaos-ap.sh flap on
 
@@ -70,20 +77,59 @@ DHCP_SECTION=lan ./chaos-ap.sh dhcp-wedge on
 
 | Var | Default | Used by | Meaning |
 | --- | --- | --- | --- |
-| `READER_IP` | _(empty)_ | `blackhole` | reader IP to drop; empty = drop **all** FORWARD traffic |
-| `IFACE` | `br-lan` | `netem` | interface that carries reader↔server traffic |
-| `DELAY` | `2000ms` | `netem` | netem added latency |
-| `LOSS` | `30%` | `netem` | netem packet loss |
+| `READER_IP` | _(empty)_ | `blackhole`, `netem` fallback, bridge-nf | reader IP to drop; empty = affect **all** FORWARD traffic |
+| `SERVER_IP` | _(empty)_ | bridge-nf | server IP; when set with `READER_IP`, same-subnet traffic enables `/proc/sys/net/bridge/bridge-nf-call-iptables` if writable |
+| `IFACE` | `br-lan` | `netem`, bridge-nf | interface that carries reader↔server traffic |
+| `DELAY` | `2000ms` | `netem` | netem added latency; ignored by statistic-loss fallback |
+| `LOSS` | `30%` | `netem` | netem packet loss or statistic fallback probability (`30%` or `0.3`) |
+| `CHAOS_AP_DISABLE_FLOW_OFFLOAD` | `0` | `blackhole`, `netem` fallback | set to `1` to temporarily disable OpenWRT flow offload before installing iptables rules |
+| `CHAOS_AP_FIREWALL_RESTART` | `reload` | flow offload | firewall action after temporary flow-offload disable: `reload`, `restart`, `start`, or `none` |
 | `RADIO` | `radio0` | `flap` | OpenWRT radio (or interface) to toggle |
 | `DHCP_SECTION` | `lan` | `dhcp-wedge` | uci `dhcp.<section>` to wedge |
 | `FLAP_DOWN` | `5` | `flap` | seconds the SSID stays down each cycle |
 | `FLAP_MIN` / `FLAP_MAX` | `15` / `30` | `flap` | random up-time window (seconds) |
 | `FLAP_PIDFILE` | `/tmp/chaos-ap-flap.pid` | `flap` | where the background flap loop records its PID |
 
+## GL.iNet / OpenWRT quirks
+
+The GL-SFT1200 bench router (OpenWRT 18.06 / Linux 4.14) needs a few extra
+safeguards for these presets to bite:
+
+- **FORWARD rule ordering matters.** OpenWRT/GL.iNet installs zone and
+  established-flow `ACCEPT` rules in `FORWARD`. `chaos-ap.sh` therefore inserts
+  dedicated `CHAOS_AP_*` jumps at `FORWARD` rule 1 instead of appending raw DROP
+  rules at the bottom.
+- **Flow offload can bypass iptables.** If
+  `firewall.@defaults[0].flow_offloading` or `flow_offloading_hw` is enabled,
+  established flows may skip netfilter entirely. By default the script warns but
+  does not change router config. For a temporary experiment you can run:
+
+  ```sh
+  CHAOS_AP_DISABLE_FLOW_OFFLOAD=1 READER_IP=192.168.8.123 ./chaos-ap.sh blackhole on
+  ```
+
+  The script uses uncommitted `uci set` changes, restarts the firewall according
+  to `CHAOS_AP_FIREWALL_RESTART`, and flushes conntrack if `conntrack` exists.
+- **GL.iNet firewall reload gotcha.** On the GL-SFT1200, toggling flow offload
+  and running a bare `/etc/init.d/firewall reload` can desync GL custom chains
+  and leave NAT/forwarding partially broken until a full firewall start or
+  reboot. Prefer leaving flow offload alone and rebooting the router/client to
+  tear down the experiment. If you do disable offload, treat a router reboot as
+  the safest teardown and avoid committing the uci changes.
+- **Bridged reader↔server traffic can skip FORWARD.** If both endpoints are on
+  `br-lan`, Linux may bridge them at L2. Set both `READER_IP` and `SERVER_IP`;
+  when they share the interface subnet and
+  `/proc/sys/net/bridge/bridge-nf-call-iptables` is writable, the script writes
+  `1` there so bridged IPv4 traffic reaches iptables.
+- **No netem module on some GL feeds.** If `sch_netem` / `kmod-sched-netem` is
+  unavailable, the `netem` preset falls back to iptables statistic loss. This is
+  useful for loss-only testing, but it does not simulate added latency.
+
 ## Notes
 
-- Presets are independent; you can stack `blackhole` + `netem`. `clear` (and a
-  reboot) removes everything.
+- Presets are independent; you can stack `blackhole` + `netem`. `clear` removes
+  the script's iptables chains/qdisc/flap loop, and a reboot removes all
+  non-persistent kernel state.
 - `flap` runs a background loop tracked by `FLAP_PIDFILE`; `flap off` / `clear`
   stops it and brings the radio back up.
 - `dhcp-wedge` keeps DNS working (dnsmasq is only restarted, not stopped) so the

--- a/tools/chaos-ap/chaos-ap.sh
+++ b/tools/chaos-ap/chaos-ap.sh
@@ -32,6 +32,10 @@ set -eu
 # IP of the reader to black-hole (blackhole preset). Empty == all FORWARD traffic.
 READER_IP="${READER_IP:-}"
 
+# Optional Attraccess server IP. If READER_IP and SERVER_IP share the interface
+# subnet, bridge netfilter is enabled so same-LAN br-lan traffic reaches FORWARD.
+SERVER_IP="${SERVER_IP:-}"
+
 # Interface that carries reader<->server traffic, where netem is attached.
 # On a typical OpenWRT AP the LAN bridge faces the readers; override for WAN.
 IFACE="${IFACE:-br-lan}"
@@ -39,6 +43,11 @@ IFACE="${IFACE:-br-lan}"
 # netem parameters (netem preset).
 DELAY="${DELAY:-2000ms}"
 LOSS="${LOSS:-30%}"
+
+# Flow offload handling is warning-only by default because GL.iNet firewall
+# reload can desync custom chains; set to 1 for temporary, uncommitted uci edits.
+CHAOS_AP_DISABLE_FLOW_OFFLOAD="${CHAOS_AP_DISABLE_FLOW_OFFLOAD:-0}"
+CHAOS_AP_FIREWALL_RESTART="${CHAOS_AP_FIREWALL_RESTART:-reload}"
 
 # Radio / DHCP section for the wifi + dhcp presets (OpenWRT uci names).
 RADIO="${RADIO:-radio0}"
@@ -52,6 +61,9 @@ FLAP_MAX="${FLAP_MAX:-30}"
 
 # Where the flap background loop records its PID.
 FLAP_PIDFILE="${FLAP_PIDFILE:-/tmp/chaos-ap-flap.pid}"
+
+BLACKHOLE_CHAIN="CHAOS_AP_BLACKHOLE"
+LOSS_CHAIN="CHAOS_AP_LOSS"
 
 # ----------------------------------------------------------------------------
 # Helpers
@@ -75,26 +87,166 @@ rand_between() {
   awk -v a="$1" -v b="$2" 'BEGIN { srand(); print a + int(rand() * (b - a + 1)) }'
 }
 
+ipt_ensure_chain() {
+  chain="$1"
+  iptables -N "$chain" 2>/dev/null || true
+  iptables -F "$chain"
+}
+
+ipt_ensure_forward_jump_top() {
+  chain="$1"
+  # Insert before OpenWRT zone_* and established ACCEPT rules. If the jump is
+  # already present, move it back to the top in case another reload reordered it.
+  while iptables -C FORWARD -j "$chain" 2>/dev/null; do
+    iptables -D FORWARD -j "$chain"
+  done
+  iptables -I FORWARD 1 -j "$chain"
+}
+
+ipt_remove_chain() {
+  chain="$1"
+  while iptables -C FORWARD -j "$chain" 2>/dev/null; do
+    iptables -D FORWARD -j "$chain"
+  done
+  iptables -F "$chain" 2>/dev/null || true
+  iptables -X "$chain" 2>/dev/null || true
+}
+
+loss_probability() {
+  printf '%s\n' "$LOSS" | awk '
+    /^([0-9]+|[0-9]*\.[0-9]+)%$/ {
+      gsub(/%/, ""); p = $0 / 100;
+      if (p < 0 || p > 1) exit 1;
+      printf "%.6f\n", p; exit 0
+    }
+    /^0?(\.[0-9]+)?$/ { printf "%.6f\n", $0; exit 0 }
+    /^1(\.0+)?$/ { printf "1.000000\n"; exit 0 }
+    { exit 1 }
+  ' || die "LOSS must be a percentage like 30% or a probability 0..1 (got '$LOSS')"
+}
+
+same_ipv4_subnet() {
+  # Usage: same_ipv4_subnet 192.168.8.10 192.168.8.20 24
+  awk -v a="$1" -v b="$2" -v prefix="$3" '
+    function ip2num(ip, parts, n) {
+      n = split(ip, parts, ".")
+      if (n != 4) return -1
+      if (parts[1] < 0 || parts[1] > 255 || parts[2] < 0 || parts[2] > 255 || parts[3] < 0 || parts[3] > 255 || parts[4] < 0 || parts[4] > 255) return -1
+      return (parts[1] * 16777216) + (parts[2] * 65536) + (parts[3] * 256) + parts[4]
+    }
+    function pow2(n, r, i) { r = 1; for (i = 0; i < n; i++) r *= 2; return r }
+    BEGIN {
+      if (prefix < 0 || prefix > 32) exit 1
+      ai = ip2num(a); bi = ip2num(b)
+      if (ai < 0 || bi < 0) exit 1
+      block = pow2(32 - prefix)
+      exit int(ai / block) == int(bi / block) ? 0 : 1
+    }
+  '
+}
+
+iface_prefix() {
+  if have ip; then
+    ip -o -4 addr show dev "$IFACE" 2>/dev/null \
+      | awk '{ for (i = 1; i <= NF; i++) if ($i == "inet") { split($(i + 1), a, "/"); print a[2]; exit } }'
+  fi
+}
+
+ensure_bridge_netfilter_if_needed() {
+  [ -n "$READER_IP" ] || return 0
+  [ -n "$SERVER_IP" ] || return 0
+  bridge_nf="/proc/sys/net/bridge/bridge-nf-call-iptables"
+  [ -w "$bridge_nf" ] || return 0
+
+  prefix="$(iface_prefix)"
+  [ -n "$prefix" ] || prefix="24"
+
+  if same_ipv4_subnet "$READER_IP" "$SERVER_IP" "$prefix"; then
+    if [ "$(cat "$bridge_nf" 2>/dev/null || echo 0)" != "1" ]; then
+      echo 1 > "$bridge_nf"
+      log "enabled bridge-nf-call-iptables for bridged $READER_IP <-> $SERVER_IP traffic"
+    fi
+  fi
+}
+
+flow_offload_enabled() {
+  have uci || return 1
+  flow="$(uci -q get firewall.@defaults[0].flow_offloading 2>/dev/null || echo 0)"
+  hw="$(uci -q get firewall.@defaults[0].flow_offloading_hw 2>/dev/null || echo 0)"
+  [ "$flow" = "1" ] || [ "$hw" = "1" ]
+}
+
+maybe_disable_flow_offload() {
+  flow_offload_enabled || return 0
+
+  if [ "$CHAOS_AP_DISABLE_FLOW_OFFLOAD" = "1" ]; then
+    uci set firewall.@defaults[0].flow_offloading='0'
+    uci set firewall.@defaults[0].flow_offloading_hw='0'
+    case "$CHAOS_AP_FIREWALL_RESTART" in
+      reload|restart|start)
+        "/etc/init.d/firewall" "$CHAOS_AP_FIREWALL_RESTART" >/dev/null 2>&1 || true
+        ;;
+      none)
+        log "flow offload disabled in uncommitted uci state; firewall restart skipped"
+        ;;
+      *)
+        die "CHAOS_AP_FIREWALL_RESTART must be reload, restart, start, or none"
+        ;;
+    esac
+    if have conntrack; then
+      conntrack -F >/dev/null 2>&1 || true
+    fi
+    log "flow offload disabled for this experiment (not committed)"
+  else
+    log "WARNING: OpenWRT flow offload is enabled; established flows may bypass iptables"
+    log "WARNING: set CHAOS_AP_DISABLE_FLOW_OFFLOAD=1 to disable temporarily, or reboot clients/router to clear offloaded flows"
+  fi
+}
+
+add_reader_scoped_drop() {
+  chain="$1"
+  if [ -n "$READER_IP" ]; then
+    iptables -A "$chain" -s "$READER_IP" -j DROP
+    iptables -A "$chain" -d "$READER_IP" -j DROP
+  else
+    iptables -A "$chain" -j DROP
+  fi
+}
+
+add_reader_scoped_statistic_drop() {
+  chain="$1"
+  probability="$2"
+  if [ -n "$READER_IP" ]; then
+    iptables -A "$chain" -s "$READER_IP" -m statistic --mode random --probability "$probability" -j DROP
+    iptables -A "$chain" -d "$READER_IP" -m statistic --mode random --probability "$probability" -j DROP
+  else
+    iptables -A "$chain" -m statistic --mode random --probability "$probability" -j DROP
+  fi
+}
+
 # ----------------------------------------------------------------------------
 # blackhole — silent DROP, no RST. Reader keeps a half-open socket. (ATT-464)
 # ----------------------------------------------------------------------------
 
 blackhole_on() {
   require_cmd iptables
+  maybe_disable_flow_offload
+  ensure_bridge_netfilter_if_needed
+  ipt_ensure_chain "$BLACKHOLE_CHAIN"
+  add_reader_scoped_drop "$BLACKHOLE_CHAIN"
+  ipt_ensure_forward_jump_top "$BLACKHOLE_CHAIN"
   if [ -n "$READER_IP" ]; then
-    iptables -C FORWARD -s "$READER_IP" -j DROP 2>/dev/null \
-      || iptables -A FORWARD -s "$READER_IP" -j DROP
-    iptables -C FORWARD -d "$READER_IP" -j DROP 2>/dev/null \
-      || iptables -A FORWARD -d "$READER_IP" -j DROP
-    log "blackhole ON: dropping FORWARD to/from $READER_IP (no RST)"
+    log "blackhole ON: dropping FORWARD to/from $READER_IP at top of chain (no RST)"
   else
-    iptables -C FORWARD -j DROP 2>/dev/null || iptables -A FORWARD -j DROP
-    log "blackhole ON: dropping ALL FORWARD traffic (no RST)"
+    log "blackhole ON: dropping ALL FORWARD traffic at top of chain (no RST)"
   fi
 }
 
 blackhole_off() {
   require_cmd iptables
+  ipt_remove_chain "$BLACKHOLE_CHAIN"
+  # Backward compatibility: remove rules created by older versions that appended
+  # raw DROP rules directly to FORWARD.
   if [ -n "$READER_IP" ]; then
     while iptables -C FORWARD -s "$READER_IP" -j DROP 2>/dev/null; do
       iptables -D FORWARD -s "$READER_IP" -j DROP
@@ -114,16 +266,52 @@ blackhole_off() {
 # netem — latency + loss on $IFACE egress. (ATT-469)
 # ----------------------------------------------------------------------------
 
+statistic_loss_on() {
+  require_cmd iptables
+  probability="$(loss_probability)"
+  maybe_disable_flow_offload
+  ensure_bridge_netfilter_if_needed
+  ipt_ensure_chain "$LOSS_CHAIN"
+  add_reader_scoped_statistic_drop "$LOSS_CHAIN" "$probability"
+  ipt_ensure_forward_jump_top "$LOSS_CHAIN"
+  if [ -n "$READER_IP" ]; then
+    log "statistic loss ON: dropping random $LOSS of FORWARD traffic to/from $READER_IP (netem unavailable)"
+  else
+    log "statistic loss ON: dropping random $LOSS of ALL FORWARD traffic (netem unavailable)"
+  fi
+}
+
+statistic_loss_off() {
+  require_cmd iptables
+  ipt_remove_chain "$LOSS_CHAIN"
+  log "statistic loss OFF"
+}
+
 netem_on() {
-  require_cmd tc
+  if ! have tc; then
+    log "WARNING: tc not found; falling back to iptables statistic loss only"
+    statistic_loss_on
+    return 0
+  fi
+
   tc qdisc del dev "$IFACE" root 2>/dev/null || true
-  tc qdisc add dev "$IFACE" root netem delay "$DELAY" loss "$LOSS"
-  log "netem ON: dev $IFACE delay $DELAY loss $LOSS"
+  if tc qdisc add dev "$IFACE" root netem delay "$DELAY" loss "$LOSS" 2>/tmp/chaos-ap-netem.err; then
+    log "netem ON: dev $IFACE delay $DELAY loss $LOSS"
+  else
+    err="$(cat /tmp/chaos-ap-netem.err 2>/dev/null || true)"
+    rm -f /tmp/chaos-ap-netem.err
+    log "WARNING: tc netem unavailable on $IFACE (${err:-tc qdisc add failed}); falling back to iptables statistic loss only"
+    statistic_loss_on
+  fi
 }
 
 netem_off() {
-  require_cmd tc
-  tc qdisc del dev "$IFACE" root 2>/dev/null || true
+  if have tc; then
+    tc qdisc del dev "$IFACE" root 2>/dev/null || true
+  fi
+  if have iptables; then
+    statistic_loss_off || true
+  fi
   log "netem OFF: dev $IFACE"
 }
 
@@ -186,12 +374,25 @@ dhcp_wedge_off() {
 status() {
   echo "== chaos-ap status =="
   if have iptables; then
-    echo "-- iptables FORWARD DROP rules --"
-    iptables -S FORWARD 2>/dev/null | grep -- '-j DROP' || echo "(none)"
+    echo "-- iptables FORWARD chaos jumps --"
+    iptables -S FORWARD 2>/dev/null | grep -- "-j CHAOS_AP_" || echo "(none)"
+    echo "-- $BLACKHOLE_CHAIN --"
+    iptables -S "$BLACKHOLE_CHAIN" 2>/dev/null || echo "(none)"
+    echo "-- $LOSS_CHAIN --"
+    iptables -S "$LOSS_CHAIN" 2>/dev/null || echo "(none)"
   fi
   if have tc; then
     echo "-- tc qdisc on $IFACE --"
     tc qdisc show dev "$IFACE" 2>/dev/null || echo "(none)"
+  fi
+  if have uci; then
+    echo "-- OpenWRT flow offload --"
+    printf 'flow_offloading=%s\n' "$(uci -q get firewall.@defaults[0].flow_offloading 2>/dev/null || echo 0)"
+    printf 'flow_offloading_hw=%s\n' "$(uci -q get firewall.@defaults[0].flow_offloading_hw 2>/dev/null || echo 0)"
+  fi
+  if [ -r /proc/sys/net/bridge/bridge-nf-call-iptables ]; then
+    echo "-- bridge netfilter --"
+    printf 'bridge-nf-call-iptables=%s\n' "$(cat /proc/sys/net/bridge/bridge-nf-call-iptables)"
   fi
   echo "-- flap --"
   if [ -f "$FLAP_PIDFILE" ] && kill -0 "$(cat "$FLAP_PIDFILE")" 2>/dev/null; then
@@ -223,7 +424,7 @@ chaos-ap.sh — network fault injection for the reader<->server bench (ATT-471 p
 
 Presets:
   blackhole   silent DROP, no RST            -> ATT-464 half-open sockets
-  netem       latency + packet loss          -> ATT-469 stalls
+  netem       latency + packet loss          -> ATT-469 stalls (falls back to iptables statistic loss)
   flap        kill SSID, flap on interval    -> ATT-465 / ATT-467 churn
   dhcp-wedge  no DHCP leases, SSID stays up  -> ATT-468 DHCP wedge
 
@@ -232,8 +433,8 @@ Usage:
   chaos-ap.sh status
   chaos-ap.sh clear
 
-Config via env (defaults in script): READER_IP IFACE DELAY LOSS RADIO
-  DHCP_SECTION FLAP_DOWN FLAP_MIN FLAP_MAX
+Config via env (defaults in script): READER_IP SERVER_IP IFACE DELAY LOSS RADIO
+  DHCP_SECTION FLAP_DOWN FLAP_MIN FLAP_MAX CHAOS_AP_DISABLE_FLOW_OFFLOAD
 
 Examples:
   READER_IP=192.168.8.123 chaos-ap.sh blackhole on


### PR DESCRIPTION
### Motivation
- The original `chaos-ap.sh` appended raw `iptables -A FORWARD ... -j DROP` rules which can be ineffective on GL.iNet/OpenWRT due to existing zone/ESTABLISHED `ACCEPT` rules and kernel flow offload bypassing netfilter. 
- Bridged reader↔server traffic can bypass the `FORWARD` chain on L2 bridges, and some GL feeds lack `netem` support so the `netem` preset may not apply. 
- The change aims to make presets reliable on GL.iNet benches without forcing unsafe persistent router commits. 

### Description
- Replace appended raw FORWARD drops with dedicated chains (`CHAOS_AP_BLACKHOLE`, `CHAOS_AP_LOSS`) and insert a jump to each chain at `FORWARD` rule 1 using `ipt_ensure_forward_jump_top`. 
- Add OpenWRT guards: detect flow offload, provide opt-in temporary disable via `CHAOS_AP_DISABLE_FLOW_OFFLOAD` and `CHAOS_AP_FIREWALL_RESTART`, and flush conntrack when disabling; auto-enable bridge netfilter when `READER_IP` and `SERVER_IP` share the interface subnet by writing `/proc/sys/net/bridge/bridge-nf-call-iptables` when writable. 
- Add a `netem` fallback that converts `LOSS` to a probability and uses `iptables -m statistic --mode random --probability ... -j DROP` when `tc`/`netem` is unavailable, plus helpers for chain management, probability parsing, and improved `status` output; update `tools/chaos-ap/README.md` to document behavior and GL.iNet quirks. 

### Testing
- Performed syntax checks with `sh -n`, `dash -n`, and `bash -n` on `tools/chaos-ap/chaos-ap.sh`, all of which succeeded. 
- Ran `./tools/chaos-ap/chaos-ap.sh --help` for basic invocation output, which succeeded. 
- Executed a mocked smoke test by providing fake `iptables`/`tc`/`uci` binaries to verify `blackhole on` installs the top-of-chain jump and `netem on` falls back to statistic loss when `tc` reports the netem error, and the mock logs show the expected calls. 
- Precommit affected lint/task runner (`pnpm nx affected --uncommitted ...`) ran as part of the commit and the lint step passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bd28995b88321b6514d16c2c561a6)