### PR TITLE
fix: retain attractap crashdump symbols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,11 +69,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-# Install esp-coredump into an isolated venv and expose it on PATH
+# Install esp-coredump plus the ESP GDB binaries it shells out to for Xtensa
+# (ESP32/S2/S3) and RISC-V (ESP32-C3/C6/H2) coredumps.
 RUN python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --no-cache-dir --upgrade pip && \
-    /opt/venv/bin/pip install --no-cache-dir esp-coredump
-ENV PATH="/opt/venv/bin:${PATH}"
+    /opt/venv/bin/pip install --no-cache-dir esp-coredump platformio && \
+    mkdir -p /opt/platformio && \
+    PLATFORMIO_HOME_DIR=/opt/platformio /opt/venv/bin/platformio pkg install --global --tool platformio/tool-xtensa-esp-elf-gdb && \
+    PLATFORMIO_HOME_DIR=/opt/platformio /opt/venv/bin/platformio pkg install --global --tool platformio/tool-riscv32-esp-elf-gdb
+ENV PLATFORMIO_HOME_DIR=/opt/platformio
+ENV PATH="/opt/venv/bin:/opt/platformio/packages/tool-xtensa-esp-elf-gdb/bin:/opt/platformio/packages/tool-riscv32-esp-elf-gdb/bin:${PATH}"
 ENV ESP_COREDUMP_CMD=/opt/venv/bin/esp-coredump
 
 # Copy the pre-built application (these will be built in the CI pipeline)

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,8 @@ RUN python3 -m venv /opt/venv && \
 ENV PLATFORMIO_HOME_DIR=/opt/platformio
 ENV PATH="/opt/venv/bin:/opt/platformio/packages/tool-xtensa-esp-elf-gdb/bin:/opt/platformio/packages/tool-riscv32-esp-elf-gdb/bin:${PATH}"
 ENV ESP_COREDUMP_CMD=/opt/venv/bin/esp-coredump
+ENV ESP_COREDUMP_XTENSA_GDB=/opt/platformio/packages/tool-xtensa-esp-elf-gdb/bin/xtensa-esp32-elf-gdb
+ENV ESP_COREDUMP_RISCV_GDB=/opt/platformio/packages/tool-riscv32-esp-elf-gdb/bin/riscv32-esp-elf-gdb
 
 # Copy the pre-built application (these will be built in the CI pipeline)
 COPY --from=builder /app/dist dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,10 @@ RUN python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/venv/bin/pip install --no-cache-dir esp-coredump platformio && \
     mkdir -p /opt/platformio && \
-    PLATFORMIO_HOME_DIR=/opt/platformio /opt/venv/bin/platformio pkg install --global --tool platformio/tool-xtensa-esp-elf-gdb && \
-    PLATFORMIO_HOME_DIR=/opt/platformio /opt/venv/bin/platformio pkg install --global --tool platformio/tool-riscv32-esp-elf-gdb
-ENV PLATFORMIO_HOME_DIR=/opt/platformio
+    PLATFORMIO_CORE_DIR=/opt/platformio PLATFORMIO_PACKAGES_DIR=/opt/platformio/packages /opt/venv/bin/platformio pkg install --global --tool platformio/tool-xtensa-esp-elf-gdb && \
+    PLATFORMIO_CORE_DIR=/opt/platformio PLATFORMIO_PACKAGES_DIR=/opt/platformio/packages /opt/venv/bin/platformio pkg install --global --tool platformio/tool-riscv32-esp-elf-gdb
+ENV PLATFORMIO_CORE_DIR=/opt/platformio
+ENV PLATFORMIO_PACKAGES_DIR=/opt/platformio/packages
 ENV PATH="/opt/venv/bin:/opt/platformio/packages/tool-xtensa-esp-elf-gdb/bin:/opt/platformio/packages/tool-riscv32-esp-elf-gdb/bin:${PATH}"
 ENV ESP_COREDUMP_CMD=/opt/venv/bin/esp-coredump
 ENV ESP_COREDUMP_XTENSA_GDB=/opt/platformio/packages/tool-xtensa-esp-elf-gdb/bin/xtensa-esp32-elf-gdb

--- a/apps/api/src/attractap/attractap.controller.ts
+++ b/apps/api/src/attractap/attractap.controller.ts
@@ -17,7 +17,6 @@ import {
 } from '@nestjs/common';
 import { AttractapGateway } from './websockets/websocket.gateway';
 import { AuthenticatedRequest, Auth, Attractap } from '@attraccess/plugins-backend-sdk';
-import { AttractapCrashReport } from '@attraccess/database-entities';
 import { ApiOperation, ApiResponse, ApiParam, ApiTags, ApiBody, ApiProduces } from '@nestjs/swagger';
 import { WebsocketService } from './websockets/websocket.service';
 import { AttractapService } from './attractap.service';
@@ -27,6 +26,7 @@ import { UpdateReaderResponseDto } from './dtos/update-reader-response.dto';
 import { EnrollNfcCardResponseDto } from './dtos/enroll-nfc-card-response.dto';
 import { ResetNfcCardResponseDto } from './dtos/reset-nfc-card-response.dto';
 import { UpdateReaderDto } from './dtos/update-reader.dto';
+import { AttractapCrashReportDto } from './dtos/crash-report.dto';
 
 @ApiTags('Attractap')
 @Controller('attractap/readers')
