### PR TITLE
fix(ATT-534): route-shadow guard mishandles multiple controllers per file

### DIFF
--- a/apps/api/src/route-shadow.spec.ts
+++ b/apps/api/src/route-shadow.spec.ts
@@ -102,27 +102,52 @@ function shadows(a: RouteDecl, b: RouteDecl): boolean {
 }
 
 /**
- * Parse a controller source file.
+ * Parse every @Controller class declared in a source file.
+ *
+ * A single file may hold multiple controllers, each with its own
+ * @Controller(prefix) — so we scan linearly and attribute each route decorator
+ * to the controller class it lives in, rather than collapsing the whole file
+ * onto its first class/prefix.
+ *
  * Skips template-literal paths (back-tick) because we cannot evaluate
  * TypeScript expressions statically; those would need a full compiler run.
  */
-function parseController(filePath: string): ControllerInfo | null {
+function parseControllers(filePath: string): ControllerInfo[] {
   const content = readFileSync(filePath, 'utf-8');
-
-  const classMatch = content.match(/export class (\w+)/);
-  if (!classMatch) return null;
-  const className = classMatch[1];
-
-  // @Controller() or @Controller('prefix') or @Controller("prefix")
-  const prefixMatch = content.match(/@Controller\(\s*(?:['"]([^'"]*)['"])?\s*\)/);
-  const prefix = normalisePath(prefixMatch?.[1] ?? '');
-
-  const routes: RouteDecl[] = [];
   const lines = content.split('\n');
+
   const methodRe = new RegExp(`@(${HTTP_METHODS.join('|')})\\(([^)]*)\\)`);
+  const controllerRe = /@Controller\(\s*(?:['"]([^'"]*)['"])?\s*\)/;
+  const classRe = /export class (\w+)/;
+
+  const controllers: ControllerInfo[] = [];
+  let pendingPrefix: string | null = null; // set by @Controller(...), consumed at the next class
+  let current: ControllerInfo | null = null;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
+
+    const cm = controllerRe.exec(line);
+    if (cm) {
+      pendingPrefix = normalisePath(cm[1] ?? '');
+      continue;
+    }
+
+    const clsMatch = classRe.exec(line);
+    if (clsMatch) {
+      if (pendingPrefix !== null) {
+        current = { className: clsMatch[1], prefix: pendingPrefix, routes: [], filePath };
+        controllers.push(current);
+        pendingPrefix = null;
+      } else {
+        // A non-controller class ends the previous controller's body.
+        current = null;
+      }
+      continue;
+    }
+
+    if (!current) continue;
+
     const m = methodRe.exec(line);
     if (!m) continue;
 
@@ -140,10 +165,10 @@ function parseController(filePath: string): ControllerInfo | null {
     if (routePath === null) continue;
 
     const segs = pathSegments(routePath);
-    routes.push({ method, path: routePath, lineNumber: i + 1, segments: segs });
+    current.routes.push({ method, path: routePath, lineNumber: i + 1, segments: segs });
   }
 
-  return { className, prefix, routes, filePath };
+  return controllers;
 }
 
 // ─── Module parsing ───────────────────────────────────────────────────────────
@@ -233,11 +258,11 @@ function detectShadowsInModule(
     const importPath = importMap.get(name);
     if (!importPath) continue;
     const absolutePath = resolve(moduleDir, importPath + '.ts');
-    const info = parseController(absolutePath);
-    if (info) {
+    for (const info of parseControllers(absolutePath)) {
       controllerMap.set(info.className, info);
-      resolved.push(info);
     }
+    const resolvedInfo = controllerMap.get(name);
+    if (resolvedInfo) resolved.push(resolvedInfo);
   }
 
   // Group controllers by their @Controller(prefix)
@@ -316,8 +341,7 @@ describe('Route-shadow guard (ATT-534)', () => {
 
     controllerMap = new Map();
     for (const file of controllerFiles) {
-      const info = parseController(file);
-      if (info) controllerMap.set(info.className, info);
+      for (const info of parseControllers(file)) controllerMap.set(info.className, info);
     }
   });
 


### PR DESCRIPTION
## Problem

`main` is red: the `test` job fails on **every** PR with a route-shadow guard violation, even on PRs that don't touch routing (ATT-563 RBAC, ATT-574 email templates). This blocks the merge queue.

```
Route-shadow guard (ATT-534) › no :param route in an earlier controller shadows a static route in a later controller sharing the same @Controller(prefix)
  In companion/companion.module.ts:
    CompanionDownloadController @Get(':id') shadows CompanionDownloadController @Get('versions')
```

## Root cause — a false positive, not a real shadow

`apps/api/src/companion/companion.controller.ts` declares **two** controllers in one file:

- `CompanionDownloadController` → `@Controller('companion')` (routes: `versions`, `download/:platform/:arch`)
- `CompanionController` → `@Controller('companion-devices')` (routes: ``, `:id`, `:id/resources`, …)

The guard's parser only read the **first** `export class` and the **first** `@Controller(prefix)` per file, then attributed *every* route decorator in the file to that single class/prefix. It collapsed both controllers into a fake `CompanionDownloadController` with prefix `companion`, so `@Get(':id')` (which actually belongs to `companion-devices`) appeared to shadow `@Get('versions')`.

The two real routes — `GET /companion/versions` and `GET /companion-devices/:id` — have different prefixes and never collide. There is no real shadow.

## Fix

Make the parser controller-aware: scan the file linearly and attribute each route decorator to the controller class it lives in, instead of merging the whole file onto its first class/prefix. One change, in the spec file only — no production code touched.

## Verification

- `pnpm nx test api --testFile=apps/api/src/route-shadow.spec.ts` — **green** (was red on current `main`).
- Full `api` suite: **1621/1621 tests pass**.
- Teeth-check: temporarily added a controller with a genuine `:id`-before-`static` shadow → guard still catches it and correctly does **not** flag a second controller with a different prefix. False positive gone, real-shadow detection intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the route-shadow guard tests to correctly handle multiple @Controller classes per file and eliminate false positives for non-colliding routes.

Enhancements:
- Refine the controller parsing logic in the route-shadow spec to track multiple controllers per file and associate route decorators with their owning controller class.
- Adjust module shadow detection to work with the new multi-controller parsing while preserving existing shadow detection behavior.