### PR TITLE
fix: balena compose depends_on (short-form) so balena push succeeds

### DIFF
--- a/.github/actions/balena-push/action.yml
+++ b/.github/actions/balena-push/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: Install balena-cli
       run: |
-        BALENA_CLI_VERSION=v24.0.3
+        BALENA_CLI_VERSION=v25.1.9
         wget -qO- "https://github.com/balena-io/balena-cli/releases/download/${BALENA_CLI_VERSION}/balena-cli-${BALENA_CLI_VERSION}-linux-x64-standalone.tar.gz" | tar -xzf -
       shell: bash
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -185,6 +185,15 @@ jobs:
       - name: Test Grafana provisioning prepare (Pushover opt-in)
         run: ./scripts/grafana-provisioning-prepare.spec.sh
 
+  balena-compose-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Validate docker-compose.balena.yml with balena's parser
+        run: node scripts/check-balena-compose.mjs
+
   containerize:
     runs-on: ubuntu-latest
     steps:

--- a/docker-compose.balena.yml
+++ b/docker-compose.balena.yml
@@ -48,9 +48,11 @@ services:
       - VALKEY_URL=redis://valkey:6379
     env_file:
       - .env.docker-compose
+    # Balena only supports the short-form depends_on (service_started); the
+    # long-form `condition: service_healthy` is rejected (ATT-593-style). The app
+    # retries Valkey connections, and restart: unless-stopped covers startup races.
     depends_on:
-      valkey:
-        condition: service_healthy
+      - valkey
 
   monitoring-init:
     build:

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "glob": "^13.0.6",
     "handlebars": "^4.7.9",
     "identity-obj-proxy": "^3.0.0",
-    "ioredis": "^5.6.1",
     "intl-pluralrules": "^2.0.1",
+    "ioredis": "^5.6.1",
     "jdenticon": "^3.3.0",
     "js-confetti": "^0.13.1",
     "lodash-es": "^4.18.1",
@@ -139,6 +139,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@babel/preset-react": "^7.29.7",
+    "@balena/compose-parser": "^0.2.6",
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^21.0.2",
     "@cyclonedx/cdxgen": "^12.3.3",
@@ -270,6 +271,7 @@
       }
     },
     "onlyBuiltDependencies": [
+      "@balena/compose-parser",
       "@nestjs/core",
       "@swc/core",
       "bcrypt",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
       '@babel/preset-react':
         specifier: ^7.29.7
         version: 7.29.7(@babel/core@7.29.7)
+      '@balena/compose-parser':
+        specifier: ^0.2.6
+        version: 0.2.6
       '@commitlint/cli':
         specifier: ^19.6.1
         version: 19.8.1(@types/node@25.9.1)(typescript@6.0.3)
@@ -684,7 +687,7 @@ importers:
         version: 1.3.0(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.4.1)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7(vitest@4.1.9))(@vitest/ui@4.1.7(vitest@4.1.9))(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       webpack-cli:
         specifier: ^7.0.2
         version: 7.0.2(webpack-dev-server@5.2.4)(webpack@5.107.2)
@@ -736,7 +739,7 @@ importers:
         version: 4.22.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7(vitest@4.1.9))(@vitest/ui@4.1.7(vitest@4.1.9))(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -1950,6 +1953,10 @@ packages:
     engines: {node: '>=20.14.0', npm: '>=10.7.0'}
     peerDependencies:
       '@balena/sbvr-types': ^7.1.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+
+  '@balena/compose-parser@0.2.6':
+    resolution: {integrity: sha512-eIkD7xw9/IELDl1dg8LiL7VTAEaH4ZlVhVO6Xuq0qDSWchhV6frTHegcu0OaXR1krpiMFGV7O4sgAQ5QLaTV6Q==}
+    engines: {node: '>= 22.14.0', npm: '>= 11.5.1'}
 
   '@balena/es-version@1.0.4':
     resolution: {integrity: sha512-9OVgZXksV0i7gklYhWKslEbvkuoDU98fd3bOXuuc+hjPKW5ogqdL42rEm+pKUezdQJ6kWEHjDCkRZ/VjBBEQAw==}
@@ -18501,6 +18508,12 @@ snapshots:
       '@types/node': 20.19.41
       common-tags: 1.8.2
 
+  '@balena/compose-parser@0.2.6':
+    dependencies:
+      semver: 7.8.4
+      tar: 7.5.13
+      typed-error: 3.2.3
+
   '@balena/es-version@1.0.4': {}
 
   '@balena/odata-parser@4.2.28': {}
@@ -21159,7 +21172,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7(vitest@4.1.9))(@vitest/ui@4.1.7(vitest@4.1.9))(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/eslint'
@@ -21181,7 +21194,7 @@ snapshots:
     optionalDependencies:
       '@nx/eslint': 22.7.4(c0f0e5e3f024bcdabfe54ce544a4be42)
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7(vitest@4.1.9))(@vitest/ui@4.1.7(vitest@4.1.9))(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -24203,7 +24216,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7(vitest@4.1.9))(@vitest/ui@4.1.7(vitest@4.1.9))(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -24253,7 +24266,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7(vitest@4.1.9))(@vitest/ui@4.1.7(vitest@4.1.9))(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -35908,7 +35921,7 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7(vitest@4.1.9))(@vitest/ui@4.1.7(vitest@4.1.9))(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))

--- a/scripts/check-balena-compose.mjs
+++ b/scripts/check-balena-compose.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+// Validate docker-compose.balena.yml with balena's OWN parser (@balena/compose-parser,
+// the exact code `balena push` runs). Catches balena-only constraints — e.g. long-form
+// `depends_on: { condition: ... }` and top-level secrets/configs — that a normal compose
+// engine accepts but balena rejects only at release time, after all other CI is green.
+import { parse } from '@balena/compose-parser';
+
+const file = process.argv[2] ?? 'docker-compose.balena.yml';
+
+try {
+  await parse(file);
+  console.log(`✓ ${file} is balena-compatible`);
+} catch (err) {
+  console.error(`✗ ${file} is not balena-compatible:\n  ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

The v1.8.1 release `balena` step failed:

```
Only "service_started" type of service dependency is supported
```

Balena's compose parser doesn't support the long-form `depends_on` with `condition: service_healthy`. The `attraccess` service used `condition: service_healthy` on `valkey`, which broke `balena push`.

## Fix

Switch to short-form `depends_on: [valkey]`. The app retries Valkey connections and `restart: unless-stopped` covers startup races, so health-gating isn't needed.

Re-ran the balena step via the manual balena pipeline (`balena-manual.yml`) against this branch for v1.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)