### PR TITLE
fix(companion): stop macOS companion relaunching itself on quit

### DIFF
--- a/apps/companion/src/macos-lock.spec.ts
+++ b/apps/companion/src/macos-lock.spec.ts
@@ -68,8 +68,10 @@ describe('installLaunchAgent', () => {
     expect(content).toContain('/Applications/Attraccess.app/Contents/MacOS/app');
     expect(content).toContain('com.attraccess.companion');
     expect(content).toContain('<key>RunAtLoad</key>');
-    expect(content).toContain('<key>KeepAlive</key>');
     expect(content).toContain('<true/>');
+    // KeepAlive must NOT be set: it relaunches the app on every quit, trapping
+    // the user in an unquittable loop. Login autostart only needs RunAtLoad.
+    expect(content).not.toContain('KeepAlive');
   });
 });
 

--- a/apps/companion/src/macos-lock.ts
+++ b/apps/companion/src/macos-lock.ts
@@ -57,8 +57,6 @@ function buildPlist(execPath: string): string {
 \t</array>
 \t<key>RunAtLoad</key>
 \t<true/>
-\t<key>KeepAlive</key>
-\t<true/>
 </dict>
 </plist>
 `;


### PR DESCRIPTION
## Problem

The macOS companion installs a login launch agent (`~/Library/LaunchAgents/com.attraccess.companion.plist`) with `KeepAlive=true`. `launchd` then relaunches the app **every time it exits — including a normal user quit**, trapping the user in an unquittable loop (quit → instantly restarts).

Reproduced on a real machine: the agent was loaded in `launchd`, and `bootout` + plist removal + kill was required to stop it.

## Fix

The intent of this agent is only "start on login," which `RunAtLoad` already provides. `KeepAlive` was the wrong key for that — it's daemon/watchdog behavior. Removed it. Kiosk "can't escape the lock" is enforced in-app via `setKiosk(true)` + `lockShortcuts`, not via launchd, so nothing else depends on `KeepAlive`.

```diff
 	<key>RunAtLoad</key>
 	<true/>
-	<key>KeepAlive</key>
-	<true/>
 </dict>
```

The test now asserts the plist does **not** contain `KeepAlive`, so this can't silently regress.

## Verification

`nx test companion` (macos-lock spec): **6/6 pass**, including the new assertion.

## Note (not in this PR)

`installLaunchAgent` overwrites the plist on call, so re-running setup heals it. If the wizard gates installation behind `isLaunchAgentInstalled`, already-deployed bad plists won't auto-rewrite — but this build is local-only so far, so no field migration is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the macOS companion launch agent configuration to prevent the app from being automatically relaunched on normal quit while still starting on user login.

Bug Fixes:
- Remove the KeepAlive setting from the macOS companion launch agent plist to stop the app from relaunching itself after a user-initiated quit.

Tests:
- Adjust the macOS companion launch agent test to assert that the generated plist no longer includes the KeepAlive key, preventing regressions.