### PR TITLE
fix(deps): repair pnpm-lock.yaml entry for acorn

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41100,8 +41100,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-import-phases: 1.0.4(acorn@8.18.0)
       browserslist: 4.28.6
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.2


### PR DESCRIPTION
## Problem

Every CI job installs with a frozen lockfile, and that install currently fails:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'acorn@8.17.0' in pnpm-lock.yaml
```

So all pipelines are red regardless of the change under test.

## Cause

The `webpack` snapshot still referenced `acorn@8.17.0` (and `acorn-import-phases@1.0.4(acorn@8.17.0)`), while the only resolved `acorn` entry in the lockfile is `8.18.0` — the usual residue of two dependency updates landing concurrently.

## Fix

Regenerated with `pnpm install --no-frozen-lockfile`. The diff is limited to those two stale references:

```diff
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-import-phases: 1.0.4(acorn@8.18.0)
```

## Verification

`pnpm install --frozen-lockfile` fails on `main` and succeeds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct pnpm-lock.yaml entries for acorn and acorn-import-phases so CI installs with a frozen lockfile no longer fail.