@@ -154,17 +154,18 @@ export class AttractapController {
   @ApiResponse({
     status: 200,
     description: 'The list of crash reports for the reader, newest first',
-    type: [AttractapCrashReport],
+    type: [AttractapCrashReportDto],
   })
-  async getReaderCrashReports(
-    @Param('readerId', ParseIntPipe) readerId: number,
-  ): Promise<AttractapCrashReport[]> {
+  async getReaderCrashReports(@Param('readerId', ParseIntPipe) readerId: number): Promise<AttractapCrashReportDto[]> {
     return await this.attractapService.getCrashReportsForReader(readerId);
   }
 
   @Get(':readerId/crash-reports/:reportId/coredump')
   @Auth('canManageResources')
-  @ApiOperation({ summary: 'Download the coredump blob of a crash report', operationId: 'getReaderCrashReportCoredump' })
+  @ApiOperation({
+    summary: 'Download the coredump blob of a crash report',
+    operationId: 'getReaderCrashReportCoredump',
+  })
   @ApiParam({ name: 'readerId', description: 'The ID of the reader', example: 1 })
   @ApiParam({ name: 'reportId', description: 'The ID of the crash report', example: 1 })
   @ApiProduces('application/octet-stream')

--- a/apps/api/src/attractap/attractap.service.ts
+++ b/apps/api/src/attractap/attractap.service.ts
@@ -11,6 +11,8 @@ import { AttractapFirmwareVersion } from '@attraccess/database-entities';
 import { EncryptionService } from '../encryption/encryption.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { CoredumpSymbolicationService } from './coredump-symbolication.service';
+import { AttractapFirmwareService } from './firmware.service';
+import { AttractapCrashReportDto } from './dtos/crash-report.dto';
 
 @Injectable()
 export class AttractapService {
@@ -32,7 +34,8 @@ export class AttractapService {
     private readonly encryptionService: EncryptionService,
     private readonly metricsService: MetricsService,
     private readonly coredumpSymbolicationService: CoredumpSymbolicationService,
-  ) { }
+    private readonly firmwareService: AttractapFirmwareService,
+  ) {}
 
   public async getNFCCardByID(id: number): Promise<NFCCard | undefined> {
     const card = await this.nfcCardRepository.findOne({ where: { id }, relations: ['user'] });
@@ -158,7 +161,12 @@ export class AttractapService {
 
   public async updateReader(
     id: number,
-    updateData: { name?: string; connectedResourceIds?: number[]; firmware?: AttractapFirmwareVersion; ledBrightness?: number },
+    updateData: {
+      name?: string;
+      connectedResourceIds?: number[];
+      firmware?: AttractapFirmwareVersion;
+      ledBrightness?: number;
+    },
     emitEvent = true,
   ): Promise<Attractap> {
     const reader = await this.findReaderById(id);
@@ -295,11 +303,71 @@ export class AttractapService {
     }
   }
 
-  public async getCrashReportsForReader(readerId: number): Promise<AttractapCrashReport[]> {
-    return await this.crashReportRepository.find({
-      where: { attractapId: readerId },
-      order: { createdAt: 'DESC' },
-    });
+  public async getCrashReportsForReader(readerId: number): Promise<AttractapCrashReportDto[]> {
+    const [reader, reports] = await Promise.all([
+      this.readerRepository.findOne({ where: { id: readerId } }),
+      this.crashReportRepository.find({
+        where: { attractapId: readerId },
+        order: { createdAt: 'DESC' },
+      }),
+    ]);
+
+    const currentReaderFirmwareVersion = reader?.firmware?.version ?? null;
+    const latestServerFirmwareVersion =
+      reader?.firmware?.name && reader?.firmware?.variant
+        ? (this.firmwareService.getFirmwareDefinition(reader.firmware.name, reader.firmware.variant)?.version ?? null)
+        : null;
+
+    return reports.map((report) =>
+      this.toCrashReportDto(report, currentReaderFirmwareVersion, latestServerFirmwareVersion),
+    );
+  }
+
+  private toCrashReportDto(
+    report: AttractapCrashReport,
+    currentReaderFirmwareVersion: string | null,
+    latestServerFirmwareVersion: string | null,
+  ): AttractapCrashReportDto {
+    const firmwareMatchesCurrentReader = this.compareNullableVersions(
+      report.firmwareVersion,
+      currentReaderFirmwareVersion,
+    );
+    const firmwareMatchesLatestServer = this.compareNullableVersions(
+      report.firmwareVersion,
+      latestServerFirmwareVersion,
+    );
+
+    return {
+      id: report.id,
+      attractapId: report.attractapId,
+      resetReason: report.resetReason,
+      rebootReason: report.rebootReason,
+      heapFreeBytes: report.heapFreeBytes,
+      largestFreeBlockBytes: report.largestFreeBlockBytes,
+      uptimeBeforeResetMs: report.uptimeBeforeResetMs,
+      wsState: report.wsState,
+      wifiState: report.wifiState,
+      firmwareVersion: report.firmwareVersion,
+      currentReaderFirmwareVersion,
+      latestServerFirmwareVersion,
+      firmwareMatchesCurrentReader,
+      firmwareMatchesLatestServer,
+      coredumpSize: report.coredumpSize,
+      coredumpBuildId: report.coredumpBuildId,
+      coredumpBuildIdKnown: report.coredumpBuildId
+        ? this.firmwareService.hasSymbolForBuildId(report.coredumpBuildId)
+        : null,
+      symbolicationStatus: report.symbolicationStatus,
+      symbolizedBacktrace: report.symbolizedBacktrace,
+      createdAt: report.createdAt,
+    };
+  }
+
+  private compareNullableVersions(left: string | null, right: string | null): boolean | null {
+    if (!left || !right) {
+      return null;
+    }
+    return left === right;
   }
 
   public async getCrashReportCoredump(
@@ -383,9 +451,7 @@ export class AttractapService {
       await this.userRepository.save(user);
       return token;
     }
-    return (
-      this.encryptionService.decryptIfEncrypted(user.nfcKeySeedToken) ?? user.nfcKeySeedToken
-    );
+    return this.encryptionService.decryptIfEncrypted(user.nfcKeySeedToken) ?? user.nfcKeySeedToken;
   }
 
   /**

--- a/apps/api/src/attractap/coredump-symbolication.service.spec.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.spec.ts
@@ -1,6 +1,6 @@
 import { CoredumpSymbolicationService } from './coredump-symbolication.service';
 import { AttractapFirmwareService } from './firmware.service';
-import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'fs';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -48,6 +48,10 @@ function buildCoredumpFixture(sha: string | null): Buffer {
 describe('CoredumpSymbolicationService', () => {
   const tempDirs: string[] = [];
   const originalCmd = process.env.ESP_COREDUMP_CMD;
+  const originalPath = process.env.PATH;
+  const originalGdb = process.env.ESP_COREDUMP_GDB;
+  const originalXtensaGdb = process.env.ESP_COREDUMP_XTENSA_GDB;
+  const originalRiscvGdb = process.env.ESP_COREDUMP_RISCV_GDB;
 
   function tempDir(): string {
     const dir = mkdtempSync(join(tmpdir(), 'symbolication-test-'));
@@ -60,6 +64,26 @@ describe('CoredumpSymbolicationService', () => {
       delete process.env.ESP_COREDUMP_CMD;
     } else {
       process.env.ESP_COREDUMP_CMD = originalCmd;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    if (originalGdb === undefined) {
+      delete process.env.ESP_COREDUMP_GDB;
+    } else {
+      process.env.ESP_COREDUMP_GDB = originalGdb;
+    }
+    if (originalXtensaGdb === undefined) {
+      delete process.env.ESP_COREDUMP_XTENSA_GDB;
+    } else {
+      process.env.ESP_COREDUMP_XTENSA_GDB = originalXtensaGdb;
+    }
+    if (originalRiscvGdb === undefined) {
+      delete process.env.ESP_COREDUMP_RISCV_GDB;
+    } else {
+      process.env.ESP_COREDUMP_RISCV_GDB = originalRiscvGdb;
     }
   });
 
@@ -235,5 +259,34 @@ describe('CoredumpSymbolicationService', () => {
     expect(result.status).toBe('success');
     expect(result.backtrace).toContain('ApplicationLoop::tick()');
     expect(result.buildId).toBe('f6899cb1067e5043');
+  });
+
+  it('passes an explicitly resolved GDB path to esp-coredump for Xtensa chips', async () => {
+    const binDir = tempDir();
+    const argsFile = join(binDir, 'args.txt');
+    const fakeTool = join(binDir, 'fake-esp-coredump');
+    const fakeGdb = join(binDir, 'xtensa-esp32s3-elf-gdb');
+    writeFileSync(fakeTool, `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsFile}"\necho "#0 0x42066718 in ApplicationLoop::tick()"\n`);
+    writeFileSync(fakeGdb, '#!/bin/sh\nexit 0\n');
+    chmodSync(fakeTool, 0o755);
+    chmodSync(fakeGdb, 0o755);
+    process.env.ESP_COREDUMP_CMD = fakeTool;
+    process.env.PATH = `${binDir}${process.env.PATH ? `:${process.env.PATH}` : ''}`;
+
+    const elfPath = join(binDir, 'fw.elf');
+    writeFileSync(elfPath, 'elf');
+    const service = makeService({
+      resolveElfFile: jest
+        .fn()
+        .mockReturnValue({ path: elfPath, firmware: { chip: 'esp32s3', buildId: 'f6899cb1067e5043' } }),
+    });
+
+    const result = await service.symbolicate(Buffer.from('core'), { variant: 'eth', buildId: null });
+    const args = readFileSync(argsFile, 'utf8').trim().split('\n');
+
+    expect(result.status).toBe('success');
+    expect(args).toEqual(
+      expect.arrayContaining(['--chip', 'esp32s3', 'info_corefile', '--gdb', fakeGdb, '--core-format', 'raw']),
+    );
   });
 });

--- a/apps/api/src/attractap/coredump-symbolication.service.spec.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.spec.ts
@@ -197,6 +197,25 @@ describe('CoredumpSymbolicationService', () => {
     expect(result.status).toBe('unavailable');
   });
 
+  it('returns unavailable when esp-coredump reports a missing GDB toolchain', async () => {
+    const binDir = tempDir();
+    const fakeTool = join(binDir, 'fake-esp-coredump');
+    writeFileSync(fakeTool, '#!/bin/sh\necho "GDB executable not found. Please install GDB."\nexit 0\n');
+    chmodSync(fakeTool, 0o755);
+    process.env.ESP_COREDUMP_CMD = fakeTool;
+
+    const elfPath = join(binDir, 'fw.elf');
+    writeFileSync(elfPath, 'elf');
+    const service = makeService({
+      resolveElfFile: jest.fn().mockReturnValue({ path: elfPath, firmware: { chip: 'esp32s3', buildId: 'abc' } }),
+    });
+
+    const result = await service.symbolicate(Buffer.from('core'), { variant: 'eth', buildId: null });
+
+    expect(result.status).toBe('unavailable');
+    expect(result.backtrace).toBeNull();
+  });
+
   it('returns success and the tool output when symbolication succeeds', async () => {
     const binDir = tempDir();
     const fakeTool = join(binDir, 'fake-esp-coredump');

--- a/apps/api/src/attractap/coredump-symbolication.service.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { execFile } from 'child_process';
+import { existsSync } from 'fs';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { delimiter, join } from 'path';
 import { AttractapFirmwareService } from './firmware.service';
 
 export type SymbolicationStatus = 'success' | 'failed' | 'skipped' | 'unavailable';
@@ -24,6 +25,7 @@ const ESP_CORE_DUMP_INFO_MARKER = Buffer.from('ESP_CORE_DUMP_INFO', 'ascii');
 const BUILD_ID_SCAN_WINDOW_BYTES = 128;
 // esp-idf truncates the app ELF SHA256 to CONFIG_APP_RETRIEVE_LEN_ELF_SHA hex chars (default 16).
 const BUILD_ID_PATTERN = /[0-9a-fA-F]{16,64}/;
+const RISCV_CHIPS = new Set(['esp32c2', 'esp32c3', 'esp32c5', 'esp32c6', 'esp32c61', 'esp32h2', 'esp32h21', 'esp32h4', 'esp32p4']);
 
 @Injectable()
 export class CoredumpSymbolicationService {
@@ -121,9 +123,11 @@ export class CoredumpSymbolicationService {
   }
 
   private runTool(elfPath: string, corePath: string, chip: string | null): Promise<string> {
+    const gdbPath = this.resolveGdbPath(chip);
     const args = [
       ...(chip ? ['--chip', chip] : []),
       'info_corefile',
+      ...(gdbPath ? ['--gdb', gdbPath] : []),
       '--core',
       corePath,
       '--core-format',
@@ -154,6 +158,47 @@ export class CoredumpSymbolicationService {
         },
       );
     });
+  }
+
+  private resolveGdbPath(chip: string | null): string | null {
+    if (process.env.ESP_COREDUMP_GDB) {
+      return process.env.ESP_COREDUMP_GDB;
+    }
+
+    const normalizedChip = chip?.toLowerCase() ?? null;
+    const isRiscv = normalizedChip ? RISCV_CHIPS.has(normalizedChip) : false;
+    const archOverride = isRiscv ? process.env.ESP_COREDUMP_RISCV_GDB : process.env.ESP_COREDUMP_XTENSA_GDB;
+    if (archOverride) {
+      return archOverride;
+    }
+
+    const candidates = isRiscv ? ['riscv32-esp-elf-gdb'] : ['xtensa-esp32-elf-gdb', 'xtensa-esp32s3-elf-gdb'];
+    for (const candidate of candidates) {
+      const resolved = this.findExecutableOnPath(candidate);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    return null;
+  }
+
+  private findExecutableOnPath(command: string): string | null {
+    if (command.includes('/')) {
+      return existsSync(command) ? command : null;
+    }
+
+    for (const directory of (process.env.PATH || '').split(delimiter)) {
+      if (!directory) {
+        continue;
+      }
+      const candidate = join(directory, command);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    return null;
   }
 
   private isToolMissing(message: string): boolean {

--- a/apps/api/src/attractap/coredump-symbolication.service.ts
+++ b/apps/api/src/attractap/coredump-symbolication.service.ts
@@ -48,9 +48,7 @@ export class CoredumpSymbolicationService {
       // different build would only produce esp-coredump's misleading SHA-mismatch failure.
       elf = this.firmwareService.resolveElfFile({ buildId });
       if (!elf) {
-        this.logger.warn(
-          `No firmware ELF matching coredump build id ${buildId} (variant=${options.variant ?? 'n/a'})`,
-        );
+        this.logger.warn(`No firmware ELF matching coredump build id ${buildId} (variant=${options.variant ?? 'n/a'})`);
         return {
           status: 'failed',
           backtrace: `No firmware ELF matching coredump build id ${buildId} was found on the server, so the coredump could not be symbolized. The reader is likely running a build that was never published with an ELF (e.g. a local development build).`,
@@ -88,7 +86,7 @@ export class CoredumpSymbolicationService {
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (this.isToolMissing(message)) {
+      if (this.isToolMissing(message) || this.isToolchainMissing(message)) {
         this.logger.error(`esp-coredump tool not available: ${message}`);
         return { status: 'unavailable', backtrace: null, buildId: buildId ?? null };
       }
@@ -116,9 +114,7 @@ export class CoredumpSymbolicationService {
     }
 
     const windowStart = markerIndex + ESP_CORE_DUMP_INFO_MARKER.length;
-    const window = coredump
-      .subarray(windowStart, windowStart + BUILD_ID_SCAN_WINDOW_BYTES)
-      .toString('latin1');
+    const window = coredump.subarray(windowStart, windowStart + BUILD_ID_SCAN_WINDOW_BYTES).toString('latin1');
 
     const match = window.match(BUILD_ID_PATTERN);
     return match ? match[0].toLowerCase() : null;
@@ -146,6 +142,10 @@ export class CoredumpSymbolicationService {
             reject(error);
             return;
           }
+          if (error || this.isToolchainMissing(combined)) {
+            reject(new Error(combined || error?.message || 'esp-coredump failed'));
+            return;
+          }
           if (!combined) {
             reject(error || new Error('esp-coredump produced no output'));
             return;
@@ -158,5 +158,9 @@ export class CoredumpSymbolicationService {
 
   private isToolMissing(message: string): boolean {
     return message.includes('ENOENT') || message.includes('not found');
+  }
+
+  private isToolchainMissing(message: string): boolean {
+    return message.includes('GDB executable not found') || message.includes('Please install GDB');
   }
 }

--- a/apps/api/src/attractap/dtos/crash-report.dto.ts
+++ b/apps/api/src/attractap/dtos/crash-report.dto.ts
@@ -1,0 +1,103 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AttractapCrashReportDto {
+  @ApiProperty({ description: 'The unique identifier of the crash report', example: 1 })
+  id!: number;
+
+  @ApiProperty({ description: 'The ID of the reader this crash report belongs to', example: 1 })
+  attractapId!: number;
+
+  @ApiProperty({ description: 'The reset reason reported by the reader', example: 'TASK_WDT' })
+  resetReason!: string;
+
+  @ApiProperty({
+    description: 'Optional deliberate reboot reason',
+    example: 'WEBSOCKET_RECONNECT_HEAP_EXHAUSTION',
+    nullable: true,
+  })
+  rebootReason!: string | null;
+
+  @ApiProperty({ description: 'Free heap in bytes captured before reset', example: 48213, nullable: true })
+  heapFreeBytes!: number | null;
+
+  @ApiProperty({
+    description: 'Largest contiguous free heap block in bytes before reset',
+    example: 20480,
+    nullable: true,
+  })
+  largestFreeBlockBytes!: number | null;
+
+  @ApiProperty({ description: 'Uptime in milliseconds before reset', example: 372000, nullable: true })
+  uptimeBeforeResetMs!: number | null;
+
+  @ApiProperty({ description: 'WebSocket state before reset', example: 'CONNECTED', nullable: true })
+  wsState!: string | null;
+
+  @ApiProperty({ description: 'WiFi state before reset', example: 'GOT_IP', nullable: true })
+  wifiState!: string | null;
+
+  @ApiProperty({
+    description: 'Firmware version reported by the reader at crash time',
+    example: '1.3.23',
+    nullable: true,
+  })
+  firmwareVersion!: string | null;
+
+  @ApiProperty({
+    description: 'Current firmware version last reported by this reader',
+    example: '1.3.24',
+    nullable: true,
+  })
+  currentReaderFirmwareVersion!: string | null;
+
+  @ApiProperty({
+    description: 'Latest firmware version currently bundled on the server for this reader type',
+    example: '1.3.24',
+    nullable: true,
+  })
+  latestServerFirmwareVersion!: string | null;
+
+  @ApiProperty({
+    description: 'Whether the crash firmware version matches the current reader firmware version',
+    example: false,
+    nullable: true,
+  })
+  firmwareMatchesCurrentReader!: boolean | null;
+
+  @ApiProperty({
+    description: 'Whether the crash firmware version matches the server-bundled firmware version',
+    example: false,
+    nullable: true,
+  })
+  firmwareMatchesLatestServer!: boolean | null;
+
+  @ApiProperty({ description: 'Size of the attached coredump blob in bytes, if any', example: 16384, nullable: true })
+  coredumpSize!: number | null;
+
+  @ApiProperty({ description: 'Build id extracted from the coredump', example: 'f6899cb1067e5043', nullable: true })
+  coredumpBuildId!: string | null;
+
+  @ApiProperty({
+    description: 'Whether the server currently has an ELF for the coredump build id',
+    example: false,
+    nullable: true,
+  })
+  coredumpBuildIdKnown!: boolean | null;
+
+  @ApiProperty({
+    description: 'Status of server-side coredump symbolication',
+    example: 'failed',
+    enum: ['pending', 'success', 'failed', 'skipped', 'unavailable'],
+    nullable: true,
+  })
+  symbolicationStatus!: string | null;
+
+  @ApiProperty({ description: 'Symbolized backtrace or symbolication failure details', nullable: true })
+  symbolizedBacktrace!: string | null;
+
+  @ApiProperty({
+    description: 'When this crash report was received by the server',
+    example: '2026-06-02T12:00:00.000Z',
+  })
+  createdAt!: Date;
+}

--- a/apps/api/src/attractap/firmware.service.ts
+++ b/apps/api/src/attractap/firmware.service.ts
@@ -1,17 +1,28 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AttractapFirmware } from './dtos/firmware.dto';
-import { readFileSync, createReadStream, existsSync, statSync } from 'fs';
+import { copyFileSync, createReadStream, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { join } from 'path';
+
+interface FirmwareSymbolEntry {
+  firmware: AttractapFirmware;
+  elfPath: string;
+}
 
 @Injectable()
 export class AttractapFirmwareService {
   private readonly firmwareAssetsDirectory: string;
+  private readonly firmwareSymbolDirectory: string;
   private readonly logger = new Logger(AttractapFirmwareService.name);
 
   private firmwares: AttractapFirmware[] = [];
+  private symbolFirmwares: FirmwareSymbolEntry[] = [];
 
   public constructor() {
     this.firmwareAssetsDirectory = join(__dirname, 'assets', 'attractap-firmwares');
+    this.firmwareSymbolDirectory = join(
+      process.env.STORAGE_ROOT || join(process.cwd(), 'storage'),
+      'attractap-firmware-symbols',
+    );
     this.logger.debug(`Firmware assets directory: ${this.firmwareAssetsDirectory}`);
 
     // read firmwares.json from assets/attractap-firmwares
@@ -25,8 +36,11 @@ export class AttractapFirmwareService {
       this.logger.error(`Firmwares file does not exist: ${firmwaresPath}`);
     }
 
-    this.logger.debug(`Loaded ${this.firmwares.length} firmware definitions`);
+    this.symbolFirmwares = this.buildBundledSymbolIndex();
+    this.archiveBundledSymbols();
+    this.loadArchivedSymbols();
 
+    this.logger.debug(`Loaded ${this.firmwares.length} firmware definitions`);
   }
 
   public async getFirmwares(): Promise<AttractapFirmware[]> {
@@ -97,40 +111,136 @@ export class AttractapFirmwareService {
     if (!normalized) {
       return undefined;
     }
-    return this.firmwares.find((firmware) => {
+    return this.symbolFirmwares.find(({ firmware }) => {
       const candidate = firmware.buildId?.toLowerCase();
       return !!candidate && (candidate.startsWith(normalized) || normalized.startsWith(candidate));
-    });
+    })?.firmware;
   }
 
   public resolveElfFile(options: {
     buildId?: string | null;
     variant?: string | null;
   }): { path: string; firmware: AttractapFirmware } | null {
-    let firmware: AttractapFirmware | undefined;
+    let entry: FirmwareSymbolEntry | undefined;
 
     if (options.buildId) {
-      firmware = this.getFirmwareByBuildId(options.buildId);
+      entry = this.getSymbolEntryByBuildId(options.buildId);
     }
 
-    if (!firmware && options.variant) {
-      firmware = this.firmwares.find((entry) => entry.variant === options.variant && !!entry.elfFilename);
+    if (!entry && options.variant) {
+      const firmware = this.firmwares.find((entry) => entry.variant === options.variant && !!entry.elfFilename);
+      entry = firmware ? (this.buildBundledSymbolEntry(firmware) ?? undefined) : undefined;
     }
 
-    if (!firmware || !firmware.elfFilename) {
-      this.logger.debug(
-        `No ELF resolved for buildId=${options.buildId ?? 'n/a'}, variant=${options.variant ?? 'n/a'}`,
+    if (!entry || !entry.firmware.elfFilename) {
+      this.logger.debug(`No ELF resolved for buildId=${options.buildId ?? 'n/a'}, variant=${options.variant ?? 'n/a'}`);
+      return null;
+    }
+
+    if (!existsSync(entry.elfPath)) {
+      this.logger.error(`ELF file does not exist: ${entry.elfPath}`);
+      return null;
+    }
+
+    return { path: entry.elfPath, firmware: entry.firmware };
+  }
+
+  public hasSymbolForBuildId(buildId?: string | null): boolean {
+    return !!buildId && !!this.getSymbolEntryByBuildId(buildId);
+  }
+
+  private getSymbolEntryByBuildId(buildId: string): FirmwareSymbolEntry | undefined {
+    const normalized = buildId.trim().toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+    return this.symbolFirmwares.find(({ firmware }) => {
+      const candidate = firmware.buildId?.toLowerCase();
+      return !!candidate && (candidate.startsWith(normalized) || normalized.startsWith(candidate));
+    });
+  }
+
+  private buildBundledSymbolIndex(): FirmwareSymbolEntry[] {
+    return this.firmwares
+      .map((firmware) => this.buildBundledSymbolEntry(firmware))
+      .filter((entry): entry is FirmwareSymbolEntry => !!entry);
+  }
+
+  private buildBundledSymbolEntry(firmware: AttractapFirmware): FirmwareSymbolEntry | null {
+    if (!firmware.elfFilename) {
+      return null;
+    }
+    return {
+      firmware,
+      elfPath: join(this.firmwareAssetsDirectory, firmware.elfFilename),
+    };
+  }
+
+  private archiveBundledSymbols(): void {
+    const archiveEntries = this.readArchivedFirmwareEntries();
+    let changed = false;
+
+    for (const firmware of this.firmwares) {
+      if (!firmware.buildId || !firmware.elfFilename) {
+        continue;
+      }
+
+      const bundledElf = join(this.firmwareAssetsDirectory, firmware.elfFilename);
+      if (!existsSync(bundledElf)) {
+        continue;
+      }
+
+      mkdirSync(this.firmwareSymbolDirectory, { recursive: true });
+      const archivedElfFilename = `${firmware.buildId.toLowerCase()}-${firmware.elfFilename}`;
+      const archivedElfPath = join(this.firmwareSymbolDirectory, archivedElfFilename);
+      if (!existsSync(archivedElfPath)) {
+        copyFileSync(bundledElf, archivedElfPath);
+      }
+
+      if (!archiveEntries.some((entry) => entry.buildId?.toLowerCase() === firmware.buildId?.toLowerCase())) {
+        archiveEntries.push({ ...firmware, elfFilename: archivedElfFilename });
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      writeFileSync(
+        join(this.firmwareSymbolDirectory, 'firmwares.json'),
+        JSON.stringify({ firmwares: archiveEntries }, null, 2),
       );
-      return null;
+    }
+  }
+
+  private loadArchivedSymbols(): void {
+    const archiveEntries = this.readArchivedFirmwareEntries();
+    for (const firmware of archiveEntries) {
+      if (!firmware.elfFilename || !firmware.buildId) {
+        continue;
+      }
+      const elfPath = join(this.firmwareSymbolDirectory, firmware.elfFilename);
+      if (!existsSync(elfPath)) {
+        continue;
+      }
+      if (this.getSymbolEntryByBuildId(firmware.buildId)) {
+        continue;
+      }
+      this.symbolFirmwares.push({ firmware, elfPath });
+    }
+  }
+
+  private readArchivedFirmwareEntries(): AttractapFirmware[] {
+    const archiveManifest = join(this.firmwareSymbolDirectory, 'firmwares.json');
+    if (!existsSync(archiveManifest)) {
+      return [];
     }
 
-    const elfPath = join(this.firmwareAssetsDirectory, firmware.elfFilename);
-    if (!existsSync(elfPath)) {
-      this.logger.error(`ELF file does not exist: ${elfPath}`);
-      return null;
+    try {
+      const parsed = JSON.parse(readFileSync(archiveManifest, 'utf8')) as { firmwares?: AttractapFirmware[] };
+      return Array.isArray(parsed.firmwares) ? parsed.firmwares : [];
+    } catch (error) {
+      this.logger.error(`Failed to read archived firmware symbols manifest: ${(error as Error).message}`);
+      return [];
     }
-
-    return { path: elfPath, firmware };
   }
 
   public getFirmwareDownloadUrl(firmwareName: string, variantName: string): string {

--- a/apps/api/src/attractap/websockets/handlers/forms-session-flow.spec.ts
+++ b/apps/api/src/attractap/websockets/handlers/forms-session-flow.spec.ts
@@ -20,6 +20,7 @@ import { ResourceFlowsExecutorService } from '../../../resources/flows/resource-
 import { SumUpService } from '../../../billing/sumup.service';
 import { ResourceListService } from './resource-list.service';
 import { AttractapEvent, AttractapEventType } from '../websocket.types';
+import { SupervisionService } from '../../../resources/supervision/supervision.service';
 
 // ATT-545 regression (backend half): the Attractap form reopens after the last
 // field only if the server re-sends RESOURCE_USAGE_FORM_REQUEST, i.e.
@@ -87,6 +88,7 @@ describe('ATT-545 attractap paged form session flow (server does not re-request 
         { provide: ResourceFlowsExecutorService, useValue: {} },
         { provide: SumUpService, useValue: { getIsEnabled: jest.fn().mockResolvedValue(false) } },
         { provide: ResourceListService, useValue: { sendResourceListToSocket: jest.fn() } },
+        { provide: SupervisionService, useValue: { settleByCard: jest.fn() } },
       ],
     }).compile();
 

--- a/apps/attractap/firmware/build_firmwares.py
+++ b/apps/attractap/firmware/build_firmwares.py
@@ -54,10 +54,14 @@ def extract_build_id(firmware_bin_path, esptool_cmd, chip):
     if not os.path.exists(firmware_bin_path):
         return None
     try:
-        info_cmd = [*esptool_cmd, '--chip', chip, 'image_info', firmware_bin_path]
+        info_cmd = [*esptool_cmd, '--chip', chip, 'image_info', '--version', '2', firmware_bin_path]
         result = subprocess.run(info_cmd, capture_output=True, text=True)
         output = (result.stdout or '') + '\n' + (result.stderr or '')
         match = re.search(r'(?:ELF file SHA256|app_elf_sha256)[^0-9a-fA-F]*([0-9a-fA-F]{64})', output)
+        if not match:
+            # Older esptool output may not include the application-info block, but the
+            # validation hash is still better than leaving the manifest unindexed.
+            match = re.search(r'Validation hash[^0-9a-fA-F]*([0-9a-fA-F]{64})', output, re.IGNORECASE)
         if match:
             return match.group(1).lower()
     except Exception as e:

--- a/apps/attractap/firmware/platformio.ini
+++ b/apps/attractap/firmware/platformio.ini
@@ -24,7 +24,7 @@ extra_scripts =
     pre:tools/build_adaptive_certs_wrapper.py
 build_flags =
 	-O2
-	-D FIRMWARE_VERSION='"1.3.25"'
+	-D FIRMWARE_VERSION='"1.3.26"'
 
 [env:attractap-touch]
 board = esp32-s3-devkitc-1-n16r8v

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.de.json
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.de.json
@@ -15,6 +15,9 @@
     "wsState": "WebSocket",
     "wifiState": "WLAN",
     "firmware": "Firmware",
+    "crashFirmware": "Crash-Firmware",
+    "currentReaderFirmware": "Reader jetzt",
+    "latestServerFirmware": "Server aktuell",
     "receivedAt": "Empfangen"
   },
   "notAvailable": "n.v.",
@@ -24,6 +27,9 @@
   "downloadFailed": "Coredump-Download fehlgeschlagen",
   "backtrace": "Symbolisierter Backtrace",
   "buildId": "Build-ID",
+  "buildIdKnown": "ELF verfügbar",
+  "buildIdMissing": "ELF fehlt",
+  "firmwareMismatch": "Firmware-Abweichung",
   "symbolication": {
     "pending": "Symbolisierung läuft…",
     "success": "Symbolisiert",

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.en.json
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.en.json
@@ -15,6 +15,9 @@
     "wsState": "WebSocket",
     "wifiState": "WiFi",
     "firmware": "Firmware",
+    "crashFirmware": "Crash firmware",
+    "currentReaderFirmware": "Reader now",
+    "latestServerFirmware": "Server latest",
     "receivedAt": "Received"
   },
   "notAvailable": "n/a",
@@ -24,6 +27,9 @@
   "downloadFailed": "Failed to download coredump",
   "backtrace": "Symbolized backtrace",
   "buildId": "Build id",
+  "buildIdKnown": "ELF available",
+  "buildIdMissing": "ELF missing",
+  "firmwareMismatch": "Firmware mismatch",
   "symbolication": {
     "pending": "Symbolizing…",
     "success": "Symbolized",

--- a/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.tsx
+++ b/apps/frontend/src/app/attractap/AttractapEditor/AttractapDiagnostics.tsx
@@ -45,6 +45,10 @@ function symbolicationChipColor(status: string | null | undefined): 'success' | 
   }
 }
 
+function mismatchChipColor(matches: boolean | null | undefined): 'danger' | 'default' {
+  return matches === false ? 'danger' : 'default';
+}
+
 export function AttractapDiagnostics(props: Readonly<Props>) {
   const { t } = useTranslations({ de, en });
   const toast = useToastMessage();
@@ -183,6 +187,11 @@ export function AttractapDiagnostics(props: Readonly<Props>) {
                       {t(`symbolication.${report.symbolicationStatus}`)}
                     </Chip>
                   )}
+                  {report.firmwareMatchesLatestServer === false && (
+                    <Chip color="danger" variant="soft" size="sm" data-cy="attractap-diagnostics-firmware-mismatch">
+                      {t('firmwareMismatch')}
+                    </Chip>
+                  )}
                 </div>
                 <span className="text-xs text-default-400">{new Date(report.createdAt).toLocaleString()}</span>
               </div>
@@ -203,20 +212,42 @@ export function AttractapDiagnostics(props: Readonly<Props>) {
                   {t('fields.wifiState')}: {report.wifiState ?? fallback}
                 </span>
                 <span className="text-default-500">
-                  {t('fields.firmware')}: {report.firmwareVersion ?? fallback}
+                  {t('fields.crashFirmware')}: {report.firmwareVersion ?? fallback}
+                </span>
+                <span className="text-default-500">
+                  {t('fields.currentReaderFirmware')}:{' '}
+                  <span className={report.firmwareMatchesCurrentReader === false ? 'text-danger' : undefined}>
+                    {report.currentReaderFirmwareVersion ?? fallback}
+                  </span>
+                </span>
+                <span className="text-default-500">
+                  {t('fields.latestServerFirmware')}:{' '}
+                  <span className={report.firmwareMatchesLatestServer === false ? 'text-danger' : undefined}>
+                    {report.latestServerFirmwareVersion ?? fallback}
+                  </span>
                 </span>
               </div>
+              {report.coredumpBuildId && (
+                <div className="flex items-center gap-2 flex-wrap text-sm">
+                  <span className="font-mono text-xs text-default-500">
+                    {t('buildId')}: {report.coredumpBuildId}
+                  </span>
+                  {report.coredumpBuildIdKnown !== null && report.coredumpBuildIdKnown !== undefined && (
+                    <Chip
+                      color={mismatchChipColor(report.coredumpBuildIdKnown)}
+                      variant="soft"
+                      size="sm"
+                      data-cy="attractap-diagnostics-build-id-known"
+                    >
+                      {report.coredumpBuildIdKnown ? t('buildIdKnown') : t('buildIdMissing')}
+                    </Chip>
+                  )}
+                </div>
+              )}
               {report.symbolizedBacktrace && (
                 <div className="flex flex-col gap-2">
                   <div className="flex items-center justify-between gap-2 flex-wrap">
-                    <span className="text-sm font-medium">
-                      {t('backtrace')}
-                      {report.coredumpBuildId ? (
-                        <span className="ml-2 font-mono text-xs text-default-400">
-                          {t('buildId')}: {report.coredumpBuildId}
-                        </span>
-                      ) : null}
-                    </span>
+                    <span className="text-sm font-medium">{t('backtrace')}</span>
                     <Button
                       variant="secondary"
                       size="sm"


### PR DESCRIPTION
## Summary

Fixes Attractap crashdump symbolication for readers that crash while running firmware that no longer matches the server's currently bundled firmware, and fixes the runtime GDB resolution failure that still prevented `esp-coredump` from producing stacks in production-like environments.

## What changed

- Archive bundled firmware ELFs into persistent storage keyed by build id so older deployed firmware can still be used for future coredump symbolication.
- Fix firmware build id extraction by using detailed esptool image info, so generated firmware manifests carry the app ELF SHA instead of `null`.
- Treat `esp-coredump` missing-GDB output as symbolication unavailable instead of success.
- Resolve and pass an explicit `--gdb` path to `esp-coredump`, including PlatformIO's `xtensa-esp32s3-elf-gdb` case where `esp-coredump` only auto-searches `xtensa-esp32-elf-gdb`.
- Install the ESP Xtensa and RISC-V GDB toolchains in the runtime Docker image and expose explicit GDB env vars there.
- Add crash-report DTO fields for crash firmware, current reader firmware, latest server firmware, version mismatch state, and build-id ELF availability.
- Show those firmware/build-id diagnostics in the Attractap diagnostics UI.

## Root cause

The server image only retained the current firmware assets, while readers can legitimately still run an older OTA firmware after a server update. Coredumps include the firmware build id, so symbolication must resolve the exact matching ELF. When that ELF had been discarded, symbolication failed.

Separately, `esp-coredump` could print `GDB executable not found` and still be shown as a successful symbolication because the API treated tool output as success without recognizing that missing-toolchain failure. The final hardware pass also showed that installing GDB was not enough on its own: for ESP32-S3, the API needs to pass the resolved GDB binary explicitly.

## Hardware validation

- Ran API from this branch on port 3000 with persistent storage and the Touch V2 reader connected over USB.
- OTA-updated reader 31 from `1.3.24` to `1.3.25`; after reconnect, reader row showed `attractap_touch_v2/wifi` `1.3.25`.
- Forced `debug.crash` on OTA-updated firmware. SQLite report `96` stored `PANIC`, firmware `1.3.25`, coredump size `27332`, build id `b468cf79551d0842d02cfafc181e00fb3beac0318cb316fd18bbf10d61959b0a`, `symbolicationStatus=success`, and the backtrace contains `SerialCommandHandler::handleCommand` at `src/serial/serialCommandHandler.cpp:202`.
- Confirmed the previous runtime failure on report `95`: same crash path produced `GDB executable not found` and was stored as `unavailable` before the explicit-GDB fix.
- Confirmed the expected negative case on report `98`: flashing a fresh local PlatformIO rebuild with the same version string produced unpublished build id `e9c929284788fc77`; the API correctly stored `failed` with “No firmware ELF matching coredump build id...”.

## Validation

- `pnpm nx lint api` passed.
- `pnpm nx build api` passed.
- `pnpm nx test api --testFile=apps/api/src/attractap/coredump-symbolication.service.spec.ts --runInBand` passed: 15 tests.
- Precommit `pnpm nx affected --uncommitted --nxBail --target=lint,typecheck,build,test,e2e` passed during commit: affected API/full-source lint/build/test/e2e, including 146 API test suites and 1534 tests.
- Fresh CI run on the latest commit passed: `attractap-firmware-version`, `commitlint`, `lint-and-typecheck`, `plugins`, `precommit-check`, `test`, `containerize`, `fail2ban-smoke`, and `grafana-provisioning-smoke`.

