### PR TITLE
fix(ATT-792): show large flows in the editor instead of an empty canvas

### DIFF
--- a/apps/frontend/src/app/resources/details/flows/flowImportExport.test.tsx
+++ b/apps/frontend/src/app/resources/details/flows/flowImportExport.test.tsx
@@ -1,0 +1,106 @@
+// Tests for useFlowImportExport: the file-picker import path.
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { useFlowImportExport } from './flowImportExport';
+
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+
+vi.mock('../../../../components/toastProvider', () => ({
+  useToastMessage: () => ({ success: toastSuccess, error: toastError }),
+}));
+
+function Harness({ onResult }: { onResult: (r: { nodes: unknown[]; edges: unknown[] }) => void }) {
+  const { handleImportClick } = useFlowImportExport({
+    nodes: [],
+    edges: [],
+    setNodes: (n) => onResult({ nodes: n as unknown[], edges: [] }),
+    setEdges: (e) => onResult({ nodes: [], edges: e as unknown[] }),
+    resourceId: 1,
+    t: (k: string) => k,
+  });
+  return <button onClick={handleImportClick}>import</button>;
+}
+
+async function runImport(json: string) {
+  const results: { nodes: unknown[]; edges: unknown[] } = { nodes: [], edges: [] };
+  const { getByText } = render(
+    <Harness
+      onResult={(r) => {
+        if (r.nodes.length) results.nodes = r.nodes;
+        if (r.edges.length) results.edges = r.edges;
+      }}
+    />,
+  );
+  getByText('import').click();
+
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  expect(input).toBeTruthy();
+
+  const file = new File([json], 'flow.json', { type: 'application/json' });
+  Object.defineProperty(input, 'files', { value: [file], configurable: true });
+  input.dispatchEvent(new Event('change'));
+
+  return { results };
+}
+
+const NODE = (id: string, type: string) => ({ id, type, position: { x: 0, y: 0 }, data: {} });
+
+describe('useFlowImportExport - import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('imports a flow with fresh ids and remapped edges', async () => {
+    const json = JSON.stringify({
+      version: 1,
+      nodes: [NODE('a', 'input.button'), NODE('b', 'processing.if')],
+      edges: [{ id: 'e1', source: 'a', target: 'b', sourceHandle: 'output', targetHandle: 'input' }],
+    });
+
+    const { results } = await runImport(json);
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(results.nodes).toHaveLength(2);
+    expect(results.edges).toHaveLength(1);
+    // ids are regenerated, topology preserved
+    const ids = (results.nodes as { id: string }[]).map((n) => n.id);
+    expect(ids).not.toContain('a');
+    const edge = (results.edges as { source: string; target: string }[])[0];
+    expect(ids).toContain(edge.source);
+    expect(ids).toContain(edge.target);
+  });
+
+  it('imports the real 83-node Bambu flow shape without error', async () => {
+    const nodes = Array.from({ length: 83 }, (_, i) => NODE(`n${i}`, 'processing.if'));
+    const edges = Array.from({ length: 82 }, (_, i) => ({
+      id: `e${i}`,
+      source: `n${i}`,
+      target: `n${i + 1}`,
+      sourceHandle: 'output-true',
+      targetHandle: 'input',
+    }));
+    const { results } = await runImport(JSON.stringify({ version: 1, nodes, edges }));
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastError).not.toHaveBeenCalled();
+    expect(results.nodes).toHaveLength(83);
+    expect(results.edges).toHaveLength(82);
+  });
+
+  it('reports an error when crypto.randomUUID is unavailable (insecure context)', async () => {
+    const original = globalThis.crypto.randomUUID;
+    // Simulate a non-secure context (e.g. the dev server reached over http://<lan-ip>)
+    Object.defineProperty(globalThis.crypto, 'randomUUID', { value: undefined, configurable: true });
+
+    const json = JSON.stringify({ version: 1, nodes: [NODE('a', 'input.button')], edges: [] });
+    await runImport(json);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastSuccess).not.toHaveBeenCalled();
+
+    Object.defineProperty(globalThis.crypto, 'randomUUID', { value: original, configurable: true });
+  });
+});

