### PR TITLE
fix(docker): strip swc-node patch by name, not pinned version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN node -e "for (const p of ['dist/apps/api/package.json','dist/apps/api-swagge
 # Strip them from both pnpm-lock.yaml (patchedDependencies block) and from the
 # root package.json so pnpm deploy sees no stale patch declarations.
 RUN node -e "const fs=require('fs'); let l=fs.readFileSync('pnpm-lock.yaml','utf8'); const pivot='\nimporters:'; const [hdr,rest]=l.split(pivot); const cleaned=hdr.replace(/\n  '@swc-node\/register@[^']+':(?:\n    [^\n]+)*/g,'').replace(/\n  ts-api-utils@[^\n:]+:(?:\n    [^\n]+)*/g,''); fs.writeFileSync('pnpm-lock.yaml',cleaned+pivot+rest);" && \
-    node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); delete p.pnpm.patchedDependencies['@swc-node/register@1.11.1']; delete p.pnpm.patchedDependencies['ts-api-utils@2.5.0']; fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
+    node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); const d=p.pnpm.patchedDependencies; for (const k of Object.keys(d)) if (k.startsWith('@swc-node/register@') || k.startsWith('ts-api-utils@')) delete d[k]; fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
 
 # pnpm 10's new deploy requires a workspace shared lockfile; --ignore-workspace
 # strips that, so use --legacy for the self-contained dist/apps/api package.


### PR DESCRIPTION
## Problem

The nightly Docker build's `containerize` job has been failing:

```
ERR_PNPM_UNUSED_PATCH  The following patches were not used: @swc-node/register@1.12.1
```

## Cause

`Dockerfile` strips dev-only patches before `pnpm deploy` (they're absent from the API's production dep tree, and pnpm 10 errors on unused patches). The lockfile half of that cleanup matches by regex on the package name; the `package.json` half deleted the key by **exact version**:

```js
delete p.pnpm.patchedDependencies['@swc-node/register@1.11.1'];
```

Renovate bumped the patch to `1.12.1` in #1563, so the delete silently became a no-op and the deploy failed.

## Fix

Match by package-name prefix, in line with the lockfile regex on the preceding line. Applied to `ts-api-utils` too, which carried the same latent pin.

Verified against the current `package.json`: both entries are stripped, `@nestjs/swagger` and `typescript` are retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)