### PR TITLE
fix(ci): stop using secrets context in step-level if conditions

### DIFF
--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -40,6 +40,9 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    env:
+      # secrets are not allowed in step-level `if`, so expose presence as job env
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -47,7 +50,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Set up macOS code signing
-        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
+        if: ${{ env.HAS_APPLE_CERT == 'true' }}
         uses: ./.github/actions/macos-codesign-setup
         with:
           certificate: ${{ secrets.APPLE_CERTIFICATE }}
@@ -64,7 +67,7 @@ jobs:
         run: pnpm nx run companion:build
 
       - name: Clean up keychain
-        if: ${{ secrets.APPLE_CERTIFICATE != '' && always() }}
+        if: ${{ env.HAS_APPLE_CERT == 'true' && always() }}
         run: '[ -n "$KEYCHAIN_PATH" ] && security delete-keychain "$KEYCHAIN_PATH" || true'
 
       - name: Upload macOS artifact
@@ -76,6 +79,8 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    env:
+      HAS_WINDOWS_CERT: ${{ secrets.WINDOWS_CERT_BASE64 != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -83,7 +88,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Set up Windows code signing
-        if: ${{ secrets.WINDOWS_CERT_BASE64 != '' }}
+        if: ${{ env.HAS_WINDOWS_CERT == 'true' }}
         uses: ./.github/actions/windows-codesign-setup
         with:
           cert-base64: ${{ secrets.WINDOWS_CERT_BASE64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,12 +131,15 @@ jobs:
     needs: check-companion
     if: needs.check-companion.outputs.exists == 'true'
     runs-on: macos-latest
+    env:
+      # secrets are not allowed in step-level `if`, so expose presence as job env
+      HAS_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Set up macOS code signing
-        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
+        if: ${{ env.HAS_APPLE_CERT == 'true' }}
         uses: ./.github/actions/macos-codesign-setup
         with:
           certificate: ${{ secrets.APPLE_CERTIFICATE }}
@@ -149,7 +152,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm nx run companion:build
       - name: Clean up keychain
-        if: ${{ secrets.APPLE_CERTIFICATE != '' && always() }}
+        if: ${{ env.HAS_APPLE_CERT == 'true' && always() }}
         run: '[ -n "$KEYCHAIN_PATH" ] && security delete-keychain "$KEYCHAIN_PATH" || true'
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
@@ -162,12 +165,14 @@ jobs:
     needs: check-companion
     if: needs.check-companion.outputs.exists == 'true'
     runs-on: windows-latest
+    env:
+      HAS_WINDOWS_CERT: ${{ secrets.WINDOWS_CERT_BASE64 != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Set up Windows code signing
-        if: ${{ secrets.WINDOWS_CERT_BASE64 != '' }}
+        if: ${{ env.HAS_WINDOWS_CERT == 'true' }}
         uses: ./.github/actions/windows-codesign-setup
         with:
           cert-base64: ${{ secrets.WINDOWS_CERT_BASE64 }}


### PR DESCRIPTION
GitHub Actions does not allow the secrets context in step-level if expressions, which made companion.yml and release.yml unparseable — every push to main produced an instant 'workflow file issue' failure since #1447. Hoist the secret-presence checks into job-level env vars (where secrets are allowed) and test those in the step conditions.

## Summary by Sourcery

CI:
- Update companion and release workflows to gate macOS and Windows code-signing steps on job-level environment flags instead of direct secrets checks to restore workflow parseability.