### PR TITLE
fix: update node-version-consistency spec for docker-build-push composite action

### DIFF
--- a/tools/generators/src/node-version-consistency.spec.ts
+++ b/tools/generators/src/node-version-consistency.spec.ts
@@ -215,6 +215,8 @@ describe('Node.js version consistency', () => {
 
     const workflowsWithDocker = [
       'docker-nightly-latest.yml',
+      'pull-requests.yml',
+      'release.yml',
     ];
 
     workflowsWithDocker.forEach((workflowFile) => {

--- a/tools/generators/src/node-version-consistency.spec.ts
+++ b/tools/generators/src/node-version-consistency.spec.ts
@@ -179,7 +179,40 @@ describe('Node.js version consistency', () => {
     });
   });
 
-  describe('GitHub Actions workflows read Node.js version from .nvmrc', () => {
+  describe('GitHub Actions Docker builds read Node.js version from .nvmrc', () => {
+    describe('docker-build-push composite action', () => {
+      let content: string;
+
+      beforeAll(() => {
+        content = readFile('.github/actions/docker-build-push/action.yml');
+      });
+
+      it('should read NODE_VERSION from .nvmrc', () => {
+        expect(content).toContain('cat .nvmrc');
+      });
+
+      it('should pass NODE_VERSION as a Docker build-arg', () => {
+        expect(content).toContain(
+          'NODE_VERSION=${{ steps.node-version.outputs.value }}'
+        );
+      });
+
+      it('should not hardcode a Node.js version in build-args', () => {
+        const buildArgLines = content
+          .split('\n')
+          .filter(
+            (l) =>
+              l.includes('NODE_VERSION=') &&
+              !l.includes('${{') &&
+              !l.includes('cat .nvmrc')
+          );
+        const hardcodedVersionArgs = buildArgLines.filter((l) =>
+          /NODE_VERSION=\d+/.test(l)
+        );
+        expect(hardcodedVersionArgs).toHaveLength(0);
+      });
+    });
+
     const workflowsWithDocker = [
       'docker-nightly-latest.yml',
     ];
@@ -192,14 +225,8 @@ describe('Node.js version consistency', () => {
           content = readFile(`.github/workflows/${workflowFile}`);
         });
 
-        it('should read NODE_VERSION from .nvmrc', () => {
-          expect(content).toContain('cat .nvmrc');
-        });
-
-        it('should pass NODE_VERSION as a Docker build-arg', () => {
-          expect(content).toContain(
-            'NODE_VERSION=${{ steps.node-version.outputs.NODE_VERSION }}'
-          );
+        it('should build Docker images via the docker-build-push action', () => {
+          expect(content).toContain('./.github/actions/docker-build-push');
         });
 
         it('should not hardcode a Node.js version in build-args', () => {
@@ -226,6 +253,7 @@ describe('Node.js version consistency', () => {
       'tools/hetzner-dns-updater/Dockerfile',
       'tools/config-ui/Dockerfile',
       '.github/actions/setup/action.yml',
+      '.github/actions/docker-build-push/action.yml',
       '.github/workflows/pull-requests.yml',
       '.github/workflows/release.yml',
       '.github/workflows/docker-nightly-latest.yml',


### PR DESCRIPTION
The nightly Docker workflow (docker-nightly-latest.yml) was refactored in
ATT-604 to delegate its Docker build steps to the docker-build-push
composite action, but the consistency spec still asserted that the
workflow itself contains 'cat .nvmrc' and the NODE_VERSION build-arg,
breaking the nightly run on main.

Assert the .nvmrc read and NODE_VERSION build-arg (now via the action's
'value' output) against the composite action instead, verify the
workflow delegates to it, and include the action in the stale
Node-version reference checks.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NiuLAJdjX9LvKTsx7Psewz