### PR TITLE
fix: correct license field to match LICENSE.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@attraccess/source",
   "version": "1.9.0",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
     "serve": "node --experimental-strip-types scripts/dev-serve.mts",
     "lint:strict": "nx affected -t lint -- --max-warnings=0",


### PR DESCRIPTION
`package.json` declared `"license": "MIT"`, which contradicts the actual licence in `LICENSE.md`.

`LICENSE.md` is the **Prosperity Public License 3.0 (modified)**:

- free for private individuals and non-profits, and for education, research and hobby projects
- commercial use requires a separate licence after a 30-day evaluation
- forks must keep the same terms

That is materially more restrictive than MIT. `package.json` is the field package managers, registries and licence scanners actually read, so the stale value understated the terms to anyone consuming the repo programmatically.

Prosperity has no SPDX identifier, so this uses npm's documented form for non-standard licences:

```json
"license": "SEE LICENSE IN LICENSE.md"
```

### Notes

- One-line change; no code, config or dependency changes.
- Spotted while writing the Maker Faire campaign copy — the emails now say "source available under a non-commercial licence" rather than "open source", and this brings the manifest in line with that.
- `LICENSE-fabinfra.md` (MIT, FabAccess) is untouched — it covers third-party code, not this project.
- The pre-commit hook (`nx affected -t lint,typecheck,build,test,e2e`) could not run: no `node_modules` in this worktree. The change is a metadata string and JSON validity was verified, but CI should be the gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)