--- a/apps/frontend/src/app/resources/details/flows/index.tsx
+++ b/apps/frontend/src/app/resources/details/flows/index.tsx
@@ -429,6 +429,11 @@ function FlowsPageInner() {
             multiSelectionKeyCode="Shift"
             colorMode={theme === 'dark' ? 'dark' : 'light'}
             fitView
+            // ponytail: fixed floor, derive it from the graph bounding box if 0.02 ever bites.
+            // React Flow's default minZoom of 0.5 clamps fitView on flows taller than the pane,
+            // which then centres on the bounding box and parks the viewport in a gap between
+            // nodes - the canvas looks empty even though every node is rendered.
+            minZoom={0.02}
             defaultEdgeOptions={{ style: { strokeWidth: 4 } }}
             nodeTypes={flowNodeTypes}
             edgeTypes={edgeTypes}


### PR DESCRIPTION
Fixes ATT-792.

## Problem

A flow whose bounding box is much taller than the canvas pane renders as a **completely empty canvas**. The nodes are loaded, in React state, and present in the DOM — they are simply outside the visible area, and Fit View cannot bring them back no matter how often you press it.

`<ReactFlow fitView>` did not set `minZoom`, so React Flow's default of `0.5` applied. `fitView` computes the zoom needed to fit the bounding box, clamps it to `minZoom`, but still translates to the bounding-box **centre** — so at a clamped zoom the visible window is a small slice around that centre, which on a tall sparse graph lands in the gap between two nodes.

## Reproduction

Measured in a running dev app on a real 83-node / 100-edge flow, after using the auto-layout button (Dagre lays a mostly-linear chain into one very tall column):

```
.react-flow__node count           = 83            <- nodes ARE rendered
.react-flow__viewport transform   = translate(-409px, -2560px) scale(0.5)
first node transform              = translate(153px, 10px)
first node bounding rect          = y: -2214       (pane starts at y: 341)
pane size                         = 702 x 362
graph bounding box                = x 0..2784, y 0..10794
```

Fitting needs zoom ≈ `362 / 10794` ≈ `0.033`; it was clamped to `0.5`.

This is easy to misdiagnose as a broken import: the import succeeds, the success toast shows, the flow saves and executes correctly, and the canvas is still blank.

## Change

`minZoom={0.02}` on the `<ReactFlow>` in the flows editor. Verified in the browser — Fit View now shows the whole graph.

Also adds `flowImportExport.test.tsx` (3 tests: happy path, an 83-node file, and the insecure-context `crypto.randomUUID` failure). That module had **no** tests despite f3678b8b (ATT-436) rewriting its node/edge ID handling, and the blank canvas initially looked like an import bug with no coverage to rule it out.

## Not done here

Left for ATT-792 follow-up, since each is a larger change than the one-line unblock:

- deriving `minZoom` from the graph bounding box instead of a fixed floor
- re-running `fitView()` when nodes arrive from the server (`fitView` is a static prop, so today it only fires on mount, before the query resolves)
- `rankdir: 'LR'` or a wrapped auto-layout for long linear chains, so flows stop becoming 10k-pixel columns in the first place

No test for the `minZoom` prop itself: jsdom has no layout, so `fitView` cannot compute a meaningful transform there. It was verified in a real browser instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust flow editor zoom behavior so very tall flows are visible instead of rendering an apparently empty canvas, and add tests for the flow import hook.

Bug Fixes:
- Allow extremely tall flows to be fully fitted into view in the editor by lowering the minimum zoom level.

Tests:
- Add tests covering flow import via useFlowImportExport, including ID remapping, large real-world flows, and insecure-context failures.