### PR TITLE
fix(billing): read SumUp merchant code from merchant_profile

### DIFF
--- a/apps/api/src/billing/sumup.service.spec.ts
+++ b/apps/api/src/billing/sumup.service.spec.ts
@@ -158,8 +158,14 @@ describe('SumUpService', () => {
       expect(settingRepository.update).not.toHaveBeenCalled();
     });
 
-    it('throws and stores nothing when /me has no merchant_profile.merchant_code', async () => {
-      mockSumUpGet.mockResolvedValue({ account: { username: 'x' } });
+    it.each([
+      ['merchant_profile is absent', { account: { username: 'x' }, personal_profile: { first_name: 'A' } }],
+      [
+        'merchant_profile carries no merchant_code',
+        { account: { username: 'x' }, merchant_profile: { company_name: 'Attraccess' } },
+      ],
+    ])('throws and stores nothing when %s', async (_case, meResponse) => {
+      mockSumUpGet.mockResolvedValue(meResponse);
       settingRepository.findOneBy.mockResolvedValue(null);
 
       await expect(service.setApiKey('token')).rejects.toBeInstanceOf(BadRequestException);

--- a/apps/api/src/billing/sumup.service.spec.ts
+++ b/apps/api/src/billing/sumup.service.spec.ts
@@ -135,7 +135,7 @@ describe('SumUpService', () => {
 
   describe('setApiKey', () => {
     it('stores encrypted API key and merchant code via update when existing', async () => {
-      mockSumUpGet.mockResolvedValue({ merchant_code: 'M123' });
+      mockSumUpGet.mockResolvedValue({ merchant_profile: { merchant_code: 'M123' } });
       settingRepository.findOneBy.mockResolvedValue({ id: 1, value: 'enc' });
       encryptionService.encrypt.mockReturnValue('encrypted');
 
@@ -147,7 +147,7 @@ describe('SumUpService', () => {
     });
 
     it('stores encrypted API key and merchant code via insert when missing', async () => {
-      mockSumUpGet.mockResolvedValue({ merchant_code: 'M123' });
+      mockSumUpGet.mockResolvedValue({ merchant_profile: { merchant_code: 'M123' } });
       settingRepository.findOneBy.mockResolvedValue(null);
       encryptionService.encrypt.mockReturnValue('encrypted');
 
@@ -155,6 +155,15 @@ describe('SumUpService', () => {
 
       expect(settingRepository.insert).toHaveBeenCalledWith({ parent: 'sumup', key: 'apiKey', value: 'encrypted' });
       expect(settingRepository.insert).toHaveBeenCalledWith({ parent: 'sumup', key: 'merchantCode', value: 'M123' });
+      expect(settingRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('throws and stores nothing when /me has no merchant_profile.merchant_code', async () => {
+      mockSumUpGet.mockResolvedValue({ account: { username: 'x' } });
+      settingRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.setApiKey('token')).rejects.toBeInstanceOf(BadRequestException);
+      expect(settingRepository.insert).not.toHaveBeenCalled();
       expect(settingRepository.update).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/billing/sumup.service.ts
+++ b/apps/api/src/billing/sumup.service.ts
@@ -39,19 +39,19 @@ export class SumUpService {
 
   async setApiKey(token: string): Promise<void> {
     const sumUp = new SumUp({ apiKey: token });
-    let merchantCode: string | undefined;
-    try {
-      // /v0.1/me nests the code under merchant_profile, it is not a top-level field
-      const me = await this.externalCallTimer.time('sumup', 'me', () =>
+    const me = await this.externalCallTimer
+      .time('sumup', 'me', () =>
         sumUp.get<{ merchant_profile?: { merchant_code?: string } }>({ path: '/v0.1/me' }),
-      );
-      merchantCode = me.merchant_profile?.merchant_code;
-    } catch (error) {
-      this.logger.error('Invalid API key', { error });
-      throw new BadRequestException('Invalid API key');
-    }
+      )
+      .catch((error) => {
+        this.logger.error('Invalid API key', { error });
+        throw new BadRequestException('Invalid API key');
+      });
 
+    // /v0.1/me nests the code under merchant_profile, it is not a top-level field
+    const merchantCode = me.merchant_profile?.merchant_code;
     if (!merchantCode) {
+      this.logger.error('SumUp /v0.1/me returned no merchant_profile.merchant_code');
       throw new BadRequestException('SumUp returned no merchant code for this API key');
     }
 

--- a/apps/api/src/billing/sumup.service.ts
+++ b/apps/api/src/billing/sumup.service.ts
@@ -39,15 +39,20 @@ export class SumUpService {
 
   async setApiKey(token: string): Promise<void> {
     const sumUp = new SumUp({ apiKey: token });
-    let merchantCode: string;
+    let merchantCode: string | undefined;
     try {
+      // /v0.1/me nests the code under merchant_profile, it is not a top-level field
       const me = await this.externalCallTimer.time('sumup', 'me', () =>
-        sumUp.get<{ merchant_code: string }>({ path: '/v0.1/me' }),
+        sumUp.get<{ merchant_profile?: { merchant_code?: string } }>({ path: '/v0.1/me' }),
       );
-      merchantCode = me.merchant_code;
+      merchantCode = me.merchant_profile?.merchant_code;
     } catch (error) {
       this.logger.error('Invalid API key', { error });
       throw new BadRequestException('Invalid API key');
+    }
+
+    if (!merchantCode) {
+      throw new BadRequestException('SumUp returned no merchant code for this API key');
     }
 
     const encryptedApiKey = this.encryptionService.encrypt(token);


### PR DESCRIPTION
## Problem

Setting a SumUp API key appeared to succeed, but every SumUp feature afterwards failed with **`SumUp merchant code not found`** — readers list, reader pairing, checkout, and the transaction-status cron.

## Root cause

Regression from the `@sumup/sdk` v0.1 migration (6edb9632, Apr 27). That commit replaced the old `sumUp.merchant.get()` call with a raw `GET /v0.1/me` and read the code as a top-level field:

```ts
const me = await sumUp.get<{ merchant_code: string }>({ path: '/v0.1/me' });
merchantCode = me.merchant_code; // always undefined
```

`/v0.1/me` nests it under `merchant_profile` — exactly as the pre-migration code did (`merchant.merchant_profile.merchant_code`). So `merchantCode` was always `undefined` and the `sumup/merchantCode` setting never received a usable value.

The unit tests mocked `{ merchant_code: 'M123' }` — the wrong shape — so CI stayed green throughout.

Not an outdated dependency: `@sumup/sdk@0.1.8` is the latest published version, and `merchants.get()` / `readers.*` are used correctly.

## Changes

- Read `me.merchant_profile?.merchant_code`.
- Reject the API key with a clear error when SumUp returns no merchant code, instead of persisting an unusable setting. The check sits outside the `try` so it isn't masked as "Invalid API key".
- Correct the test mocks to the real response shape, plus a new case covering a `/me` response without `merchant_profile`.

## Verification

`pnpm nx test api` — 175 suites, 1816 tests, all passing. Full precommit (lint, build, test, e2e) green.

## Upgrade note

Existing installs must **re-save their SumUp API key** after deploying — that is what repopulates the `merchantCode` setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate and persist SumUp merchant codes correctly when setting the API key, and reject API keys that do not return a usable merchant code.

Bug Fixes:
- Read the SumUp merchant code from merchant_profile.merchant_code instead of an incorrect top-level field to restore SumUp functionality.

Enhancements:
- Return a clear BadRequest error when SumUp does not provide a merchant code for a given API key instead of saving an unusable configuration.

Tests:
- Update SumUp /me response mocks to match the real API shape and add coverage for responses that lack a merchant_profile.merchant_code.